### PR TITLE
Fix native module externalization under Vite 8 / Rolldown

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -14,6 +15,18 @@ const aliases = {
     "@shared": path.resolve(rootDir, "src/shared"),
 };
 
+// In Vite 8 / Rolldown, ssr.noExternal:true (set by electron-vite's preset) overrides
+// externals added via plugin config() hooks. Static rollupOptions.external still works,
+// so we compute the list here rather than relying solely on externalizeDepsPlugin().
+const pkg = JSON.parse(
+    readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
+);
+const mainExternal = [
+    "electron",
+    /^electron\/.+/,
+    ...Object.keys(pkg.dependencies ?? {}),
+];
+
 export default defineConfig({
     main: {
         plugins: [externalizeDepsPlugin()],
@@ -22,6 +35,9 @@ export default defineConfig({
         },
         build: {
             outDir: "out/main",
+            rollupOptions: {
+                external: mainExternal,
+            },
         },
     },
     preload: {
@@ -32,6 +48,7 @@ export default defineConfig({
         build: {
             outDir: "out/preload",
             rollupOptions: {
+                external: mainExternal,
                 output: {
                     entryFileNames: "[name].cjs",
                     format: "cjs",

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -15,16 +15,26 @@ const aliases = {
     "@shared": path.resolve(rootDir, "src/shared"),
 };
 
+interface PackageJson {
+    readonly dependencies?: Record<string, string>;
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 // In Vite 8 / Rolldown, ssr.noExternal:true (set by electron-vite's preset) overrides
 // externals added via plugin config() hooks. Static rollupOptions.external still works,
 // so we compute the list here rather than relying solely on externalizeDepsPlugin().
 const pkg = JSON.parse(
     readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
-);
+) as PackageJson;
+const dependencies = Object.keys(pkg.dependencies ?? {});
 const mainExternal = [
     "electron",
     /^electron\/.+/,
-    ...Object.keys(pkg.dependencies ?? {}),
+    ...dependencies,
+    new RegExp(`^(${dependencies.map(escapeRegExp).join("|")})/.+`),
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

- Vite 8 (upgraded in #116d3f6) switches from Rollup to Rolldown. With `ssr.noExternal: true` that electron-vite's preset sets on every main-process build, Rolldown silently ignores externals registered via plugin `config()` hooks — including those from `externalizeDepsPlugin()` and the preset's own `rollupOptions.external`. Every third-party package was bundled inline, breaking native modules.
- For worker sub-builds, `modulePathPlugin` passes the **raw user config** (before hooks run) as static config into the worker bundle job. Rolldown respects externals present as static config at build start, even under `ssr.noExternal: true`.
- Fix: compute the external list from `package.json` at config time and set it as `static rollupOptions.external` in both `main` and `preload` configs. This value is present before any hooks fire, so Rolldown treats it correctly for both the main build and all worker sub-builds.

## What was broken

After the Vite 7 → 8 upgrade:

1. **`better-sqlite3` was bundled into the DB worker** — the `bindings` package inside it uses `__dirname` to locate the `.node` file relative to `node_modules/better-sqlite3/`, which breaks when bundled at `out/main/worker-*.js`. Startup error: `Could not locate the bindings file: better_sqlite3.node`.

2. **`electron` (and other deps) were bundled into the main entry** — CJS code inside the `electron` npm package uses `__dirname`, which is unavailable in the ESM output Rolldown produces with `"type": "module"` in `package.json`. Startup error: `ReferenceError: __dirname is not defined in ES module scope`.

## Test plan

- [ ] `pnpm run build` completes without errors
- [ ] `out/main/index.js` line 2: `import { BrowserWindow, ... } from "electron"` (external import, not bundled)
- [ ] `out/main/worker-*DB*.js` line ~5: `import Database from "better-sqlite3"` (external import, not bundled)
- [ ] App launches without the `Could not locate the bindings file` error