### PR TITLE
Support gh CLI as GitHub auth fallback

### DIFF
--- a/src/main/github/auth.test.ts
+++ b/src/main/github/auth.test.ts
@@ -1,0 +1,113 @@
+import { EventEmitter } from "node:events";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+    spawn: spawnMock,
+}));
+
+import { loadGhCliToken } from "@main/github/auth";
+
+describe("GitHub auth", () => {
+    beforeEach(() => {
+        spawnMock.mockReset();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("loads a token from the gh CLI for github.com", async () => {
+        spawnMock.mockImplementationOnce(() =>
+            createGhProcess({ stdout: "gho_cli_token\n" }),
+        );
+
+        await expect(loadGhCliToken("github.com")).resolves.toBe(
+            "gho_cli_token",
+        );
+        expect(spawnMock).toHaveBeenCalledWith("gh", ["auth", "token"], {
+            stdio: ["ignore", "pipe", "ignore"],
+        });
+    });
+
+    it("passes a hostname for GitHub Enterprise hosts", async () => {
+        spawnMock.mockImplementationOnce(() =>
+            createGhProcess({ stdout: "ghe_token\n" }),
+        );
+
+        await expect(
+            loadGhCliToken("https://ghe.example.com/acme/repo"),
+        ).resolves.toBe("ghe_token");
+        expect(spawnMock).toHaveBeenCalledWith(
+            "gh",
+            ["auth", "token", "--hostname", "ghe.example.com"],
+            {
+                stdio: ["ignore", "pipe", "ignore"],
+            },
+        );
+    });
+
+    it("returns null when gh is unavailable or exits unsuccessfully", async () => {
+        spawnMock
+            .mockImplementationOnce(() =>
+                createGhProcess({ error: new Error("ENOENT") }),
+            )
+            .mockImplementationOnce(() => createGhProcess({ code: 1 }));
+
+        await expect(loadGhCliToken("github.com")).resolves.toBeNull();
+        await expect(loadGhCliToken("github.com")).resolves.toBeNull();
+    });
+
+    it("kills gh and returns null when token lookup times out", async () => {
+        vi.useFakeTimers();
+        const child = createGhProcess({ autoClose: false });
+        spawnMock.mockReturnValueOnce(child);
+
+        const token = loadGhCliToken("github.com");
+        await vi.advanceTimersByTimeAsync(5000);
+
+        await expect(token).resolves.toBeNull();
+        expect(child.kill).toHaveBeenCalled();
+    });
+});
+
+function createGhProcess({
+    autoClose = true,
+    code = 0,
+    error = null,
+    stdout = "",
+}: {
+    readonly autoClose?: boolean;
+    readonly code?: number;
+    readonly error?: Error | null;
+    readonly stdout?: string;
+}) {
+    const child = new EventEmitter() as EventEmitter & {
+        kill: ReturnType<typeof vi.fn>;
+        stdout: EventEmitter & {
+            setEncoding: ReturnType<typeof vi.fn>;
+        };
+    };
+    child.kill = vi.fn();
+    child.stdout = new EventEmitter() as EventEmitter & {
+        setEncoding: ReturnType<typeof vi.fn>;
+    };
+    child.stdout.setEncoding = vi.fn();
+
+    if (autoClose) {
+        queueMicrotask(() => {
+            if (error) {
+                child.emit("error", error);
+                return;
+            }
+            if (stdout) {
+                child.stdout.emit("data", stdout);
+            }
+            child.emit("close", code);
+        });
+    }
+
+    return child;
+}

--- a/src/main/github/auth.ts
+++ b/src/main/github/auth.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from "node:child_process";
+
 import type { SecretStoreGateway } from "@main/ai/secret-store";
 
 export const DEFAULT_GITHUB_HOST = "github.com";
@@ -37,6 +39,23 @@ export class GitHubAuthStore {
             token,
         );
     }
+}
+
+export function loadGhCliToken(hostInput?: string | null): string | null {
+    const host = normalizeGitHubHost(hostInput);
+    const args = ["auth", "token"];
+    if (host !== DEFAULT_GITHUB_HOST) {
+        args.push("--hostname", host);
+    }
+    try {
+        const result = spawnSync("gh", args, { encoding: "utf-8", timeout: 5000 });
+        if (result.status === 0 && result.stdout) {
+            return result.stdout.trim() || null;
+        }
+    } catch {
+        // gh not installed or otherwise inaccessible
+    }
+    return null;
 }
 
 export function buildGitHubApiBaseUrl(hostInput?: string | null): string {

--- a/src/main/github/auth.ts
+++ b/src/main/github/auth.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 
 import type { SecretStoreGateway } from "@main/ai/secret-store";
 
@@ -6,6 +6,7 @@ export const DEFAULT_GITHUB_HOST = "github.com";
 export const GITHUB_SECRET_NAMESPACE = "github";
 
 const DEFAULT_GITHUB_TOKEN_SECRET_ID = "token";
+const GH_CLI_TOKEN_TIMEOUT_MS = 5000;
 
 export class GitHubAuthStore {
     readonly #secretStore: SecretStoreGateway;
@@ -41,21 +42,59 @@ export class GitHubAuthStore {
     }
 }
 
-export function loadGhCliToken(hostInput?: string | null): string | null {
+export async function loadGhCliToken(
+    hostInput?: string | null,
+): Promise<string | null> {
     const host = normalizeGitHubHost(hostInput);
     const args = ["auth", "token"];
     if (host !== DEFAULT_GITHUB_HOST) {
         args.push("--hostname", host);
     }
-    try {
-        const result = spawnSync("gh", args, { encoding: "utf-8", timeout: 5000 });
-        if (result.status === 0 && result.stdout) {
-            return result.stdout.trim() || null;
+
+    return await new Promise((resolve) => {
+        let stdout = "";
+        let settled = false;
+        let child: ReturnType<typeof spawn>;
+
+        const finish = (token: string | null) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            clearTimeout(timeout);
+            resolve(token);
+        };
+
+        const timeout = setTimeout(() => {
+            child?.kill();
+            finish(null);
+        }, GH_CLI_TOKEN_TIMEOUT_MS);
+
+        try {
+            child = spawn("gh", args, {
+                stdio: ["ignore", "pipe", "ignore"],
+            });
+        } catch {
+            finish(null);
+            return;
         }
-    } catch {
-        // gh not installed or otherwise inaccessible
-    }
-    return null;
+
+        if (!child.stdout) {
+            finish(null);
+            return;
+        }
+
+        child.stdout.setEncoding("utf8");
+        child.stdout.on("data", (chunk: string) => {
+            stdout += chunk;
+        });
+        child.on("error", () => {
+            finish(null);
+        });
+        child.on("close", (code) => {
+            finish(code === 0 ? stdout.trim() || null : null);
+        });
+    });
 }
 
 export function buildGitHubApiBaseUrl(hostInput?: string | null): string {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -437,6 +437,7 @@ export class GitHubApiClient {
                 host,
                 readOnly: !canWriteIssues && !canWritePullRequests,
                 state: "authenticated",
+                tokenSource: null,
                 user: mapUser(response.data),
             };
         } catch (error) {
@@ -452,6 +453,7 @@ export class GitHubApiClient {
                     readOnly: true,
                     state:
                         error.code === "invalid_auth" ? "invalid" : "unknown",
+                    tokenSource: null,
                     user: null,
                 };
             }

--- a/src/main/github/service.test.ts
+++ b/src/main/github/service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { GitHubFetch } from "@main/github/client";
 import { loadGhCliToken } from "@main/github/auth";
@@ -9,7 +9,7 @@ import type { GitHubRepositoryRef } from "@shared/ipc";
 vi.mock("@main/github/auth", async (importOriginal) => {
     const original =
         await importOriginal<typeof import("@main/github/auth")>();
-    return { ...original, loadGhCliToken: vi.fn().mockReturnValue(null) };
+    return { ...original, loadGhCliToken: vi.fn().mockResolvedValue(null) };
 });
 
 const repository: GitHubRepositoryRef = {
@@ -19,6 +19,10 @@ const repository: GitHubRepositoryRef = {
 };
 
 describe("GitHubService", () => {
+    afterEach(() => {
+        vi.mocked(loadGhCliToken).mockResolvedValue(null);
+    });
+
     it("lists issues with a saved token and filters pull requests", async () => {
         const fetchMock = vi.fn<GitHubFetch>().mockResolvedValue(
             jsonResponse(
@@ -176,7 +180,7 @@ describe("GitHubService", () => {
     });
 
     it("falls back to gh CLI when no PAT is stored", async () => {
-        vi.mocked(loadGhCliToken).mockReturnValue("gho_cli_token");
+        vi.mocked(loadGhCliToken).mockResolvedValue("gho_cli_token");
         const fetchMock = vi.fn<GitHubFetch>().mockResolvedValue(
             jsonResponse(rawUser(), { headers: { "x-oauth-scopes": "" } }),
         );
@@ -195,8 +199,6 @@ describe("GitHubService", () => {
             throw new Error("Expected GitHub fetch headers record.");
         }
         expect(init.headers.Authorization).toBe("Bearer gho_cli_token");
-
-        vi.mocked(loadGhCliToken).mockReturnValue(null);
     });
 
     it("reports tokenSource:null when neither PAT nor gh CLI is available", async () => {
@@ -206,6 +208,28 @@ describe("GitHubService", () => {
 
         expect(status.state).toBe("missing");
         expect(status.tokenSource).toBeNull();
+    });
+
+    it("falls back to gh CLI after clearing a stored PAT", async () => {
+        vi.mocked(loadGhCliToken).mockResolvedValue("gho_cli_token");
+        const fetchMock = vi.fn<GitHubFetch>().mockResolvedValue(
+            jsonResponse(rawUser(), { headers: { "x-oauth-scopes": "" } }),
+        );
+        const service = createService(fetchMock);
+
+        const status = await service.clearToken({ host: "github.com" });
+
+        expect(status.state).toBe("authenticated");
+        expect(status.tokenSource).toBe("gh_cli");
+        const [, init] = fetchMock.mock.calls[0] ?? [];
+        if (
+            !init?.headers ||
+            init.headers instanceof Headers ||
+            Array.isArray(init.headers)
+        ) {
+            throw new Error("Expected GitHub fetch headers record.");
+        }
+        expect(init.headers.Authorization).toBe("Bearer gho_cli_token");
     });
 
     it("maps forbidden responses distinctly from rate limits", async () => {

--- a/src/main/github/service.test.ts
+++ b/src/main/github/service.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { GitHubFetch } from "@main/github/client";
+import { loadGhCliToken } from "@main/github/auth";
 import { GitHubService } from "@main/github/service";
 import type { SecretStoreGateway } from "@main/ai/secret-store";
 import type { GitHubRepositoryRef } from "@shared/ipc";
+
+vi.mock("@main/github/auth", async (importOriginal) => {
+    const original =
+        await importOriginal<typeof import("@main/github/auth")>();
+    return { ...original, loadGhCliToken: vi.fn().mockReturnValue(null) };
+});
 
 const repository: GitHubRepositoryRef = {
     host: "github.com",
@@ -155,6 +162,50 @@ describe("GitHubService", () => {
             errorCode: "missing_auth",
             state: "missing",
         });
+    });
+
+    it("reports tokenSource:stored_token when a PAT is saved", async () => {
+        const fetchMock = vi.fn<GitHubFetch>().mockResolvedValue(
+            jsonResponse(rawUser(), { headers: { "x-oauth-scopes": "" } }),
+        );
+        const service = createService(fetchMock);
+
+        const status = await service.getAuthStatus({ host: "github.com" });
+
+        expect(status.tokenSource).toBe("stored_token");
+    });
+
+    it("falls back to gh CLI when no PAT is stored", async () => {
+        vi.mocked(loadGhCliToken).mockReturnValue("gho_cli_token");
+        const fetchMock = vi.fn<GitHubFetch>().mockResolvedValue(
+            jsonResponse(rawUser(), { headers: { "x-oauth-scopes": "" } }),
+        );
+        const service = createService(fetchMock, { token: null });
+
+        const status = await service.getAuthStatus({ host: "github.com" });
+
+        expect(status.state).toBe("authenticated");
+        expect(status.tokenSource).toBe("gh_cli");
+        const [, init] = fetchMock.mock.calls[0] ?? [];
+        if (
+            !init?.headers ||
+            init.headers instanceof Headers ||
+            Array.isArray(init.headers)
+        ) {
+            throw new Error("Expected GitHub fetch headers record.");
+        }
+        expect(init.headers.Authorization).toBe("Bearer gho_cli_token");
+
+        vi.mocked(loadGhCliToken).mockReturnValue(null);
+    });
+
+    it("reports tokenSource:null when neither PAT nor gh CLI is available", async () => {
+        const service = createService(vi.fn<GitHubFetch>(), { token: null });
+
+        const status = await service.getAuthStatus({ host: "github.com" });
+
+        expect(status.state).toBe("missing");
+        expect(status.tokenSource).toBeNull();
     });
 
     it("maps forbidden responses distinctly from rate limits", async () => {

--- a/src/main/github/service.ts
+++ b/src/main/github/service.ts
@@ -1,5 +1,9 @@
 import type { SecretStoreGateway } from "@main/ai/secret-store";
-import { GitHubAuthStore, loadGhCliToken, normalizeGitHubHost } from "@main/github/auth";
+import {
+    GitHubAuthStore,
+    loadGhCliToken,
+    normalizeGitHubHost,
+} from "@main/github/auth";
 import {
     GitHubApiClient,
     GitHubApiError,
@@ -154,7 +158,7 @@ export class GitHubService implements GitHubGateway {
         input: GitHubAuthStatusInput,
     ): Promise<GitHubAuthStatus> {
         const host = normalizeGitHubHost(input.host);
-        const resolved = this.#resolveToken(host);
+        const resolved = await this.#resolveToken(host);
         if (!resolved) {
             return createMissingAuthStatus(host);
         }
@@ -177,56 +181,62 @@ export class GitHubService implements GitHubGateway {
         const host = normalizeGitHubHost(input.host);
         await this.#authStore.clearToken(host);
 
-        return createMissingAuthStatus(host);
+        return await this.getAuthStatus({ host });
     }
 
     async listIssues(
         input: GitHubListIssuesInput,
     ): Promise<GitHubListIssuesResult> {
-        return await this.#createClient(input.repository.host).listIssues(input);
+        return await (
+            await this.#createClient(input.repository.host)
+        ).listIssues(input);
     }
 
     async listLabels(
         input: GitHubListLabelsInput,
     ): Promise<GitHubListLabelsResult> {
-        return await this.#createClient(input.repository.host).listLabels(input);
+        return await (
+            await this.#createClient(input.repository.host)
+        ).listLabels(input);
     }
 
     async getIssue(
         input: GitHubGetIssueInput,
     ): Promise<GitHubIssueDetail | null> {
-        return await this.#createClient(input.repository.host).getIssue(input);
+        return await (await this.#createClient(input.repository.host)).getIssue(
+            input,
+        );
     }
 
     async createIssue(
         input: GitHubCreateIssueInput,
     ): Promise<GitHubIssueDetail> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).createIssue(input),
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).createIssue(input),
         );
     }
 
     async updateIssue(
         input: GitHubUpdateIssueInput,
     ): Promise<GitHubIssueDetail> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).updateIssue(input),
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).updateIssue(input),
         );
     }
 
     async commentIssue(
         input: GitHubCommentIssueInput,
     ): Promise<GitHubCommentSummary> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).commentIssue(input),
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).commentIssue(input),
         );
     }
 
     async closeIssue(
         input: GitHubSetIssueStateInput,
     ): Promise<GitHubIssueDetail> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).setIssueState({
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).setIssueState({
                 ...input,
                 state: "closed",
             }),
@@ -236,8 +246,8 @@ export class GitHubService implements GitHubGateway {
     async reopenIssue(
         input: GitHubSetIssueStateInput,
     ): Promise<GitHubIssueDetail> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).setIssueState({
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).setIssueState({
                 ...input,
                 state: "open",
             }),
@@ -247,104 +257,112 @@ export class GitHubService implements GitHubGateway {
     async listPullRequests(
         input: GitHubListPullRequestsInput,
     ): Promise<GitHubListPullRequestsResult> {
-        return await this.#createClient(input.repository.host).listPullRequests(
-            input,
-        );
+        return await (
+            await this.#createClient(input.repository.host)
+        ).listPullRequests(input);
     }
 
     async getPullRequest(
         input: GitHubGetPullRequestInput,
     ): Promise<GitHubPullRequestDetail | null> {
-        return await this.#createClient(input.repository.host).getPullRequest(
-            input,
-        );
+        return await (
+            await this.#createClient(input.repository.host)
+        ).getPullRequest(input);
     }
 
     async listPullRequestChecks(
         input: GitHubPullRequestChecksInput,
     ): Promise<GitHubPullRequestChecksResult> {
-        return await this.#createClient(
-            input.repository.host,
+        return await (
+            await this.#createClient(input.repository.host)
         ).listPullRequestChecks(input);
     }
 
     async listWorkflowRuns(
         input: GitHubWorkflowRunsInput,
     ): Promise<GitHubWorkflowRunsResult> {
-        return await this.#createClient(input.repository.host).listWorkflowRuns(
-            input,
-        );
+        return await (
+            await this.#createClient(input.repository.host)
+        ).listWorkflowRuns(input);
     }
 
     async listWorkflowRunJobs(
         input: GitHubWorkflowRunJobsInput,
     ): Promise<GitHubWorkflowRunJobsResult> {
-        return await this.#createClient(
-            input.repository.host,
+        return await (
+            await this.#createClient(input.repository.host)
         ).listWorkflowRunJobs(input);
     }
 
     async getWorkflowJobLogs(
         input: GitHubWorkflowJobLogsInput,
     ): Promise<GitHubWorkflowJobLogsResult> {
-        return await this.#createClient(input.repository.host).getWorkflowJobLogs(
-            input,
-        );
+        return await (
+            await this.#createClient(input.repository.host)
+        ).getWorkflowJobLogs(input);
     }
 
     async listWorkflowRunArtifacts(
         input: GitHubWorkflowRunArtifactsInput,
     ): Promise<GitHubWorkflowRunArtifactsResult> {
-        return await this.#createClient(
-            input.repository.host,
+        return await (
+            await this.#createClient(input.repository.host)
         ).listWorkflowRunArtifacts(input);
     }
 
     async listCheckRunAnnotations(
         input: GitHubCheckRunAnnotationsInput,
     ): Promise<GitHubCheckRunAnnotationsResult> {
-        return await this.#createClient(
-            input.repository.host,
+        return await (
+            await this.#createClient(input.repository.host)
         ).listCheckRunAnnotations(input);
     }
 
     async createPullRequest(
         input: GitHubCreatePullRequestInput,
     ): Promise<GitHubPullRequestDetail> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).createPullRequest(input),
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).createPullRequest(
+                input,
+            ),
         );
     }
 
     async updatePullRequest(
         input: GitHubUpdatePullRequestInput,
     ): Promise<GitHubPullRequestDetail> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).updatePullRequest(input),
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).updatePullRequest(
+                input,
+            ),
         );
     }
 
     async commentPullRequest(
         input: GitHubCommentPullRequestInput,
     ): Promise<GitHubCommentSummary> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).commentPullRequest(input),
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).commentPullRequest(
+                input,
+            ),
         );
     }
 
     async updateComment(
         input: GitHubUpdateCommentInput,
     ): Promise<GitHubCommentSummary> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).updateComment(input),
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).updateComment(input),
         );
     }
 
     async markPullRequestReady(
         input: GitHubSetPullRequestDraftStateInput,
     ): Promise<GitHubPullRequestDetail> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).setPullRequestDraftState({
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (
+                await this.#createClient(input.repository.host)
+            ).setPullRequestDraftState({
                 ...input,
                 draft: false,
             }),
@@ -354,8 +372,10 @@ export class GitHubService implements GitHubGateway {
     async convertPullRequestToDraft(
         input: GitHubSetPullRequestDraftStateInput,
     ): Promise<GitHubPullRequestDetail> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).setPullRequestDraftState({
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (
+                await this.#createClient(input.repository.host)
+            ).setPullRequestDraftState({
                 ...input,
                 draft: true,
             }),
@@ -365,10 +385,10 @@ export class GitHubService implements GitHubGateway {
     async requestPullRequestReviewers(
         input: GitHubRequestPullRequestReviewInput,
     ): Promise<GitHubPullRequestDetail> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).requestPullRequestReviewers(
-                input,
-            ),
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (
+                await this.#createClient(input.repository.host)
+            ).requestPullRequestReviewers(input),
         );
     }
 
@@ -395,66 +415,70 @@ export class GitHubService implements GitHubGateway {
     async listNotifications(
         input: GitHubNotificationsInput,
     ): Promise<GitHubNotificationsResult> {
-        return await this.#createClient(input.host).listNotifications(input);
+        return await (await this.#createClient(input.host)).listNotifications(
+            input,
+        );
     }
 
     async listReleases(
         input: GitHubListReleasesInput,
     ): Promise<GitHubListReleasesResult> {
-        return await this.#createClient(input.repository.host).listReleases(
-            input,
-        );
+        return await (
+            await this.#createClient(input.repository.host)
+        ).listReleases(input);
     }
 
     async generateReleaseNotes(
         input: GitHubGenerateReleaseNotesInput,
     ): Promise<GitHubGeneratedReleaseNotes> {
-        return await this.#createClient(
-            input.repository.host,
+        return await (
+            await this.#createClient(input.repository.host)
         ).generateReleaseNotes(input);
     }
 
     async createRelease(
         input: GitHubCreateReleaseInput,
     ): Promise<GitHubReleaseSummary> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).createRelease(input),
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).createRelease(input),
         );
     }
 
     async publishRelease(
         input: GitHubPublishReleaseInput,
     ): Promise<GitHubReleaseSummary> {
-        return await this.#dedupeMutation(input.clientRequestId, () =>
-            this.#createClient(input.repository.host).publishRelease(input),
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).publishRelease(input),
         );
     }
 
     async listMilestones(
         input: GitHubListMilestonesInput,
     ): Promise<GitHubListMilestonesResult> {
-        return await this.#createClient(input.repository.host).listMilestones(
-            input,
-        );
+        return await (
+            await this.#createClient(input.repository.host)
+        ).listMilestones(input);
     }
 
-    #resolveToken(
+    async #resolveToken(
         host: string,
-    ): { token: string; source: GitHubTokenSource } | null {
+    ): Promise<{ token: string; source: GitHubTokenSource } | null> {
         const storedToken = this.#authStore.loadToken(host);
         if (storedToken) {
             return { token: storedToken, source: "stored_token" };
         }
-        const ghCliToken = loadGhCliToken(host);
+        const ghCliToken = await loadGhCliToken(host);
         if (ghCliToken) {
             return { token: ghCliToken, source: "gh_cli" };
         }
         return null;
     }
 
-    #createClient(hostInput: string | null | undefined): GitHubApiClient {
+    async #createClient(
+        hostInput: string | null | undefined,
+    ): Promise<GitHubApiClient> {
         const host = normalizeGitHubHost(hostInput);
-        const resolved = this.#resolveToken(host);
+        const resolved = await this.#resolveToken(host);
         if (!resolved) {
             throw new GitHubApiError(
                 "GitHub token is missing.",
@@ -474,7 +498,7 @@ export class GitHubService implements GitHubGateway {
         run: (client: GitHubApiClient) => Promise<T>,
     ): Promise<T> {
         const host = normalizeGitHubHost(hostInput);
-        const resolved = this.#resolveToken(host);
+        const resolved = await this.#resolveToken(host);
         if (!resolved) {
             throw new GitHubApiError(
                 "GitHub token is missing.",

--- a/src/main/github/service.ts
+++ b/src/main/github/service.ts
@@ -1,5 +1,5 @@
 import type { SecretStoreGateway } from "@main/ai/secret-store";
-import { GitHubAuthStore, normalizeGitHubHost } from "@main/github/auth";
+import { GitHubAuthStore, loadGhCliToken, normalizeGitHubHost } from "@main/github/auth";
 import {
     GitHubApiClient,
     GitHubApiError,
@@ -53,6 +53,7 @@ import type {
     GitHubWorkflowRunJobsInput,
     GitHubWorkflowRunJobsResult,
     GitHubWorkflowRunMutationInput,
+    GitHubTokenSource,
     GitHubWorkflowRunsInput,
     GitHubWorkflowRunsResult,
 } from "@shared/ipc";
@@ -153,15 +154,16 @@ export class GitHubService implements GitHubGateway {
         input: GitHubAuthStatusInput,
     ): Promise<GitHubAuthStatus> {
         const host = normalizeGitHubHost(input.host);
-        const token = this.#authStore.loadToken(host);
-        if (!token) {
+        const resolved = this.#resolveToken(host);
+        if (!resolved) {
             return createMissingAuthStatus(host);
         }
 
-        return await new GitHubApiClient({
+        const status = await new GitHubApiClient({
             fetch: this.#fetch,
-            token,
+            token: resolved.token,
         }).getAuthStatus(host);
+        return { ...status, tokenSource: resolved.source };
     }
 
     async saveToken(input: GitHubSaveTokenInput): Promise<GitHubAuthStatus> {
@@ -436,10 +438,24 @@ export class GitHubService implements GitHubGateway {
         );
     }
 
+    #resolveToken(
+        host: string,
+    ): { token: string; source: GitHubTokenSource } | null {
+        const storedToken = this.#authStore.loadToken(host);
+        if (storedToken) {
+            return { token: storedToken, source: "stored_token" };
+        }
+        const ghCliToken = loadGhCliToken(host);
+        if (ghCliToken) {
+            return { token: ghCliToken, source: "gh_cli" };
+        }
+        return null;
+    }
+
     #createClient(hostInput: string | null | undefined): GitHubApiClient {
         const host = normalizeGitHubHost(hostInput);
-        const token = this.#authStore.loadToken(host);
-        if (!token) {
+        const resolved = this.#resolveToken(host);
+        if (!resolved) {
             throw new GitHubApiError(
                 "GitHub token is missing.",
                 "missing_auth",
@@ -449,7 +465,7 @@ export class GitHubService implements GitHubGateway {
 
         return new GitHubApiClient({
             fetch: this.#fetch,
-            token,
+            token: resolved.token,
         });
     }
 
@@ -458,8 +474,8 @@ export class GitHubService implements GitHubGateway {
         run: (client: GitHubApiClient) => Promise<T>,
     ): Promise<T> {
         const host = normalizeGitHubHost(hostInput);
-        const token = this.#authStore.loadToken(host);
-        if (!token) {
+        const resolved = this.#resolveToken(host);
+        if (!resolved) {
             throw new GitHubApiError(
                 "GitHub token is missing.",
                 "missing_auth",
@@ -468,7 +484,7 @@ export class GitHubService implements GitHubGateway {
         }
         const client = new GitHubApiClient({
             fetch: this.#fetch,
-            token,
+            token: resolved.token,
         });
         const status = await client.getAuthStatus(host);
         if (status.state !== "authenticated" || !status.canWriteActions) {
@@ -516,6 +532,7 @@ function createMissingAuthStatus(host: string): GitHubAuthStatus {
         host,
         readOnly: true,
         state: "missing",
+        tokenSource: null,
         user: null,
     };
 }

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -662,6 +662,11 @@ export function SettingsApp() {
             return;
         }
 
+        if (githubAuthStatus.tokenSource === "gh_cli") {
+            setGitHubNotice("Use gh auth logout to revoke gh CLI access.");
+            return;
+        }
+
         if (
             !window.confirm(
                 "Disconnect GitHub?\n\nThis removes the saved token from this machine.",
@@ -679,7 +684,11 @@ export function SettingsApp() {
             });
             setGitHubAuthStatus(nextStatus);
             setGitHubTokenDraft("");
-            setGitHubNotice("GitHub token removed from this machine.");
+            setGitHubNotice(
+                nextStatus.tokenSource === "gh_cli"
+                    ? "Stored GitHub token removed. Using gh CLI fallback."
+                    : "GitHub token removed from this machine.",
+            );
         } catch (error) {
             setGitHubError(
                 error instanceof Error
@@ -689,7 +698,7 @@ export function SettingsApp() {
         } finally {
             setGitHubLoading(false);
         }
-    }, []);
+    }, [githubAuthStatus.tokenSource]);
 
     return (
         <SettingsWindow

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -969,6 +969,7 @@ function createDefaultGitHubAuthStatus(): GitHubAuthStatus {
         host: "github.com",
         readOnly: true,
         state: "missing",
+        tokenSource: null,
         user: null,
     };
 }

--- a/src/renderer/src/app/store/github-store.test.ts
+++ b/src/renderer/src/app/store/github-store.test.ts
@@ -693,6 +693,7 @@ describe("github-store", () => {
             host: "github.com",
             readOnly: false,
             state: "authenticated" as const,
+            tokenSource: null,
             user: null,
         };
         useGitHubStore.setState({

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -62,7 +62,6 @@ import type {
     SettingsUpdatesState,
     SettingsWindowProps,
     ShortcutEntryOption,
-    ThemeMode,
 } from "./settings-types";
 
 type Category =
@@ -176,9 +175,19 @@ const STATIC_CATEGORY_SEARCH_VALUES: Record<Category, readonly SearchValue[]> = 
     github: [
         "GitHub",
         "Connect GitHub",
+        "Token source",
+        "gh CLI",
+        "gh auth login",
+        "stored_token",
+        "PAT",
+        "stored PAT",
+        "Token read from the gh CLI",
+        "A stored PAT takes priority if both are present.",
+        "No token found. Add a PAT below or run gh auth login.",
         "Personal access token",
         "Save Token",
         "Disconnect",
+        "gh auth logout",
         "Token saved securely on this machine.",
         "Missing token",
         "Invalid token",
@@ -360,6 +369,7 @@ function getDynamicCategorySearchValues(
                 context.github.status.errorCode,
                 context.github.status.host,
                 context.github.status.state,
+                context.github.status.tokenSource,
                 context.github.status.user?.login,
                 context.github.status.readOnly ? "Read-only access" : null,
                 context.github.status.canReadActions
@@ -1182,6 +1192,10 @@ function GitHubContent({
     state: SettingsGitHubState;
 }) {
     const canSave = state.tokenDraft.trim().length > 0 && !state.saving;
+    const canDisconnect =
+        state.status.tokenSource === "stored_token" &&
+        state.status.state !== "missing" &&
+        state.status.state !== "unknown";
     const isConnected = state.status.state === "authenticated";
     const showConnection = sectionHasMatches(searchQuery, "Connection", [
         [
@@ -1192,8 +1206,14 @@ function GitHubContent({
             "Token saved securely on this machine.",
             "Missing token",
             "Invalid token",
+            "Token source",
             "gh CLI",
             "gh auth login",
+            "stored_token",
+            "PAT",
+            "stored PAT",
+            "Token read from the gh CLI",
+            "No token found. Add a PAT below or run gh auth login.",
             state.status.state,
             state.status.tokenSource,
             state.status.user?.login,
@@ -1379,11 +1399,14 @@ function GitHubContent({
                 control={
                     <IdeActionButton
                         disabled={
-                            state.loading ||
-                            state.status.state === "missing" ||
-                            state.status.state === "unknown"
+                            state.loading || !canDisconnect
                         }
                         onClick={() => state.onDisconnect?.()}
+                        title={
+                            state.status.tokenSource === "gh_cli"
+                                ? "Use gh auth logout to revoke gh CLI access"
+                                : "Remove stored GitHub token"
+                        }
                     >
                         disconnect
                     </IdeActionButton>
@@ -1518,7 +1541,7 @@ function formatGitHubStatusDescription(state: SettingsGitHubState): string {
                 : `Connected to ${state.status.host}${source}.`;
         }
         case "invalid":
-            return "The saved token is invalid or expired. Paste a new token to reconnect.";
+            return "The GitHub token is invalid or expired. Paste a new token to reconnect.";
         case "missing":
             return "No token found. Paste a PAT below or log in with the gh CLI.";
         case "unknown":
@@ -1649,9 +1672,9 @@ function AppearanceContent({
                     <SegmentedControl
                         value={state.mode}
                         options={[
-                            { value: "system" as ThemeMode, label: "System" },
-                            { value: "light" as ThemeMode, label: "Light" },
-                            { value: "dark" as ThemeMode, label: "Dark" },
+                            { value: "system", label: "System" },
+                            { value: "light", label: "Light" },
+                            { value: "dark", label: "Dark" },
                         ]}
                         onChange={(v) => state.onModeChange?.(v)}
                     />

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -1192,7 +1192,10 @@ function GitHubContent({
             "Token saved securely on this machine.",
             "Missing token",
             "Invalid token",
+            "gh CLI",
+            "gh auth login",
             state.status.state,
+            state.status.tokenSource,
             state.status.user?.login,
             state.error,
             state.notice,
@@ -1250,8 +1253,41 @@ function GitHubContent({
             <SearchableRow
                 searchQuery={searchQuery}
                 section="Connection"
+                label="Token source"
+                description={
+                    state.status.tokenSource === "gh_cli"
+                        ? "Token read from the gh CLI (gh auth login). A stored PAT takes priority if both are present."
+                        : state.status.tokenSource === "stored_token"
+                          ? "Using a personal access token stored securely on this machine."
+                          : "No token found. Add a PAT below or run gh auth login."
+                }
+                keywords={["gh CLI", "gh auth login", "stored_token", "PAT"]}
+                control={
+                    <span
+                        style={{
+                            color:
+                                state.status.tokenSource === "gh_cli"
+                                    ? "var(--color-success)"
+                                    : state.status.tokenSource === "stored_token"
+                                      ? "var(--color-success)"
+                                      : "var(--color-muted)",
+                            fontFamily: "var(--font-mono)",
+                            fontSize: "0.85em",
+                        }}
+                    >
+                        {state.status.tokenSource === "gh_cli"
+                            ? "gh CLI"
+                            : state.status.tokenSource === "stored_token"
+                              ? "PAT"
+                              : "none"}
+                    </span>
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Connection"
                 label="Personal access token"
-                description="Paste a fine-grained PAT. Comando stores it securely on this machine and never exposes the saved token to the renderer."
+                description="Paste a fine-grained PAT. Stored tokens take priority over gh CLI. Comando stores it securely on this machine and never exposes the saved token to the renderer."
                 keywords={[
                     "Connect GitHub",
                     "Save Token",
@@ -1334,7 +1370,11 @@ function GitHubContent({
                 searchQuery={searchQuery}
                 section="Connection"
                 label="Disconnect"
-                description="Remove the saved GitHub token from this machine. Existing workspace tabs stay open, but GitHub refreshes will require a new token."
+                description={
+                    state.status.tokenSource === "gh_cli"
+                        ? "No stored PAT to remove. To revoke gh CLI access run: gh auth logout."
+                        : "Remove the stored PAT from this machine. If gh CLI is logged in, it will be used as a fallback automatically."
+                }
                 keywords={["clear token", "remove token", "logout"]}
                 control={
                     <IdeActionButton
@@ -1469,15 +1509,18 @@ function StatusText({
 
 function formatGitHubStatusDescription(state: SettingsGitHubState): string {
     const login = state.status.user?.login;
+    const viaGhCli = state.status.tokenSource === "gh_cli";
     switch (state.status.state) {
-        case "authenticated":
+        case "authenticated": {
+            const source = viaGhCli ? " via gh CLI" : "";
             return login
-                ? `Connected to ${state.status.host} as ${login}.`
-                : `Connected to ${state.status.host}.`;
+                ? `Connected to ${state.status.host} as ${login}${source}.`
+                : `Connected to ${state.status.host}${source}.`;
+        }
         case "invalid":
             return "The saved token is invalid or expired. Paste a new token to reconnect.";
         case "missing":
-            return "Missing token. Connect GitHub to enable Issues and Pull Requests.";
+            return "No token found. Paste a PAT below or log in with the gh CLI.";
         case "unknown":
         default:
             return "GitHub auth status could not be verified yet.";

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -990,6 +990,8 @@ export type GitHubAuthState =
     | "missing"
     | "unknown";
 
+export type GitHubTokenSource = "gh_cli" | "stored_token";
+
 export type GitHubErrorCode =
     | "forbidden"
     | "invalid_auth"
@@ -1025,6 +1027,7 @@ export interface GitHubAuthStatus {
     readonly host: string;
     readonly readOnly: boolean;
     readonly state: GitHubAuthState;
+    readonly tokenSource: GitHubTokenSource | null;
     readonly user: GitHubUserSummary | null;
 }
 


### PR DESCRIPTION
## Summary

- When no personal access token is stored, the app now falls back to the `gh` CLI automatically — no manual setup required if you're already logged in via `gh auth login`.
- Stored PATs keep priority: if both a PAT and a `gh` CLI session exist, the PAT wins.
- A new **Token source** row in the GitHub settings panel shows whether auth came from a PAT, the gh CLI, or neither.

## How it works

`loadGhCliToken(host)` runs `gh auth token` (or `gh auth token --hostname <host>` for GHE) via `spawnSync`. It returns `null` gracefully if `gh` is not installed, not on `PATH`, or not logged in — no error surfaced.

The private `#resolveToken(host)` method in `GitHubService` checks the secret store first, then the gh CLI. All API paths (`getAuthStatus`, `#createClient`, `#withActionsWritePermission`) use it consistently.

`GitHubAuthStatus` gains a `tokenSource: "stored_token" | "gh_cli" | null` field so the renderer can show exactly how the connection was made.

## Settings UI changes

| Token source | Status description | Source badge | Disconnect description |
|---|---|---|---|
| `stored_token` | Connected as @login. | **PAT** | Remove stored PAT; gh CLI becomes fallback if available. |
| `gh_cli` | Connected as @login via gh CLI. | **gh CLI** | No stored PAT to remove; use `gh auth logout` to revoke. |
| `null` | No token found. Paste a PAT or run `gh auth login`. | **none** | — |

## Test plan

- [ ] `pnpm run typecheck` passes
- [ ] `vitest run src/main/github/` — all 20 tests pass (17 existing + 3 new)
- [ ] With no PAT saved and `gh` logged in: settings shows "gh CLI" source badge and "Connected as @login via gh CLI."
- [ ] Saving a PAT while gh CLI is active: source switches to "PAT"
- [ ] After clearing the PAT: falls back to gh CLI automatically
- [ ] With `gh` not installed: no error, state is "missing" as before