### PR TITLE
Fix gh CLI token lookup in packaged app

### DIFF
--- a/src/main/github/auth.test.ts
+++ b/src/main/github/auth.test.ts
@@ -1,8 +1,27 @@
 import { EventEmitter } from "node:events";
+import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const spawnMock = vi.hoisted(() => vi.fn());
+type GhProcess = EventEmitter & {
+    kill: ReturnType<typeof vi.fn>;
+    stdout: EventEmitter & {
+        setEncoding: ReturnType<typeof vi.fn>;
+    };
+};
+
+interface GhSpawnOptions {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly stdio: readonly ["ignore", "pipe", "ignore"];
+}
+
+type GhSpawnMock = (
+    command: string,
+    args: readonly string[],
+    options: GhSpawnOptions,
+) => GhProcess;
+
+const spawnMock = vi.hoisted(() => vi.fn<GhSpawnMock>());
 
 vi.mock("node:child_process", () => ({
     spawn: spawnMock,
@@ -11,11 +30,15 @@ vi.mock("node:child_process", () => ({
 import { loadGhCliToken } from "@main/github/auth";
 
 describe("GitHub auth", () => {
+    const originalPath = process.env.PATH;
+
     beforeEach(() => {
         spawnMock.mockReset();
+        process.env.PATH = originalPath;
     });
 
     afterEach(() => {
+        process.env.PATH = originalPath;
         vi.useRealTimers();
     });
 
@@ -27,9 +50,11 @@ describe("GitHub auth", () => {
         await expect(loadGhCliToken("github.com")).resolves.toBe(
             "gho_cli_token",
         );
-        expect(spawnMock).toHaveBeenCalledWith("gh", ["auth", "token"], {
-            stdio: ["ignore", "pipe", "ignore"],
-        });
+        const [command, args, options] = readSpawnCall();
+        expect(command).toBe("gh");
+        expect(args).toEqual(["auth", "token"]);
+        expect(options.env?.PATH).toEqual(expect.any(String));
+        expect(options.stdio).toEqual(["ignore", "pipe", "ignore"]);
     });
 
     it("passes a hostname for GitHub Enterprise hosts", async () => {
@@ -40,12 +65,35 @@ describe("GitHub auth", () => {
         await expect(
             loadGhCliToken("https://ghe.example.com/acme/repo"),
         ).resolves.toBe("ghe_token");
-        expect(spawnMock).toHaveBeenCalledWith(
-            "gh",
+        const [command, args, options] = readSpawnCall();
+        expect(command).toBe("gh");
+        expect(args).toEqual(
             ["auth", "token", "--hostname", "ghe.example.com"],
-            {
-                stdio: ["ignore", "pipe", "ignore"],
-            },
+        );
+        expect(options.stdio).toEqual(["ignore", "pipe", "ignore"]);
+    });
+
+    it("adds common Homebrew paths before launching gh", async () => {
+        process.env.PATH = ["/usr/bin", "/bin", "/opt/homebrew/bin"].join(
+            path.delimiter,
+        );
+        spawnMock.mockImplementationOnce(() =>
+            createGhProcess({ stdout: "gho_cli_token\n" }),
+        );
+
+        await expect(loadGhCliToken("github.com")).resolves.toBe(
+            "gho_cli_token",
+        );
+
+        const [, , options] = readSpawnCall();
+        expect(options.env?.PATH).toBe(
+            [
+                "/opt/homebrew/bin",
+                "/usr/local/bin",
+                "/opt/local/bin",
+                "/usr/bin",
+                "/bin",
+            ].join(path.delimiter),
         );
     });
 
@@ -73,6 +121,19 @@ describe("GitHub auth", () => {
     });
 });
 
+function readSpawnCall(): readonly [
+    command: string,
+    args: readonly string[],
+    options: GhSpawnOptions,
+] {
+    const call = spawnMock.mock.calls[0];
+    if (!call) {
+        throw new Error("Expected gh spawn to be called.");
+    }
+
+    return call;
+}
+
 function createGhProcess({
     autoClose = true,
     code = 0,
@@ -83,13 +144,8 @@ function createGhProcess({
     readonly code?: number;
     readonly error?: Error | null;
     readonly stdout?: string;
-}) {
-    const child = new EventEmitter() as EventEmitter & {
-        kill: ReturnType<typeof vi.fn>;
-        stdout: EventEmitter & {
-            setEncoding: ReturnType<typeof vi.fn>;
-        };
-    };
+}): GhProcess {
+    const child = new EventEmitter() as GhProcess;
     child.kill = vi.fn();
     child.stdout = new EventEmitter() as EventEmitter & {
         setEncoding: ReturnType<typeof vi.fn>;

--- a/src/main/github/auth.ts
+++ b/src/main/github/auth.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import path from "node:path";
 
 import type { SecretStoreGateway } from "@main/ai/secret-store";
 
@@ -7,6 +8,11 @@ export const GITHUB_SECRET_NAMESPACE = "github";
 
 const DEFAULT_GITHUB_TOKEN_SECRET_ID = "token";
 const GH_CLI_TOKEN_TIMEOUT_MS = 5000;
+const GH_CLI_EXTRA_PATH_ENTRIES = [
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    "/opt/local/bin",
+] as const;
 
 export class GitHubAuthStore {
     readonly #secretStore: SecretStoreGateway;
@@ -72,6 +78,7 @@ export async function loadGhCliToken(
 
         try {
             child = spawn("gh", args, {
+                env: buildGhCliSpawnEnv(process.env),
                 stdio: ["ignore", "pipe", "ignore"],
             });
         } catch {
@@ -95,6 +102,19 @@ export async function loadGhCliToken(
             finish(code === 0 ? stdout.trim() || null : null);
         });
     });
+}
+
+function buildGhCliSpawnEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+    const pathEntries = [
+        ...GH_CLI_EXTRA_PATH_ENTRIES,
+        ...(env.PATH?.split(path.delimiter).filter(Boolean) ?? []),
+    ];
+    const dedupedPathEntries = [...new Set(pathEntries)];
+
+    return {
+        ...env,
+        PATH: dedupedPathEntries.join(path.delimiter),
+    };
 }
 
 export function buildGitHubApiBaseUrl(hostInput?: string | null): string {


### PR DESCRIPTION
## Summary
- Add common package-manager bin directories to the PATH used for gh CLI token lookup
- Preserve existing gh auth fallback behavior while making packaged macOS launches find Homebrew gh
- Cover the enriched PATH behavior in GitHub auth tests

## Verification
- npm test -- --run src/main/github/auth.test.ts src/main/github/service.test.ts
- pnpm exec eslint src/main/github/auth.ts src/main/github/auth.test.ts
- pnpm run typecheck
- pnpm run build

Note: full pnpm run lint still fails on existing unrelated lint debt outside this change.