### PR TITLE
Add native OpenCode ACP review support

### DIFF
--- a/src/main/ai/ACP.md
+++ b/src/main/ai/ACP.md
@@ -172,7 +172,7 @@ OpenCode auth remains external to Comando. The primary setup flow opens:
 opencode auth login
 ```
 
-Comando also treats `OPENCODE_API_KEY` as an external environment credential. It does not persist an OpenCode API key in V1, and disconnecting OpenCode from Comando only clears the selected Comando auth method and invalidates the local readiness marker; it does not delete OpenCode CLI credentials.
+Comando also treats `OPENCODE_API_KEY` and common provider API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `CODEX_API_KEY`) as external environment credentials for OpenCode readiness. It does not persist an OpenCode API key in V1, and disconnecting OpenCode from Comando only clears the selected Comando auth method and invalidates the local readiness marker; it does not delete OpenCode CLI credentials.
 
 ---
 
@@ -695,6 +695,11 @@ On Linux and Windows, Kilo and OpenCode paths can vary through `XDG_DATA_HOME` a
 | `GOOGLE_CLOUD_LOCATION` | Gemini process | Google Cloud location hint |
 | `GEMINI_DEFAULT_AUTH_TYPE` | Gemini process | Default Gemini auth mode |
 | `OPENCODE_API_KEY` | OpenCode process | External OpenCode API key recognized by diagnostics/status but not stored by Comando |
+| `OPENAI_API_KEY` | OpenCode process | Provider API key recognized by OpenCode readiness when OpenCode owns provider selection |
+| `ANTHROPIC_API_KEY` | OpenCode process | Provider API key recognized by OpenCode readiness when OpenCode owns provider selection |
+| `GEMINI_API_KEY` | OpenCode process | Provider API key recognized by OpenCode readiness when OpenCode owns provider selection |
+| `GOOGLE_API_KEY` | OpenCode process | Provider API key recognized by OpenCode readiness when OpenCode owns provider selection |
+| `CODEX_API_KEY` | OpenCode process | Provider API key recognized by OpenCode readiness when OpenCode owns provider selection |
 | `NO_BROWSER` | Claude/Codex auth UX | Forces remote-style Claude auth behavior and hides the Codex ChatGPT browser login option |
 | `SSH_CONNECTION` | Claude auth UX | Marks the environment as remote |
 | `SSH_CLIENT` | Claude auth UX | Marks the environment as remote |

--- a/src/main/ai/ACP.md
+++ b/src/main/ai/ACP.md
@@ -1,26 +1,27 @@
 # ACP (Agent Client Protocol) — Architecture Reference
 
-Comando currently integrates four AI runtimes through the Agent Client Protocol:
+Comando currently integrates five AI runtimes through the Agent Client Protocol:
 
 - **Claude**
 - **Codex**
 - **Gemini**
 - **Kilo**
+- **OpenCode**
 
-All four communicate with the app over ACP / JSON-RPC on stdio.
+All five communicate with the app over ACP / JSON-RPC on stdio.
 
 ---
 
 ## Runtimes at a Glance
 
-| | Claude | Codex | Gemini | Kilo |
-|---|---|---|---|---|
-| **Source** | TypeScript (`@agentclientprotocol/claude-agent-acp` `0.35.0`, vendored upstream snapshot) | Rust (`codex-acp` `0.15.0`, vendored on top of `openai/codex` `rust-v0.133.0` + local patches) | External Gemini CLI binary | External Kilo CLI binary |
-| **Runtime command** | `node .../claude-agent-acp/dist/index.js` or `claude-agent-acp` | `codex-acp` | `gemini --acp` | `kilo acp` |
-| **Release packaging** | Embedded Node runtime + embedded vendor JS project | Bundled native binary under `resources/ai/binaries/` | Not bundled today | Not bundled today |
-| **Auth methods exposed by Comando** | `claude-ai-login`, `claude-login`, `console-login`, `gateway` | `chatgpt`, `codex-api-key`, `openai-api-key` | `login_with_google`, `use_gemini` | `kilo-login` |
-| **Runtime discovery** | env, settings, vendor JS, embedded bundle, PATH fallback | env, settings, bundled binary, embedded target cache, legacy vendor target cache, PATH fallback | env, settings, PATH | env, settings, PATH |
-| **Notes** | Debug builds prefer vendored JS directly. Gateway auth is supported. | Detects and rejects plain `codex` CLI because current integration still expects ACP. | Login readiness is inferred from `~/.gemini/settings.json`. | Login readiness is inferred from system-level Kilo auth stores (`XDG_DATA_HOME`, `LOCALAPPDATA`, `~/.local/share`). |
+| | Claude | Codex | Gemini | Kilo | OpenCode |
+|---|---|---|---|---|---|
+| **Source** | TypeScript (`@agentclientprotocol/claude-agent-acp` `0.35.0`, vendored upstream snapshot) | Rust (`codex-acp` `0.15.0`, vendored on top of `openai/codex` `rust-v0.133.0` + local patches) | External Gemini CLI binary | External Kilo CLI binary | External OpenCode CLI binary |
+| **Runtime command** | `node .../claude-agent-acp/dist/index.js` or `claude-agent-acp` | `codex-acp` | `gemini --acp` | `kilo acp` | `opencode acp` |
+| **Release packaging** | Embedded Node runtime + embedded vendor JS project | Bundled native binary under `resources/ai/binaries/` | Not bundled today | Not bundled today | Not bundled today |
+| **Auth methods exposed by Comando** | `claude-ai-login`, `claude-login`, `console-login`, `gateway` | `chatgpt`, `codex-api-key`, `openai-api-key` | `login_with_google`, `use_gemini` | `kilo-login` | `opencode-login` |
+| **Runtime discovery** | env, settings, vendor JS, embedded bundle, PATH fallback | env, settings, bundled binary, embedded target cache, legacy vendor target cache, PATH fallback | env, settings, PATH | env, settings, PATH | env, settings, PATH |
+| **Notes** | Debug builds prefer vendored JS directly. Gateway auth is supported. | Detects and rejects plain `codex` CLI because current integration still expects ACP. | Login readiness is inferred from `~/.gemini/settings.json`. | Login readiness is inferred from system-level Kilo auth stores (`XDG_DATA_HOME`, `LOCALAPPDATA`, `~/.local/share`). | Auth is owned by the OpenCode CLI. Comando treats `OPENCODE_API_KEY`, `auth.json`, and selected external auth as valid setup signals without storing OpenCode secrets. |
 
 Notes:
 
@@ -31,7 +32,7 @@ Notes:
 - The vendored Codex ACP snapshot currently includes a local Fast Mode patch carried over into Comando. It exposes the ACP session config option `service_tier`, the `/fast` slash command, and rehydrates `service_tier` when a session is resumed.
 - The vendored Codex ACP snapshot also carries a local image-generation bridge: live Codex `ImageGenerationBegin` / `ImageGenerationEnd` events and replayed `ResponseItem::ImageGenerationCall` items are emitted as ACP tool updates with `codexAcpEventType = "image_generation"` and `codex-acp:image:` IDs so Comando can render generated images inline instead of as generic status activity. `TurnItem::ImageGeneration` is intentionally ignored for the live bridge because Codex also emits the begin/end events, and handling both would duplicate image cards.
 - The current Codex vendor also carries compatibility glue for the `rust-v0.133.0` runtime API shape, including state DB/thread-store wiring, installation IDs, async auth reload/logout, permission-profile modes, newer event payloads, and local custom prompt handling.
-- Gemini and Kilo are integrated in the UI and service layer, but they are not part of the staging/bundling pipeline today.
+- Gemini, Kilo and OpenCode are integrated in the UI and service layer, but they are not part of the staging/bundling pipeline today.
 - Status metadata currently uses `codexAcp*` names while Comando keeps app-branded `comando*` aliases for compatibility paths it owns.
 
 ---
@@ -64,6 +65,7 @@ Credential precedence is runtime-specific:
 | Gemini | `use_gemini` | `GEMINI_API_KEY`/`GOOGLE_API_KEY` environment variables, then Comando-managed secrets |
 | Gemini | `login_with_google` | External Gemini CLI login |
 | Kilo | `kilo-login` | External Kilo auth stores |
+| OpenCode | `opencode-login` | External OpenCode auth state, `OPENCODE_API_KEY`, provider env vars, project `.env`, or providers configured with `/connect` |
 
 Comando stores secrets through Electron `safeStorage`. On macOS this delegates protection to Keychain, on Windows to DPAPI, and on Linux to the selected keyring backend. Linux `basic_text` and `unknown` backends are treated as weak: Comando still reads existing secrets best-effort for compatibility, but blocks new secret writes and reports the storage warning through runtime status.
 
@@ -145,6 +147,33 @@ so the effective command is:
 kilo acp
 ```
 
+### OpenCode (`opencode/setup.ts` → `resolveOpenCodeBinary`)
+
+1. `COMANDO_OPENCODE_ACP_BIN`
+2. Custom path from settings
+3. `opencode` in PATH
+4. On macOS, common Homebrew installs such as `/opt/homebrew/bin/opencode` and `/usr/local/bin/opencode`
+
+When spawned, Comando appends:
+
+```text
+acp
+```
+
+so the effective command is:
+
+```text
+opencode acp
+```
+
+OpenCode auth remains external to Comando. The primary setup flow opens:
+
+```text
+opencode auth login
+```
+
+Comando also treats `OPENCODE_API_KEY` as an external environment credential. It does not persist an OpenCode API key in V1, and disconnecting OpenCode from Comando only clears the selected Comando auth method and invalidates the local readiness marker; it does not delete OpenCode CLI credentials.
+
 ---
 
 ## Binary Staging (build-time)
@@ -163,7 +192,7 @@ Today `stage:ai` stages:
 - **Codex**
 - **Claude**
 
-It does **not** stage Gemini or Kilo.
+It does **not** stage Gemini, Kilo, or OpenCode.
 
 ### Codex staging (`scripts/ai/stage-codex-runtime.mjs`)
 

--- a/src/main/ai/ACP.md
+++ b/src/main/ai/ACP.md
@@ -665,9 +665,10 @@ External auth state also used:
 ~/.gemini/settings.json
 ~/.local/share/kilo/auth.json
 ~/.local/share/kilo/kilo.db
+~/.local/share/opencode/auth.json
 ```
 
-On Linux and Windows, the Kilo paths vary through `XDG_DATA_HOME` and `LOCALAPPDATA`.
+On Linux and Windows, Kilo and OpenCode paths can vary through `XDG_DATA_HOME` and `LOCALAPPDATA`.
 
 ---
 
@@ -680,6 +681,7 @@ On Linux and Windows, the Kilo paths vary through `XDG_DATA_HOME` and `LOCALAPPD
 | `COMANDO_CODEX_ACP_BUNDLE_BIN` | Codex staging | Override the binary copied into bundled resources |
 | `COMANDO_GEMINI_ACP_BIN` | Gemini runtime | Override Gemini CLI path or command |
 | `COMANDO_KILO_ACP_BIN` | Kilo runtime | Override Kilo CLI path or command |
+| `COMANDO_OPENCODE_ACP_BIN` | OpenCode runtime | Override OpenCode CLI path or command |
 | `COMANDO_EMBEDDED_NODE_BIN` | Claude staging | Override the Node binary embedded for Claude |
 | `COMANDO_APP_CHANNEL` | App runtime | Forces `dev` or `release` channel identity |
 | `ANTHROPIC_BASE_URL` | Claude process | Custom Anthropic-compatible gateway URL |
@@ -692,6 +694,7 @@ On Linux and Windows, the Kilo paths vary through `XDG_DATA_HOME` and `LOCALAPPD
 | `GOOGLE_CLOUD_PROJECT` | Gemini process | Google Cloud project hint |
 | `GOOGLE_CLOUD_LOCATION` | Gemini process | Google Cloud location hint |
 | `GEMINI_DEFAULT_AUTH_TYPE` | Gemini process | Default Gemini auth mode |
+| `OPENCODE_API_KEY` | OpenCode process | External OpenCode API key recognized by diagnostics/status but not stored by Comando |
 | `NO_BROWSER` | Claude/Codex auth UX | Forces remote-style Claude auth behavior and hides the Codex ChatGPT browser login option |
 | `SSH_CONNECTION` | Claude auth UX | Marks the environment as remote |
 | `SSH_CLIENT` | Claude auth UX | Marks the environment as remote |

--- a/src/main/ai/contracts.ts
+++ b/src/main/ai/contracts.ts
@@ -205,6 +205,7 @@ export interface LiveAcpSession {
     pendingAdditionalRoots: readonly string[] | null;
     pendingLaunch: AiWorkerSessionLaunchInput | null;
     pendingPersistTimer: ReturnType<typeof setTimeout> | null;
+    preEditSnapshots: Map<string, string>;
     processedDiffPaths: Map<string, Set<string>>;
     projectRoot: string | null;
     resolvedRuntime: ResolvedAcpRuntime;

--- a/src/main/ai/data-dir.ts
+++ b/src/main/ai/data-dir.ts
@@ -1,0 +1,32 @@
+import path from "node:path";
+
+// Resolves the user-level data directory where ACP runtimes persist auth
+// state on disk (e.g. <data-dir>/<runtime>/auth.json). Lookup order:
+//
+//   1. XDG_DATA_HOME, if set.
+//   2. LOCALAPPDATA on Windows, if set.
+//   3. HOME or USERPROFILE joined with ".local/share".
+//
+// Returns null when none of those resolve to a non-empty path.
+export function resolveXdgDataDir(
+    env: NodeJS.ProcessEnv = process.env,
+): string | null {
+    const xdgDataHome = env.XDG_DATA_HOME?.trim() ?? "";
+    if (xdgDataHome) {
+        return xdgDataHome;
+    }
+
+    if (process.platform === "win32") {
+        const localAppData = env.LOCALAPPDATA?.trim() ?? "";
+        if (localAppData) {
+            return localAppData;
+        }
+    }
+
+    const homeDir = env.HOME?.trim() || env.USERPROFILE?.trim() || "";
+    if (!homeDir) {
+        return null;
+    }
+
+    return path.join(homeDir, ".local", "share");
+}

--- a/src/main/ai/environment-diagnostics.test.ts
+++ b/src/main/ai/environment-diagnostics.test.ts
@@ -226,6 +226,11 @@ function createSettings(
             binaryPath: null,
             hasKiloApiKey: false,
         },
+        opencode: {
+            authInvalidatedAtMs: null,
+            authMethod: null,
+            binaryPath: null,
+        },
         ...overrides,
     };
 }

--- a/src/main/ai/environment-diagnostics.test.ts
+++ b/src/main/ai/environment-diagnostics.test.ts
@@ -26,6 +26,7 @@ describe("AI environment diagnostics", () => {
             const codexPath = writeExecutable(binDir, "codex-acp");
             const geminiPath = writeExecutable(binDir, "gemini");
             const kiloPath = writeExecutable(binDir, "kilo");
+            const opencodePath = writeExecutable(binDir, "opencode");
             const diagnostics = createAiEnvironmentDiagnostics({
                 env: {
                     CODEX_API_KEY: "codex-secret-value",
@@ -33,8 +34,10 @@ describe("AI environment diagnostics", () => {
                     COMANDO_CODEX_ACP_BIN: codexPath,
                     COMANDO_GEMINI_ACP_BIN: geminiPath,
                     COMANDO_KILO_ACP_BIN: kiloPath,
+                    COMANDO_OPENCODE_ACP_BIN: opencodePath,
                     GEMINI_API_KEY: "gemini-secret-value",
                     HOME: homeDir,
+                    OPENAI_API_KEY: "openai-secret-value",
                     PATH: binDir,
                 },
                 now: () => new Date("2026-05-19T12:00:00.000Z"),
@@ -118,11 +121,37 @@ describe("AI environment diagnostics", () => {
                     (runtime) => runtime.runtimeId === "gemini",
                 )?.preferredPathEntries[0],
             ).toBe(binDir);
+            expect(
+                diagnostics.runtimes.find(
+                    (runtime) => runtime.runtimeId === "opencode",
+                ),
+            ).toMatchObject({
+                authCredentialSource: "environment",
+                authMethod: "opencode-login",
+                authReady: true,
+                command: `${opencodePath} acp`,
+                executablePath: opencodePath,
+                source: "env",
+                state: "ready",
+            });
+            expect(
+                diagnostics.credentialEnvironment.find(
+                    (entry) =>
+                        entry.name === "OPENAI_API_KEY" &&
+                        entry.runtimeId === "opencode",
+                ),
+            ).toMatchObject({
+                present: true,
+                runtimeId: "opencode",
+            });
             expect(JSON.stringify(diagnostics)).not.toContain(
                 "codex-secret-value",
             );
             expect(JSON.stringify(diagnostics)).not.toContain(
                 "gemini-secret-value",
+            );
+            expect(JSON.stringify(diagnostics)).not.toContain(
+                "openai-secret-value",
             );
             expect(process.env.PATH).toBe(previousPath);
         } finally {

--- a/src/main/ai/environment-diagnostics.ts
+++ b/src/main/ai/environment-diagnostics.ts
@@ -125,6 +125,26 @@ const CREDENTIAL_ENVIRONMENT: readonly {
         runtimeId: "opencode",
     },
     {
+        name: "ANTHROPIC_API_KEY",
+        runtimeId: "opencode",
+    },
+    {
+        name: "CODEX_API_KEY",
+        runtimeId: "opencode",
+    },
+    {
+        name: "GEMINI_API_KEY",
+        runtimeId: "opencode",
+    },
+    {
+        name: "GOOGLE_API_KEY",
+        runtimeId: "opencode",
+    },
+    {
+        name: "OPENAI_API_KEY",
+        runtimeId: "opencode",
+    },
+    {
         name: "OPENAI_API_KEY",
         runtimeId: "codex",
     },

--- a/src/main/ai/environment-diagnostics.ts
+++ b/src/main/ai/environment-diagnostics.ts
@@ -23,6 +23,10 @@ import {
 import { getGeminiRuntimeStatus, resolveGeminiRuntime } from "./gemini/setup";
 import { getKiloRuntimeStatus, resolveKiloRuntime } from "./kilo/setup";
 import {
+    getOpenCodeRuntimeStatus,
+    resolveOpenCodeRuntime,
+} from "./opencode/setup";
+import {
     resolveCodexRuntime,
     type ResolveCodexRuntimeOptions,
 } from "./resolver/runtime-resolver";
@@ -46,6 +50,7 @@ const EXECUTABLE_PROBES = [
     "codex",
     "gemini",
     "kilo",
+    "opencode",
     "node",
 ] as const;
 
@@ -68,6 +73,10 @@ const RUNTIME_PATH_OVERRIDES: readonly {
     {
         name: "COMANDO_KILO_ACP_BIN",
         runtimeId: "kilo",
+    },
+    {
+        name: "COMANDO_OPENCODE_ACP_BIN",
+        runtimeId: "opencode",
     },
 ];
 
@@ -110,6 +119,10 @@ const CREDENTIAL_ENVIRONMENT: readonly {
     {
         name: "KILO_API_KEY",
         runtimeId: "kilo",
+    },
+    {
+        name: "OPENCODE_API_KEY",
+        runtimeId: "opencode",
     },
     {
         name: "OPENAI_API_KEY",
@@ -186,6 +199,11 @@ function createRuntimeDiagnostics(
     const kiloStatus = readRuntimeStatus("kilo", settings.kilo, () =>
         getKiloRuntimeStatus(settings.kilo, secretStore),
     );
+    const opencodeStatus = readRuntimeStatus(
+        "opencode",
+        settings.opencode,
+        () => getOpenCodeRuntimeStatus(settings.opencode, secretStore),
+    );
 
     return [
         toRuntimeDiagnostic(
@@ -206,6 +224,11 @@ function createRuntimeDiagnostics(
         toRuntimeDiagnostic(
             kiloStatus,
             resolveRuntimeExecutable("kilo", input),
+            env,
+        ),
+        toRuntimeDiagnostic(
+            opencodeStatus,
+            resolveRuntimeExecutable("opencode", input),
             env,
         ),
     ];
@@ -262,6 +285,11 @@ function resolveRuntimeExecutable(
             case "kilo":
                 return resolveKiloRuntime(
                     input.settings.kilo,
+                    input.secretStore,
+                ).program;
+            case "opencode":
+                return resolveOpenCodeRuntime(
+                    input.settings.opencode,
                     input.secretStore,
                 ).program;
         }

--- a/src/main/ai/environment-diagnostics.ts
+++ b/src/main/ai/environment-diagnostics.ts
@@ -80,6 +80,10 @@ const RUNTIME_PATH_OVERRIDES: readonly {
     },
 ];
 
+// Entries with the same env var name but different runtimeId are intentional:
+// a single variable (e.g. OPENAI_API_KEY) can satisfy multiple runtimes. The
+// diagnostics consumer renders one row per (runtimeId, name) pair; React keys
+// in SettingsApp use `credential-${runtimeId}-${name}` to avoid collisions.
 const CREDENTIAL_ENVIRONMENT: readonly {
     readonly name: CredentialEnvironmentName;
     readonly runtimeId: AiRuntimeId;

--- a/src/main/ai/kilo/setup.ts
+++ b/src/main/ai/kilo/setup.ts
@@ -12,6 +12,7 @@ import type {
 
 import type { SecretRecordPatch, SecretStoreGateway } from "../secret-store.ts";
 import { launchTerminalLoginCommand } from "../auth/terminal-login.ts";
+import { resolveXdgDataDir } from "../data-dir.ts";
 import { debugBenignError } from "../../observability/logging.ts";
 
 const KILO_PROGRAM_NAME = "kilo";
@@ -837,35 +838,13 @@ function normalizeTimestampToMillis(value: number | null): number | null {
 }
 
 function getKiloAuthStorePath(): string | null {
-    const baseDir = getKiloDataDir();
+    const baseDir = resolveXdgDataDir();
     return baseDir ? path.join(baseDir, "kilo", "auth.json") : null;
 }
 
 function getKiloSqliteStorePath(): string | null {
-    const baseDir = getKiloDataDir();
+    const baseDir = resolveXdgDataDir();
     return baseDir ? path.join(baseDir, "kilo", "kilo.db") : null;
-}
-
-function getKiloDataDir(): string | null {
-    const xdgDataHome = process.env.XDG_DATA_HOME?.trim() ?? "";
-    if (xdgDataHome) {
-        return xdgDataHome;
-    }
-
-    if (process.platform === "win32") {
-        const localAppData = process.env.LOCALAPPDATA?.trim() ?? "";
-        if (localAppData) {
-            return localAppData;
-        }
-    }
-
-    const homeDir =
-        process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || "";
-    if (!homeDir) {
-        return null;
-    }
-
-    return path.join(homeDir, ".local", "share");
 }
 
 function getFileModifiedAtMs(filePath: string): number | null {

--- a/src/main/ai/opencode/setup.test.ts
+++ b/src/main/ai/opencode/setup.test.ts
@@ -15,6 +15,7 @@ import {
 
 const originalOpenCodeApiKey = process.env.OPENCODE_API_KEY;
 const originalOpenCodeEnv = process.env.COMANDO_OPENCODE_ACP_BIN;
+const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
 const originalHome = process.env.HOME;
 const originalLocalAppData = process.env.LOCALAPPDATA;
 const originalPath = process.env.PATH;
@@ -24,6 +25,7 @@ const originalXdgDataHome = process.env.XDG_DATA_HOME;
 beforeEach(() => {
     delete process.env.COMANDO_OPENCODE_ACP_BIN;
     delete process.env.OPENCODE_API_KEY;
+    delete process.env.OPENAI_API_KEY;
     delete process.env.XDG_DATA_HOME;
 });
 
@@ -31,6 +33,7 @@ afterEach(() => {
     process.env.PATH = originalPath;
     restoreEnv("COMANDO_OPENCODE_ACP_BIN", originalOpenCodeEnv);
     restoreEnv("OPENCODE_API_KEY", originalOpenCodeApiKey);
+    restoreEnv("OPENAI_API_KEY", originalOpenAiApiKey);
     restoreEnv("HOME", originalHome);
     restoreEnv("LOCALAPPDATA", originalLocalAppData);
     restoreEnv("USERPROFILE", originalUserProfile);
@@ -130,6 +133,16 @@ describe("OpenCode setup", () => {
         expect(status.authCredentialSource).toBe("environment");
     });
 
+    it("detects provider API keys as external OpenCode environment auth", () => {
+        process.env.OPENAI_API_KEY = "env-openai-key";
+
+        const status = getOpenCodeRuntimeStatus(createOpenCodeSettings());
+
+        expect(status.authMethod).toBe("opencode-login");
+        expect(status.authReady).toBe(true);
+        expect(status.authCredentialSource).toBe("environment");
+    });
+
     it("treats the selected OpenCode auth method as ready even without a verifiable auth file", () => {
         const tempDir = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-opencode-selected-auth-"),
@@ -153,6 +166,30 @@ describe("OpenCode setup", () => {
         }
     });
 
+    it("does not treat a selected OpenCode auth method as ready after invalidation", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-opencode-invalid-selected-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "opencode");
+            process.env.XDG_DATA_HOME = path.join(tempDir, "xdg");
+            const status = getOpenCodeRuntimeStatus(
+                createOpenCodeSettings({
+                    authInvalidatedAtMs: Date.now(),
+                    authMethod: "opencode-login",
+                    binaryPath,
+                }),
+            );
+
+            expect(status.authReady).toBe(false);
+            expect(status.authMethod).toBeNull();
+            expect(status.onboardingRequired).toBe(true);
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
     it("ignores auth.json when it was invalidated after the file changed", () => {
         const tempDir = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-opencode-invalidated-"),
@@ -171,6 +208,29 @@ describe("OpenCode setup", () => {
 
             expect(status.authReady).toBe(false);
             expect(status.authMethod).toBeNull();
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("does not treat empty or corrupt auth.json files as active auth", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-opencode-empty-auth-"),
+        );
+
+        try {
+            process.env.XDG_DATA_HOME = tempDir;
+            const authPath = writeOpenCodeAuthFile(tempDir);
+
+            fs.writeFileSync(authPath, "", "utf8");
+            expect(
+                getOpenCodeRuntimeStatus(createOpenCodeSettings()).authReady,
+            ).toBe(false);
+
+            fs.writeFileSync(authPath, "{not-json", "utf8");
+            expect(
+                getOpenCodeRuntimeStatus(createOpenCodeSettings()).authReady,
+            ).toBe(false);
         } finally {
             fs.rmSync(tempDir, { force: true, recursive: true });
         }

--- a/src/main/ai/opencode/setup.test.ts
+++ b/src/main/ai/opencode/setup.test.ts
@@ -1,0 +1,232 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCodeRuntimeSettings } from "@shared/ipc";
+
+import {
+    applyOpenCodeAuthEnv,
+    getOpenCodeRuntimeStatus,
+    isOpenCodeAuthenticationError,
+    resolveOpenCodeRuntime,
+} from "./setup";
+
+const originalOpenCodeApiKey = process.env.OPENCODE_API_KEY;
+const originalOpenCodeEnv = process.env.COMANDO_OPENCODE_ACP_BIN;
+const originalHome = process.env.HOME;
+const originalLocalAppData = process.env.LOCALAPPDATA;
+const originalPath = process.env.PATH;
+const originalUserProfile = process.env.USERPROFILE;
+const originalXdgDataHome = process.env.XDG_DATA_HOME;
+
+beforeEach(() => {
+    delete process.env.COMANDO_OPENCODE_ACP_BIN;
+    delete process.env.OPENCODE_API_KEY;
+    delete process.env.XDG_DATA_HOME;
+});
+
+afterEach(() => {
+    process.env.PATH = originalPath;
+    restoreEnv("COMANDO_OPENCODE_ACP_BIN", originalOpenCodeEnv);
+    restoreEnv("OPENCODE_API_KEY", originalOpenCodeApiKey);
+    restoreEnv("HOME", originalHome);
+    restoreEnv("LOCALAPPDATA", originalLocalAppData);
+    restoreEnv("USERPROFILE", originalUserProfile);
+    restoreEnv("XDG_DATA_HOME", originalXdgDataHome);
+});
+
+describe("OpenCode setup", () => {
+    it("resolves OpenCode from COMANDO_OPENCODE_ACP_BIN with acp", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-opencode-env-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "custom-opencode");
+            process.env.COMANDO_OPENCODE_ACP_BIN = binaryPath;
+            process.env.PATH = "";
+
+            const resolved = resolveOpenCodeRuntime(
+                createOpenCodeSettings({ authMethod: "opencode-login" }),
+            );
+
+            expect(resolved.program).toBe(binaryPath);
+            expect(resolved.args).toEqual(["acp"]);
+            expect(resolved.command).toBe(`${binaryPath} acp`);
+            expect(resolved.status.source).toBe("env");
+            expect(resolved.status.state).toBe("ready");
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("resolves OpenCode from configured path and falls back to PATH", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-opencode-path-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "opencode");
+            process.env.PATH = tempDir;
+
+            const fromSettings = resolveOpenCodeRuntime(
+                createOpenCodeSettings({
+                    authMethod: "opencode-login",
+                    binaryPath,
+                }),
+            );
+            const fromPath = resolveOpenCodeRuntime(
+                createOpenCodeSettings({ authMethod: "opencode-login" }),
+            );
+
+            expect(fromSettings.program).toBe(binaryPath);
+            expect(fromSettings.status.source).toBe("settings");
+            expect(fromPath.program).toBe(binaryPath);
+            expect(fromPath.status.source).toBe("path");
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("reports missing when OpenCode cannot be found", () => {
+        process.env.PATH = "";
+
+        const status = getOpenCodeRuntimeStatus(createOpenCodeSettings());
+
+        expect(status.runtimeId).toBe("opencode");
+        expect(status.state).toBe("missing");
+        expect(status.onboardingRequired).toBe(true);
+        expect(status.message).toContain("OpenCode CLI was not found");
+    });
+
+    it("detects external auth from auth.json", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-opencode-auth-file-"),
+        );
+
+        try {
+            process.env.XDG_DATA_HOME = tempDir;
+            writeOpenCodeAuthFile(tempDir);
+
+            const status = getOpenCodeRuntimeStatus(createOpenCodeSettings());
+
+            expect(status.authMethod).toBe("opencode-login");
+            expect(status.authReady).toBe(true);
+            expect(status.authCredentialSource).toBe("external-runtime");
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("detects OPENCODE_API_KEY as external environment auth", () => {
+        process.env.OPENCODE_API_KEY = "env-opencode-key";
+
+        const status = getOpenCodeRuntimeStatus(createOpenCodeSettings());
+
+        expect(status.authMethod).toBe("opencode-login");
+        expect(status.authReady).toBe(true);
+        expect(status.authCredentialSource).toBe("environment");
+    });
+
+    it("treats the selected OpenCode auth method as ready even without a verifiable auth file", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-opencode-selected-auth-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "opencode");
+            process.env.XDG_DATA_HOME = path.join(tempDir, "xdg");
+            const status = getOpenCodeRuntimeStatus(
+                createOpenCodeSettings({
+                    authMethod: "opencode-login",
+                    binaryPath,
+                }),
+            );
+
+            expect(status.authReady).toBe(true);
+            expect(status.authCredentialSource).toBe("external-runtime");
+            expect(status.message).toContain("could not verify");
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("ignores auth.json when it was invalidated after the file changed", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-opencode-invalidated-"),
+        );
+
+        try {
+            process.env.XDG_DATA_HOME = tempDir;
+            const authPath = writeOpenCodeAuthFile(tempDir);
+            const modifiedAtMs = fs.statSync(authPath).mtimeMs;
+
+            const status = getOpenCodeRuntimeStatus(
+                createOpenCodeSettings({
+                    authInvalidatedAtMs: modifiedAtMs + 1_000,
+                }),
+            );
+
+            expect(status.authReady).toBe(false);
+            expect(status.authMethod).toBeNull();
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("does not mutate auth env in V1", () => {
+        const env = {
+            OPENCODE_API_KEY: "external-key",
+            PATH: "/bin",
+        };
+
+        expect(
+            applyOpenCodeAuthEnv(env, createOpenCodeSettings()),
+        ).toEqual(env);
+    });
+
+    it("recognizes common OpenCode auth errors", () => {
+        expect(isOpenCodeAuthenticationError("authentication required")).toBe(
+            true,
+        );
+        expect(isOpenCodeAuthenticationError("missing api key")).toBe(true);
+        expect(isOpenCodeAuthenticationError("please use /connect")).toBe(true);
+        expect(isOpenCodeAuthenticationError("syntax error")).toBe(false);
+    });
+});
+
+function createOpenCodeSettings(
+    overrides: Partial<OpenCodeRuntimeSettings> = {},
+): OpenCodeRuntimeSettings {
+    return {
+        authInvalidatedAtMs: null,
+        authMethod: null,
+        binaryPath: null,
+        ...overrides,
+    };
+}
+
+function writeExecutable(dir: string, name: string): string {
+    const binaryPath = path.join(dir, name);
+    fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
+    fs.chmodSync(binaryPath, 0o755);
+    return binaryPath;
+}
+
+function writeOpenCodeAuthFile(dataDir: string): string {
+    const authDir = path.join(dataDir, "opencode");
+    fs.mkdirSync(authDir, { recursive: true });
+    const authPath = path.join(authDir, "auth.json");
+    fs.writeFileSync(authPath, '{"provider":"test"}\n', "utf8");
+    return authPath;
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+    if (typeof value === "string") {
+        process.env[name] = value;
+    } else {
+        delete process.env[name];
+    }
+}

--- a/src/main/ai/opencode/setup.ts
+++ b/src/main/ai/opencode/setup.ts
@@ -1,0 +1,494 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type {
+    AiAuthCredentialSource,
+    AiAuthMethod,
+    AiRuntimeStatus,
+    OpenCodeAuthMethodId,
+    OpenCodeRuntimeSettings,
+} from "@shared/ipc";
+
+import { launchTerminalLoginCommand } from "../auth/terminal-login";
+import type { SecretStoreGateway } from "../secret-store";
+import { debugBenignError } from "../../observability/logging";
+
+const OPENCODE_PROGRAM_NAME = "opencode";
+const OPENCODE_ACP_SUBCOMMAND = "acp";
+const OPENCODE_AUTH_LOGIN_SUBCOMMAND = ["auth", "login"] as const;
+const OPENCODE_ENV_BIN = "COMANDO_OPENCODE_ACP_BIN";
+const OPENCODE_API_KEY_ENV = "OPENCODE_API_KEY";
+const OPENCODE_LOGIN_METHOD_ID =
+    "opencode-login" satisfies OpenCodeAuthMethodId;
+const OPENCODE_MACOS_FALLBACK_DIRS = [
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+] as const;
+
+interface ResolvedOpenCodeBinary {
+    readonly args: readonly string[];
+    readonly command: string | null;
+    readonly message: string | null;
+    readonly program: string | null;
+    readonly source: AiRuntimeStatus["source"];
+    readonly state: AiRuntimeStatus["state"];
+}
+
+export interface ResolvedOpenCodeRuntimeCommand {
+    readonly args: readonly string[];
+    readonly command: string;
+    readonly program: string;
+    readonly status: AiRuntimeStatus;
+}
+
+interface OpenCodeAuthStoreStatus {
+    readonly hasActiveAuth: boolean;
+    readonly modifiedAtMs: number | null;
+}
+
+export function getOpenCodeRuntimeStatus(
+    settings: OpenCodeRuntimeSettings,
+    secretStore?: SecretStoreGateway | null,
+): AiRuntimeStatus {
+    const resolved = resolveOpenCodeBinary(settings);
+    const authMethods = getOpenCodeAuthMethods();
+    const authMethod = detectOpenCodeAuthMethod(settings);
+    const credentialSource = getOpenCodeCredentialSource(authMethod);
+    const storageStatus = secretStore?.getStorageStatus?.() ?? {
+        encryptionAvailable: true,
+        isWeakBackend: false,
+        message: null,
+        platform: process.platform,
+        selectedBackend: null,
+    };
+    const binaryReady = resolved.state === "ready" && Boolean(resolved.program);
+    const authReady = authMethod !== null;
+
+    let message = resolved.message;
+    if (binaryReady && !authReady) {
+        message =
+            "Run OpenCode auth login, use /connect in OpenCode, set OPENCODE_API_KEY, or provide credentials through a project .env.";
+    } else if (
+        binaryReady &&
+        authMethod === OPENCODE_LOGIN_METHOD_ID &&
+        !openCodeLoginAvailable(settings) &&
+        !environmentOpenCodeApiKeyReady(process.env)
+    ) {
+        message =
+            "OpenCode auth is selected. Comando could not verify local OpenCode credentials, but OpenCode may still load providers from /connect, environment variables, or a project .env.";
+    }
+
+    return {
+        authMethod,
+        authMethods,
+        authReady,
+        authCredentialSource: credentialSource,
+        authCredentialSourceLabel: getCredentialSourceLabel(credentialSource),
+        authSessionMessage:
+            "This affects new sessions. Active sessions may keep using credentials loaded at launch.",
+        authStorageMessage: storageStatus.message,
+        canDisconnectAuth:
+            readSelectedOpenCodeAuthMethod(settings) !== null ||
+            openCodeLoginAvailable(settings) ||
+            settings.authInvalidatedAtMs !== null,
+        canLogoutAuth: false,
+        checkedAt: new Date().toISOString(),
+        command: resolved.command,
+        hasCustomBinaryPath: Boolean(settings.binaryPath?.trim()),
+        hasGatewayConfig: false,
+        hasGatewayUrl: false,
+        message,
+        onboardingRequired: !binaryReady || !authReady,
+        runtimeId: "opencode",
+        source: resolved.source,
+        state: resolved.state,
+    };
+}
+
+export function resolveOpenCodeRuntime(
+    settings: OpenCodeRuntimeSettings,
+    secretStore?: SecretStoreGateway | null,
+): ResolvedOpenCodeRuntimeCommand {
+    const resolved = resolveOpenCodeBinary(settings);
+    const status = getOpenCodeRuntimeStatus(settings, secretStore);
+
+    if (resolved.program === null || resolved.command === null) {
+        throw new Error(
+            status.message ??
+                "OpenCode ACP is not available on this machine.",
+        );
+    }
+
+    return {
+        args: resolved.args,
+        command: resolved.command,
+        program: resolved.program,
+        status,
+    };
+}
+
+export function applyOpenCodeAuthEnv(
+    baseEnv: NodeJS.ProcessEnv,
+    _settings: OpenCodeRuntimeSettings,
+    _secretStore?: SecretStoreGateway | null,
+): NodeJS.ProcessEnv {
+    return { ...baseEnv };
+}
+
+export function markOpenCodeAuthInvalidated(
+    settings: OpenCodeRuntimeSettings,
+): OpenCodeRuntimeSettings {
+    return {
+        ...settings,
+        authInvalidatedAtMs: Date.now(),
+    };
+}
+
+export function launchOpenCodeLogin(
+    settings: OpenCodeRuntimeSettings,
+    cwd?: string | null,
+): Promise<void> {
+    const resolved = resolveOpenCodeBinary(settings);
+    if (!resolved.program) {
+        throw new Error(
+            resolved.message ??
+                "OpenCode CLI was not found. Install opencode or provide a custom runtime path.",
+        );
+    }
+
+    return launchTerminalLoginCommand({
+        commandParts: [resolved.program, ...OPENCODE_AUTH_LOGIN_SUBCOMMAND],
+        cwd,
+        missingTerminalMessage:
+            "No compatible terminal launcher was found for OpenCode auth.",
+        scriptPrefix: "comando-opencode-login",
+    });
+}
+
+export function isOpenCodeAuthenticationError(message: string): boolean {
+    const normalized = message.trim().toLowerCase();
+    return (
+        normalized.includes("auth required") ||
+        normalized.includes("auth_required") ||
+        normalized.includes("authentication required") ||
+        normalized.includes("missing api key") ||
+        normalized.includes("no provider configured") ||
+        normalized.includes("run opencode auth login") ||
+        normalized.includes("run `opencode auth login`") ||
+        normalized.includes("use /connect") ||
+        normalized.includes("unauthorized") ||
+        normalized.includes("401")
+    );
+}
+
+function detectOpenCodeAuthMethod(
+    settings: OpenCodeRuntimeSettings,
+): OpenCodeAuthMethodId | null {
+    if (environmentOpenCodeApiKeyReady(process.env)) {
+        return OPENCODE_LOGIN_METHOD_ID;
+    }
+
+    const selectedAuthMethod = readSelectedOpenCodeAuthMethod(settings);
+    if (selectedAuthMethod === OPENCODE_LOGIN_METHOD_ID) {
+        return OPENCODE_LOGIN_METHOD_ID;
+    }
+
+    if (openCodeLoginAvailable(settings)) {
+        return OPENCODE_LOGIN_METHOD_ID;
+    }
+
+    return null;
+}
+
+function getOpenCodeAuthMethods(): readonly AiAuthMethod[] {
+    return [
+        {
+            description:
+                "Use providers and credentials configured by the OpenCode CLI.",
+            id: OPENCODE_LOGIN_METHOD_ID,
+            name: "OpenCode auth",
+        },
+    ];
+}
+
+function getOpenCodeCredentialSource(
+    authMethod: OpenCodeAuthMethodId | null,
+    env: NodeJS.ProcessEnv = process.env,
+): AiAuthCredentialSource {
+    if (authMethod === null) {
+        return "none";
+    }
+
+    if (environmentOpenCodeApiKeyReady(env)) {
+        return "environment";
+    }
+
+    return "external-runtime";
+}
+
+function getCredentialSourceLabel(source: AiAuthCredentialSource): string {
+    switch (source) {
+        case "environment":
+            return "Using environment variable";
+        case "external-runtime":
+            return "Using external OpenCode auth";
+        case "comando-secret":
+            return "Using Comando stored credentials";
+        case "none":
+        default:
+            return "Needs authentication";
+    }
+}
+
+function readSelectedOpenCodeAuthMethod(
+    settings: OpenCodeRuntimeSettings,
+): OpenCodeAuthMethodId | null {
+    const authMethod = (settings as { readonly authMethod?: unknown })
+        .authMethod;
+    return authMethod === OPENCODE_LOGIN_METHOD_ID ? authMethod : null;
+}
+
+function openCodeLoginAvailable(settings: OpenCodeRuntimeSettings): boolean {
+    const status = getOpenCodeAuthStoreStatus();
+    if (!status?.hasActiveAuth) {
+        return false;
+    }
+
+    if (
+        settings.authInvalidatedAtMs !== null &&
+        status.modifiedAtMs !== null &&
+        status.modifiedAtMs <= settings.authInvalidatedAtMs
+    ) {
+        return false;
+    }
+
+    return true;
+}
+
+function getOpenCodeAuthStoreStatus(): OpenCodeAuthStoreStatus | null {
+    const authPath = getOpenCodeAuthStorePath();
+    if (!authPath || !isFile(authPath)) {
+        return null;
+    }
+
+    return {
+        hasActiveAuth: true,
+        modifiedAtMs: getFileModifiedAtMs(authPath),
+    };
+}
+
+function getOpenCodeAuthStorePath(): string | null {
+    const baseDir = getOpenCodeDataDir();
+    return baseDir ? path.join(baseDir, "opencode", "auth.json") : null;
+}
+
+function getOpenCodeDataDir(): string | null {
+    const xdgDataHome = process.env.XDG_DATA_HOME?.trim() ?? "";
+    if (xdgDataHome) {
+        return xdgDataHome;
+    }
+
+    if (process.platform === "win32") {
+        const localAppData = process.env.LOCALAPPDATA?.trim() ?? "";
+        if (localAppData) {
+            return localAppData;
+        }
+    }
+
+    const homeDir =
+        process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || "";
+    if (!homeDir) {
+        return null;
+    }
+
+    return path.join(homeDir, ".local", "share");
+}
+
+function environmentOpenCodeApiKeyReady(env: NodeJS.ProcessEnv): boolean {
+    return Boolean(env[OPENCODE_API_KEY_ENV]?.trim());
+}
+
+function resolveOpenCodeBinary(
+    settings: OpenCodeRuntimeSettings,
+): ResolvedOpenCodeBinary {
+    const envPath = process.env[OPENCODE_ENV_BIN]?.trim() ?? "";
+    const configuredPath = settings.binaryPath?.trim() ?? "";
+
+    if (envPath) {
+        return resolveCommandCandidate(envPath, "env");
+    }
+
+    if (configuredPath) {
+        return resolveCommandCandidate(configuredPath, "settings");
+    }
+
+    const pathResolved = resolveFromPath(OPENCODE_PROGRAM_NAME);
+    if (pathResolved) {
+        return commandFromExistingPath(pathResolved, "path");
+    }
+
+    const macOsResolved = resolveFromMacOsFallbackDirs(OPENCODE_PROGRAM_NAME);
+    if (macOsResolved) {
+        return commandFromExistingPath(macOsResolved, "path");
+    }
+
+    return {
+        args: [],
+        command: null,
+        message:
+            "OpenCode CLI was not found. Install `opencode` or provide a custom runtime path.",
+        program: null,
+        source: null,
+        state: "missing",
+    };
+}
+
+function resolveCommandCandidate(
+    raw: string,
+    source: AiRuntimeStatus["source"],
+): ResolvedOpenCodeBinary {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+        return {
+            args: [],
+            command: null,
+            message: "OpenCode runtime path is empty.",
+            program: null,
+            source,
+            state: "missing",
+        };
+    }
+
+    const looksLikePath =
+        path.isAbsolute(trimmed) ||
+        trimmed.includes(path.sep) ||
+        trimmed.includes("/") ||
+        trimmed.includes("\\");
+
+    if (looksLikePath) {
+        const candidate = path.resolve(trimmed);
+        if (!isExecutableFile(candidate)) {
+            return {
+                args: [],
+                command: candidate,
+                message: `Could not execute the configured OpenCode runtime: ${candidate}`,
+                program: null,
+                source,
+                state: "error",
+            };
+        }
+
+        return commandFromExistingPath(candidate, source);
+    }
+
+    const found = resolveFromPath(trimmed);
+    if (!found) {
+        return {
+            args: [],
+            command: trimmed,
+            message: `Configured command was not found: ${trimmed}`,
+            program: null,
+            source,
+            state: "missing",
+        };
+    }
+
+    return commandFromExistingPath(found, source);
+}
+
+function commandFromExistingPath(
+    candidatePath: string,
+    source: AiRuntimeStatus["source"],
+): ResolvedOpenCodeBinary {
+    if (!isExecutableFile(candidatePath)) {
+        return {
+            args: [],
+            command: candidatePath,
+            message: `OpenCode runtime is not executable: ${candidatePath}`,
+            program: null,
+            source,
+            state: "error",
+        };
+    }
+
+    return {
+        args: [OPENCODE_ACP_SUBCOMMAND],
+        command: `${candidatePath} ${OPENCODE_ACP_SUBCOMMAND}`,
+        message: null,
+        program: candidatePath,
+        source,
+        state: "ready",
+    };
+}
+
+function getFileModifiedAtMs(filePath: string): number | null {
+    try {
+        return fs.statSync(filePath).mtimeMs;
+    } catch (error) {
+        debugBenignError("ai.opencode.getFileModifiedAtMs", error);
+        return null;
+    }
+}
+
+function resolveFromPath(command: string): string | null {
+    const pathEntries = (process.env.PATH ?? "")
+        .split(path.delimiter)
+        .filter(Boolean);
+    const pathextEntries =
+        process.platform === "win32"
+            ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+                  .split(";")
+                  .filter(Boolean)
+            : [""];
+
+    for (const entry of pathEntries) {
+        for (const ext of pathextEntries) {
+            const candidate = path.join(
+                entry,
+                process.platform === "win32" &&
+                    !command.toLowerCase().endsWith(ext.toLowerCase())
+                    ? `${command}${ext}`
+                    : command,
+            );
+            if (isExecutableFile(candidate)) {
+                return candidate;
+            }
+        }
+    }
+
+    return null;
+}
+
+function resolveFromMacOsFallbackDirs(command: string): string | null {
+    if (process.platform !== "darwin") {
+        return null;
+    }
+
+    for (const entry of OPENCODE_MACOS_FALLBACK_DIRS) {
+        const candidate = path.join(entry, command);
+        if (isExecutableFile(candidate)) {
+            return candidate;
+        }
+    }
+
+    return null;
+}
+
+function isExecutableFile(candidatePath: string): boolean {
+    try {
+        fs.accessSync(candidatePath, fs.constants.X_OK);
+        return fs.statSync(candidatePath).isFile();
+    } catch (error) {
+        debugBenignError("ai.opencode.isExecutableFile", error);
+        return false;
+    }
+}
+
+function isFile(candidatePath: string): boolean {
+    try {
+        return fs.statSync(candidatePath).isFile();
+    } catch (error) {
+        debugBenignError("ai.opencode.isFile", error);
+        return false;
+    }
+}

--- a/src/main/ai/opencode/setup.ts
+++ b/src/main/ai/opencode/setup.ts
@@ -189,6 +189,12 @@ export function isOpenCodeAuthenticationError(message: string): boolean {
     );
 }
 
+export function isOpenCodeEnvironmentCredentialReady(
+    env: NodeJS.ProcessEnv = process.env,
+): boolean {
+    return environmentOpenCodeCredentialReady(env);
+}
+
 function detectOpenCodeAuthMethod(
     settings: OpenCodeRuntimeSettings,
 ): OpenCodeAuthMethodId | null {

--- a/src/main/ai/opencode/setup.ts
+++ b/src/main/ai/opencode/setup.ts
@@ -10,6 +10,7 @@ import type {
 } from "@shared/ipc";
 
 import { launchTerminalLoginCommand } from "../auth/terminal-login";
+import { resolveXdgDataDir } from "../data-dir";
 import type { SecretStoreGateway } from "../secret-store";
 import { debugBenignError } from "../../observability/logging";
 
@@ -292,30 +293,8 @@ function getOpenCodeAuthStoreStatus(): OpenCodeAuthStoreStatus | null {
 }
 
 function getOpenCodeAuthStorePath(): string | null {
-    const baseDir = getOpenCodeDataDir();
+    const baseDir = resolveXdgDataDir();
     return baseDir ? path.join(baseDir, "opencode", "auth.json") : null;
-}
-
-function getOpenCodeDataDir(): string | null {
-    const xdgDataHome = process.env.XDG_DATA_HOME?.trim() ?? "";
-    if (xdgDataHome) {
-        return xdgDataHome;
-    }
-
-    if (process.platform === "win32") {
-        const localAppData = process.env.LOCALAPPDATA?.trim() ?? "";
-        if (localAppData) {
-            return localAppData;
-        }
-    }
-
-    const homeDir =
-        process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || "";
-    if (!homeDir) {
-        return null;
-    }
-
-    return path.join(homeDir, ".local", "share");
 }
 
 function environmentOpenCodeCredentialReady(env: NodeJS.ProcessEnv): boolean {

--- a/src/main/ai/opencode/setup.ts
+++ b/src/main/ai/opencode/setup.ts
@@ -18,6 +18,14 @@ const OPENCODE_ACP_SUBCOMMAND = "acp";
 const OPENCODE_AUTH_LOGIN_SUBCOMMAND = ["auth", "login"] as const;
 const OPENCODE_ENV_BIN = "COMANDO_OPENCODE_ACP_BIN";
 const OPENCODE_API_KEY_ENV = "OPENCODE_API_KEY";
+const OPENCODE_PROVIDER_API_KEY_ENVS = [
+    OPENCODE_API_KEY_ENV,
+    "ANTHROPIC_API_KEY",
+    "CODEX_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENAI_API_KEY",
+] as const;
 const OPENCODE_LOGIN_METHOD_ID =
     "opencode-login" satisfies OpenCodeAuthMethodId;
 const OPENCODE_MACOS_FALLBACK_DIRS = [
@@ -72,7 +80,7 @@ export function getOpenCodeRuntimeStatus(
         binaryReady &&
         authMethod === OPENCODE_LOGIN_METHOD_ID &&
         !openCodeLoginAvailable(settings) &&
-        !environmentOpenCodeApiKeyReady(process.env)
+        !environmentOpenCodeCredentialReady(process.env)
     ) {
         message =
             "OpenCode auth is selected. Comando could not verify local OpenCode credentials, but OpenCode may still load providers from /connect, environment variables, or a project .env.";
@@ -184,12 +192,15 @@ export function isOpenCodeAuthenticationError(message: string): boolean {
 function detectOpenCodeAuthMethod(
     settings: OpenCodeRuntimeSettings,
 ): OpenCodeAuthMethodId | null {
-    if (environmentOpenCodeApiKeyReady(process.env)) {
+    if (environmentOpenCodeCredentialReady(process.env)) {
         return OPENCODE_LOGIN_METHOD_ID;
     }
 
     const selectedAuthMethod = readSelectedOpenCodeAuthMethod(settings);
-    if (selectedAuthMethod === OPENCODE_LOGIN_METHOD_ID) {
+    if (
+        selectedAuthMethod === OPENCODE_LOGIN_METHOD_ID &&
+        settings.authInvalidatedAtMs === null
+    ) {
         return OPENCODE_LOGIN_METHOD_ID;
     }
 
@@ -219,7 +230,7 @@ function getOpenCodeCredentialSource(
         return "none";
     }
 
-    if (environmentOpenCodeApiKeyReady(env)) {
+    if (environmentOpenCodeCredentialReady(env)) {
         return "environment";
     }
 
@@ -271,10 +282,7 @@ function getOpenCodeAuthStoreStatus(): OpenCodeAuthStoreStatus | null {
         return null;
     }
 
-    return {
-        hasActiveAuth: true,
-        modifiedAtMs: getFileModifiedAtMs(authPath),
-    };
+    return readOpenCodeAuthStoreStatus(authPath);
 }
 
 function getOpenCodeAuthStorePath(): string | null {
@@ -304,8 +312,47 @@ function getOpenCodeDataDir(): string | null {
     return path.join(homeDir, ".local", "share");
 }
 
-function environmentOpenCodeApiKeyReady(env: NodeJS.ProcessEnv): boolean {
-    return Boolean(env[OPENCODE_API_KEY_ENV]?.trim());
+function environmentOpenCodeCredentialReady(env: NodeJS.ProcessEnv): boolean {
+    return OPENCODE_PROVIDER_API_KEY_ENVS.some((name) =>
+        Boolean(env[name]?.trim()),
+    );
+}
+
+function readOpenCodeAuthStoreStatus(
+    authPath: string,
+): OpenCodeAuthStoreStatus | null {
+    try {
+        const raw = fs.readFileSync(authPath, "utf8").trim();
+        if (!raw) {
+            return {
+                hasActiveAuth: false,
+                modifiedAtMs: getFileModifiedAtMs(authPath),
+            };
+        }
+
+        return {
+            hasActiveAuth: hasNonEmptyAuthPayload(JSON.parse(raw)),
+            modifiedAtMs: getFileModifiedAtMs(authPath),
+        };
+    } catch (error) {
+        debugBenignError("ai.opencode.readAuthStoreStatus", error);
+        return {
+            hasActiveAuth: false,
+            modifiedAtMs: getFileModifiedAtMs(authPath),
+        };
+    }
+}
+
+function hasNonEmptyAuthPayload(value: unknown): boolean {
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+
+    return Object.keys(value).length > 0;
 }
 
 function resolveOpenCodeBinary(

--- a/src/main/ai/persistence.test.ts
+++ b/src/main/ai/persistence.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { AiSessionSnapshot } from "@shared/ipc";
+import type { AiRuntimeId, AiSessionSnapshot } from "@shared/ipc";
 
 import { databaseMigrations } from "@main/db/migrations";
 import {
@@ -1288,7 +1288,7 @@ function seedChatSession(
         readonly pinnedAt?: string | null;
         readonly preview?: string | null;
         readonly projectId?: string | null;
-        readonly runtimeId: "claude" | "codex" | "gemini" | "kilo";
+        readonly runtimeId: AiRuntimeId;
         readonly sessionId: string;
         readonly transcript: Record<string, unknown>;
         readonly updatedAt: string;

--- a/src/main/ai/persistence.ts
+++ b/src/main/ai/persistence.ts
@@ -2203,7 +2203,8 @@ function normalizeRuntimeId(
     return value === "claude" ||
         value === "codex" ||
         value === "gemini" ||
-        value === "kilo"
+        value === "kilo" ||
+        value === "opencode"
         ? value
         : "codex";
 }

--- a/src/main/ai/review-core.ts
+++ b/src/main/ai/review-core.ts
@@ -1301,6 +1301,38 @@ function isClaudeEditReEmission(
     return newSnippet.length === 0 || base.includes(newSnippet);
 }
 
+function isAlreadyAppliedSnippetDiff(
+    diff: { readonly newText: string; readonly oldText: string },
+    existing: AiTrackedFile | undefined,
+    base: string,
+    context: DiffResolutionContext | undefined,
+): boolean {
+    if (!existing || !context) {
+        return false;
+    }
+
+    if (existing.toolCallId && existing.toolCallId !== context.toolCallId) {
+        return false;
+    }
+
+    const oldSnippet = diff.oldText;
+    const newSnippet = diff.newText;
+    if (oldSnippet.length === 0 && newSnippet.length === 0) {
+        return false;
+    }
+
+    if (oldSnippet.length > 0 && base.includes(oldSnippet)) {
+        return false;
+    }
+
+    const diffBase = getTrackedFileDiffBase(existing);
+    if (oldSnippet.length > 0 && !diffBase.includes(oldSnippet)) {
+        return false;
+    }
+
+    return newSnippet.length === 0 || base.includes(newSnippet);
+}
+
 export function resolveDiffToFullTexts(
     diff: Diff,
     existing: AiTrackedFile | undefined,
@@ -1341,7 +1373,16 @@ export function resolveDiffToFullTexts(
 
     const first = base.indexOf(oldSnippet);
     if (first === -1 || first !== base.lastIndexOf(oldSnippet)) {
-        if (existing && isClaudeEditReEmission(diff, existing, base, context)) {
+        if (
+            existing &&
+            (isClaudeEditReEmission(diff, existing, base, context) ||
+                isAlreadyAppliedSnippetDiff(
+                    { newText: newSnippet, oldText: oldSnippet },
+                    existing,
+                    base,
+                    context,
+                ))
+        ) {
             return {
                 ...diff,
                 oldText: getTrackedFileDiffBase(existing),

--- a/src/main/ai/review-core.ts
+++ b/src/main/ai/review-core.ts
@@ -1488,9 +1488,36 @@ function resolveAlreadyAppliedPreEditSnapshotDiff(
 }
 
 interface UnifiedPatchHunk {
+    readonly newTrailingNewline?: boolean;
     readonly oldStart: number;
+    readonly oldTrailingNewline?: boolean;
     readonly newStart: number;
     readonly lines: readonly string[];
+}
+
+function resolveAlreadyAppliedExternalDiff(
+    diff: { readonly newText: string; readonly oldText: string },
+    base: string,
+    liveSession: Pick<LiveAcpSession, "cwd" | "projectRoot">,
+    normalizedPath: string,
+    context: DiffResolutionContext | undefined,
+): { readonly newText: string; readonly oldText: string } | null {
+    const resolvedFromUnifiedPatch = resolveAlreadyAppliedUnifiedPatchDiff(
+        diff,
+        base,
+        liveSession,
+        normalizedPath,
+        context?.rawOutput,
+    );
+    if (resolvedFromUnifiedPatch) {
+        return resolvedFromUnifiedPatch;
+    }
+
+    return resolveAlreadyAppliedPreEditSnapshotDiff(
+        diff,
+        base,
+        context?.preEditSnapshot,
+    );
 }
 
 function resolveAlreadyAppliedUnifiedPatchDiff(
@@ -1569,8 +1596,14 @@ function readOpenCodeFileDiffPath(rawOutput: unknown): string | null {
 function parseUnifiedPatchHunks(patch: string): UnifiedPatchHunk[] {
     const hunks: UnifiedPatchHunk[] = [];
     const lines = patch.replace(/\r\n/g, "\n").split("\n");
-    let current: { oldStart: number; newStart: number; lines: string[] } | null =
-        null;
+    let current: {
+        lines: string[];
+        newStart: number;
+        newTrailingNewline?: boolean;
+        oldStart: number;
+        oldTrailingNewline?: boolean;
+    } | null = null;
+    let previousPatchLine: string | null = null;
 
     for (const line of lines) {
         const header = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
@@ -1583,10 +1616,23 @@ function parseUnifiedPatchHunks(patch: string): UnifiedPatchHunk[] {
                 newStart: Number(header[2]),
                 oldStart: Number(header[1]),
             };
+            previousPatchLine = null;
             continue;
         }
 
         if (!current) {
+            continue;
+        }
+
+        if (line === "\\ No newline at end of file") {
+            if (previousPatchLine?.startsWith(" ")) {
+                current.oldTrailingNewline = false;
+                current.newTrailingNewline = false;
+            } else if (previousPatchLine?.startsWith("-")) {
+                current.oldTrailingNewline = false;
+            } else if (previousPatchLine?.startsWith("+")) {
+                current.newTrailingNewline = false;
+            }
             continue;
         }
 
@@ -1596,6 +1642,7 @@ function parseUnifiedPatchHunks(patch: string): UnifiedPatchHunk[] {
             line.startsWith("+")
         ) {
             current.lines.push(line);
+            previousPatchLine = line;
         }
     }
 
@@ -1617,6 +1664,7 @@ function applyUnifiedPatch(
     direction: "forward" | "reverse",
 ): string | null {
     let lines = splitPatchTextLines(text);
+    let trailingNewline = text.endsWith("\n");
     const orderedHunks = [...hunks].reverse();
 
     for (const hunk of orderedHunks) {
@@ -1641,15 +1689,53 @@ function applyUnifiedPatch(
         if (matchIndex === null) {
             return null;
         }
+        const nextTrailingNewline = resolvePatchTrailingNewline(
+            hunk,
+            direction,
+            trailingNewline,
+        );
+        if (nextTrailingNewline === null) {
+            return null;
+        }
 
         lines = [
             ...lines.slice(0, matchIndex),
             ...replacementLines,
             ...lines.slice(matchIndex + matchLines.length),
         ];
+        trailingNewline = nextTrailingNewline;
     }
 
-    return joinPatchTextLines(lines, text.endsWith("\n"));
+    return joinPatchTextLines(lines, trailingNewline);
+}
+
+function resolvePatchTrailingNewline(
+    hunk: UnifiedPatchHunk,
+    direction: "forward" | "reverse",
+    inputTrailingNewline: boolean,
+): boolean | null {
+    const inputMissingTrailingNewline =
+        direction === "forward"
+            ? hunk.oldTrailingNewline === false
+            : hunk.newTrailingNewline === false;
+    const outputMissingTrailingNewline =
+        direction === "forward"
+            ? hunk.newTrailingNewline === false
+            : hunk.oldTrailingNewline === false;
+
+    if (inputMissingTrailingNewline && inputTrailingNewline) {
+        return null;
+    }
+
+    if (outputMissingTrailingNewline) {
+        return false;
+    }
+
+    if (inputMissingTrailingNewline) {
+        return true;
+    }
+
+    return inputTrailingNewline;
 }
 
 function splitPatchTextLines(text: string): string[] {
@@ -1774,38 +1860,28 @@ export function resolveDiffToFullTexts(
     }
 
     const first = base.indexOf(oldSnippet);
-    if (first === -1 || first !== base.lastIndexOf(oldSnippet)) {
-        if (!existing && first === -1) {
-            const resolvedFromUnifiedPatch =
-                resolveAlreadyAppliedUnifiedPatchDiff(
-                    { newText: newSnippet, oldText: oldSnippet },
-                    base,
-                    liveSession,
-                    normalizedPath,
-                    context?.rawOutput,
-                );
-            if (resolvedFromUnifiedPatch) {
-                return {
-                    ...diff,
-                    oldText: resolvedFromUnifiedPatch.oldText,
-                    newText: resolvedFromUnifiedPatch.newText,
-                };
-            }
-
-            const resolvedFromPreEditSnapshot =
-                resolveAlreadyAppliedPreEditSnapshotDiff(
-                    { newText: newSnippet, oldText: oldSnippet },
-                    base,
-                    context?.preEditSnapshot,
-                );
-            if (resolvedFromPreEditSnapshot) {
-                return {
-                    ...diff,
-                    oldText: resolvedFromPreEditSnapshot.oldText,
-                    newText: resolvedFromPreEditSnapshot.newText,
-                };
-            }
+    const shouldTryExternalResolution =
+        !existing &&
+        (first === -1 ||
+            (newSnippet.length > 0 && base.includes(newSnippet)));
+    if (shouldTryExternalResolution) {
+        const resolvedAlreadyApplied = resolveAlreadyAppliedExternalDiff(
+            { newText: newSnippet, oldText: oldSnippet },
+            base,
+            liveSession,
+            normalizedPath,
+            context,
+        );
+        if (resolvedAlreadyApplied) {
+            return {
+                ...diff,
+                oldText: resolvedAlreadyApplied.oldText,
+                newText: resolvedAlreadyApplied.newText,
+            };
         }
+    }
+
+    if (first === -1 || first !== base.lastIndexOf(oldSnippet)) {
         if (
             existing &&
             (isClaudeEditReEmission(diff, existing, base, context) ||

--- a/src/main/ai/review-core.ts
+++ b/src/main/ai/review-core.ts
@@ -1180,7 +1180,22 @@ function rememberReadSnapshotFromToolUpdate(
     snapshots.set(normalizedPath, snapshot);
 }
 
-function parseCompleteNumberedFileOutput(rawOutput: unknown): string | null {
+// Parses the numbered file body that OpenCode's Read tool emits, for example:
+//
+//   <content>
+//   1: alpha
+//   2: beta
+//   (End of file - total 2 lines)
+//   </content>
+//
+// Returns the raw file contents (with newlines preserved) when the body is a
+// complete, consistent snapshot, or null otherwise — including when the wrapper
+// tags are missing, the trailing line count differs from the parsed numbered
+// lines, or the numbering is not strictly 1..N. Callers treat null as "fall
+// back to other diff-resolution paths" (filediff.patch, prior tracked state).
+export function parseCompleteNumberedFileOutput(
+    rawOutput: unknown,
+): string | null {
     const output =
         typeof rawOutput === "string"
             ? rawOutput

--- a/src/main/ai/review-core.ts
+++ b/src/main/ai/review-core.ts
@@ -48,6 +48,7 @@ import { toPosixPath } from "./session-core";
 import { debugBenignError } from "@main/observability/logging";
 
 const TERMINAL_OUTPUT_MAX_LENGTH = 10_000;
+const PRE_EDIT_SNAPSHOT_MAX_ENTRIES = 128;
 const TRACKED_DIFF_MAX_READ_BYTES = 5 * 1024 * 1024;
 
 interface ClaudeStructuredPatchHunk {
@@ -67,7 +68,9 @@ interface ClaudeStructuredPatchDiffCandidate {
 
 interface DiffResolutionContext {
     readonly meta: unknown;
+    readonly preEditSnapshot?: string;
     readonly readOpenFileBuffer?: (absolutePath: string) => string | null;
+    readonly rawOutput?: unknown;
     readonly sessionUpdate: "tool_call" | "tool_call_update";
     readonly toolCallId: string;
 }
@@ -76,7 +79,9 @@ export function mapToolCallUpdate(
     liveSession: Pick<
         LiveAcpSession,
         "cwd" | "projectRoot" | "processedDiffPaths" | "terminalOutputBuffers"
-    >,
+    > & {
+        readonly preEditSnapshots?: Map<string, string>;
+    },
     snapshot: AiSessionSnapshot,
     update: ToolCall | ToolCallUpdate,
     updateKind: "tool_call" | "tool_call_update",
@@ -147,6 +152,13 @@ export function mapToolCallUpdate(
         normalizeTrackedDiffPath(liveSession, candidatePath);
     const shouldCollectReviewDiffs = !isSubagentBreadcrumbToolUpdate(update);
     const pathsProcessedInThisUpdate = new Set<string>();
+    rememberReadSnapshotFromToolUpdate(
+        liveSession,
+        toolKind,
+        update.rawInput,
+        update.rawOutput,
+        normalizeDiffPath,
+    );
     const updateLocations =
         update.locations?.map(normalizeToolCallLocation) ?? null;
     const readInputLocations = deriveReadInputLocation(
@@ -227,14 +239,6 @@ export function mapToolCallUpdate(
                   return acc;
               }
               pathsProcessedInThisUpdate.add(normalizedPath);
-              if (processedPaths) {
-                  processedPaths.add(normalizedPath);
-              } else {
-                  liveSession.processedDiffPaths.set(
-                      update.toolCallId,
-                      new Set([normalizedPath]),
-                  );
-              }
 
               const existing = acc.find(
                   (candidate) =>
@@ -248,11 +252,29 @@ export function mapToolCallUpdate(
                   normalizedPath,
                   {
                       meta: update._meta,
+                      preEditSnapshot:
+                          liveSession.preEditSnapshots?.get(normalizedPath),
+                      rawOutput: update.rawOutput,
                       readOpenFileBuffer: options.readOpenFileBuffer,
                       sessionUpdate: updateKind,
                       toolCallId: update.toolCallId,
                   },
               );
+              const anchoredHunks =
+                  anchoredHunksByContentIndex.get(contentIndex) ?? null;
+              if (
+                  shouldDedupResolvedDiff(entry, resolvedDiff) ||
+                  anchoredHunks !== null
+              ) {
+                  if (processedPaths) {
+                      processedPaths.add(normalizedPath);
+                  } else {
+                      liveSession.processedDiffPaths.set(
+                          update.toolCallId,
+                          new Set([normalizedPath]),
+                      );
+                  }
+              }
               return upsertTrackedFile(
                   acc,
                   diffToTrackedFile(
@@ -261,7 +283,7 @@ export function mapToolCallUpdate(
                       toolKind,
                       update.toolCallId,
                       updatedAt,
-                      anchoredHunksByContentIndex.get(contentIndex) ?? null,
+                      anchoredHunks,
                       normalizeDiffPath,
                   ),
               );
@@ -1048,7 +1070,7 @@ function deriveReadInputLocation(
         return null;
     }
 
-    const pathValue = rawInput.file_path ?? rawInput.path;
+    const pathValue = rawInput.file_path ?? rawInput.filePath ?? rawInput.path;
     if (typeof pathValue !== "string" || pathValue.trim().length === 0) {
         return null;
     }
@@ -1115,6 +1137,107 @@ function normalizeNonNegativeLineNumber(value: unknown): number | null {
     }
 
     return value;
+}
+
+function rememberReadSnapshotFromToolUpdate(
+    liveSession: { readonly preEditSnapshots?: Map<string, string> },
+    toolKind: string,
+    rawInput: unknown,
+    rawOutput: unknown,
+    normalizePath: (candidatePath: string) => string,
+): void {
+    if (toolKind.toLowerCase() !== "read" || !isRecord(rawInput)) {
+        return;
+    }
+
+    const pathValue = rawInput.file_path ?? rawInput.filePath ?? rawInput.path;
+    if (typeof pathValue !== "string" || pathValue.trim().length === 0) {
+        return;
+    }
+
+    const snapshot = parseCompleteNumberedFileOutput(rawOutput);
+    if (snapshot === null || snapshot.length > TRACKED_DIFF_MAX_READ_BYTES) {
+        return;
+    }
+
+    const snapshots = liveSession.preEditSnapshots;
+    if (!snapshots) {
+        return;
+    }
+
+    const normalizedPath = normalizePath(pathValue);
+    if (snapshots.has(normalizedPath)) {
+        return;
+    }
+
+    if (snapshots.size >= PRE_EDIT_SNAPSHOT_MAX_ENTRIES) {
+        const oldestKey = snapshots.keys().next().value;
+        if (oldestKey !== undefined) {
+            snapshots.delete(oldestKey);
+        }
+    }
+
+    snapshots.set(normalizedPath, snapshot);
+}
+
+function parseCompleteNumberedFileOutput(rawOutput: unknown): string | null {
+    const output =
+        typeof rawOutput === "string"
+            ? rawOutput
+            : isRecord(rawOutput) && typeof rawOutput.output === "string"
+              ? rawOutput.output
+              : null;
+    if (!output) {
+        return null;
+    }
+
+    const contentStart = output.indexOf("<content>");
+    const contentEnd = output.lastIndexOf("</content>");
+    if (contentStart === -1 || contentEnd === -1 || contentEnd <= contentStart) {
+        return null;
+    }
+
+    const body = output
+        .slice(contentStart + "<content>".length, contentEnd)
+        .replace(/^\r?\n/, "")
+        .replace(/\r\n/g, "\n");
+    const lines = body.split("\n");
+    const footerIndex = lines.findIndex((line) =>
+        /^\(End of file - total \d+ lines?\)$/.test(line.trim()),
+    );
+    if (footerIndex === -1) {
+        return null;
+    }
+
+    const totalMatch = lines[footerIndex]
+        ?.trim()
+        .match(/^\(End of file - total (\d+) lines?\)$/);
+    const totalLines = totalMatch ? Number(totalMatch[1]) : NaN;
+    if (!Number.isInteger(totalLines) || totalLines < 0) {
+        return null;
+    }
+
+    const numberedLines = lines.slice(0, footerIndex);
+    while (numberedLines.at(-1) === "") {
+        numberedLines.pop();
+    }
+
+    if (numberedLines.length !== totalLines) {
+        return null;
+    }
+
+    const contentLines: string[] = [];
+    for (let index = 0; index < numberedLines.length; index += 1) {
+        const expectedLineNumber = index + 1;
+        const line = numberedLines[index] ?? "";
+        const match = line.match(/^(\d+): ?(.*)$/);
+        if (!match || Number(match[1]) !== expectedLineNumber) {
+            return null;
+        }
+        contentLines.push(match[2]);
+    }
+
+    return contentLines.join("\n");
 }
 
 function buildToolSummary(
@@ -1333,6 +1456,285 @@ function isAlreadyAppliedSnippetDiff(
     return newSnippet.length === 0 || base.includes(newSnippet);
 }
 
+function resolveAlreadyAppliedPreEditSnapshotDiff(
+    diff: { readonly newText: string; readonly oldText: string },
+    base: string,
+    preEditSnapshot: string | undefined,
+): { readonly newText: string; readonly oldText: string } | null {
+    if (!preEditSnapshot || diff.oldText.length === 0) {
+        return null;
+    }
+
+    const first = preEditSnapshot.indexOf(diff.oldText);
+    if (
+        first === -1 ||
+        first !== preEditSnapshot.lastIndexOf(diff.oldText)
+    ) {
+        return null;
+    }
+
+    const spliced =
+        preEditSnapshot.slice(0, first) +
+        diff.newText +
+        preEditSnapshot.slice(first + diff.oldText.length);
+    if (spliced !== base) {
+        return null;
+    }
+
+    return {
+        oldText: preEditSnapshot,
+        newText: base,
+    };
+}
+
+interface UnifiedPatchHunk {
+    readonly oldStart: number;
+    readonly newStart: number;
+    readonly lines: readonly string[];
+}
+
+function resolveAlreadyAppliedUnifiedPatchDiff(
+    diff: { readonly newText: string; readonly oldText: string },
+    base: string,
+    liveSession: Pick<LiveAcpSession, "cwd" | "projectRoot">,
+    normalizedPath: string,
+    rawOutput: unknown,
+): { readonly newText: string; readonly oldText: string } | null {
+    const patch = readOpenCodeFileDiffPatch(rawOutput);
+    if (!patch) {
+        return null;
+    }
+
+    const patchPath = readOpenCodeFileDiffPath(rawOutput);
+    if (patchPath) {
+        const normalizedPatchPath = normalizeTrackedDiffPath(
+            liveSession,
+            patchPath,
+        );
+        if (normalizedPatchPath !== normalizedPath) {
+            return null;
+        }
+    }
+
+    const hunks = parseUnifiedPatchHunks(patch);
+    if (hunks.length === 0) {
+        return null;
+    }
+
+    const oldText = applyUnifiedPatch(base, hunks, "reverse");
+    if (oldText === null) {
+        return null;
+    }
+
+    const validatedBase = applyUnifiedPatch(oldText, hunks, "forward");
+    if (validatedBase !== base) {
+        return null;
+    }
+
+    if (diff.oldText.length > 0 && !oldText.includes(diff.oldText)) {
+        return null;
+    }
+
+    if (diff.newText.length > 0 && !base.includes(diff.newText)) {
+        return null;
+    }
+
+    return { oldText, newText: base };
+}
+
+function readOpenCodeFileDiffPatch(rawOutput: unknown): string | null {
+    if (!isRecord(rawOutput) || !isRecord(rawOutput.metadata)) {
+        return null;
+    }
+
+    const filediff = rawOutput.metadata.filediff;
+    if (!isRecord(filediff) || typeof filediff.patch !== "string") {
+        return null;
+    }
+
+    return filediff.patch;
+}
+
+function readOpenCodeFileDiffPath(rawOutput: unknown): string | null {
+    if (!isRecord(rawOutput) || !isRecord(rawOutput.metadata)) {
+        return null;
+    }
+
+    const filediff = rawOutput.metadata.filediff;
+    return isRecord(filediff) && typeof filediff.file === "string"
+        ? filediff.file
+        : null;
+}
+
+function parseUnifiedPatchHunks(patch: string): UnifiedPatchHunk[] {
+    const hunks: UnifiedPatchHunk[] = [];
+    const lines = patch.replace(/\r\n/g, "\n").split("\n");
+    let current: { oldStart: number; newStart: number; lines: string[] } | null =
+        null;
+
+    for (const line of lines) {
+        const header = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+        if (header) {
+            if (current) {
+                hunks.push(current);
+            }
+            current = {
+                lines: [],
+                newStart: Number(header[2]),
+                oldStart: Number(header[1]),
+            };
+            continue;
+        }
+
+        if (!current) {
+            continue;
+        }
+
+        if (
+            line.startsWith(" ") ||
+            line.startsWith("-") ||
+            line.startsWith("+")
+        ) {
+            current.lines.push(line);
+        }
+    }
+
+    if (current) {
+        hunks.push(current);
+    }
+
+    return hunks.filter(
+        (hunk) =>
+            Number.isInteger(hunk.oldStart) &&
+            Number.isInteger(hunk.newStart) &&
+            hunk.lines.length > 0,
+    );
+}
+
+function applyUnifiedPatch(
+    text: string,
+    hunks: readonly UnifiedPatchHunk[],
+    direction: "forward" | "reverse",
+): string | null {
+    let lines = splitPatchTextLines(text);
+    const orderedHunks = [...hunks].reverse();
+
+    for (const hunk of orderedHunks) {
+        const matchLines =
+            direction === "forward"
+                ? getUnifiedPatchOldLines(hunk)
+                : getUnifiedPatchNewLines(hunk);
+        const replacementLines =
+            direction === "forward"
+                ? getUnifiedPatchNewLines(hunk)
+                : getUnifiedPatchOldLines(hunk);
+        const preferredIndex =
+            Math.max(
+                1,
+                direction === "forward" ? hunk.oldStart : hunk.newStart,
+            ) - 1;
+        const matchIndex = findPatchLineSequence(
+            lines,
+            matchLines,
+            preferredIndex,
+        );
+        if (matchIndex === null) {
+            return null;
+        }
+
+        lines = [
+            ...lines.slice(0, matchIndex),
+            ...replacementLines,
+            ...lines.slice(matchIndex + matchLines.length),
+        ];
+    }
+
+    return joinPatchTextLines(lines, text.endsWith("\n"));
+}
+
+function splitPatchTextLines(text: string): string[] {
+    if (text.length === 0) {
+        return [];
+    }
+
+    const lines = text.split("\n");
+    if (text.endsWith("\n")) {
+        lines.pop();
+    }
+    return lines;
+}
+
+function joinPatchTextLines(
+    lines: readonly string[],
+    trailingNewline: boolean,
+): string {
+    if (lines.length === 0) {
+        return trailingNewline ? "\n" : "";
+    }
+
+    return lines.join("\n") + (trailingNewline ? "\n" : "");
+}
+
+function getUnifiedPatchOldLines(hunk: UnifiedPatchHunk): string[] {
+    return hunk.lines
+        .filter((line) => line.startsWith(" ") || line.startsWith("-"))
+        .map((line) => line.slice(1));
+}
+
+function getUnifiedPatchNewLines(hunk: UnifiedPatchHunk): string[] {
+    return hunk.lines
+        .filter((line) => line.startsWith(" ") || line.startsWith("+"))
+        .map((line) => line.slice(1));
+}
+
+function findPatchLineSequence(
+    lines: readonly string[],
+    sequence: readonly string[],
+    preferredIndex: number,
+): number | null {
+    if (sequence.length === 0) {
+        return Math.min(Math.max(preferredIndex, 0), lines.length);
+    }
+
+    if (matchesPatchLineSequence(lines, sequence, preferredIndex)) {
+        return preferredIndex;
+    }
+
+    let matchIndex: number | null = null;
+    for (let index = 0; index <= lines.length - sequence.length; index += 1) {
+        if (!matchesPatchLineSequence(lines, sequence, index)) {
+            continue;
+        }
+
+        if (matchIndex !== null) {
+            return null;
+        }
+        matchIndex = index;
+    }
+
+    return matchIndex;
+}
+
+function matchesPatchLineSequence(
+    lines: readonly string[],
+    sequence: readonly string[],
+    index: number,
+): boolean {
+    if (index < 0 || index + sequence.length > lines.length) {
+        return false;
+    }
+
+    return sequence.every((line, offset) => lines[index + offset] === line);
+}
+
+function shouldDedupResolvedDiff(original: Diff, resolved: Diff): boolean {
+    return (
+        resolved !== original &&
+        (resolved.oldText !== original.oldText ||
+            resolved.newText !== original.newText)
+    );
+}
+
 export function resolveDiffToFullTexts(
     diff: Diff,
     existing: AiTrackedFile | undefined,
@@ -1373,6 +1775,37 @@ export function resolveDiffToFullTexts(
 
     const first = base.indexOf(oldSnippet);
     if (first === -1 || first !== base.lastIndexOf(oldSnippet)) {
+        if (!existing && first === -1) {
+            const resolvedFromUnifiedPatch =
+                resolveAlreadyAppliedUnifiedPatchDiff(
+                    { newText: newSnippet, oldText: oldSnippet },
+                    base,
+                    liveSession,
+                    normalizedPath,
+                    context?.rawOutput,
+                );
+            if (resolvedFromUnifiedPatch) {
+                return {
+                    ...diff,
+                    oldText: resolvedFromUnifiedPatch.oldText,
+                    newText: resolvedFromUnifiedPatch.newText,
+                };
+            }
+
+            const resolvedFromPreEditSnapshot =
+                resolveAlreadyAppliedPreEditSnapshotDiff(
+                    { newText: newSnippet, oldText: oldSnippet },
+                    base,
+                    context?.preEditSnapshot,
+                );
+            if (resolvedFromPreEditSnapshot) {
+                return {
+                    ...diff,
+                    oldText: resolvedFromPreEditSnapshot.oldText,
+                    newText: resolvedFromPreEditSnapshot.newText,
+                };
+            }
+        }
         if (
             existing &&
             (isClaudeEditReEmission(diff, existing, base, context) ||

--- a/src/main/ai/service.opencode.test.ts
+++ b/src/main/ai/service.opencode.test.ts
@@ -1,0 +1,283 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+    AiRuntimeStatus,
+    AiSessionSnapshot,
+    OpenCodeRuntimeSettings,
+} from "@shared/ipc";
+
+import { AiService } from "./service";
+import type { AiWorkerGateway } from "./contracts";
+
+describe("AiService OpenCode branch", () => {
+    it("stores OpenCode settings and emits runtime status", async () => {
+        let savedSettings: OpenCodeRuntimeSettings | null = null;
+        const runtimeStatusEvents: AiRuntimeStatus[] = [];
+        const settingsService = createSettingsService({
+            loadOpenCodeRuntimeSettings: vi.fn(() =>
+                createOpenCodeSettings(),
+            ),
+            saveOpenCodeRuntimeSettings: (
+                settings: OpenCodeRuntimeSettings,
+            ) => {
+                savedSettings = settings;
+            },
+        });
+        const service = createService({
+            onRuntimeStatus: (status) => runtimeStatusEvents.push(status),
+            settingsService,
+        });
+
+        const status = await service.saveOpenCodeRuntimeSettings({
+            authMethod: "opencode-login",
+            binaryPath: "/opt/homebrew/bin/opencode",
+        });
+
+        expect(savedSettings).toEqual({
+            authInvalidatedAtMs: null,
+            authMethod: "opencode-login",
+            binaryPath: "/opt/homebrew/bin/opencode",
+        });
+        expect(status.runtimeId).toBe("opencode");
+        expect(runtimeStatusEvents.at(-1)?.runtimeId).toBe("opencode");
+    });
+
+    it("disconnects OpenCode from Comando without deleting external credentials", async () => {
+        let savedSettings: OpenCodeRuntimeSettings | null = null;
+        const service = createService({
+            settingsService: createSettingsService({
+                loadOpenCodeRuntimeSettings: vi.fn(() =>
+                    createOpenCodeSettings({
+                        authMethod: "opencode-login",
+                        binaryPath: "/opt/homebrew/bin/opencode",
+                    }),
+                ),
+                saveOpenCodeRuntimeSettings: (
+                    settings: OpenCodeRuntimeSettings,
+                ) => {
+                    savedSettings = settings;
+                },
+            }),
+        });
+
+        await service.disconnectRuntimeAuth({ runtimeId: "opencode" });
+
+        expect(savedSettings).not.toBeNull();
+        const nextSettings =
+            savedSettings as unknown as OpenCodeRuntimeSettings;
+        expect(nextSettings.binaryPath).toBe("/opt/homebrew/bin/opencode");
+        expect(nextSettings.authMethod).toBeNull();
+        expect(nextSettings.authInvalidatedAtMs).toEqual(expect.any(Number));
+    });
+
+    it("prepares OpenCode sessions with opencode acp launch details", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-opencode-service-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "opencode");
+            const preparedSnapshot = createSessionSnapshot();
+            const prepareSession = vi.fn<AiWorkerGateway["prepareSession"]>(
+                async () => preparedSnapshot,
+            );
+            const aiWorker = createAiWorker({ prepareSession });
+            const service = createService({
+                aiWorker,
+                settingsService: createSettingsService({
+                    loadOpenCodeRuntimeSettings: vi.fn(() =>
+                        createOpenCodeSettings({
+                            authMethod: "opencode-login",
+                            binaryPath,
+                        }),
+                    ),
+                }),
+            });
+
+            await service.prepareSession(
+                {
+                    projectId: null,
+                    runtimeId: "opencode",
+                    sessionId: "session-opencode",
+                    title: "OpenCode 1",
+                    worktreeId: null,
+                },
+                "window-1",
+            );
+
+            const launch = prepareSession.mock.calls[0][0].launch;
+            expect(launch.resolvedRuntime.executable).toBe(binaryPath);
+            expect(launch.resolvedRuntime.args).toEqual(["acp"]);
+            expect(launch.resolvedRuntime.command).toBe(`${binaryPath} acp`);
+            expect(launch.resolvedRuntime.status.runtimeId).toBe("opencode");
+            expect(launch.resolvedRuntime.status.onboardingRequired).toBe(
+                false,
+            );
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+});
+
+function createService(overrides: {
+    readonly aiWorker?: AiWorkerGateway;
+    readonly onRuntimeStatus?: (status: AiRuntimeStatus) => void;
+    readonly settingsService?: unknown;
+}): AiService {
+    return new AiService({
+        aiWorker: overrides.aiWorker ?? null,
+        onRuntimeStatus: overrides.onRuntimeStatus ?? vi.fn(),
+        onSessionSnapshot: vi.fn(),
+        persistence: {
+            loadLatestRuntimeCatalog: vi.fn(() => null),
+            loadRuntimeSelectionPreferences: vi.fn(() => ({
+                configOptions: {},
+                modeId: null,
+                modelId: null,
+            })),
+            loadSessionSnapshot: vi.fn(() => null),
+            saveRuntimeModePreference: vi.fn(),
+            saveRuntimeModelPreference: vi.fn(),
+            saveRuntimeSelectionPreferenceOption: vi.fn(),
+            saveSessionSnapshot: vi.fn(),
+        } as never,
+        projectService: {
+            getProjectRootPath: vi.fn(() => process.cwd()),
+            listProjectWorktrees: vi.fn(() => []),
+        } as never,
+        secretStore: {
+            cacheSecretPatches: vi.fn(),
+            getStorageStatus: vi.fn(() => ({
+                encryptionAvailable: true,
+                isWeakBackend: false,
+                message: null,
+                platform: process.platform,
+                selectedBackend: null,
+            })),
+            loadSecret: vi.fn(() => null),
+            saveSecret: vi.fn(),
+        } as never,
+        settingsService: (overrides.settingsService ??
+            createSettingsService({})) as never,
+    });
+}
+
+function createSettingsService(overrides: Record<string, unknown>) {
+    return {
+        loadClaudeRuntimeSettings: vi.fn(() => ({
+            authInvalidatedAtMs: null,
+            authMethod: null,
+            bedrockGatewayBaseUrl: null,
+            binaryPath: null,
+            gatewayBaseUrl: null,
+            hasAnthropicApiKey: false,
+            hasGatewayAuthToken: false,
+            hasGatewayCustomHeaders: false,
+        })),
+        loadCodexRuntimeSettings: vi.fn(() => ({
+            authMethod: null,
+            binaryPath: null,
+            hasCodexApiKey: false,
+            hasOpenAiApiKey: false,
+        })),
+        loadGeminiRuntimeSettings: vi.fn(() => ({
+            authInvalidatedAtMs: null,
+            authMethod: null,
+            binaryPath: null,
+            googleCloudLocation: null,
+            googleCloudProject: null,
+            hasGeminiApiKey: false,
+            hasGoogleApiKey: false,
+        })),
+        loadKiloRuntimeSettings: vi.fn(() => ({
+            authInvalidatedAtMs: null,
+            authMethod: null,
+            binaryPath: null,
+            hasKiloApiKey: false,
+        })),
+        loadOpenCodeRuntimeSettings: vi.fn(() => createOpenCodeSettings()),
+        saveClaudeRuntimeSettings: vi.fn(),
+        saveCodexRuntimeSettings: vi.fn(),
+        saveGeminiRuntimeSettings: vi.fn(),
+        saveKiloRuntimeSettings: vi.fn(),
+        saveOpenCodeRuntimeSettings: vi.fn(),
+        ...overrides,
+    } as never;
+}
+
+function createAiWorker(overrides: Partial<AiWorkerGateway>): AiWorkerGateway {
+    return {
+        cancelSession: vi.fn(),
+        close: vi.fn(),
+        closeOwnedByWindow: vi.fn(),
+        closeSession: vi.fn(),
+        keepAllTrackedFiles: vi.fn(),
+        keepTrackedFile: vi.fn(),
+        keepTrackedFileHunks: vi.fn(),
+        notifyFileBuffer: vi.fn(),
+        prepareSession: vi.fn(),
+        refreshProjectScopes: vi.fn(),
+        rejectAllTrackedFiles: vi.fn(),
+        rejectTrackedFile: vi.fn(),
+        rejectTrackedFileHunks: vi.fn(),
+        renameSession: vi.fn(),
+        respondPermission: vi.fn(),
+        respondUserInput: vi.fn(),
+        sendPrompt: vi.fn(),
+        setSessionConfigOption: vi.fn(),
+        setSessionMode: vi.fn(),
+        setSessionModel: vi.fn(),
+        ...overrides,
+    };
+}
+
+function createOpenCodeSettings(
+    overrides: Partial<OpenCodeRuntimeSettings> = {},
+): OpenCodeRuntimeSettings {
+    return {
+        authInvalidatedAtMs: null,
+        authMethod: null,
+        binaryPath: null,
+        ...overrides,
+    };
+}
+
+function createSessionSnapshot(): AiSessionSnapshot {
+    return {
+        activeTurnStartedAt: null,
+        availableCommands: [],
+        configOptions: [],
+        lastError: null,
+        messages: [],
+        modeId: null,
+        modes: [],
+        modelId: null,
+        models: [],
+        parentSessionId: null,
+        pendingPermission: null,
+        pendingUserInput: null,
+        plan: null,
+        projectId: null,
+        runtimeId: "opencode",
+        runtimeSessionId: "runtime-opencode",
+        sessionId: "session-opencode",
+        status: "idle",
+        title: "OpenCode 1",
+        tokenUsage: null,
+        toolActivity: [],
+        trackedFiles: [],
+        updatedAt: "2026-05-22T00:00:00.000Z",
+        worktreeId: null,
+    };
+}
+
+function writeExecutable(dir: string, name: string): string {
+    const binaryPath = path.join(dir, name);
+    fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
+    fs.chmodSync(binaryPath, 0o755);
+    return binaryPath;
+}

--- a/src/main/ai/service.opencode.test.ts
+++ b/src/main/ai/service.opencode.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
     AiRuntimeStatus,
@@ -12,6 +12,33 @@ import type {
 
 import { AiService } from "./service";
 import type { AiWorkerGateway } from "./contracts";
+
+const OPENCODE_ENV_CREDENTIAL_NAMES = [
+    "ANTHROPIC_API_KEY",
+    "CODEX_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENCODE_API_KEY",
+] as const;
+const originalEnvCredentials = Object.fromEntries(
+    OPENCODE_ENV_CREDENTIAL_NAMES.map((name) => [name, process.env[name]]),
+) as Record<(typeof OPENCODE_ENV_CREDENTIAL_NAMES)[number], string | undefined>;
+const originalXdgDataHome = process.env.XDG_DATA_HOME;
+
+beforeEach(() => {
+    for (const name of OPENCODE_ENV_CREDENTIAL_NAMES) {
+        delete process.env[name];
+    }
+    delete process.env.XDG_DATA_HOME;
+});
+
+afterEach(() => {
+    for (const name of OPENCODE_ENV_CREDENTIAL_NAMES) {
+        restoreEnv(name, originalEnvCredentials[name]);
+    }
+    restoreEnv("XDG_DATA_HOME", originalXdgDataHome);
+});
 
 describe("AiService OpenCode branch", () => {
     it("stores OpenCode settings and emits runtime status", async () => {
@@ -44,6 +71,88 @@ describe("AiService OpenCode branch", () => {
         });
         expect(status.runtimeId).toBe("opencode");
         expect(runtimeStatusEvents.at(-1)?.runtimeId).toBe("opencode");
+    });
+
+    it("does not clear an invalidated OpenCode login on an unchanged save", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-opencode-unchanged-save-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "opencode");
+            process.env.XDG_DATA_HOME = path.join(tempDir, "xdg");
+            let savedSettings: OpenCodeRuntimeSettings | null = null;
+            const currentSettings = createOpenCodeSettings({
+                authInvalidatedAtMs: 12345,
+                authMethod: "opencode-login",
+                binaryPath,
+            });
+            const service = createService({
+                settingsService: createSettingsService({
+                    loadOpenCodeRuntimeSettings: vi.fn(() => currentSettings),
+                    saveOpenCodeRuntimeSettings: (
+                        settings: OpenCodeRuntimeSettings,
+                    ) => {
+                        savedSettings = settings;
+                    },
+                }),
+            });
+
+            const status = await service.saveOpenCodeRuntimeSettings({
+                authMethod: "opencode-login",
+                binaryPath,
+            });
+
+            expect(savedSettings).toEqual(currentSettings);
+            expect(status.authReady).toBe(false);
+            expect(status.onboardingRequired).toBe(true);
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("clears OpenCode invalidation when settings change explicitly", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-opencode-changed-save-"),
+        );
+
+        try {
+            const currentBinaryPath = writeExecutable(tempDir, "opencode");
+            const nextBinaryPath = writeExecutable(tempDir, "next-opencode");
+            process.env.XDG_DATA_HOME = path.join(tempDir, "xdg");
+            let savedSettings: OpenCodeRuntimeSettings | null = null;
+            const service = createService({
+                settingsService: createSettingsService({
+                    loadOpenCodeRuntimeSettings: vi.fn(() =>
+                        createOpenCodeSettings({
+                            authInvalidatedAtMs: 12345,
+                            authMethod: "opencode-login",
+                            binaryPath: currentBinaryPath,
+                        }),
+                    ),
+                    saveOpenCodeRuntimeSettings: (
+                        settings: OpenCodeRuntimeSettings,
+                    ) => {
+                        savedSettings = settings;
+                    },
+                }),
+            });
+
+            const status = await service.saveOpenCodeRuntimeSettings({
+                authMethod: "opencode-login",
+                binaryPath: nextBinaryPath,
+            });
+
+            expect(savedSettings).toMatchObject({
+                authInvalidatedAtMs: null,
+                authMethod: "opencode-login",
+                binaryPath: nextBinaryPath,
+            });
+            expect(status.authReady).toBe(true);
+            expect(status.onboardingRequired).toBe(false);
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
     });
 
     it("disconnects OpenCode from Comando without deleting external credentials", async () => {
@@ -81,6 +190,7 @@ describe("AiService OpenCode branch", () => {
 
         try {
             const binaryPath = writeExecutable(tempDir, "opencode");
+            process.env.XDG_DATA_HOME = path.join(tempDir, "xdg");
             const preparedSnapshot = createSessionSnapshot();
             const prepareSession = vi.fn<AiWorkerGateway["prepareSession"]>(
                 async () => preparedSnapshot,
@@ -280,4 +390,12 @@ function writeExecutable(dir: string, name: string): string {
     fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
     fs.chmodSync(binaryPath, 0o755);
     return binaryPath;
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+    if (typeof value === "string") {
+        process.env[name] = value;
+    } else {
+        delete process.env[name];
+    }
 }

--- a/src/main/ai/service.review.test.ts
+++ b/src/main/ai/service.review.test.ts
@@ -619,6 +619,108 @@ describe("resolveDiffToFullTexts", () => {
         expect(resolved.newText).toBe("new");
     });
 
+    it("uses a pre-edit snapshot when a snippet diff was already applied externally", () => {
+        const originalContent = "alpha\nremove me\nomega\n";
+        const nextContent = "alpha\nomega\n";
+        const absolutePath = path.join(tempDir, "foo.ts");
+        fs.writeFileSync(absolutePath, nextContent, "utf8");
+        const liveSession = { cwd: tempDir, projectRoot: tempDir };
+
+        const resolved = __testing.resolveDiffToFullTexts(
+            {
+                path: "foo.ts",
+                oldText: "remove me\n",
+                newText: "",
+            } as never,
+            undefined,
+            liveSession,
+            "foo.ts",
+            {
+                meta: null,
+                preEditSnapshot: originalContent,
+                sessionUpdate: "tool_call_update",
+                toolCallId: "opencode-edit",
+            },
+        );
+
+        expect(resolved.oldText).toBe(originalContent);
+        expect(resolved.newText).toBe(nextContent);
+    });
+
+    it("uses OpenCode filediff patches when a snippet diff was already applied externally", () => {
+        const originalContent = "alpha\nbeta\nremove me\nomega\n";
+        const nextContent = "alpha\nbeta\nomega\n";
+        const absolutePath = path.join(tempDir, "foo.ts");
+        fs.writeFileSync(absolutePath, nextContent, "utf8");
+        const liveSession = { cwd: tempDir, projectRoot: tempDir };
+
+        const resolved = __testing.resolveDiffToFullTexts(
+            {
+                path: "foo.ts",
+                oldText: "remove me\n",
+                newText: "",
+            } as never,
+            undefined,
+            liveSession,
+            "foo.ts",
+            {
+                meta: null,
+                rawOutput: {
+                    metadata: {
+                        filediff: {
+                            file: absolutePath,
+                            patch: [
+                                `Index: ${absolutePath}`,
+                                "===================================================================",
+                                `--- ${absolutePath}`,
+                                `+++ ${absolutePath}`,
+                                "@@ -1,4 +1,3 @@",
+                                " alpha",
+                                " beta",
+                                "-remove me",
+                                " omega",
+                                "",
+                            ].join("\n"),
+                        },
+                    },
+                },
+                sessionUpdate: "tool_call_update",
+                toolCallId: "opencode-edit",
+            },
+        );
+
+        expect(resolved.oldText).toBe(originalContent);
+        expect(resolved.newText).toBe(nextContent);
+    });
+
+    it("does not use an ambiguous pre-edit snapshot for external snippet diffs", () => {
+        const originalContent = "alpha\nremove me\nomega\nremove me\nend\n";
+        const nextContent = "alpha\nomega\nend\n";
+        const absolutePath = path.join(tempDir, "foo.ts");
+        fs.writeFileSync(absolutePath, nextContent, "utf8");
+        const liveSession = { cwd: tempDir, projectRoot: tempDir };
+
+        const resolved = __testing.resolveDiffToFullTexts(
+            {
+                path: "foo.ts",
+                oldText: "remove me\n",
+                newText: "",
+            } as never,
+            undefined,
+            liveSession,
+            "foo.ts",
+            {
+                meta: null,
+                preEditSnapshot: originalContent,
+                sessionUpdate: "tool_call_update",
+                toolCallId: "opencode-edit",
+            },
+        );
+
+        expect(resolved.oldText).toBe("remove me\n");
+        expect(resolved.newText).toBe("");
+    });
+
     it("prefers the in-editor buffer over the disk when the file is open with unsaved changes", () => {
         const diskContent = "alpha\nbeta\ngamma\n";
         const bufferContent = "alpha\nbeta-WIP\ngamma\n";
@@ -773,6 +875,7 @@ describe("mapToolCallUpdate dedup by toolCallId", () => {
     function makeLiveSession() {
         return {
             cwd: tempDir,
+            preEditSnapshots: new Map<string, string>(),
             projectRoot: tempDir,
             processedDiffPaths: new Map<string, Set<string>>(),
             terminalOutputBuffers: new Map<string, string>(),
@@ -981,6 +1084,74 @@ describe("mapToolCallUpdate dedup by toolCallId", () => {
             20,
         ]);
         expect(liveSession.processedDiffPaths.has("edit-1")).toBe(false);
+    });
+
+    it("records complete OpenCode read output as a pre-edit snapshot", () => {
+        const absolutePath = path.join(tempDir, "foo.ts");
+        const originalContent = "alpha\nremove me\nomega\n";
+        const nextContent = "alpha\nomega\n";
+        fs.writeFileSync(absolutePath, originalContent, "utf8");
+        const liveSession = makeLiveSession();
+        const afterRead = __testing.mapToolCallUpdate(
+            liveSession,
+            makeSnapshot(),
+            {
+                kind: "read",
+                rawInput: {
+                    filePath: absolutePath,
+                },
+                rawOutput: {
+                    output: [
+                        `<path>${absolutePath}</path>`,
+                        "<type>file</type>",
+                        "<content>",
+                        "1: alpha",
+                        "2: remove me",
+                        "3: omega",
+                        "4: ",
+                        "",
+                        "(End of file - total 4 lines)",
+                        "</content>",
+                    ].join("\n"),
+                },
+                sessionUpdate: "tool_call_update",
+                status: "completed",
+                title: "Read foo.ts",
+                toolCallId: "read-1",
+            } as never,
+            "tool_call_update",
+            "2026-04-20T12:00:01.000Z",
+        );
+        fs.writeFileSync(absolutePath, nextContent, "utf8");
+
+        const afterEdit = __testing.mapToolCallUpdate(
+            liveSession,
+            afterRead,
+            {
+                content: [
+                    {
+                        newText: "",
+                        oldText: "remove me\n",
+                        path: absolutePath,
+                        type: "diff",
+                    },
+                ],
+                kind: "edit",
+                sessionUpdate: "tool_call_update",
+                status: "completed",
+                title: "Edited foo.ts",
+                toolCallId: "opencode-edit",
+            } as never,
+            "tool_call_update",
+            "2026-04-20T12:00:02.000Z",
+        );
+
+        expect(afterEdit.trackedFiles[0]).toMatchObject({
+            newText: nextContent,
+            oldText: originalContent,
+            path: "foo.ts",
+            toolCallId: "opencode-edit",
+        });
     });
 
     it("records the active turn start from Codex status turn activities", () => {

--- a/src/main/ai/service.review.test.ts
+++ b/src/main/ai/service.review.test.ts
@@ -1481,3 +1481,70 @@ describe("mapToolCallUpdate dedup by toolCallId", () => {
         });
     });
 });
+
+describe("parseCompleteNumberedFileOutput", () => {
+    function buildOpenCodeReadOutput(
+        body: readonly string[],
+        footer: string,
+    ): string {
+        return ["<content>", ...body, footer, "</content>"].join("\n");
+    }
+
+    it("parses a single-line file body with singular footer wording", () => {
+        const output = buildOpenCodeReadOutput(
+            ["1: only line"],
+            "(End of file - total 1 line)",
+        );
+
+        expect(__testing.parseCompleteNumberedFileOutput(output)).toBe(
+            "only line",
+        );
+    });
+
+    it("accepts a rawOutput record whose `output` field carries the body", () => {
+        const output = buildOpenCodeReadOutput(
+            ["1: alpha", "2: beta"],
+            "(End of file - total 2 lines)",
+        );
+
+        expect(
+            __testing.parseCompleteNumberedFileOutput({ output }),
+        ).toBe("alpha\nbeta");
+    });
+
+    it("returns null when the <content> wrapper tags are missing", () => {
+        const output = [
+            "1: alpha",
+            "2: beta",
+            "(End of file - total 2 lines)",
+        ].join("\n");
+
+        expect(__testing.parseCompleteNumberedFileOutput(output)).toBeNull();
+    });
+
+    it("returns null when the footer line count is missing", () => {
+        const output = ["<content>", "1: alpha", "2: beta", "</content>"].join(
+            "\n",
+        );
+
+        expect(__testing.parseCompleteNumberedFileOutput(output)).toBeNull();
+    });
+
+    it("returns null when the declared line count does not match the body", () => {
+        const output = buildOpenCodeReadOutput(
+            ["1: alpha", "2: beta"],
+            "(End of file - total 5 lines)",
+        );
+
+        expect(__testing.parseCompleteNumberedFileOutput(output)).toBeNull();
+    });
+
+    it("returns null when the line numbering skips a value", () => {
+        const output = buildOpenCodeReadOutput(
+            ["1: alpha", "3: gamma"],
+            "(End of file - total 2 lines)",
+        );
+
+        expect(__testing.parseCompleteNumberedFileOutput(output)).toBeNull();
+    });
+});

--- a/src/main/ai/service.review.test.ts
+++ b/src/main/ai/service.review.test.ts
@@ -693,6 +693,128 @@ describe("resolveDiffToFullTexts", () => {
         expect(resolved.newText).toBe(nextContent);
     });
 
+    it("uses OpenCode filediff patches for already-applied insertions that keep the old snippet", () => {
+        const originalContent = "alpha\nanchor\nomega\n";
+        const nextContent = "alpha\nanchor\ninserted\nomega\n";
+        const duplicatedContent = "alpha\nanchor\ninserted\ninserted\nomega\n";
+        const absolutePath = path.join(tempDir, "foo.ts");
+        fs.writeFileSync(absolutePath, nextContent, "utf8");
+        const liveSession = { cwd: tempDir, projectRoot: tempDir };
+
+        const resolved = __testing.resolveDiffToFullTexts(
+            {
+                path: "foo.ts",
+                oldText: "anchor\n",
+                newText: "anchor\ninserted\n",
+            } as never,
+            undefined,
+            liveSession,
+            "foo.ts",
+            {
+                meta: null,
+                rawOutput: {
+                    metadata: {
+                        filediff: {
+                            file: absolutePath,
+                            patch: [
+                                `Index: ${absolutePath}`,
+                                "===================================================================",
+                                `--- ${absolutePath}`,
+                                `+++ ${absolutePath}`,
+                                "@@ -1,3 +1,4 @@",
+                                " alpha",
+                                " anchor",
+                                "+inserted",
+                                " omega",
+                                "",
+                            ].join("\n"),
+                        },
+                    },
+                },
+                sessionUpdate: "tool_call_update",
+                toolCallId: "opencode-edit",
+            },
+        );
+
+        expect(resolved.oldText).toBe(originalContent);
+        expect(resolved.newText).toBe(nextContent);
+        expect(resolved.newText).not.toBe(duplicatedContent);
+    });
+
+    it("uses pre-edit snapshots for already-applied insertions that keep the old snippet", () => {
+        const originalContent = "alpha\nanchor\nomega\n";
+        const nextContent = "alpha\nanchor\ninserted\nomega\n";
+        const absolutePath = path.join(tempDir, "foo.ts");
+        fs.writeFileSync(absolutePath, nextContent, "utf8");
+        const liveSession = { cwd: tempDir, projectRoot: tempDir };
+
+        const resolved = __testing.resolveDiffToFullTexts(
+            {
+                path: "foo.ts",
+                oldText: "anchor\n",
+                newText: "anchor\ninserted\n",
+            } as never,
+            undefined,
+            liveSession,
+            "foo.ts",
+            {
+                meta: null,
+                preEditSnapshot: originalContent,
+                sessionUpdate: "tool_call_update",
+                toolCallId: "opencode-edit",
+            },
+        );
+
+        expect(resolved.oldText).toBe(originalContent);
+        expect(resolved.newText).toBe(nextContent);
+    });
+
+    it("preserves trailing newline changes from OpenCode filediff patches", () => {
+        const originalContent = "alpha\nbeta\n";
+        const nextContent = "alpha\nbeta";
+        const absolutePath = path.join(tempDir, "foo.ts");
+        fs.writeFileSync(absolutePath, nextContent, "utf8");
+        const liveSession = { cwd: tempDir, projectRoot: tempDir };
+
+        const resolved = __testing.resolveDiffToFullTexts(
+            {
+                path: "foo.ts",
+                oldText: "beta\n",
+                newText: "beta",
+            } as never,
+            undefined,
+            liveSession,
+            "foo.ts",
+            {
+                meta: null,
+                rawOutput: {
+                    metadata: {
+                        filediff: {
+                            file: absolutePath,
+                            patch: [
+                                `Index: ${absolutePath}`,
+                                "===================================================================",
+                                `--- ${absolutePath}`,
+                                `+++ ${absolutePath}`,
+                                "@@ -1,2 +1,2 @@",
+                                " alpha",
+                                "-beta",
+                                "+beta",
+                                "\\ No newline at end of file",
+                                "",
+                            ].join("\n"),
+                        },
+                    },
+                },
+                sessionUpdate: "tool_call_update",
+                toolCallId: "opencode-edit",
+            },
+        );
+
+        expect(resolved.oldText).toBe(originalContent);
+        expect(resolved.newText).toBe(nextContent);
+    });
+
     it("does not use an ambiguous pre-edit snapshot for external snippet diffs", () => {
         const originalContent = "alpha\nremove me\nomega\nremove me\nend\n";
         const nextContent = "alpha\nomega\nend\n";

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -429,7 +429,10 @@ export class AiService {
         const currentSettings =
             this.#settingsService.loadOpenCodeRuntimeSettings();
         const nextSettings = {
-            authInvalidatedAtMs: currentSettings.authInvalidatedAtMs,
+            authInvalidatedAtMs:
+                settings.authMethod === "opencode-login"
+                    ? null
+                    : currentSettings.authInvalidatedAtMs,
             authMethod: settings.authMethod,
             binaryPath: normalizeOptionalText(settings.binaryPath),
         };

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -86,6 +86,7 @@ import {
     diffToAiFileDiff,
     mapToolCallUpdate,
     normalizeTrackedDiffPath,
+    parseCompleteNumberedFileOutput,
     resolveDiffToFullTexts,
     shouldSuppressToolActivityUpdate,
 } from "./review-core";
@@ -2026,6 +2027,7 @@ export const __testing = {
     diffToAiFileDiff,
     mapToolCallUpdate,
     normalizeTrackedDiffPath,
+    parseCompleteNumberedFileOutput,
     resolveDiffToFullTexts,
     resolveTrackedFileHunks,
     shouldSuppressToolActivityUpdate,

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -131,6 +131,7 @@ import {
 import {
     applyOpenCodeAuthEnv,
     getOpenCodeRuntimeStatus,
+    isOpenCodeEnvironmentCredentialReady,
     isOpenCodeAuthenticationError,
     launchOpenCodeLogin,
     markOpenCodeAuthInvalidated,
@@ -428,13 +429,22 @@ export class AiService {
     ): Promise<AiRuntimeStatus> {
         const currentSettings =
             this.#settingsService.loadOpenCodeRuntimeSettings();
+        const binaryPath = normalizeOptionalText(settings.binaryPath);
+        const settingsChanged =
+            currentSettings.authMethod !== settings.authMethod ||
+            normalizeOptionalText(currentSettings.binaryPath) !== binaryPath;
+        const shouldClearInvalidation =
+            settings.authMethod === "opencode-login" &&
+            (currentSettings.authInvalidatedAtMs === null ||
+                settingsChanged ||
+                isOpenCodeEnvironmentCredentialReady(process.env));
         const nextSettings = {
             authInvalidatedAtMs:
-                settings.authMethod === "opencode-login"
+                shouldClearInvalidation
                     ? null
                     : currentSettings.authInvalidatedAtMs,
             authMethod: settings.authMethod,
-            binaryPath: normalizeOptionalText(settings.binaryPath),
+            binaryPath,
         };
 
         await this.#saveOpenCodeAuthSettings(nextSettings);

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -1924,14 +1924,22 @@ export class AiService {
             return;
         }
 
-        if (runtimeId !== "kilo" || !isKiloAuthenticationError(message)) {
-            if (
-                runtimeId !== "opencode" ||
-                !isOpenCodeAuthenticationError(message)
-            ) {
-                return;
-            }
+        if (runtimeId === "kilo" && isKiloAuthenticationError(message)) {
+            const nextSettings = markKiloAuthInvalidated({
+                ...this.#settingsService.loadKiloRuntimeSettings(),
+                authMethod: "kilo-login",
+            });
+            this.#settingsService.saveKiloRuntimeSettings(nextSettings);
+            this.#onRuntimeStatus(
+                getKiloRuntimeStatus(nextSettings, this.#secretStore),
+            );
+            return;
+        }
 
+        if (
+            runtimeId === "opencode" &&
+            isOpenCodeAuthenticationError(message)
+        ) {
             const nextSettings = markOpenCodeAuthInvalidated({
                 ...this.#settingsService.loadOpenCodeRuntimeSettings(),
                 authMethod: "opencode-login",
@@ -1940,17 +1948,7 @@ export class AiService {
             this.#onRuntimeStatus(
                 getOpenCodeRuntimeStatus(nextSettings, this.#secretStore),
             );
-            return;
         }
-
-        const nextSettings = markKiloAuthInvalidated({
-            ...this.#settingsService.loadKiloRuntimeSettings(),
-            authMethod: "kilo-login",
-        });
-        this.#settingsService.saveKiloRuntimeSettings(nextSettings);
-        this.#onRuntimeStatus(
-            getKiloRuntimeStatus(nextSettings, this.#secretStore),
-        );
     }
 }
 

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -36,6 +36,7 @@ import type {
     GetAiSessionTranscriptPageInput,
     KiloRuntimeSettingsInput,
     ListAiSessionHistoryInput,
+    OpenCodeRuntimeSettingsInput,
     SecretValuePatch,
     SendAiPromptInput,
 } from "@shared/ipc";
@@ -127,6 +128,14 @@ import {
     markKiloAuthInvalidated,
     resolveKiloRuntime,
 } from "./kilo/setup";
+import {
+    applyOpenCodeAuthEnv,
+    getOpenCodeRuntimeStatus,
+    isOpenCodeAuthenticationError,
+    launchOpenCodeLogin,
+    markOpenCodeAuthInvalidated,
+    resolveOpenCodeRuntime,
+} from "./opencode/setup";
 
 function toWebByteWritable(stream: Writable): WritableStream<Uint8Array> {
     return Writable.toWeb(stream) as WritableStream<Uint8Array>;
@@ -272,6 +281,7 @@ export class AiService {
                 codex: this.#settingsService.loadCodexRuntimeSettings(),
                 gemini: this.#settingsService.loadGeminiRuntimeSettings(),
                 kilo: this.#settingsService.loadKiloRuntimeSettings(),
+                opencode: this.#settingsService.loadOpenCodeRuntimeSettings(),
             },
         });
     }
@@ -408,6 +418,25 @@ export class AiService {
         await this.#saveKiloAuthSettings(nextSettings, secretPatch.patches);
         const status = this.#withPersistedRuntimeCatalog(
             getKiloRuntimeStatus(nextSettings, this.#secretStore),
+        );
+        this.#onRuntimeStatus(status);
+        return status;
+    }
+
+    async saveOpenCodeRuntimeSettings(
+        settings: OpenCodeRuntimeSettingsInput,
+    ): Promise<AiRuntimeStatus> {
+        const currentSettings =
+            this.#settingsService.loadOpenCodeRuntimeSettings();
+        const nextSettings = {
+            authInvalidatedAtMs: currentSettings.authInvalidatedAtMs,
+            authMethod: settings.authMethod,
+            binaryPath: normalizeOptionalText(settings.binaryPath),
+        };
+
+        await this.#saveOpenCodeAuthSettings(nextSettings);
+        const status = this.#withPersistedRuntimeCatalog(
+            getOpenCodeRuntimeStatus(nextSettings, this.#secretStore),
         );
         this.#onRuntimeStatus(status);
         return status;
@@ -769,6 +798,26 @@ export class AiService {
             return;
         }
 
+        if (input.runtimeId === "opencode") {
+            if (input.methodId !== "opencode-login") {
+                throw new Error(
+                    "Select OpenCode auth before opening authentication.",
+                );
+            }
+
+            const nextSettings = markOpenCodeAuthInvalidated({
+                ...this.#settingsService.loadOpenCodeRuntimeSettings(),
+                authMethod: "opencode-login",
+            });
+            await this.#saveOpenCodeAuthSettings(nextSettings);
+
+            await launchOpenCodeLogin(nextSettings, cwd);
+            this.#onRuntimeStatus(
+                getOpenCodeRuntimeStatus(nextSettings, this.#secretStore),
+            );
+            return;
+        }
+
         if (input.runtimeId === "codex") {
             const currentSettings =
                 this.#settingsService.loadCodexRuntimeSettings();
@@ -991,6 +1040,21 @@ export class AiService {
             await this.#saveGeminiAuthSettings(nextSettings, secretPatch.patches);
             const status = this.#withPersistedRuntimeCatalog(
                 getGeminiRuntimeStatus(nextSettings, this.#secretStore),
+            );
+            this.#onRuntimeStatus(status);
+            return status;
+        }
+
+        if (input.runtimeId === "opencode") {
+            const nextSettings = {
+                ...markOpenCodeAuthInvalidated(
+                    this.#settingsService.loadOpenCodeRuntimeSettings(),
+                ),
+                authMethod: null,
+            };
+            await this.#saveOpenCodeAuthSettings(nextSettings);
+            const status = this.#withPersistedRuntimeCatalog(
+                getOpenCodeRuntimeStatus(nextSettings, this.#secretStore),
             );
             this.#onRuntimeStatus(status);
             return status;
@@ -1510,6 +1574,13 @@ export class AiService {
             );
         }
 
+        if (runtimeId === "opencode") {
+            return getOpenCodeRuntimeStatus(
+                this.#settingsService.loadOpenCodeRuntimeSettings(),
+                this.#secretStore,
+            );
+        }
+
         return getCodexRuntimeStatus(
             this.#settingsService.loadCodexRuntimeSettings(),
             loadCodexSecretBundle(this.#secretStore),
@@ -1570,6 +1641,20 @@ export class AiService {
 
         await this.#saveSecretPatches(secrets);
         this.#settingsService.saveKiloRuntimeSettings(settings);
+    }
+
+    async #saveOpenCodeAuthSettings(
+        settings: ReturnType<SettingsGateway["loadOpenCodeRuntimeSettings"]>,
+        secrets: readonly SecretRecordPatch[] = [],
+    ): Promise<void> {
+        if (this.#settingsService.saveOpenCodeAuth) {
+            await this.#settingsService.saveOpenCodeAuth(settings, secrets);
+            this.#secretStore.cacheSecretPatches?.(secrets);
+            return;
+        }
+
+        await this.#saveSecretPatches(secrets);
+        this.#settingsService.saveOpenCodeRuntimeSettings(settings);
     }
 
     async #saveSecretPatches(
@@ -1655,6 +1740,30 @@ export class AiService {
                 command: resolved.command,
                 env: buildRuntimeSpawnEnv(
                     applyKiloAuthEnv(process.env, settings, this.#secretStore),
+                    resolved.program,
+                ),
+                executable: resolved.program,
+                status: resolved.status,
+            };
+        }
+
+        if (runtimeId === "opencode") {
+            const settings =
+                this.#settingsService.loadOpenCodeRuntimeSettings();
+            const resolved = resolveOpenCodeRuntime(
+                settings,
+                this.#secretStore,
+            );
+
+            return {
+                args: resolved.args,
+                command: resolved.command,
+                env: buildRuntimeSpawnEnv(
+                    applyOpenCodeAuthEnv(
+                        process.env,
+                        settings,
+                        this.#secretStore,
+                    ),
                     resolved.program,
                 ),
                 executable: resolved.program,
@@ -1803,6 +1912,21 @@ export class AiService {
         }
 
         if (runtimeId !== "kilo" || !isKiloAuthenticationError(message)) {
+            if (
+                runtimeId !== "opencode" ||
+                !isOpenCodeAuthenticationError(message)
+            ) {
+                return;
+            }
+
+            const nextSettings = markOpenCodeAuthInvalidated({
+                ...this.#settingsService.loadOpenCodeRuntimeSettings(),
+                authMethod: "opencode-login",
+            });
+            this.#settingsService.saveOpenCodeRuntimeSettings(nextSettings);
+            this.#onRuntimeStatus(
+                getOpenCodeRuntimeStatus(nextSettings, this.#secretStore),
+            );
             return;
         }
 

--- a/src/main/ai/session-core.ts
+++ b/src/main/ai/session-core.ts
@@ -123,6 +123,8 @@ export function getRuntimeDisplayName(runtimeId: AiRuntimeId): string {
             return "Gemini";
         case "kilo":
             return "Kilo";
+        case "opencode":
+            return "OpenCode";
         case "codex":
         default:
             return "Codex";

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -2583,6 +2583,61 @@ describe("AiWorkerRuntime prepareSession", () => {
         );
     });
 
+    it("uses a pre-edit read snapshot for snippet-only external edits", async () => {
+        const { client, emittedEvents, tempDir } =
+            await setupPreparedRuntimeWithClient("OpenCode external snippet");
+        const targetPath = path.join(tempDir, "notes.md");
+        const originalContent = ["alpha", "remove me", "omega"].join("\n");
+        const nextContent = ["alpha", "omega"].join("\n");
+
+        await fs.writeFile(targetPath, originalContent, "utf8");
+        await expect(
+            client.readTextFile({
+                line: 2,
+                limit: 1,
+                path: "notes.md",
+            }),
+        ).resolves.toEqual({
+            content: "remove me",
+        });
+        await fs.writeFile(targetPath, nextContent, "utf8");
+
+        await client.sessionUpdate({
+            sessionId: "runtime-session-1",
+            update: {
+                content: [
+                    {
+                        newText: "",
+                        oldText: "remove me\n",
+                        path: "notes.md",
+                        type: "diff",
+                    },
+                ],
+                kind: "edit",
+                sessionUpdate: "tool_call_update",
+                status: "completed",
+                title: "Edited notes.md",
+                toolCallId: "opencode-external-edit",
+            },
+        });
+
+        await vi.waitFor(() => {
+            const trackedFile = getLatestTrackedFiles(
+                emittedEvents,
+                "session-1",
+            )?.find((candidate) => candidate.path === "notes.md");
+            expect(trackedFile).toEqual(
+                expect.objectContaining({
+                    currentText: nextContent,
+                    diffBase: originalContent,
+                    newText: nextContent,
+                    oldText: originalContent,
+                    toolCallId: "opencode-external-edit",
+                }),
+            );
+        });
+    });
+
     it("writes directly to additional roots inside the allowed scope", async () => {
         const tempDir = await fs.mkdtemp(
             path.join(os.tmpdir(), "comando-ai-worker-"),
@@ -3079,6 +3134,161 @@ describe("AiWorkerRuntime prepareSession", () => {
                 trackedFiles: [],
             }),
         });
+    });
+
+    it("refuses to reject a snippet-only tracked file over a larger disk file", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const filePath = path.join(tempDir, "notes.md");
+        const diskText = "alpha\nremove me\nomega\n";
+        await fs.writeFile(filePath, diskText, "utf8");
+        const runtime = createRuntime();
+        const trackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks("remove me\n", "", "notes.md"),
+            identityKey: "notes.md",
+            isText: true,
+            kind: "update",
+            newText: "",
+            oldText: "remove me\n",
+            path: "notes.md",
+            previousPath: null,
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-1",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const snapshot = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Snippet review safety test",
+        }).persistedSnapshot;
+
+        await expect(
+            runtime.dispatchMethod("ai.rejectTrackedFile", {
+                context: {
+                    additionalRoots: [],
+                    cwd: tempDir,
+                    ownerWindowId: "",
+                    projectRoot: tempDir,
+                    snapshot: {
+                        ...snapshot,
+                        trackedFiles: [trackedFile],
+                    },
+                },
+                input: {
+                    path: "notes.md",
+                    sessionId: "session-1",
+                },
+            }),
+        ).rejects.toThrow("Cannot safely apply this review change");
+
+        await expect(fs.readFile(filePath, "utf8")).resolves.toBe(diskText);
+    });
+
+    it("refuses reject-all when a tracked file is snippet-only", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const filePath = path.join(tempDir, "notes.md");
+        const diskText = "alpha\nremove me\nomega\n";
+        await fs.writeFile(filePath, diskText, "utf8");
+        const runtime = createRuntime();
+        const trackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks("remove me\n", "", "notes.md"),
+            identityKey: "notes.md",
+            isText: true,
+            kind: "update",
+            newText: "",
+            oldText: "remove me\n",
+            path: "notes.md",
+            previousPath: null,
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-1",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const snapshot = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Snippet reject-all safety test",
+        }).persistedSnapshot;
+
+        await expect(
+            runtime.dispatchMethod("ai.rejectAllTrackedFiles", {
+                context: {
+                    additionalRoots: [],
+                    cwd: tempDir,
+                    ownerWindowId: "",
+                    projectRoot: tempDir,
+                    snapshot: {
+                        ...snapshot,
+                        trackedFiles: [trackedFile],
+                    },
+                },
+                input: "session-1",
+            }),
+        ).rejects.toThrow("Cannot safely apply this review change");
+
+        await expect(fs.readFile(filePath, "utf8")).resolves.toBe(diskText);
+    });
+
+    it("refuses partial hunk rejection when the tracked file is snippet-only", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const filePath = path.join(tempDir, "notes.md");
+        const diskText = "alpha\nremove me\nomega\n";
+        await fs.writeFile(filePath, diskText, "utf8");
+        const runtime = createRuntime();
+        const hunks = computeDiffHunks("remove me\n", "", "notes.md");
+        const trackedFile: AiTrackedFile = {
+            hunks,
+            identityKey: "notes.md",
+            isText: true,
+            kind: "update",
+            newText: "",
+            oldText: "remove me\n",
+            path: "notes.md",
+            previousPath: null,
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-1",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const snapshot = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Snippet hunk review safety test",
+        }).persistedSnapshot;
+
+        await expect(
+            runtime.dispatchMethod("ai.rejectTrackedFileHunks", {
+                context: {
+                    additionalRoots: [],
+                    cwd: tempDir,
+                    ownerWindowId: "",
+                    projectRoot: tempDir,
+                    snapshot: {
+                        ...snapshot,
+                        trackedFiles: [trackedFile],
+                    },
+                },
+                input: {
+                    hunkIds: hunks.map((hunk) => hunk.id),
+                    path: "notes.md",
+                    sessionId: "session-1",
+                },
+            }),
+        ).rejects.toThrow("Cannot safely apply this review change");
+
+        await expect(fs.readFile(filePath, "utf8")).resolves.toBe(diskText);
     });
 
     it("applies partial hunk rejections inside additional roots", async () => {

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -3311,6 +3311,298 @@ describe("AiWorkerRuntime prepareSession", () => {
         );
     });
 
+    it("rolls back reject-all when a later filesystem write fails", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const firstPath = path.join(tempDir, "first.md");
+        const secondPath = path.join(tempDir, "second.md");
+        const firstOriginalText = "first before\n";
+        const firstCurrentText = "first after\n";
+        const secondOriginalText = "second before\n";
+        const secondCurrentText = "second after\n";
+        await fs.writeFile(firstPath, firstCurrentText, "utf8");
+        await fs.writeFile(secondPath, secondCurrentText, "utf8");
+        const runtime = createRuntime();
+        const firstTrackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks(
+                firstOriginalText,
+                firstCurrentText,
+                "first.md",
+            ),
+            identityKey: "first.md",
+            isText: true,
+            kind: "update",
+            newText: firstCurrentText,
+            oldText: firstOriginalText,
+            path: "first.md",
+            previousPath: null,
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-first",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const secondTrackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks(
+                secondOriginalText,
+                secondCurrentText,
+                "second.md",
+            ),
+            identityKey: "second.md",
+            isText: true,
+            kind: "update",
+            newText: secondCurrentText,
+            oldText: secondOriginalText,
+            path: "second.md",
+            previousPath: null,
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-second",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const launch = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Transactional reject-all write failure test",
+        });
+        const snapshotWithTrackedFiles = {
+            ...launch.persistedSnapshot,
+            trackedFiles: [firstTrackedFile, secondTrackedFile],
+        };
+        await runtime.dispatchMethod("ai.notifyFileBuffer", {
+            absolutePath: firstPath,
+            content: "first unsaved buffer\n",
+        });
+
+        const originalWriteFile = fs.writeFile.bind(fs);
+        const writeFileSpy = vi.spyOn(fs, "writeFile");
+        let writeCount = 0;
+        writeFileSpy.mockImplementation(async (...args) => {
+            writeCount += 1;
+            if (writeCount === 2) {
+                throw new Error("synthetic write failure");
+            }
+
+            return await originalWriteFile(...args);
+        });
+
+        try {
+            await expect(
+                runtime.dispatchMethod("ai.rejectAllTrackedFiles", {
+                    context: {
+                        additionalRoots: [],
+                        cwd: tempDir,
+                        ownerWindowId: "",
+                        projectRoot: tempDir,
+                        snapshot: snapshotWithTrackedFiles,
+                    },
+                    input: "session-1",
+                }),
+            ).rejects.toThrow("synthetic write failure");
+        } finally {
+            writeFileSpy.mockRestore();
+        }
+
+        await expect(fs.readFile(firstPath, "utf8")).resolves.toBe(
+            firstCurrentText,
+        );
+        await expect(fs.readFile(secondPath, "utf8")).resolves.toBe(
+            secondCurrentText,
+        );
+        expect(snapshotWithTrackedFiles.trackedFiles).toHaveLength(2);
+
+        await runtime.dispatchMethod("ai.prepareSession", {
+            input: launch.input,
+            launch,
+        });
+        const client = latestClientFactory?.();
+        expect(client).toBeDefined();
+        await expect(
+            client!.readTextFile({
+                path: "first.md",
+            }),
+        ).resolves.toEqual({
+            content: "first unsaved buffer\n",
+        });
+    });
+
+    it("rolls back moved paths when reject-all fails while removing the moved file", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const previousPath = path.join(tempDir, "before.md");
+        const movedPath = path.join(tempDir, "after.md");
+        const originalText = "before move\n";
+        const currentText = "after move\n";
+        await fs.writeFile(movedPath, currentText, "utf8");
+        const runtime = createRuntime();
+        const trackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks(originalText, currentText, "after.md"),
+            identityKey: "after.md",
+            isText: true,
+            kind: "move",
+            newText: currentText,
+            oldText: originalText,
+            path: "after.md",
+            previousPath: "before.md",
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-move",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const snapshot = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Transactional reject-all move failure test",
+        }).persistedSnapshot;
+        const snapshotWithTrackedFiles = {
+            ...snapshot,
+            trackedFiles: [trackedFile],
+        };
+
+        const originalRm = fs.rm.bind(fs);
+        const rmSpy = vi.spyOn(fs, "rm");
+        rmSpy.mockImplementation(async (...args) => {
+            if (args[0] === movedPath) {
+                throw new Error("synthetic rm failure");
+            }
+
+            return await originalRm(...args);
+        });
+
+        try {
+            await expect(
+                runtime.dispatchMethod("ai.rejectAllTrackedFiles", {
+                    context: {
+                        additionalRoots: [],
+                        cwd: tempDir,
+                        ownerWindowId: "",
+                        projectRoot: tempDir,
+                        snapshot: snapshotWithTrackedFiles,
+                    },
+                    input: "session-1",
+                }),
+            ).rejects.toThrow("synthetic rm failure");
+        } finally {
+            rmSpy.mockRestore();
+        }
+
+        await expect(fs.readFile(movedPath, "utf8")).resolves.toBe(currentText);
+        await expect(fs.stat(previousPath)).rejects.toMatchObject({
+            code: "ENOENT",
+        });
+        expect(snapshotWithTrackedFiles.trackedFiles).toHaveLength(1);
+    });
+
+    it("removes directories created by a failed reject-all rollback", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const restoredPath = path.join(tempDir, "nested", "restored.md");
+        const failingPath = path.join(tempDir, "failing.md");
+        const restoredOriginalText = "deleted before\n";
+        const failingOriginalText = "failing before\n";
+        const failingCurrentText = "failing after\n";
+        await fs.writeFile(failingPath, failingCurrentText, "utf8");
+        const runtime = createRuntime();
+        const restoredTrackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks(
+                restoredOriginalText,
+                "",
+                "nested/restored.md",
+            ),
+            identityKey: "nested/restored.md",
+            isText: true,
+            kind: "delete",
+            newText: null,
+            oldText: restoredOriginalText,
+            path: "nested/restored.md",
+            previousPath: null,
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-restored",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const failingTrackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks(
+                failingOriginalText,
+                failingCurrentText,
+                "failing.md",
+            ),
+            identityKey: "failing.md",
+            isText: true,
+            kind: "update",
+            newText: failingCurrentText,
+            oldText: failingOriginalText,
+            path: "failing.md",
+            previousPath: null,
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-failing",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const snapshot = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Transactional reject-all mkdir rollback test",
+        }).persistedSnapshot;
+
+        const originalWriteFile = fs.writeFile.bind(fs);
+        const writeFileSpy = vi.spyOn(fs, "writeFile");
+        let writeCount = 0;
+        writeFileSpy.mockImplementation(async (...args) => {
+            writeCount += 1;
+            if (writeCount === 2) {
+                throw new Error("synthetic nested rollback failure");
+            }
+
+            return await originalWriteFile(...args);
+        });
+
+        try {
+            await expect(
+                runtime.dispatchMethod("ai.rejectAllTrackedFiles", {
+                    context: {
+                        additionalRoots: [],
+                        cwd: tempDir,
+                        ownerWindowId: "",
+                        projectRoot: tempDir,
+                        snapshot: {
+                            ...snapshot,
+                            trackedFiles: [
+                                restoredTrackedFile,
+                                failingTrackedFile,
+                            ],
+                        },
+                    },
+                    input: "session-1",
+                }),
+            ).rejects.toThrow("synthetic nested rollback failure");
+        } finally {
+            writeFileSpy.mockRestore();
+        }
+
+        await expect(fs.stat(restoredPath)).rejects.toMatchObject({
+            code: "ENOENT",
+        });
+        await expect(fs.stat(path.dirname(restoredPath))).rejects.toMatchObject({
+            code: "ENOENT",
+        });
+        await expect(fs.readFile(failingPath, "utf8")).resolves.toBe(
+            failingCurrentText,
+        );
+    });
+
     it("refuses partial hunk rejection when the tracked file is snippet-only", async () => {
         const tempDir = await fs.mkdtemp(
             path.join(os.tmpdir(), "comando-ai-worker-"),

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -3237,6 +3237,80 @@ describe("AiWorkerRuntime prepareSession", () => {
         await expect(fs.readFile(filePath, "utf8")).resolves.toBe(diskText);
     });
 
+    it("does not partially revert reject-all when a later tracked file fails safety validation", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const safePath = path.join(tempDir, "safe.md");
+        const unsafePath = path.join(tempDir, "unsafe.md");
+        const safeOriginalText = "before\n";
+        const safeCurrentText = "after\n";
+        const unsafeDiskText = "alpha\nremove me\nomega\n";
+        await fs.writeFile(safePath, safeCurrentText, "utf8");
+        await fs.writeFile(unsafePath, unsafeDiskText, "utf8");
+        const runtime = createRuntime();
+        const safeTrackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks(safeOriginalText, safeCurrentText, "safe.md"),
+            identityKey: "safe.md",
+            isText: true,
+            kind: "update",
+            newText: safeCurrentText,
+            oldText: safeOriginalText,
+            path: "safe.md",
+            previousPath: null,
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-safe",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const unsafeTrackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks("remove me\n", "", "unsafe.md"),
+            identityKey: "unsafe.md",
+            isText: true,
+            kind: "update",
+            newText: "",
+            oldText: "remove me\n",
+            path: "unsafe.md",
+            previousPath: null,
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-unsafe",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const snapshot = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Atomic reject-all safety test",
+        }).persistedSnapshot;
+
+        await expect(
+            runtime.dispatchMethod("ai.rejectAllTrackedFiles", {
+                context: {
+                    additionalRoots: [],
+                    cwd: tempDir,
+                    ownerWindowId: "",
+                    projectRoot: tempDir,
+                    snapshot: {
+                        ...snapshot,
+                        trackedFiles: [safeTrackedFile, unsafeTrackedFile],
+                    },
+                },
+                input: "session-1",
+            }),
+        ).rejects.toThrow("Cannot safely apply this review change");
+
+        await expect(fs.readFile(safePath, "utf8")).resolves.toBe(
+            safeCurrentText,
+        );
+        await expect(fs.readFile(unsafePath, "utf8")).resolves.toBe(
+            unsafeDiskText,
+        );
+    });
+
     it("refuses partial hunk rejection when the tracked file is snippet-only", async () => {
         const tempDir = await fs.mkdtemp(
             path.join(os.tmpdir(), "comando-ai-worker-"),

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -2521,6 +2521,68 @@ describe("AiWorkerRuntime prepareSession", () => {
         ).resolves.toBe("worker-write");
     });
 
+    it("keeps full-file review state when a runtime re-emits an already-applied snippet diff", async () => {
+        const { client, emittedEvents, tempDir } =
+            await setupPreparedRuntimeWithClient("OpenCode snippet replay");
+        const targetPath = path.join(tempDir, "notes.md");
+        const originalContent = [
+            "alpha",
+            "**ALIANZA: PROVISORIA**",
+            "**INTERFAZ: MANIFIESTA DEUDA**",
+            "omega",
+        ].join("\n");
+        const nextContent = ["alpha", "omega"].join("\n");
+        const removedSnippet = [
+            "**ALIANZA: PROVISORIA**",
+            "**INTERFAZ: MANIFIESTA DEUDA**",
+        ].join("\n");
+
+        await fs.writeFile(targetPath, originalContent, "utf8");
+        await client.writeTextFile({
+            content: nextContent,
+            path: targetPath,
+        });
+        emittedEvents.length = 0;
+
+        await client.sessionUpdate({
+            sessionId: "runtime-session-1",
+            update: {
+                content: [
+                    {
+                        newText: "",
+                        oldText: removedSnippet,
+                        path: targetPath,
+                        type: "diff",
+                    },
+                ],
+                kind: "edit",
+                sessionUpdate: "tool_call_update",
+                status: "completed",
+                title: "Edited notes.md",
+                toolCallId: "opencode-edit",
+            },
+        });
+
+        await vi.waitFor(() => {
+            const trackedFile = getLatestTrackedFiles(
+                emittedEvents,
+                "session-1",
+            )?.find((candidate) => candidate.path === "notes.md");
+            expect(trackedFile).toEqual(
+                expect.objectContaining({
+                    currentText: nextContent,
+                    diffBase: originalContent,
+                    newText: nextContent,
+                    oldText: originalContent,
+                    toolCallId: "opencode-edit",
+                }),
+            );
+        });
+        await expect(fs.readFile(targetPath, "utf8")).resolves.toBe(
+            nextContent,
+        );
+    });
+
     it("writes directly to additional roots inside the allowed scope", async () => {
         const tempDir = await fs.mkdtemp(
             path.join(os.tmpdir(), "comando-ai-worker-"),

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -3136,6 +3136,154 @@ describe("AiWorkerRuntime prepareSession", () => {
         });
     });
 
+    it("refuses to reject a moved tracked file when the original path already exists", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const previousPath = path.join(tempDir, "before.md");
+        const movedPath = path.join(tempDir, "after.md");
+        const originalText = "before move\n";
+        const currentText = "after move\n";
+        const recreatedText = "user recreated path\n";
+        await fs.writeFile(previousPath, recreatedText, "utf8");
+        await fs.writeFile(movedPath, currentText, "utf8");
+        const runtime = createRuntime();
+        const trackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks(originalText, currentText, "after.md"),
+            identityKey: "after.md",
+            isText: true,
+            kind: "move",
+            newText: currentText,
+            oldText: originalText,
+            path: "after.md",
+            previousPath: "before.md",
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-move",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const snapshot = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Move reject safety test",
+        }).persistedSnapshot;
+
+        await expect(
+            runtime.dispatchMethod("ai.rejectTrackedFile", {
+                context: {
+                    additionalRoots: [],
+                    cwd: tempDir,
+                    ownerWindowId: "",
+                    projectRoot: tempDir,
+                    snapshot: {
+                        ...snapshot,
+                        trackedFiles: [trackedFile],
+                    },
+                },
+                input: {
+                    path: "after.md",
+                    sessionId: "session-1",
+                },
+            }),
+        ).rejects.toThrow("original path for a moved file already exists");
+
+        await expect(fs.readFile(previousPath, "utf8")).resolves.toBe(
+            recreatedText,
+        );
+        await expect(fs.readFile(movedPath, "utf8")).resolves.toBe(currentText);
+    });
+
+    it("does not partially reject-all when a moved file's original path already exists", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const safePath = path.join(tempDir, "safe.md");
+        const previousPath = path.join(tempDir, "before.md");
+        const movedPath = path.join(tempDir, "after.md");
+        const safeOriginalText = "safe before\n";
+        const safeCurrentText = "safe after\n";
+        const moveOriginalText = "before move\n";
+        const moveCurrentText = "after move\n";
+        const recreatedText = "user recreated path\n";
+        await fs.writeFile(safePath, safeCurrentText, "utf8");
+        await fs.writeFile(previousPath, recreatedText, "utf8");
+        await fs.writeFile(movedPath, moveCurrentText, "utf8");
+        const runtime = createRuntime();
+        const safeTrackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks(
+                safeOriginalText,
+                safeCurrentText,
+                "safe.md",
+            ),
+            identityKey: "safe.md",
+            isText: true,
+            kind: "update",
+            newText: safeCurrentText,
+            oldText: safeOriginalText,
+            path: "safe.md",
+            previousPath: null,
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-safe",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const moveTrackedFile: AiTrackedFile = {
+            hunks: computeDiffHunks(
+                moveOriginalText,
+                moveCurrentText,
+                "after.md",
+            ),
+            identityKey: "after.md",
+            isText: true,
+            kind: "move",
+            newText: moveCurrentText,
+            oldText: moveOriginalText,
+            path: "after.md",
+            previousPath: "before.md",
+            reviewState: "pending",
+            reversible: true,
+            sessionId: "session-1",
+            toolCallId: "tool-move",
+            updatedAt: "2026-04-15T22:23:13.719838Z",
+            version: 1,
+        };
+        const snapshot = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Move reject-all safety test",
+        }).persistedSnapshot;
+
+        await expect(
+            runtime.dispatchMethod("ai.rejectAllTrackedFiles", {
+                context: {
+                    additionalRoots: [],
+                    cwd: tempDir,
+                    ownerWindowId: "",
+                    projectRoot: tempDir,
+                    snapshot: {
+                        ...snapshot,
+                        trackedFiles: [safeTrackedFile, moveTrackedFile],
+                    },
+                },
+                input: "session-1",
+            }),
+        ).rejects.toThrow("original path for a moved file already exists");
+
+        await expect(fs.readFile(safePath, "utf8")).resolves.toBe(
+            safeCurrentText,
+        );
+        await expect(fs.readFile(previousPath, "utf8")).resolves.toBe(
+            recreatedText,
+        );
+        await expect(fs.readFile(movedPath, "utf8")).resolves.toBe(
+            moveCurrentText,
+        );
+    });
+
     it("refuses to reject a snippet-only tracked file over a larger disk file", async () => {
         const tempDir = await fs.mkdtemp(
             path.join(os.tmpdir(), "comando-ai-worker-"),

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -119,6 +119,19 @@ export interface AiWorkerRuntimeOptions {
     readonly emitEvent: (message: AiWorkerEventMessage) => void;
 }
 
+interface TrackedPathRollbackBackup {
+    readonly absolutePath: string;
+    readonly bufferContent: string | null;
+    readonly content: Buffer | null;
+    readonly hadBuffer: boolean;
+    readonly mode: number | null;
+}
+
+interface TrackedFileRollbackState {
+    readonly missingDirectories: readonly string[];
+    readonly pathBackups: readonly TrackedPathRollbackBackup[];
+}
+
 const DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT = 128 * 1024;
 const TERMINAL_PERMISSION_ALLOW_OPTION_ID = "comando.terminal.allow_once";
 const TERMINAL_PERMISSION_REJECT_OPTION_ID = "comando.terminal.reject_once";
@@ -654,8 +667,19 @@ export class AiWorkerRuntime {
                 await this.#assertTrackedFileCanBeReverted(session, trackedFile);
             }
 
-            for (const trackedFile of trackedFiles) {
-                await this.#revertTrackedFile(session, trackedFile);
+            const rollbackState =
+                await this.#createTrackedFileRollbackBackups(
+                    session,
+                    trackedFiles,
+                );
+
+            try {
+                for (const trackedFile of trackedFiles) {
+                    await this.#revertTrackedFile(session, trackedFile);
+                }
+            } catch (error) {
+                await this.#restoreTrackedFileRollbackState(rollbackState);
+                throw error;
             }
 
             session.snapshot = {
@@ -2524,6 +2548,217 @@ export class AiWorkerRuntime {
             resolvedPath.absolutePath,
             trackedFile,
         );
+    }
+
+    async #createTrackedFileRollbackBackups(
+        liveSession: LiveAcpSession,
+        trackedFiles: readonly AiTrackedFile[],
+    ): Promise<TrackedFileRollbackState> {
+        const backups = new Map<string, TrackedPathRollbackBackup>();
+        const missingDirectories = new Set<string>();
+        for (const trackedFile of trackedFiles) {
+            for (const absolutePath of this.#getTrackedFileRevertPaths(
+                liveSession,
+                trackedFile,
+            )) {
+                if (backups.has(absolutePath)) {
+                    continue;
+                }
+
+                backups.set(
+                    absolutePath,
+                    await this.#createTrackedPathRollbackBackup(absolutePath),
+                );
+            }
+
+            for (const absolutePath of this.#getTrackedFileRevertWritePaths(
+                liveSession,
+                trackedFile,
+            )) {
+                await this.#rememberMissingParentDirectories(
+                    absolutePath,
+                    missingDirectories,
+                );
+            }
+        }
+
+        return {
+            missingDirectories: Array.from(missingDirectories).sort(
+                (left, right) => right.length - left.length,
+            ),
+            pathBackups: Array.from(backups.values()),
+        };
+    }
+
+    #getTrackedFileRevertPaths(
+        liveSession: LiveAcpSession,
+        trackedFile: AiTrackedFile,
+    ): readonly string[] {
+        const absolutePaths = [
+            this.#resolveWritableSessionPathInfo(
+                liveSession,
+                trackedFile.path,
+            ).absolutePath,
+        ];
+
+        if (trackedFile.kind === "move" && trackedFile.previousPath) {
+            absolutePaths.push(
+                this.#resolveWritableSessionPathInfo(
+                    liveSession,
+                    trackedFile.previousPath,
+                ).absolutePath,
+            );
+        }
+
+        return absolutePaths;
+    }
+
+    #getTrackedFileRevertWritePaths(
+        liveSession: LiveAcpSession,
+        trackedFile: AiTrackedFile,
+    ): readonly string[] {
+        if (trackedFile.oldText === null) {
+            return [];
+        }
+
+        if (trackedFile.kind === "move" && trackedFile.previousPath) {
+            return [
+                this.#resolveWritableSessionPathInfo(
+                    liveSession,
+                    trackedFile.previousPath,
+                ).absolutePath,
+            ];
+        }
+
+        if (trackedFile.kind === "create") {
+            return [];
+        }
+
+        return [
+            this.#resolveWritableSessionPathInfo(
+                liveSession,
+                trackedFile.path,
+            ).absolutePath,
+        ];
+    }
+
+    async #rememberMissingParentDirectories(
+        absolutePath: string,
+        missingDirectories: Set<string>,
+    ): Promise<void> {
+        const discoveredDirectories: string[] = [];
+        let currentDirectory = path.dirname(absolutePath);
+
+        while (true) {
+            if (missingDirectories.has(currentDirectory)) {
+                break;
+            }
+
+            try {
+                const stat = await fs.promises.stat(currentDirectory);
+                if (!stat.isDirectory()) {
+                    throw new Error(
+                        `Cannot safely prepare review rollback because ${currentDirectory} is not a directory.`,
+                    );
+                }
+                break;
+            } catch (error) {
+                if (!isNodeError(error) || error.code !== "ENOENT") {
+                    throw error;
+                }
+            }
+
+            discoveredDirectories.push(currentDirectory);
+            const parentDirectory = path.dirname(currentDirectory);
+            if (parentDirectory === currentDirectory) {
+                break;
+            }
+            currentDirectory = parentDirectory;
+        }
+
+        for (const directory of discoveredDirectories) {
+            missingDirectories.add(directory);
+        }
+    }
+
+    async #createTrackedPathRollbackBackup(
+        absolutePath: string,
+    ): Promise<TrackedPathRollbackBackup> {
+        const hadBuffer = this.#fileBuffers.has(absolutePath);
+        const bufferContent = hadBuffer
+            ? (this.#fileBuffers.get(absolutePath) ?? null)
+            : null;
+
+        try {
+            const [content, stat] = await Promise.all([
+                fs.promises.readFile(absolutePath),
+                fs.promises.stat(absolutePath),
+            ]);
+
+            return {
+                absolutePath,
+                bufferContent,
+                content,
+                hadBuffer,
+                mode: stat.mode,
+            };
+        } catch (error) {
+            if (isNodeError(error) && error.code === "ENOENT") {
+                return {
+                    absolutePath,
+                    bufferContent,
+                    content: null,
+                    hadBuffer,
+                    mode: null,
+                };
+            }
+
+            throw error;
+        }
+    }
+
+    async #restoreTrackedFileRollbackState(
+        rollbackState: TrackedFileRollbackState,
+    ): Promise<void> {
+        for (const backup of [...rollbackState.pathBackups].reverse()) {
+            if (backup.content === null) {
+                await fs.promises.rm(backup.absolutePath, { force: true });
+            } else {
+                await fs.promises.mkdir(path.dirname(backup.absolutePath), {
+                    recursive: true,
+                });
+                await fs.promises.writeFile(backup.absolutePath, backup.content);
+                if (backup.mode !== null) {
+                    await fs.promises.chmod(backup.absolutePath, backup.mode);
+                }
+            }
+
+            if (backup.hadBuffer) {
+                this.#fileBuffers.set(
+                    backup.absolutePath,
+                    backup.bufferContent ?? "",
+                );
+            } else {
+                this.#fileBuffers.delete(backup.absolutePath);
+            }
+        }
+
+        for (const directory of rollbackState.missingDirectories) {
+            try {
+                await fs.promises.rmdir(directory);
+            } catch (error) {
+                if (
+                    isNodeError(error) &&
+                    (error.code === "ENOENT" ||
+                        error.code === "ENOTEMPTY" ||
+                        error.code === "EEXIST")
+                ) {
+                    continue;
+                }
+
+                throw error;
+            }
+        }
     }
 
     async #revertTrackedFile(

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -2548,6 +2548,16 @@ export class AiWorkerRuntime {
             resolvedPath.absolutePath,
             trackedFile,
         );
+
+        if (trackedFile.kind === "move" && trackedFile.previousPath) {
+            const previousPath = this.#resolveWritableSessionPathInfo(
+                liveSession,
+                trackedFile.previousPath,
+            );
+            await this.#assertTrackedMovePreviousPathAvailable(
+                previousPath.absolutePath,
+            );
+        }
     }
 
     async #createTrackedFileRollbackBackups(
@@ -2781,13 +2791,19 @@ export class AiWorkerRuntime {
             );
 
             if (trackedFile.oldText !== null) {
+                await this.#assertTrackedMovePreviousPathAvailable(
+                    previousPath.absolutePath,
+                );
                 await fs.promises.mkdir(path.dirname(previousPath.absolutePath), {
                     recursive: true,
                 });
                 await fs.promises.writeFile(
                     previousPath.absolutePath,
                     trackedFile.oldText,
-                    "utf8",
+                    {
+                        encoding: "utf8",
+                        flag: "wx",
+                    },
                 );
                 this.#fileBuffers.set(
                     previousPath.absolutePath,
@@ -2897,6 +2913,30 @@ export class AiWorkerRuntime {
 
         throw new Error(
             "Cannot safely apply this review change because the file no longer matches the reviewed content. Reopen the diff or rerun the agent before accepting or rejecting it.",
+        );
+    }
+
+    async #assertTrackedMovePreviousPathAvailable(
+        absolutePath: string,
+    ): Promise<void> {
+        if (this.#fileBuffers.has(absolutePath)) {
+            throw new Error(
+                "Cannot safely apply this review change because the original path for a moved file already exists. Reopen the diff or rerun the agent before accepting or rejecting it.",
+            );
+        }
+
+        try {
+            await fs.promises.lstat(absolutePath);
+        } catch (error) {
+            if (isNodeError(error) && error.code === "ENOENT") {
+                return;
+            }
+
+            throw error;
+        }
+
+        throw new Error(
+            "Cannot safely apply this review change because the original path for a moved file already exists. Reopen the diff or rerun the agent before accepting or rejecting it.",
         );
     }
 

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -649,7 +649,12 @@ export class AiWorkerRuntime {
         params: AiWorkerRpcMethodMap["ai.rejectAllTrackedFiles"]["params"],
     ): Promise<AiWorkerReviewMutationResult> {
         return await this.#withReviewSession(params.context, async (session) => {
-            for (const trackedFile of session.snapshot.trackedFiles) {
+            const trackedFiles = session.snapshot.trackedFiles;
+            for (const trackedFile of trackedFiles) {
+                await this.#assertTrackedFileCanBeReverted(session, trackedFile);
+            }
+
+            for (const trackedFile of trackedFiles) {
                 await this.#revertTrackedFile(session, trackedFile);
             }
 
@@ -2505,6 +2510,20 @@ export class AiWorkerRuntime {
             terminals: new Map(),
             terminalOutputBuffers: new Map(),
         };
+    }
+
+    async #assertTrackedFileCanBeReverted(
+        liveSession: LiveAcpSession,
+        trackedFile: AiTrackedFile,
+    ): Promise<void> {
+        const resolvedPath = this.#resolveWritableSessionPathInfo(
+            liveSession,
+            trackedFile.path,
+        );
+        await this.#assertTrackedFileCurrentState(
+            resolvedPath.absolutePath,
+            trackedFile,
+        );
     }
 
     async #revertTrackedFile(

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -38,6 +38,7 @@ import {
 } from "@shared/ai-attachments";
 import {
     computeDiffHunks,
+    getTrackedFileCurrentText,
     replaceTrackedFile,
     resolveTrackedFileHunks,
     syncTrackedFile,
@@ -128,6 +129,8 @@ const CODEX_ACP_SUBAGENT_RESUME_BEGIN_EVENT_TYPE = "resume_begin";
 const CODEX_ACP_SUBAGENT_RESUME_END_EVENT_TYPE = "resume_end";
 const CODEX_ACP_SUBAGENT_WAITING_END_EVENT_TYPE = "waiting_end";
 const MAX_PENDING_SESSION_UPDATES_PER_RUNTIME_SESSION = 16;
+const PRE_EDIT_SNAPSHOT_MAX_ENTRIES = 128;
+const PRE_EDIT_SNAPSHOT_MAX_BYTES = 5 * 1024 * 1024;
 
 function setDesiredConfigValue(
     values: Map<string, boolean | string>,
@@ -375,6 +378,7 @@ export class AiWorkerRuntime {
             throw new Error("Type a prompt before sending it.");
         }
 
+        liveSession.preEditSnapshots.clear();
         liveSession.snapshot = finalizeStreamingMessages({
             ...liveSession.snapshot,
             activeTurnStartedAt: now,
@@ -610,7 +614,11 @@ export class AiWorkerRuntime {
             if (!nextTrackedFile) {
                 await this.#revertTrackedFile(session, trackedFile);
             } else if (nextTrackedFile.newText !== null) {
-                await this.#applyTrackedFileText(session, nextTrackedFile);
+                await this.#applyTrackedFileText(
+                    session,
+                    nextTrackedFile,
+                    trackedFile,
+                );
             }
 
             session.snapshot = {
@@ -1090,6 +1098,7 @@ export class AiWorkerRuntime {
             },
             terminals: new Map(),
             terminalOutputBuffers: new Map(),
+            preEditSnapshots: new Map(),
             stderrChunks: [],
             stderrHandler: null,
         } satisfies LiveAcpSession);
@@ -1477,6 +1486,7 @@ export class AiWorkerRuntime {
             pendingPermission: null,
             pendingPermissions: new Map(),
             pendingPersistTimer: null,
+            preEditSnapshots: new Map(),
             processedDiffPaths: new Map(),
             projectRoot: parentSession.projectRoot,
             resolvedRuntime: liveConnection.resolvedRuntime,
@@ -1799,6 +1809,7 @@ export class AiWorkerRuntime {
         turnId: string | null,
         updatedAt: string,
     ): void {
+        liveSession.preEditSnapshots.clear();
         liveSession.activeTurnId = turnId;
         liveSession.snapshot = finalizeStreamingMessages({
             ...liveSession.snapshot,
@@ -2127,13 +2138,21 @@ export class AiWorkerRuntime {
         liveSession: LiveAcpSession,
         params: ReadTextFileRequest,
     ): Promise<{ content: string }> {
-        const absolutePath = this.#resolveReadableSessionPath(
+        const resolvedPath = this.#resolveSessionPathInfo(
             liveSession,
             params.path,
+            {
+                allowAdditionalRoots: true,
+            },
         );
         const fullContent =
-            this.#fileBuffers.get(absolutePath) ??
-            (await fs.promises.readFile(absolutePath, "utf8"));
+            this.#fileBuffers.get(resolvedPath.absolutePath) ??
+            (await fs.promises.readFile(resolvedPath.absolutePath, "utf8"));
+        this.#rememberPreEditSnapshot(
+            liveSession,
+            resolvedPath.relativePath ?? resolvedPath.displayPath,
+            fullContent,
+        );
 
         if (!params.line && !params.limit) {
             return {
@@ -2164,6 +2183,13 @@ export class AiWorkerRuntime {
         const previousContent =
             this.#fileBuffers.get(resolvedPath.absolutePath) ??
             (await readTextIfExists(resolvedPath.absolutePath));
+        if (previousContent !== null) {
+            this.#rememberPreEditSnapshot(
+                liveSession,
+                resolvedPath.relativePath ?? resolvedPath.displayPath,
+                previousContent,
+            );
+        }
 
         await fs.promises.mkdir(path.dirname(resolvedPath.absolutePath), {
             recursive: true,
@@ -2447,6 +2473,7 @@ export class AiWorkerRuntime {
             pendingPermission: null,
             pendingPermissions: new Map(),
             pendingPersistTimer: null,
+            preEditSnapshots: new Map(),
             processedDiffPaths: new Map(),
             projectRoot: context.projectRoot,
             resolvedRuntime: {
@@ -2494,6 +2521,11 @@ export class AiWorkerRuntime {
                 trackedFile.previousPath,
             );
 
+            await this.#assertTrackedFileCurrentState(
+                nextPath.absolutePath,
+                trackedFile,
+            );
+
             if (trackedFile.oldText !== null) {
                 await fs.promises.mkdir(path.dirname(previousPath.absolutePath), {
                     recursive: true,
@@ -2517,6 +2549,11 @@ export class AiWorkerRuntime {
         const resolvedPath = this.#resolveWritableSessionPathInfo(
             liveSession,
             trackedFile.path,
+        );
+
+        await this.#assertTrackedFileCurrentState(
+            resolvedPath.absolutePath,
+            trackedFile,
         );
 
         if (trackedFile.kind === "create") {
@@ -2543,6 +2580,7 @@ export class AiWorkerRuntime {
     async #applyTrackedFileText(
         liveSession: LiveAcpSession,
         trackedFile: AiTrackedFile,
+        expectedCurrentState: AiTrackedFile = trackedFile,
     ): Promise<void> {
         if (trackedFile.newText === null) {
             return;
@@ -2551,6 +2589,11 @@ export class AiWorkerRuntime {
         const resolvedPath = this.#resolveWritableSessionPathInfo(
             liveSession,
             trackedFile.path,
+        );
+
+        await this.#assertTrackedFileCurrentState(
+            resolvedPath.absolutePath,
+            expectedCurrentState,
         );
 
         await fs.promises.mkdir(path.dirname(resolvedPath.absolutePath), {
@@ -2562,6 +2605,45 @@ export class AiWorkerRuntime {
             "utf8",
         );
         this.#fileBuffers.set(resolvedPath.absolutePath, trackedFile.newText);
+    }
+
+    async #assertTrackedFileCurrentState(
+        absolutePath: string,
+        trackedFile: AiTrackedFile,
+    ): Promise<void> {
+        const expectedCurrentText =
+            trackedFile.newText === null
+                ? null
+                : getTrackedFileCurrentText(trackedFile);
+
+        try {
+            const currentText = await fs.promises.readFile(
+                absolutePath,
+                "utf8",
+            );
+            if (
+                expectedCurrentText !== null &&
+                currentText === expectedCurrentText
+            ) {
+                return;
+            }
+        } catch (error) {
+            if (
+                isNodeError(error) &&
+                error.code === "ENOENT" &&
+                (expectedCurrentText === null || trackedFile.kind === "create")
+            ) {
+                return;
+            }
+
+            if (!isNodeError(error) || error.code !== "ENOENT") {
+                throw error;
+            }
+        }
+
+        throw new Error(
+            "Cannot safely apply this review change because the file no longer matches the reviewed content. Reopen the diff or rerun the agent before accepting or rejecting it.",
+        );
     }
 
     #markSnapshotExternallySynchronized(liveSession: LiveAcpSession): void {
@@ -3138,13 +3220,29 @@ export class AiWorkerRuntime {
         return liveSession.snapshot.runtimeSessionId;
     }
 
-    #resolveReadableSessionPath(
+    #rememberPreEditSnapshot(
         liveSession: LiveAcpSession,
-        candidatePath: string,
-    ): string {
-        return this.#resolveSessionPathInfo(liveSession, candidatePath, {
-            allowAdditionalRoots: true,
-        }).absolutePath;
+        trackedPath: string,
+        content: string,
+    ): void {
+        if (
+            liveSession.preEditSnapshots.has(trackedPath) ||
+            Buffer.byteLength(content, "utf8") > PRE_EDIT_SNAPSHOT_MAX_BYTES
+        ) {
+            return;
+        }
+
+        while (
+            liveSession.preEditSnapshots.size >= PRE_EDIT_SNAPSHOT_MAX_ENTRIES
+        ) {
+            const oldestKey = liveSession.preEditSnapshots.keys().next().value;
+            if (typeof oldestKey !== "string") {
+                break;
+            }
+            liveSession.preEditSnapshots.delete(oldestKey);
+        }
+
+        liveSession.preEditSnapshots.set(trackedPath, content);
     }
 
     #resolveWritableSessionPathInfo(
@@ -3983,4 +4081,8 @@ function stringifyJson(value: unknown): string | null {
 
 function isRecordValue(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+    return typeof error === "object" && error !== null && "code" in error;
 }

--- a/src/main/db/client.ts
+++ b/src/main/db/client.ts
@@ -19,6 +19,7 @@ import type {
     CodexRuntimeSettings,
     GeminiRuntimeSettings,
     KiloRuntimeSettings,
+    OpenCodeRuntimeSettings,
     PersistedShellState,
     ProjectAppDataSummary,
     ProjectSettingsSnapshot,
@@ -94,6 +95,7 @@ const runtimeIds = [
     "codex",
     "gemini",
     "kilo",
+    "opencode",
 ] as const satisfies readonly AiRuntimeId[];
 
 const DB_WORKER_METHOD_TIMEOUTS_MS: Readonly<Record<string, number>> = {
@@ -414,6 +416,15 @@ class SettingsClient implements SettingsGateway {
         this.#dispatch("settings.saveKiloRuntimeSettings", settings);
     }
 
+    loadOpenCodeRuntimeSettings(): OpenCodeRuntimeSettings {
+        return requireAiSettings(this.#snapshot.ai).opencode;
+    }
+
+    saveOpenCodeRuntimeSettings(settings: OpenCodeRuntimeSettings): void {
+        this.#setOpenCodeRuntimeSettings(settings);
+        this.#dispatch("settings.saveOpenCodeRuntimeSettings", settings);
+    }
+
     async saveCodexAuth(
         settings: CodexRuntimeSettings,
         secrets: readonly SecretRecordPatch[],
@@ -486,6 +497,24 @@ class SettingsClient implements SettingsGateway {
         }
     }
 
+    async saveOpenCodeAuth(
+        settings: OpenCodeRuntimeSettings,
+        secrets: readonly SecretRecordPatch[],
+    ): Promise<void> {
+        const records = serializeSecretRecordPatches(secrets);
+        const previousSettings = this.loadOpenCodeRuntimeSettings();
+        this.#setOpenCodeRuntimeSettings(settings);
+        try {
+            await this.#rpc.call("ai.saveOpenCodeAuth", {
+                secrets: records,
+                settings,
+            });
+        } catch (error) {
+            this.#setOpenCodeRuntimeSettings(previousSettings);
+            throw error;
+        }
+    }
+
     #setCodexRuntimeSettings(settings: CodexRuntimeSettings): void {
         this.#snapshot = {
             ...this.#snapshot,
@@ -522,6 +551,16 @@ class SettingsClient implements SettingsGateway {
             ai: {
                 ...requireAiSettings(this.#snapshot.ai),
                 kilo: settings,
+            },
+        };
+    }
+
+    #setOpenCodeRuntimeSettings(settings: OpenCodeRuntimeSettings): void {
+        this.#snapshot = {
+            ...this.#snapshot,
+            ai: {
+                ...requireAiSettings(this.#snapshot.ai),
+                opencode: settings,
             },
         };
     }

--- a/src/main/db/worker.ts
+++ b/src/main/db/worker.ts
@@ -9,6 +9,7 @@ import type {
     GetAiSessionTranscriptPageInput,
     KiloRuntimeSettings,
     ListAiSessionHistoryInput,
+    OpenCodeRuntimeSettings,
     PersistenceSnapshot,
 } from "@shared/ipc";
 
@@ -77,6 +78,7 @@ const runtimeIds = [
     "codex",
     "gemini",
     "kilo",
+    "opencode",
 ] as const satisfies readonly AiRuntimeId[];
 
 export const bootstrapSecretKeys = [
@@ -472,6 +474,17 @@ function dispatchMethod(method: string, params: unknown): unknown {
             });
             return null;
         }
+        case "ai.saveOpenCodeAuth": {
+            const settings = requireSettingsService();
+            const input = params as {
+                readonly secrets: readonly SecretRecordMutation[];
+                readonly settings: OpenCodeRuntimeSettings;
+            };
+            runAuthSettingsTransaction(input.secrets, () => {
+                settings.saveOpenCodeRuntimeSettings(input.settings);
+            });
+            return null;
+        }
         case "settings.loadSnapshot":
             return settingsService.loadSnapshot();
         case "settings.saveSnapshot":
@@ -528,6 +541,13 @@ function dispatchMethod(method: string, params: unknown): unknown {
             settingsService.saveKiloRuntimeSettings(
                 params as Parameters<
                     SettingsService["saveKiloRuntimeSettings"]
+                >[0],
+            );
+            return null;
+        case "settings.saveOpenCodeRuntimeSettings":
+            settingsService.saveOpenCodeRuntimeSettings(
+                params as Parameters<
+                    SettingsService["saveOpenCodeRuntimeSettings"]
                 >[0],
             );
             return null;

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -129,6 +129,7 @@ import {
     type GeminiRuntimeSettingsInput,
     type KiloRuntimeSettingsInput,
     type RenameProjectEntryInput,
+    type OpenCodeRuntimeSettingsInput,
     type RevealProjectEntryInput,
     type ResizeTerminalSessionInput,
     type SearchProjectEntriesInput,
@@ -344,6 +345,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.saveClaudeRuntimeSettings);
     ipcMain.removeHandler(IPC_CHANNELS.saveGeminiRuntimeSettings);
     ipcMain.removeHandler(IPC_CHANNELS.saveKiloRuntimeSettings);
+    ipcMain.removeHandler(IPC_CHANNELS.saveOpenCodeRuntimeSettings);
     ipcMain.removeHandler(IPC_CHANNELS.verifyCodexRuntimeSettings);
     ipcMain.removeHandler(IPC_CHANNELS.launchAiRuntimeAuth);
 
@@ -1739,6 +1741,11 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         IPC_CHANNELS.saveKiloRuntimeSettings,
         (_event, settings: KiloRuntimeSettingsInput) =>
             options.aiService.saveKiloRuntimeSettings(settings),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.saveOpenCodeRuntimeSettings,
+        (_event, settings: OpenCodeRuntimeSettingsInput) =>
+            options.aiService.saveOpenCodeRuntimeSettings(settings),
     );
     ipcMain.handle(
         IPC_CHANNELS.verifyCodexRuntimeSettings,

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -260,6 +260,33 @@ describe("SettingsService", () => {
         });
     });
 
+    it("stores and reloads OpenCode settings", () => {
+        const connection = createFakeSettingsConnection();
+        const service = new SettingsService(
+            connection as unknown as Database.Database,
+        );
+
+        service.saveOpenCodeRuntimeSettings({
+            authInvalidatedAtMs: 9012,
+            authMethod: "opencode-login",
+            binaryPath: "/opt/homebrew/bin/opencode",
+        });
+
+        expect(service.loadOpenCodeRuntimeSettings()).toEqual({
+            authInvalidatedAtMs: 9012,
+            authMethod: "opencode-login",
+            binaryPath: "/opt/homebrew/bin/opencode",
+        });
+        expect(service.loadSnapshot().ai).toEqual({
+            ...createEmptyAiSettings(),
+            opencode: {
+                authInvalidatedAtMs: 9012,
+                authMethod: "opencode-login",
+                binaryPath: "/opt/homebrew/bin/opencode",
+            },
+        });
+    });
+
     it("ignores project-specific settings and clears legacy overrides", () => {
         const connection = createFakeSettingsConnection();
         const service = new SettingsService(
@@ -421,6 +448,11 @@ function createEmptyAiSettings() {
             authMethod: null,
             binaryPath: null,
             hasKiloApiKey: false,
+        },
+        opencode: {
+            authInvalidatedAtMs: null,
+            authMethod: null,
+            binaryPath: null,
         },
     };
 }

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -24,6 +24,7 @@ import type {
     EditorFontFamily,
     GeminiRuntimeSettings,
     KiloRuntimeSettings,
+    OpenCodeRuntimeSettings,
     PersistedShellState,
     ProjectSettingsSnapshot,
     SettingsSnapshot,
@@ -76,6 +77,10 @@ const KILO_AUTH_INVALIDATED_AT_KEY = "ai.kilo.auth_invalidated_at_ms";
 const KILO_AUTH_METHOD_KEY = "ai.kilo.auth_method";
 const KILO_BINARY_PATH_KEY = "ai.kilo.binary_path";
 const KILO_HAS_KILO_API_KEY_KEY = "ai.kilo.has_kilo_api_key";
+const OPENCODE_AUTH_INVALIDATED_AT_KEY =
+    "ai.opencode.auth_invalidated_at_ms";
+const OPENCODE_AUTH_METHOD_KEY = "ai.opencode.auth_method";
+const OPENCODE_BINARY_PATH_KEY = "ai.opencode.binary_path";
 const APP_BOOST_CODE_CONTRAST_KEY = "appearance.boost_code_contrast";
 const APP_AGENTS_SIDEBAR_SCALE_KEY = "appearance.agents_sidebar_scale";
 const APP_FILE_TREE_SCALE_KEY = "appearance.file_tree_scale";
@@ -199,6 +204,10 @@ export interface SettingsGateway {
         settings: KiloRuntimeSettings,
         secrets: readonly SecretRecordPatch[],
     ): Promise<void>;
+    saveOpenCodeAuth?(
+        settings: OpenCodeRuntimeSettings,
+        secrets: readonly SecretRecordPatch[],
+    ): Promise<void>;
     loadSnapshot(): SettingsSnapshot;
     saveSnapshot(snapshot: SettingsSnapshot): void;
     loadAppAppearanceSettings(): AppAppearanceSettings;
@@ -217,6 +226,8 @@ export interface SettingsGateway {
     saveGeminiRuntimeSettings(settings: GeminiRuntimeSettings): void;
     loadKiloRuntimeSettings(): KiloRuntimeSettings;
     saveKiloRuntimeSettings(settings: KiloRuntimeSettings): void;
+    loadOpenCodeRuntimeSettings(): OpenCodeRuntimeSettings;
+    saveOpenCodeRuntimeSettings(settings: OpenCodeRuntimeSettings): void;
 }
 
 export class SettingsService {
@@ -237,6 +248,7 @@ export class SettingsService {
                 codex: this.loadCodexRuntimeSettings(),
                 gemini: this.loadGeminiRuntimeSettings(),
                 kilo: this.loadKiloRuntimeSettings(),
+                opencode: this.loadOpenCodeRuntimeSettings(),
             },
             aiChat: this.loadAiChatSettings(),
             appearance: this.loadAppAppearanceSettings(),
@@ -270,6 +282,10 @@ export class SettingsService {
 
         if (snapshot.ai?.kilo) {
             this.saveKiloRuntimeSettings(snapshot.ai.kilo);
+        }
+
+        if (snapshot.ai?.opencode) {
+            this.saveOpenCodeRuntimeSettings(snapshot.ai.opencode);
         }
 
         if (snapshot.aiChat) {
@@ -672,6 +688,35 @@ export class SettingsService {
         this.#saveBooleanSetting(
             KILO_HAS_KILO_API_KEY_KEY,
             settings.hasKiloApiKey,
+        );
+    }
+
+    loadOpenCodeRuntimeSettings(): OpenCodeRuntimeSettings {
+        return {
+            authInvalidatedAtMs: this.#loadNumberSetting(
+                OPENCODE_AUTH_INVALIDATED_AT_KEY,
+            ),
+            authMethod:
+                (this.#loadStringSetting(
+                    OPENCODE_AUTH_METHOD_KEY,
+                ) as OpenCodeRuntimeSettings["authMethod"]) ?? null,
+            binaryPath:
+                this.#loadStringSetting(OPENCODE_BINARY_PATH_KEY) ?? null,
+        };
+    }
+
+    saveOpenCodeRuntimeSettings(settings: OpenCodeRuntimeSettings): void {
+        this.#saveOptionalTrimmedStringSetting(
+            OPENCODE_AUTH_METHOD_KEY,
+            settings.authMethod,
+        );
+        this.#saveOptionalTrimmedStringSetting(
+            OPENCODE_BINARY_PATH_KEY,
+            settings.binaryPath,
+        );
+        this.#saveOptionalNumberSetting(
+            OPENCODE_AUTH_INVALIDATED_AT_KEY,
+            settings.authInvalidatedAtMs,
         );
     }
 

--- a/src/main/workspace/service.ts
+++ b/src/main/workspace/service.ts
@@ -454,7 +454,8 @@ function deserializeTabRow(row: WorkspaceTabRow): WorkspaceTab | null {
                 chatPayload.runtimeId === "claude" ||
                 chatPayload.runtimeId === "codex" ||
                 chatPayload.runtimeId === "gemini" ||
-                chatPayload.runtimeId === "kilo"
+                chatPayload.runtimeId === "kilo" ||
+                chatPayload.runtimeId === "opencode"
                     ? chatPayload.runtimeId
                     : "codex",
             sessionId:

--- a/src/main/workspace/service.ts
+++ b/src/main/workspace/service.ts
@@ -508,7 +508,8 @@ function deserializeTabRow(row: WorkspaceTabRow): WorkspaceTab | null {
                 reviewPayload.runtimeId === "claude" ||
                 reviewPayload.runtimeId === "codex" ||
                 reviewPayload.runtimeId === "gemini" ||
-                reviewPayload.runtimeId === "kilo"
+                reviewPayload.runtimeId === "kilo" ||
+                reviewPayload.runtimeId === "opencode"
                     ? reviewPayload.runtimeId
                     : "codex",
             sessionId:

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -138,6 +138,7 @@ import {
     type GitWorktreeSummary,
     type KiloRuntimeSettingsInput,
     type ListProjectEntriesInput,
+    type OpenCodeRuntimeSettingsInput,
     type RenameProjectEntryInput,
     type RevealProjectEntryInput,
     type ResizeTerminalSessionInput,
@@ -1119,6 +1120,11 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.saveGeminiRuntimeSettings, settings),
     saveKiloRuntimeSettings: (settings: KiloRuntimeSettingsInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.saveKiloRuntimeSettings, settings),
+    saveOpenCodeRuntimeSettings: (settings: OpenCodeRuntimeSettingsInput) =>
+        ipcRenderer.invoke(
+            IPC_CHANNELS.saveOpenCodeRuntimeSettings,
+            settings,
+        ),
     closeTerminalSession: (sessionId: string) =>
         ipcRenderer.invoke(IPC_CHANNELS.closeTerminalSession, sessionId),
     touchProject: (projectId: string) =>

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -18,6 +18,7 @@ import type {
     GeminiRuntimeSettingsInput,
     GitHubAuthStatus,
     KiloRuntimeSettingsInput,
+    OpenCodeRuntimeSettingsInput,
     ThemeMode,
     ThemePreset,
 } from "@shared/ipc";
@@ -71,6 +72,7 @@ export function SettingsApp() {
         codex: null,
         gemini: null,
         kilo: null,
+        opencode: null,
     });
     const [runtimeSettings, setRuntimeSettings] =
         useState<AiSettingsSnapshot | null>(null);
@@ -133,13 +135,14 @@ export function SettingsApp() {
             return;
         }
 
-        const [settingsSnapshot, codex, claude, gemini, kilo] =
+        const [settingsSnapshot, codex, claude, gemini, kilo, opencode] =
             await Promise.all([
                 window.comando.getSettingsSnapshot(),
                 window.comando.getAiRuntimeStatus("codex"),
                 window.comando.getAiRuntimeStatus("claude"),
                 window.comando.getAiRuntimeStatus("gemini"),
                 window.comando.getAiRuntimeStatus("kilo"),
+                window.comando.getAiRuntimeStatus("opencode"),
             ]);
 
         setRuntimeSettings(settingsSnapshot.ai ?? null);
@@ -148,6 +151,7 @@ export function SettingsApp() {
             codex,
             gemini,
             kilo,
+            opencode,
         });
     }, []);
 
@@ -528,6 +532,10 @@ export function SettingsApp() {
                 case "kilo":
                     return await window.comando.saveKiloRuntimeSettings(
                         settings as KiloRuntimeSettingsInput,
+                    );
+                case "opencode":
+                    return await window.comando.saveOpenCodeRuntimeSettings(
+                        settings as OpenCodeRuntimeSettingsInput,
                     );
             }
         },
@@ -973,6 +981,8 @@ function getRuntimeName(runtimeId: AiRuntimeId): string {
             return "Gemini";
         case "kilo":
             return "Kilo";
+        case "opencode":
+            return "OpenCode";
         case "codex":
         default:
             return "Codex";

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -1082,7 +1082,7 @@ function mapEnvironmentDiagnostics(
             ),
             ...diagnostics.credentialEnvironment.map(
                 (credential): AiProviderDiagnosticEntry => ({
-                id: `credential-${credential.name}`,
+                id: `credential-${credential.runtimeId}-${credential.name}`,
                 label: credential.name,
                 message: credential.present
                     ? "Environment credential is present."

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -28,6 +28,8 @@ import type {
     GeminiRuntimeSettingsInput,
     KiloRuntimeSettings,
     KiloRuntimeSettingsInput,
+    OpenCodeRuntimeSettings,
+    OpenCodeRuntimeSettingsInput,
     SecretValuePatch,
 } from "@shared/ipc";
 import { resolveTrackedFileHunks } from "@shared/ai-tracked-file";
@@ -131,6 +133,7 @@ interface AiStore {
     readonly codexSettings: CodexRuntimeSettings;
     readonly geminiSettings: GeminiRuntimeSettings;
     readonly kiloSettings: KiloRuntimeSettings;
+    readonly opencodeSettings: OpenCodeRuntimeSettings;
     readonly runtimeCatalogById: Partial<Record<AiRuntimeId, AiRuntimeCatalog>>;
     readonly runtimeStatusById: Partial<Record<AiRuntimeId, AiRuntimeStatus>>;
     readonly sessions: Record<string, AiSessionClientState>;
@@ -202,6 +205,9 @@ interface AiStore {
     saveKiloRuntimeSettings: (
         settings: KiloRuntimeSettingsInput,
     ) => Promise<AiRuntimeStatus>;
+    saveOpenCodeRuntimeSettings: (
+        settings: OpenCodeRuntimeSettingsInput,
+    ) => Promise<AiRuntimeStatus>;
     saveCodexRuntimeSettings: (
         settings: CodexRuntimeSettingsInput,
     ) => Promise<AiRuntimeStatus>;
@@ -252,6 +258,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
     codexSettings: createEmptyCodexSettings(),
     geminiSettings: createEmptyGeminiSettings(),
     kiloSettings: createEmptyKiloSettings(),
+    opencodeSettings: createEmptyOpenCodeSettings(),
     runtimeCatalogById: {},
     runtimeStatusById: {},
     sessions: {},
@@ -816,6 +823,8 @@ export const useAiStore = create<AiStore>((set, get) => ({
             codexSettings: settings?.codex ?? createEmptyCodexSettings(),
             geminiSettings: settings?.gemini ?? createEmptyGeminiSettings(),
             kiloSettings: settings?.kilo ?? createEmptyKiloSettings(),
+            opencodeSettings:
+                settings?.opencode ?? createEmptyOpenCodeSettings(),
         });
     },
 
@@ -1090,6 +1099,8 @@ export const useAiStore = create<AiStore>((set, get) => ({
             codexSettings: snapshot.ai?.codex ?? state.codexSettings,
             geminiSettings: snapshot.ai?.gemini ?? state.geminiSettings,
             kiloSettings: snapshot.ai?.kilo ?? state.kiloSettings,
+            opencodeSettings:
+                snapshot.ai?.opencode ?? state.opencodeSettings,
             runtimeStatusById: {
                 ...state.runtimeStatusById,
                 [input.runtimeId]: status,
@@ -1108,6 +1119,8 @@ export const useAiStore = create<AiStore>((set, get) => ({
             codexSettings: snapshot.ai?.codex ?? state.codexSettings,
             geminiSettings: snapshot.ai?.gemini ?? state.geminiSettings,
             kiloSettings: snapshot.ai?.kilo ?? state.kiloSettings,
+            opencodeSettings:
+                snapshot.ai?.opencode ?? state.opencodeSettings,
             runtimeStatusById: {
                 ...state.runtimeStatusById,
                 [input.runtimeId]: status,
@@ -1208,6 +1221,23 @@ export const useAiStore = create<AiStore>((set, get) => ({
             runtimeStatusById: {
                 ...state.runtimeStatusById,
                 kilo: status,
+            },
+        }));
+
+        return status;
+    },
+
+    saveOpenCodeRuntimeSettings: async (settings) => {
+        const status =
+            await getComandoApi().saveOpenCodeRuntimeSettings(settings);
+        const snapshot = await getComandoApi().getSettingsSnapshot();
+
+        set((state) => ({
+            opencodeSettings:
+                snapshot.ai?.opencode ?? state.opencodeSettings,
+            runtimeStatusById: {
+                ...state.runtimeStatusById,
+                opencode: status,
             },
         }));
 
@@ -1635,6 +1665,14 @@ function createEmptyKiloSettings(): KiloRuntimeSettings {
         authMethod: null,
         binaryPath: null,
         hasKiloApiKey: false,
+    };
+}
+
+function createEmptyOpenCodeSettings(): OpenCodeRuntimeSettings {
+    return {
+        authInvalidatedAtMs: null,
+        authMethod: null,
+        binaryPath: null,
     };
 }
 
@@ -2538,6 +2576,8 @@ function getRuntimeDisplayName(runtimeId: AiRuntimeId): string {
             return "Gemini";
         case "kilo":
             return "Kilo";
+        case "opencode":
+            return "OpenCode";
         case "codex":
         default:
             return "Codex";

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -74,7 +74,7 @@ function createWorkspaceFileTab(id: string, relativePath: string) {
 function createWorkspaceChatTab(
     id: string,
     sessionId: string,
-    runtimeId: "claude" | "codex" | "gemini" | "kilo",
+    runtimeId: "claude" | "codex" | "gemini" | "kilo" | "opencode",
 ) {
     return {
         createdAt: "2026-04-14T00:00:00.000Z",
@@ -221,6 +221,25 @@ describe("workspace file opening", () => {
             true,
         );
         vi.unstubAllGlobals();
+    });
+
+    it("creates OpenCode chat tabs with OpenCode titles", async () => {
+        await useWorkspaceStore
+            .getState()
+            .createChatTab("project-1", null, "opencode");
+
+        const state = useWorkspaceStore.getState();
+        const chatTab = Object.values(state.tabsById).find(
+            (tab) => tab.kind === "chat" && tab.runtimeId === "opencode",
+        );
+
+        expect(chatTab).toMatchObject({
+            kind: "chat",
+            runtimeId: "opencode",
+            title: "OpenCode 1",
+        });
+        expect(state.lastFocusedRuntimeId).toBe("opencode");
+        expect(state.lastQuickCreateAction).toBe("opencode");
     });
 
     it("opens a file in the requested pane instead of the globally active pane", async () => {

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -90,6 +90,7 @@ export type WorkspaceQuickCreateAction =
     | "git"
     | "history"
     | "kilo"
+    | "opencode"
     | "file"
     | "terminal";
 
@@ -485,14 +486,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         runtimeId: AiRuntimeId = "codex",
     ) => {
         const paneId = get().activePaneId;
-        const runtimeTitle =
-            runtimeId === "claude"
-                ? "Claude"
-                : runtimeId === "gemini"
-                  ? "Gemini"
-                  : runtimeId === "kilo"
-                    ? "Kilo"
-                    : "Codex";
+        const runtimeTitle = getRuntimeDisplayName(runtimeId);
         const tab: WorkspaceChatTab = {
             createdAt: new Date().toISOString(),
             draft: "",
@@ -3033,6 +3027,22 @@ function countRuntimeChatTabs(
     return Object.values(get().tabsById).filter(
         (tab) => tab.kind === "chat" && tab.runtimeId === runtimeId,
     ).length;
+}
+
+function getRuntimeDisplayName(runtimeId: AiRuntimeId): string {
+    switch (runtimeId) {
+        case "claude":
+            return "Claude";
+        case "gemini":
+            return "Gemini";
+        case "kilo":
+            return "Kilo";
+        case "opencode":
+            return "OpenCode";
+        case "codex":
+        default:
+            return "Codex";
+    }
 }
 
 function getFileTitle(relativePath: string): string {

--- a/src/renderer/src/components/settings/AIProvidersSettings.test.tsx
+++ b/src/renderer/src/components/settings/AIProvidersSettings.test.tsx
@@ -52,6 +52,16 @@ const RUNTIME_STATUSES: AiProviderRuntimeStatusMap = {
         source: "bundled",
         state: "missing",
     },
+    opencode: {
+        authCredentialSourceLabel: "Using external OpenCode auth",
+        authMethod: "opencode-login",
+        authReady: true,
+        checkedAt: "2026-05-19T12:00:00.000Z",
+        command: "opencode acp",
+        runtimeId: "opencode",
+        source: "path",
+        state: "ready",
+    },
 };
 
 const RUNTIME_SETTINGS: AiProviderRuntimeSettingsMap = {
@@ -79,6 +89,10 @@ const RUNTIME_SETTINGS: AiProviderRuntimeSettingsMap = {
         binaryPath: null,
         hasKiloApiKey: true,
     },
+    opencode: {
+        authMethod: "opencode-login",
+        binaryPath: null,
+    },
 };
 
 describe("AIProvidersSettings", () => {
@@ -95,6 +109,7 @@ describe("AIProvidersSettings", () => {
         expect(markup).toContain("Claude");
         expect(markup).toContain("Gemini");
         expect(markup).toContain("Kilo");
+        expect(markup).toContain("OpenCode");
         expect(markup).toContain("Anthropic API key");
         expect(markup).toContain("Bedrock gateway");
         expect(markup).toContain("Custom headers JSON");
@@ -102,6 +117,8 @@ describe("AIProvidersSettings", () => {
         expect(markup).toContain("Gemini API key");
         expect(markup).toContain("Google Cloud project");
         expect(markup).toContain("Kilo API key");
+        expect(markup).toContain("OpenCode auth");
+        expect(markup).toContain("project .env");
         expect(markup).toContain("Open sign-in terminal");
     });
 

--- a/src/renderer/src/components/settings/AIProvidersSettings.tsx
+++ b/src/renderer/src/components/settings/AIProvidersSettings.tsx
@@ -31,6 +31,7 @@ import {
     type CodexProviderAuthMethodId,
     type GeminiProviderAuthMethodId,
     type KiloProviderAuthMethodId,
+    type OpenCodeProviderAuthMethodId,
 } from "./aiProviderSettingsModel";
 
 export interface AIProvidersSettingsProps {
@@ -60,6 +61,7 @@ interface ProviderDrafts {
     readonly codex: CodexProviderDraft;
     readonly gemini: GeminiProviderDraft;
     readonly kilo: KiloProviderDraft;
+    readonly opencode: OpenCodeProviderDraft;
 }
 
 interface CodexProviderDraft {
@@ -92,6 +94,11 @@ interface KiloProviderDraft {
     readonly authMethod: KiloProviderAuthMethodId | null;
     readonly binaryPath: string;
     readonly kiloApiKey: AiProviderSecretDraft;
+}
+
+interface OpenCodeProviderDraft {
+    readonly authMethod: OpenCodeProviderAuthMethodId | null;
+    readonly binaryPath: string;
 }
 
 const PROVIDER_CARD_STYLE: CSSProperties = {
@@ -286,6 +293,15 @@ export function AIProvidersSettings({
                     kiloApiKey: createEmptySecretDraft(),
                 },
             }));
+        });
+    };
+
+    const saveOpenCode = () => {
+        runProviderAction("opencode", async () => {
+            await onSaveProviderSettings?.("opencode", {
+                authMethod: drafts.opencode.authMethod,
+                binaryPath: normalizeNullableText(drafts.opencode.binaryPath),
+            });
         });
     };
 
@@ -635,6 +651,71 @@ export function AIProvidersSettings({
                         ),
                         providerId: "kilo",
                         save: saveKilo,
+                    })}
+                </ProviderCard>
+
+                <ProviderCard
+                    error={
+                        errorByProviderId?.opencode ?? localErrors.opencode
+                    }
+                    expanded={expandedProviderIds.has("opencode")}
+                    methodId={resolveMethodId(
+                        "opencode",
+                        drafts.opencode.authMethod,
+                        runtimeStatuses?.opencode,
+                    )}
+                    providerId="opencode"
+                    status={runtimeStatuses?.opencode ?? null}
+                    onToggle={() => toggleExpanded("opencode")}
+                >
+                    <CommonFields
+                        binaryPath={drafts.opencode.binaryPath}
+                        binaryPathPlaceholder="Custom OpenCode runtime path, for example opencode"
+                        notice={getRuntimeNotice(runtimeStatuses?.opencode)}
+                        onBinaryPathChange={(binaryPath) =>
+                            setDrafts((current) => ({
+                                ...current,
+                                opencode: {
+                                    ...current.opencode,
+                                    binaryPath,
+                                },
+                            }))
+                        }
+                    />
+                    <MethodPicker
+                        methods={getAvailableProviderMethods(
+                            "opencode",
+                            runtimeStatuses?.opencode,
+                        )}
+                        value={resolveMethodId(
+                            "opencode",
+                            drafts.opencode.authMethod,
+                            runtimeStatuses?.opencode,
+                        )}
+                        onChange={(authMethod) =>
+                            setDrafts((current) => ({
+                                ...current,
+                                opencode: {
+                                    ...current.opencode,
+                                    authMethod,
+                                },
+                            }))
+                        }
+                    />
+                    <InfoNote>
+                        OpenCode uses providers and credentials configured by
+                        the OpenCode CLI. Run OpenCode auth login, use /connect
+                        in OpenCode, set environment variables, or rely on a
+                        project .env.
+                    </InfoNote>
+                    {renderActions({
+                        methodId: resolveMethodId(
+                            "opencode",
+                            drafts.opencode.authMethod,
+                            runtimeStatuses?.opencode,
+                        ),
+                        providerId: "opencode",
+                        save: saveOpenCode,
                     })}
                 </ProviderCard>
             </div>
@@ -1709,6 +1790,7 @@ function createInitialDrafts(
     const codexAuthMethod = settings?.codex?.authMethod;
     const geminiAuthMethod = settings?.gemini?.authMethod;
     const kiloAuthMethod = settings?.kilo?.authMethod;
+    const opencodeAuthMethod = settings?.opencode?.authMethod;
 
     return {
         claude: {
@@ -1746,6 +1828,12 @@ function createInitialDrafts(
                 : null,
             binaryPath: settings?.kilo?.binaryPath ?? "",
             kiloApiKey: createEmptySecretDraft(),
+        },
+        opencode: {
+            authMethod: isMethodIdForProvider("opencode", opencodeAuthMethod)
+                ? opencodeAuthMethod
+                : null,
+            binaryPath: settings?.opencode?.binaryPath ?? "",
         },
     };
 }

--- a/src/renderer/src/components/settings/aiProviderSettingsModel.ts
+++ b/src/renderer/src/components/settings/aiProviderSettingsModel.ts
@@ -346,7 +346,14 @@ export const AI_PROVIDER_DEFINITIONS = {
     opencode: {
         defaultMethodId: "opencode-login",
         description: "OpenCode runtime using the local CLI auth state.",
-        envVars: ["OPENCODE_API_KEY"],
+        envVars: [
+            "OPENCODE_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "CODEX_API_KEY",
+        ],
         id: "opencode",
         methods: [
             {

--- a/src/renderer/src/components/settings/aiProviderSettingsModel.ts
+++ b/src/renderer/src/components/settings/aiProviderSettingsModel.ts
@@ -1,4 +1,10 @@
-export const AI_PROVIDER_IDS = ["codex", "claude", "gemini", "kilo"] as const;
+export const AI_PROVIDER_IDS = [
+    "codex",
+    "claude",
+    "gemini",
+    "kilo",
+    "opencode",
+] as const;
 
 export type AiProviderId = (typeof AI_PROVIDER_IDS)[number];
 
@@ -19,11 +25,14 @@ export type GeminiProviderAuthMethodId = "login_with_google" | "use_gemini";
 
 export type KiloProviderAuthMethodId = "kilo-login" | "kilo-api-key";
 
+export type OpenCodeProviderAuthMethodId = "opencode-login";
+
 export interface AiProviderAuthMethodById {
     readonly codex: CodexProviderAuthMethodId;
     readonly claude: ClaudeProviderAuthMethodId;
     readonly gemini: GeminiProviderAuthMethodId;
     readonly kilo: KiloProviderAuthMethodId;
+    readonly opencode: OpenCodeProviderAuthMethodId;
 }
 
 export type AiProviderAuthMethodId =
@@ -145,11 +154,23 @@ export interface KiloProviderSettingsInput {
     readonly kiloApiKey: AiProviderSecretPatch;
 }
 
+export interface OpenCodeProviderSettings {
+    readonly authInvalidatedAtMs?: number | null;
+    readonly authMethod?: OpenCodeProviderAuthMethodId | null;
+    readonly binaryPath?: string | null;
+}
+
+export interface OpenCodeProviderSettingsInput {
+    readonly authMethod: OpenCodeProviderAuthMethodId | null;
+    readonly binaryPath: string | null;
+}
+
 export interface AiProviderRuntimeSettingsById {
     readonly codex: CodexProviderSettings;
     readonly claude: ClaudeProviderSettings;
     readonly gemini: GeminiProviderSettings;
     readonly kilo: KiloProviderSettings;
+    readonly opencode: OpenCodeProviderSettings;
 }
 
 export interface AiProviderRuntimeSettingsInputById {
@@ -157,6 +178,7 @@ export interface AiProviderRuntimeSettingsInputById {
     readonly claude: ClaudeProviderSettingsInput;
     readonly gemini: GeminiProviderSettingsInput;
     readonly kilo: KiloProviderSettingsInput;
+    readonly opencode: OpenCodeProviderSettingsInput;
 }
 
 export type AiProviderRuntimeSettingsMap = Partial<{
@@ -320,6 +342,22 @@ export const AI_PROVIDER_DEFINITIONS = {
             },
         ],
         name: "Kilo",
+    },
+    opencode: {
+        defaultMethodId: "opencode-login",
+        description: "OpenCode runtime using the local CLI auth state.",
+        envVars: ["OPENCODE_API_KEY"],
+        id: "opencode",
+        methods: [
+            {
+                description:
+                    "Use providers and credentials configured by the OpenCode CLI.",
+                id: "opencode-login",
+                label: "OpenCode auth",
+                terminalAuth: true,
+            },
+        ],
+        name: "OpenCode",
     },
 } satisfies {
     readonly [K in AiProviderId]: AiProviderDefinition<K>;

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -85,6 +85,7 @@ const SIDEBAR_AGENTS_NEW_RUNTIMES: readonly AiRuntimeId[] = [
     "claude",
     "gemini",
     "kilo",
+    "opencode",
 ];
 const SIDEBAR_AGENT_DRAG_THRESHOLD_PX = 6;
 

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -3001,6 +3001,8 @@ function getRuntimeDisplayName(
             return "Gemini";
         case "kilo":
             return "Kilo";
+        case "opencode":
+            return "OpenCode";
         case "codex":
         default:
             return "Codex";

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -1832,6 +1832,13 @@ function WorkspacePaneView({
                     "kilo",
                 );
                 return;
+            case "opencode":
+                void createChatTab(
+                    defaultProjectId,
+                    defaultWorktreeId ?? null,
+                    "opencode",
+                );
+                return;
             case "terminal":
                 void createTerminalTab(
                     defaultProjectId,
@@ -1927,6 +1934,15 @@ function WorkspacePaneView({
                                 "kilo",
                             ),
                         label: "Kilo",
+                    },
+                    {
+                        action: () =>
+                            void createChatTab(
+                                defaultProjectId,
+                                defaultWorktreeId ?? null,
+                                "opencode",
+                            ),
+                        label: "OpenCode",
                     },
                 ],
             },
@@ -2862,6 +2878,8 @@ function getQuickCreateButtonTitle(
             return "Open last item: Gemini chat";
         case "kilo":
             return "Open last item: Kilo chat";
+        case "opencode":
+            return "Open last item: OpenCode chat";
         case "terminal":
             return "Open last item: terminal";
         case "git":
@@ -6148,6 +6166,25 @@ function ChatProviderIcon({ runtimeId }: { readonly runtimeId: AiRuntimeId }) {
                 width={12}
             >
                 <path d="M8 1.2c.25 3.55 1.6 5.35 6.8 6.8-5.2 1.45-6.55 3.25-6.8 6.8-.25-3.55-1.6-5.35-6.8-6.8C6.4 6.55 7.75 4.75 8 1.2Z" />
+            </svg>
+        );
+    }
+
+    if (runtimeId === "opencode") {
+        return (
+            <svg
+                className="shrink-0 opacity-55"
+                fill="none"
+                height={12}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                viewBox="0 0 16 16"
+                width={12}
+            >
+                <circle cx="8" cy="8" r="5.25" strokeWidth="1.1" />
+                <path d="M4.9 8h6.2M8 4.9v6.2" strokeWidth="1.1" />
+                <path d="M11.1 4.9 4.9 11.1" strokeWidth="0.9" />
             </svg>
         );
     }

--- a/src/renderer/src/components/workspace/chat-history/historyPresentation.ts
+++ b/src/renderer/src/components/workspace/chat-history/historyPresentation.ts
@@ -12,6 +12,8 @@ export function getHistoryRuntimeLabel(runtimeId: AiRuntimeId): string {
             return "Gemini";
         case "kilo":
             return "Kilo";
+        case "opencode":
+            return "OpenCode";
         case "codex":
         default:
             return "Codex";

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
@@ -169,6 +169,53 @@ describe("ToolActivityItem", () => {
         expect(markup).not.toContain("Reject");
     });
 
+    it("does not revive historical diffs as inline review after tracked files are cleared", () => {
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivityItem, {
+                activity: createActivity({
+                    diffs: [
+                        {
+                            hunks: [
+                                {
+                                    id: "hunk-1",
+                                    lines: [
+                                        {
+                                            id: "line-1",
+                                            text: "const before = true;",
+                                            type: "remove",
+                                        },
+                                    ],
+                                    newCount: 0,
+                                    newStart: 8,
+                                    oldCount: 1,
+                                    oldStart: 8,
+                                },
+                            ],
+                            isText: true,
+                            kind: "update",
+                            newText: "",
+                            oldText: "const before = true;\n",
+                            path: "src/app.ts",
+                            previousPath: null,
+                            reversible: true,
+                        },
+                    ],
+                }),
+                expansionMode: "expanded",
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                trackedFiles: [],
+                worktreeId: null,
+            }),
+        );
+
+        expect(markup).toContain("Edit file");
+        expect(markup).not.toContain("Edited app.ts");
+        expect(markup).not.toContain("change-review-panel:");
+        expect(markup).not.toContain("Accept");
+        expect(markup).not.toContain("Reject");
+    });
+
     it("expands file tool details when the card policy is always expanded", () => {
         const markup = renderToStaticMarkup(
             createElement(ToolActivityItem, {

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
@@ -1216,8 +1216,7 @@ export const ToolActivityItem = memo(function ToolActivityItem({
     const pendingTrackedFiles = trackedFiles.filter(
         (trackedFile) => trackedFile.reviewState === "pending",
     );
-    const hasInlineReview =
-        activity.diffs.length > 0 || trackedFiles.length > 0;
+    const hasInlineReview = trackedFiles.length > 0;
 
     useRenderProbe("ToolActivityItem", {
         activityId: activity.id,

--- a/src/shared/chatTitle.test.ts
+++ b/src/shared/chatTitle.test.ts
@@ -20,6 +20,7 @@ describe("isDefaultChatTitle", () => {
         expect(isDefaultChatTitle("Gemini 12")).toBe(true);
         expect(isDefaultChatTitle("Codex 3")).toBe(true);
         expect(isDefaultChatTitle("Kilo 4")).toBe(true);
+        expect(isDefaultChatTitle("OpenCode 5")).toBe(true);
         expect(isDefaultChatTitle("Agent 9")).toBe(true);
     });
 

--- a/src/shared/chatTitle.ts
+++ b/src/shared/chatTitle.ts
@@ -3,7 +3,7 @@ export const CHAT_TITLE_HISTORY_MAX_CHARS = 70;
 export const CHAT_TITLE_STORED_MAX_CHARS = 100;
 
 export const DEFAULT_CHAT_TITLE_PATTERN =
-    /^(Claude|Gemini|Codex|Kilo|Agent) \d+$/;
+    /^(Claude|Gemini|Codex|Kilo|OpenCode|Agent) \d+$/;
 
 const PILL_OPEN = "\u200B\u00AB";
 const PILL_CLOSE = "\u00BB\u200B";

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -27,6 +27,7 @@ export const IPC_CHANNELS = {
     saveClaudeRuntimeSettings: "settings:save-claude-runtime-settings",
     saveGeminiRuntimeSettings: "settings:save-gemini-runtime-settings",
     saveKiloRuntimeSettings: "settings:save-kilo-runtime-settings",
+    saveOpenCodeRuntimeSettings: "settings:save-opencode-runtime-settings",
     getSystemTheme: "app:get-system-theme",
     saveSettingsSnapshot: "settings:save-snapshot",
     saveProjectSettings: "settings:save-project-settings",
@@ -278,7 +279,12 @@ export interface PersistedShellState {
         | "pull_requests";
 }
 
-export type AiRuntimeId = "claude" | "codex" | "gemini" | "kilo";
+export type AiRuntimeId =
+    | "claude"
+    | "codex"
+    | "gemini"
+    | "kilo"
+    | "opencode";
 
 export interface AiAuthMethod {
     readonly description: string;
@@ -297,6 +303,8 @@ export type ClaudeAuthMethodId =
 export type GeminiAuthMethodId = "login_with_google" | "use_gemini";
 
 export type KiloAuthMethodId = "kilo-login" | "kilo-api-key";
+
+export type OpenCodeAuthMethodId = "opencode-login";
 
 export type CodexAuthMethodId = "chatgpt" | "codex-api-key" | "openai-api-key";
 
@@ -379,11 +387,23 @@ export interface KiloRuntimeSettingsInput {
     readonly kiloApiKey: SecretValuePatch;
 }
 
+export interface OpenCodeRuntimeSettings {
+    readonly authInvalidatedAtMs: number | null;
+    readonly authMethod: OpenCodeAuthMethodId | null;
+    readonly binaryPath: string | null;
+}
+
+export interface OpenCodeRuntimeSettingsInput {
+    readonly authMethod: OpenCodeAuthMethodId | null;
+    readonly binaryPath: string | null;
+}
+
 export interface AiSettingsSnapshot {
     readonly claude: ClaudeRuntimeSettings;
     readonly codex: CodexRuntimeSettings;
     readonly gemini: GeminiRuntimeSettings;
     readonly kilo: KiloRuntimeSettings;
+    readonly opencode: OpenCodeRuntimeSettings;
 }
 
 export type AiRuntimeSource =
@@ -459,7 +479,8 @@ export interface AiRuntimePathOverrideDiagnostic {
         | "COMANDO_CLAUDE_ACP_BIN"
         | "COMANDO_CODEX_ACP_BIN"
         | "COMANDO_GEMINI_ACP_BIN"
-        | "COMANDO_KILO_ACP_BIN";
+        | "COMANDO_KILO_ACP_BIN"
+        | "COMANDO_OPENCODE_ACP_BIN";
     readonly pathOrCommand: string | null;
     readonly present: boolean;
     readonly runtimeId: AiRuntimeId;
@@ -476,6 +497,7 @@ export interface AiCredentialEnvironmentDiagnostic {
         | "GEMINI_API_KEY"
         | "GOOGLE_API_KEY"
         | "KILO_API_KEY"
+        | "OPENCODE_API_KEY"
         | "OPENAI_API_KEY";
     readonly present: boolean;
     readonly runtimeId: AiRuntimeId;
@@ -2741,6 +2763,9 @@ export interface ComandoApi {
     ) => Promise<AiRuntimeStatus>;
     saveKiloRuntimeSettings: (
         settings: KiloRuntimeSettingsInput,
+    ) => Promise<AiRuntimeStatus>;
+    saveOpenCodeRuntimeSettings: (
+        settings: OpenCodeRuntimeSettingsInput,
     ) => Promise<AiRuntimeStatus>;
     createTerminalSession: (
         input: CreateTerminalSessionInput,


### PR DESCRIPTION
## Summary

- Adds native OpenCode ACP runtime support and default title recognition.
- Reconstructs OpenCode review diffs from full-file snapshots, metadata patches, and pre-edit snapshots so inline review does not collapse to snippet-only content.
- Hardens accept/reject/reject-all review flows with safety validation, transactional rollback, and moved-file path guards.

## Root Cause

OpenCode can report edit activity as narrow snippets or patch metadata instead of the same full-file shape used by the existing review pipeline. The UI and worker were able to treat those snippets as complete files, which made inline review appear as if the whole file had been replaced or deleted. Reopened chats could also revive historical diff activity as active review state.

## Validation

- pnpm run typecheck
- pnpm exec vitest run src/main/ai/worker-runtime.test.ts
- pnpm test
- git diff --check
