### PR TITLE
Fix subagent message visibility

### DIFF
--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -17,7 +17,11 @@ import type {
 } from "@shared/ipc";
 import { computeDiffHunks } from "@shared/ai-tracked-file";
 
-import type { AiWorkerEventMessage, AiWorkerSessionLaunchInput } from "./contracts";
+import {
+    CODEX_ACP_USER_INPUT_RESPONSE_PREFIX,
+    type AiWorkerEventMessage,
+    type AiWorkerSessionLaunchInput,
+} from "./contracts";
 
 const initializeMock = vi.fn(() => Promise.resolve(undefined));
 type MockSessionCatalogResponse = {
@@ -737,6 +741,85 @@ describe("AiWorkerRuntime prepareSession", () => {
         ).resolves.toEqual({
             sessionId: "session-1",
             stopReason: "completed",
+        });
+    });
+
+    it("retries buffered subagent creation after the parent runtime session mapping is registered", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const emittedEvents: AiWorkerEventMessage[] = [];
+        const runtime = new AiWorkerRuntime({
+            emitEvent: (event) => {
+                emittedEvents.push(event);
+            },
+        });
+        const launch = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Buffered subagent parent",
+        });
+        const subagentMeta = {
+            codexAcpAgentNickname: "Galileo",
+            codexAcpChildSessionId: "runtime-subagent-early",
+            codexAcpCwd: tempDir,
+            codexAcpEventType: "subagent_session_created",
+            codexAcpParentSessionId: "runtime-session-1",
+        };
+        loadSessionMock.mockImplementationOnce(async () => {
+            const client = latestClientFactory?.();
+            await client?.sessionUpdate({
+                _meta: subagentMeta,
+                sessionId: "runtime-subagent-early",
+                update: {
+                    _meta: subagentMeta,
+                    sessionUpdate: "session_info_update",
+                    title: "Galileo",
+                },
+            });
+            await client?.sessionUpdate({
+                sessionId: "runtime-subagent-early",
+                update: {
+                    content: {
+                        text: "early child output",
+                        type: "text",
+                    },
+                    messageId: "early-child-message-1",
+                    sessionUpdate: "agent_message_chunk",
+                },
+            });
+            return {
+                configOptions: [],
+                modes: [],
+                models: [],
+            };
+        });
+
+        await runtime.dispatchMethod("ai.prepareSession", {
+            input: launch.input,
+            launch,
+        });
+
+        await vi.waitFor(() => {
+            const childSnapshot = getLatestSnapshot(
+                emittedEvents,
+                (snapshot) =>
+                    snapshot.parentSessionId === "session-1" &&
+                    snapshot.runtimeSessionId === "runtime-subagent-early",
+            );
+            expect(childSnapshot).toEqual(
+                expect.objectContaining({
+                    messages: [
+                        expect.objectContaining({
+                            content: "early child output",
+                            kind: "assistant",
+                        }),
+                    ],
+                    parentSessionId: "session-1",
+                    runtimeSessionId: "runtime-subagent-early",
+                    title: "Galileo",
+                }),
+            );
         });
     });
 
@@ -1630,6 +1713,60 @@ describe("AiWorkerRuntime prepareSession", () => {
                         message.content === "Inspect the failing chat stream",
                 ),
             ).toHaveLength(1);
+        });
+    });
+
+    it("mirrors repeated subagent prompts with distinct tool call ids", async () => {
+        const { client, emittedEvents, tempDir } =
+            await setupPreparedRuntimeWithClient("Subagent repeated prompt parent");
+        const childSnapshot = await registerSubagentSession(
+            client,
+            emittedEvents,
+            tempDir,
+            {
+                nickname: "Galileo",
+                runtimeSessionId: "runtime-subagent-1",
+            },
+        );
+        emittedEvents.length = 0;
+
+        for (const toolCallId of [
+            "codex-acp:subagent:interaction-repeat-1",
+            "codex-acp:subagent:interaction-repeat-2",
+        ]) {
+            const interactionBeginMeta = {
+                codexAcpChildSessionId: "runtime-subagent-1",
+                codexAcpEventType: "subagent_breadcrumb",
+                codexAcpParentSessionId: "runtime-session-1",
+                codexAcpSubagentEventType: "interaction_begin",
+            };
+            await client.sessionUpdate({
+                _meta: interactionBeginMeta,
+                sessionId: "runtime-session-1",
+                update: {
+                    _meta: interactionBeginMeta,
+                    kind: "other",
+                    rawInput: {
+                        prompt: "Repeat this prompt",
+                    },
+                    sessionUpdate: "tool_call",
+                    status: "in_progress",
+                    title: "Contacting subagent",
+                    toolCallId,
+                },
+            });
+        }
+
+        await vi.waitFor(() => {
+            const userMessages =
+                getLatestPatchMessages(
+                    emittedEvents,
+                    childSnapshot.sessionId,
+                )?.filter((message) => message.kind === "user") ?? [];
+            expect(userMessages.map((message) => message.content)).toEqual([
+                "Repeat this prompt",
+                "Repeat this prompt",
+            ]);
         });
     });
 
@@ -3244,6 +3381,152 @@ describe("AiWorkerRuntime prepareSession", () => {
                     ],
                     content: "hello",
                 }),
+            ]);
+        });
+    });
+
+    it("suppresses internal guided-input payload echoes while keeping the human summary", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const emittedEvents: AiWorkerEventMessage[] = [];
+        const runtime = new AiWorkerRuntime({
+            emitEvent: (event) => {
+                emittedEvents.push(event);
+            },
+        });
+        const baseLaunch = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Guided input echo",
+        });
+        const launch: AiWorkerSessionLaunchInput = {
+            ...baseLaunch,
+            persistedSnapshot: {
+                ...baseLaunch.persistedSnapshot,
+                pendingUserInput: {
+                    questions: [
+                        {
+                            header: "Choice",
+                            id: "choice",
+                            isOther: false,
+                            isSecret: false,
+                            options: [],
+                            question: "Pick one",
+                        },
+                    ],
+                    requestId: "guided-input-1",
+                    sessionId: "session-1",
+                    title: "Guided input",
+                    toolCallId: "guided-tool-1",
+                    turnId: "turn-1",
+                    updatedAt: "2026-04-15T22:23:13.719838Z",
+                },
+                status: "waiting_user_input",
+            },
+        };
+
+        await runtime.dispatchMethod("ai.prepareSession", {
+            input: launch.input,
+            launch,
+        });
+        emittedEvents.length = 0;
+
+        const client = latestClientFactory?.();
+        expect(client).toBeDefined();
+        promptMock.mockImplementationOnce(async (...args: readonly unknown[]) => {
+            const params = args[0] as {
+                readonly messageId: string;
+                readonly prompt: readonly { readonly text: string; readonly type: string }[];
+            };
+            await client!.sessionUpdate({
+                sessionId: "runtime-session-1",
+                update: {
+                    content: {
+                        text: params.prompt[0]?.text ?? "",
+                        type: "text",
+                    },
+                    messageId: params.messageId,
+                    sessionUpdate: "user_message_chunk",
+                },
+            });
+            return {
+                stopReason: "completed",
+            };
+        });
+
+        await runtime.dispatchMethod("ai.respondUserInput", {
+            input: {
+                answers: [
+                    {
+                        answers: ["yes"],
+                        questionId: "choice",
+                    },
+                ],
+                requestId: "guided-input-1",
+                sessionId: "session-1",
+            },
+        });
+
+        await vi.waitFor(() => {
+            const userMessages =
+                getLatestPatchMessages(emittedEvents, "session-1")?.filter(
+                    (message) => message.kind === "user",
+                ) ?? [];
+            expect(userMessages.map((message) => message.content)).toEqual([
+                "Choice: yes",
+            ]);
+            expect(
+                userMessages.some((message) =>
+                    message.content.includes(CODEX_ACP_USER_INPUT_RESPONSE_PREFIX),
+                ),
+            ).toBe(false);
+        });
+    });
+
+    it("does not suppress unexpected text that reuses the prompt message id", async () => {
+        const { client, emittedEvents, launch, runtime } =
+            await setupPreparedRuntimeWithClient("Prompt text same id");
+        emittedEvents.length = 0;
+        promptMock.mockImplementationOnce(async (...args: readonly unknown[]) => {
+            const params = args[0] as { readonly messageId: string };
+            await client.sessionUpdate({
+                sessionId: "runtime-session-1",
+                update: {
+                    content: {
+                        text: "unexpected user echo",
+                        type: "text",
+                    },
+                    messageId: params.messageId,
+                    sessionUpdate: "user_message_chunk",
+                },
+            });
+            return {
+                stopReason: "completed",
+            };
+        });
+
+        await runtime.dispatchMethod("ai.sendPrompt", {
+            input: {
+                attachments: [],
+                projectId: null,
+                prompt: "hello",
+                runtimeId: "codex",
+                sessionId: "session-1",
+                title: "Prompt text same id",
+                worktreeId: null,
+            },
+            launch,
+        });
+
+        await vi.waitFor(() => {
+            const userMessages =
+                getLatestPatchMessages(emittedEvents, "session-1")?.filter(
+                    (message) => message.kind === "user",
+                ) ?? [];
+            expect(userMessages.map((message) => message.content)).toEqual([
+                "hello",
+                "unexpected user echo",
             ]);
         });
     });

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -2037,7 +2037,7 @@ describe("AiWorkerRuntime prepareSession", () => {
                 content: [
                     {
                         content: {
-                            text: "Receiver: runtime-subagent-1\nPrompt: sin cambios",
+                            text: "Receiver: runtime-subagent-1\nPrompt: sin cambios\ncon contexto adicional",
                             type: "text",
                         },
                         type: "content",
@@ -2061,7 +2061,7 @@ describe("AiWorkerRuntime prepareSession", () => {
                     childSnapshot.sessionId,
                 )?.filter((message) => message.kind === "user") ?? [];
             expect(userMessages.map((message) => message.content)).toEqual([
-                "sin cambios",
+                "sin cambios\ncon contexto adicional",
             ]);
         });
     });

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -823,6 +823,124 @@ describe("AiWorkerRuntime prepareSession", () => {
         });
     });
 
+    it("preserves buffered subagent creation when early child updates overflow the buffer", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const emittedEvents: AiWorkerEventMessage[] = [];
+        const runtime = new AiWorkerRuntime({
+            emitEvent: (event) => {
+                emittedEvents.push(event);
+            },
+        });
+        const launch = createLaunch({
+            cwd: tempDir,
+            projectRoot: tempDir,
+            title: "Buffered subagent overflow parent",
+        });
+        const subagentMeta = {
+            codexAcpAgentNickname: "Galileo",
+            codexAcpChildSessionId: "runtime-subagent-overflow",
+            codexAcpCwd: tempDir,
+            codexAcpEventType: "subagent_session_created",
+            codexAcpParentSessionId: "runtime-session-1",
+        };
+        loadSessionMock.mockImplementationOnce(async () => {
+            const client = latestClientFactory?.();
+            await client?.sessionUpdate({
+                _meta: subagentMeta,
+                sessionId: "runtime-subagent-overflow",
+                update: {
+                    _meta: subagentMeta,
+                    sessionUpdate: "session_info_update",
+                    title: "Galileo",
+                },
+            });
+            for (let index = 0; index < 20; index += 1) {
+                await client?.sessionUpdate({
+                    sessionId: "runtime-subagent-overflow",
+                    update: {
+                        content: {
+                            text: `buffered child output ${index}`,
+                            type: "text",
+                        },
+                        messageId: `overflow-child-message-${index}`,
+                        sessionUpdate: "agent_message_chunk",
+                    },
+                });
+            }
+            return {
+                configOptions: [],
+                modes: [],
+                models: [],
+            };
+        });
+
+        await runtime.dispatchMethod("ai.prepareSession", {
+            input: launch.input,
+            launch,
+        });
+
+        await vi.waitFor(() => {
+            const childSnapshot = getLatestSnapshot(
+                emittedEvents,
+                (snapshot) =>
+                    snapshot.parentSessionId === "session-1" &&
+                    snapshot.runtimeSessionId === "runtime-subagent-overflow",
+            );
+            expect(childSnapshot).toEqual(
+                expect.objectContaining({
+                    parentSessionId: "session-1",
+                    runtimeSessionId: "runtime-subagent-overflow",
+                    title: "Galileo",
+                }),
+            );
+            expect(childSnapshot?.messages).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        content: "buffered child output 19",
+                        kind: "assistant",
+                    }),
+                ]),
+            );
+        });
+    });
+
+    it("registers Codex subagent sessions from thread metadata when session metadata is absent", async () => {
+        const { client, emittedEvents, tempDir } =
+            await setupPreparedRuntimeWithClient("Subagent thread metadata parent");
+        const subagentMeta = {
+            codexAcpAgentNickname: "Galileo",
+            codexAcpChildThreadId: "runtime-subagent-thread-1",
+            codexAcpCwd: tempDir,
+            codexAcpEventType: "subagent_session_created",
+            codexAcpParentThreadId: "runtime-session-1",
+        };
+        await client.sessionUpdate({
+            _meta: subagentMeta,
+            sessionId: "runtime-subagent-thread-1",
+            update: {
+                _meta: subagentMeta,
+                sessionUpdate: "session_info_update",
+                title: "Galileo",
+            },
+        });
+
+        const childSnapshot = getLatestSnapshot(
+            emittedEvents,
+            (snapshot) =>
+                snapshot.parentSessionId === "session-1" &&
+                snapshot.runtimeSessionId === "runtime-subagent-thread-1",
+        );
+        expect(childSnapshot).toEqual(
+            expect.objectContaining({
+                parentSessionId: "session-1",
+                runtimeSessionId: "runtime-subagent-thread-1",
+                title: "Galileo",
+            }),
+        );
+    });
+
     it("applies Codex subagent model metadata to the initial child snapshot", async () => {
         loadSessionMock.mockResolvedValueOnce(createCodexCatalogResponse());
         const tempDir = await fs.mkdtemp(
@@ -1288,6 +1406,106 @@ describe("AiWorkerRuntime prepareSession", () => {
                 (changes) => changes.status === "streaming" || changes.status === "idle",
             ),
         ).toBe(false);
+    });
+
+    it("keeps a terminal subagent breadcrumb response that arrives before turn complete", async () => {
+        const { client, emittedEvents, tempDir } =
+            await setupPreparedRuntimeWithClient("Subagent terminal before complete");
+        const childSnapshot = await registerSubagentSession(
+            client,
+            emittedEvents,
+            tempDir,
+            {
+                nickname: "Galileo",
+                runtimeSessionId: "runtime-subagent-1",
+            },
+        );
+        const interactionMeta = {
+            codexAcpChildSessionId: "runtime-subagent-1",
+            codexAcpEventType: "subagent_breadcrumb",
+            codexAcpParentSessionId: "runtime-session-1",
+            codexAcpSubagentEventType: "interaction_begin",
+        };
+        await client.sessionUpdate({
+            _meta: interactionMeta,
+            sessionId: "runtime-session-1",
+            update: {
+                _meta: interactionMeta,
+                kind: "other",
+                rawInput: {
+                    prompt: "Inspect the failing stream",
+                },
+                sessionUpdate: "tool_call",
+                status: "in_progress",
+                title: "Contacting subagent",
+                toolCallId: "codex-acp:subagent:interaction-terminal-race",
+            },
+        });
+        await sendTurnLifecycle(client, {
+            eventType: "turn_started",
+            runtimeSessionId: "runtime-subagent-1",
+            turnId: "turn-1",
+        });
+
+        emittedEvents.length = 0;
+        const endMeta = {
+            codexAcpChildSessionId: "runtime-subagent-1",
+            codexAcpEventType: "subagent_breadcrumb",
+            codexAcpParentSessionId: "runtime-session-1",
+            codexAcpSubagentEventType: "interaction_end",
+        };
+        await client.sessionUpdate({
+            _meta: endMeta,
+            sessionId: "runtime-session-1",
+            update: {
+                _meta: endMeta,
+                rawOutput: {
+                    status: {
+                        completed: "terminal response before lifecycle end",
+                    },
+                },
+                sessionUpdate: "tool_call_update",
+                status: "completed",
+                title: "Galileo responded",
+                toolCallId: "codex-acp:subagent:interaction-terminal-race",
+            },
+        });
+
+        await vi.waitFor(() => {
+            expect(
+                getLatestPatchMessages(
+                    emittedEvents,
+                    childSnapshot.sessionId,
+                )?.filter(
+                    (message) =>
+                        message.kind === "assistant" &&
+                        message.content ===
+                            "terminal response before lifecycle end",
+                ),
+            ).toHaveLength(1);
+        });
+        expect(
+            hasPatchChangesMatching(
+                emittedEvents,
+                childSnapshot.sessionId,
+                (changes) => changes.status === "idle",
+            ),
+        ).toBe(false);
+
+        await sendTurnLifecycle(client, {
+            eventType: "turn_complete",
+            runtimeSessionId: "runtime-subagent-1",
+            turnId: "turn-1",
+        });
+        await vi.waitFor(() => {
+            expect(
+                hasPatchChangesMatching(
+                    emittedEvents,
+                    childSnapshot.sessionId,
+                    (changes) => changes.status === "idle",
+                ),
+            ).toBe(true);
+        });
     });
 
     it("attaches open-session actions to Codex subagent breadcrumbs", async () => {

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -1484,6 +1484,29 @@ describe("AiWorkerRuntime prepareSession", () => {
                 ),
             ).toHaveLength(1);
         });
+        for (const text of ["terminal response ", "before lifecycle end"]) {
+            await client.sessionUpdate({
+                sessionId: "runtime-subagent-1",
+                update: {
+                    content: {
+                        text,
+                        type: "text",
+                    },
+                    messageId: "child-terminal-echo",
+                    sessionUpdate: "agent_message_chunk",
+                },
+            });
+        }
+        await vi.waitFor(() => {
+            const assistantMessages =
+                getLatestPatchMessages(
+                    emittedEvents,
+                    childSnapshot.sessionId,
+                )?.filter((message) => message.kind === "assistant") ?? [];
+            expect(assistantMessages.map((message) => message.content)).toEqual([
+                "terminal response before lifecycle end",
+            ]);
+        });
         expect(
             hasPatchChangesMatching(
                 emittedEvents,

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -1896,6 +1896,63 @@ describe("AiWorkerRuntime prepareSession", () => {
         });
     });
 
+    it("mirrors subagent prompts from breadcrumb content when raw input lacks prompt", async () => {
+        const { client, emittedEvents, tempDir } =
+            await setupPreparedRuntimeWithClient("Subagent prompt content fallback");
+        const childSnapshot = await registerSubagentSession(
+            client,
+            emittedEvents,
+            tempDir,
+            {
+                nickname: "Galileo",
+                runtimeSessionId: "runtime-subagent-1",
+            },
+        );
+        emittedEvents.length = 0;
+
+        const resumeBeginMeta = {
+            codexAcpChildSessionId: "runtime-subagent-1",
+            codexAcpEventType: "subagent_breadcrumb",
+            codexAcpParentSessionId: "runtime-session-1",
+            codexAcpSubagentEventType: "resume_begin",
+        };
+        await client.sessionUpdate({
+            _meta: resumeBeginMeta,
+            sessionId: "runtime-session-1",
+            update: {
+                _meta: resumeBeginMeta,
+                content: [
+                    {
+                        content: {
+                            text: "Receiver: runtime-subagent-1\nPrompt: sin cambios",
+                            type: "text",
+                        },
+                        type: "content",
+                    },
+                ],
+                kind: "other",
+                rawInput: {
+                    receiver_thread_id: "runtime-subagent-1",
+                },
+                sessionUpdate: "tool_call",
+                status: "in_progress",
+                title: "Resuming Galileo",
+                toolCallId: "codex-acp:subagent:resume-content-prompt",
+            },
+        });
+
+        await vi.waitFor(() => {
+            const userMessages =
+                getLatestPatchMessages(
+                    emittedEvents,
+                    childSnapshot.sessionId,
+                )?.filter((message) => message.kind === "user") ?? [];
+            expect(userMessages.map((message) => message.content)).toEqual([
+                "sin cambios",
+            ]);
+        });
+    });
+
     it("does not duplicate mirrored subagent prompts when user chunks also arrive", async () => {
         const { client, emittedEvents, tempDir } =
             await setupPreparedRuntimeWithClient("Subagent user dedupe parent");
@@ -3722,6 +3779,56 @@ describe("AiWorkerRuntime prepareSession", () => {
                     message.content.includes(CODEX_ACP_USER_INPUT_RESPONSE_PREFIX),
                 ),
             ).toBe(false);
+        });
+    });
+
+    it("suppresses late chunked internal guided-input payload echoes", async () => {
+        const { client, emittedEvents } =
+            await setupPreparedRuntimeWithClient("Late chunked guided input echo");
+        emittedEvents.length = 0;
+
+        await client.sessionUpdate({
+            sessionId: "runtime-session-1",
+            update: {
+                content: {
+                    text: `${CODEX_ACP_USER_INPUT_RESPONSE_PREFIX}{"response":`,
+                    type: "text",
+                },
+                messageId: "late-guided-echo",
+                sessionUpdate: "user_message_chunk",
+            },
+        });
+        await client.sessionUpdate({
+            sessionId: "runtime-session-1",
+            update: {
+                content: {
+                    text: '{"answers":{"choice":{"answers":["yes"]}}},"turn_id":"turn-1"}',
+                    type: "text",
+                },
+                messageId: "late-guided-echo",
+                sessionUpdate: "user_message_chunk",
+            },
+        });
+        await client.sessionUpdate({
+            sessionId: "runtime-session-1",
+            update: {
+                content: {
+                    text: "visible answer",
+                    type: "text",
+                },
+                messageId: "assistant-after-guided-echo",
+                sessionUpdate: "agent_message_chunk",
+            },
+        });
+
+        await vi.waitFor(() => {
+            const messages = getLatestPatchMessages(emittedEvents, "session-1");
+            expect(messages).toEqual([
+                expect.objectContaining({
+                    content: "visible answer",
+                    kind: "assistant",
+                }),
+            ]);
         });
     });
 

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -1851,6 +1851,119 @@ describe("AiWorkerRuntime prepareSession", () => {
         ]);
     });
 
+    it("hides internal tool activity rows from Codex subagent child sessions", async () => {
+        const { client, emittedEvents, tempDir } =
+            await setupPreparedRuntimeWithClient("Subagent hidden tools parent");
+        const childSnapshot = await registerSubagentSession(
+            client,
+            emittedEvents,
+            tempDir,
+            {
+                nickname: "Galileo",
+                runtimeSessionId: "runtime-subagent-1",
+            },
+        );
+
+        emittedEvents.length = 0;
+        await client.sessionUpdate({
+            sessionId: "runtime-subagent-1",
+            update: {
+                kind: "execute",
+                rawInput: {
+                    command: "pnpm test",
+                },
+                sessionUpdate: "tool_call",
+                status: "in_progress",
+                title: "exec_command",
+                toolCallId: "child-exec",
+            },
+        });
+        await client.sessionUpdate({
+            sessionId: "runtime-subagent-1",
+            update: {
+                _meta: {
+                    terminal_output: {
+                        data: "running\n",
+                        terminal_id: "term-1",
+                    },
+                },
+                kind: "execute",
+                sessionUpdate: "tool_call_update",
+                status: "completed",
+                title: "Tool call",
+                toolCallId: "child-exec",
+            },
+        });
+        await client.sessionUpdate({
+            sessionId: "runtime-subagent-1",
+            update: {
+                kind: "plan",
+                sessionUpdate: "tool_call",
+                status: "completed",
+                title: "update_plan",
+                toolCallId: "child-plan",
+            },
+        });
+
+        await vi.waitFor(() => {
+            expect(
+                hasPatchChangesMatching(
+                    emittedEvents,
+                    childSnapshot.sessionId,
+                    (changes) => changes.status === "streaming",
+                ),
+            ).toBe(true);
+        });
+        expect(
+            hasToolActivityMatching(
+                emittedEvents,
+                childSnapshot.sessionId,
+                (activity) =>
+                    activity.id === "child-exec" ||
+                    activity.id === "child-plan" ||
+                    activity.title === "exec_command" ||
+                    activity.title === "update_plan",
+            ),
+        ).toBe(false);
+
+        emittedEvents.length = 0;
+        await client.sessionUpdate({
+            sessionId: "runtime-subagent-1",
+            update: {
+                content: [
+                    {
+                        newText: "export const value = 2;\n",
+                        oldText: "export const value = 1;\n",
+                        path: path.join(tempDir, "src/subagent-tool.ts"),
+                        type: "diff",
+                    },
+                ],
+                kind: "edit",
+                sessionUpdate: "tool_call_update",
+                status: "completed",
+                title: "Edit",
+                toolCallId: "child-edit",
+            },
+        });
+
+        await vi.waitFor(() => {
+            expect(
+                hasTrackedFileEvent(
+                    emittedEvents,
+                    childSnapshot.sessionId,
+                    "src/subagent-tool.ts",
+                ),
+            ).toBe(true);
+        });
+        expect(
+            hasToolActivityMatching(
+                emittedEvents,
+                childSnapshot.sessionId,
+                (activity) => activity.id === "child-edit",
+            ),
+        ).toBe(false);
+    });
+
     it("renders Codex subagent user message chunks in the child thread", async () => {
         const { client, emittedEvents, tempDir } =
             await setupPreparedRuntimeWithClient("Subagent user chunk parent");

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -79,6 +79,7 @@ import {
     CODEX_ACP_TURN_ID_KEY,
     CODEX_ACP_TURN_LIFECYCLE_EVENT_TYPE,
     CODEX_ACP_TURN_STARTED_EVENT_TYPE,
+    CODEX_ACP_USER_INPUT_RESPONSE_PREFIX,
     type LiveAcpConnection,
     type LiveAcpSession,
     type LiveAcpTerminal,
@@ -825,8 +826,13 @@ export class AiWorkerRuntime {
             pendingUserInput.turnId,
             answers,
         );
+        const responseMessageId = randomUUID();
         const now = new Date().toISOString();
 
+        this.#setPendingUserTextEcho(liveSession, {
+            expectedTexts: [promptText],
+            messageId: responseMessageId,
+        });
         liveSession.snapshot = finalizeStreamingMessages({
             ...liveSession.snapshot,
             activeTurnStartedAt: liveSession.snapshot.activeTurnStartedAt ?? now,
@@ -853,7 +859,7 @@ export class AiWorkerRuntime {
 
         try {
             await liveSession.connection.prompt({
-                messageId: randomUUID(),
+                messageId: responseMessageId,
                 prompt: [
                     {
                         text: promptText,
@@ -871,7 +877,9 @@ export class AiWorkerRuntime {
             });
             this.#queueSnapshotFlush(liveSession);
             this.#schedulePendingScopeRefresh(params.input.sessionId);
+            this.#clearPendingUserTextEcho(liveSession);
         } catch (error) {
+            this.#clearPendingUserTextEcho(liveSession);
             const message =
                 error instanceof Error
                     ? error.message
@@ -1659,6 +1667,14 @@ export class AiWorkerRuntime {
             return Promise.resolve();
         }
 
+        if (
+            update.sessionUpdate === "user_message_chunk" &&
+            isInternalUserInputResponseEcho(update.content) &&
+            !this.#pendingUserTextEchoes.has(liveSession.snapshot.sessionId)
+        ) {
+            return Promise.resolve();
+        }
+
         const shouldMarkStreaming =
             update.sessionUpdate === "user_message_chunk" ||
             update.sessionUpdate === "agent_message_chunk" ||
@@ -1698,12 +1714,14 @@ export class AiWorkerRuntime {
                 );
                 nextSnapshot = echoResult.snapshot;
                 if (!echoResult.handled) {
-                    nextSnapshot = appendContentBlockToSnapshot(
-                        nextSnapshot,
-                        "user",
-                        update.content,
-                        update.messageId ?? null,
-                    );
+                    if (!isInternalUserInputResponseEcho(update.content)) {
+                        nextSnapshot = appendContentBlockToSnapshot(
+                            nextSnapshot,
+                            "user",
+                            update.content,
+                            update.messageId ?? null,
+                        );
+                    }
                 }
                 break;
             }
@@ -1925,6 +1943,19 @@ export class AiWorkerRuntime {
                 (expectedContent) =>
                     isSamePromptEchoContentBlock(expectedContent, content),
             );
+            if (!matchesExpectedContent && hasMatchingMessageId) {
+                this.#clearPendingUserTextEcho(liveSession);
+                return {
+                    handled: true,
+                    snapshot: appendContentBlockToSnapshot(
+                        snapshot,
+                        "user",
+                        content,
+                        null,
+                    ),
+                };
+            }
+
             return {
                 handled: matchesExpectedContent,
                 snapshot,
@@ -1940,6 +1971,7 @@ export class AiWorkerRuntime {
             };
         }
 
+        const wasTextMatched = pending.textMatched;
         pending.bufferedText = `${pending.bufferedText}${text}`;
         const normalizedBufferedText = normalizeEchoText(pending.bufferedText);
         const normalizedExpectedTexts = pending.expectedTexts
@@ -1954,7 +1986,7 @@ export class AiWorkerRuntime {
                 expectedText.startsWith(normalizedBufferedText),
             );
 
-        if (hasMatchingMessageId || isExpectedPrefix) {
+        if (isExpectedPrefix) {
             if (matchesExpectedText) {
                 pending.textMatched = true;
                 if (pending.expectedContentBlocks.length === 0) {
@@ -1967,7 +1999,7 @@ export class AiWorkerRuntime {
             };
         }
 
-        const bufferedText = pending.bufferedText;
+        const bufferedText = wasTextMatched ? text : pending.bufferedText;
         this.#clearPendingUserTextEcho(liveSession);
         return {
             handled: true,
@@ -1978,7 +2010,7 @@ export class AiWorkerRuntime {
                     text: bufferedText,
                     type: "text",
                 },
-                messageId,
+                hasMatchingMessageId ? null : messageId,
             ),
         };
     }
@@ -3656,6 +3688,10 @@ export class AiWorkerRuntime {
             appSessionId,
         );
         this.#drainPendingSessionUpdates(liveConnection, runtimeSessionId);
+        this.#drainPendingSubagentCreatesForParent(
+            liveConnection,
+            runtimeSessionId,
+        );
     }
 
     #bufferPendingSessionUpdate(
@@ -3711,6 +3747,46 @@ export class AiWorkerRuntime {
 
         for (const update of pending) {
             void this.#handleSessionUpdate(liveSession, update);
+        }
+    }
+
+    #drainPendingSubagentCreatesForParent(
+        liveConnection: LiveAcpConnection,
+        runtimeParentSessionId: string,
+    ): void {
+        const pendingSubagentCreates: SessionNotification[] = [];
+
+        for (const [
+            pendingRuntimeSessionId,
+            pendingUpdates,
+        ] of liveConnection.pendingSessionUpdatesByRuntimeSessionId) {
+            const remainingUpdates = pendingUpdates.filter((pendingUpdate) => {
+                const meta = getSessionNotificationMeta(pendingUpdate);
+                const shouldRetry =
+                    readMetaString(meta, CODEX_ACP_STATUS_EVENT_TYPE_KEY) ===
+                        CODEX_ACP_SUBAGENT_SESSION_CREATED_EVENT_TYPE &&
+                    readMetaString(meta, CODEX_ACP_PARENT_SESSION_ID_KEY) ===
+                        runtimeParentSessionId;
+                if (shouldRetry) {
+                    pendingSubagentCreates.push(pendingUpdate);
+                }
+                return !shouldRetry;
+            });
+
+            if (remainingUpdates.length > 0) {
+                liveConnection.pendingSessionUpdatesByRuntimeSessionId.set(
+                    pendingRuntimeSessionId,
+                    remainingUpdates,
+                );
+            } else {
+                liveConnection.pendingSessionUpdatesByRuntimeSessionId.delete(
+                    pendingRuntimeSessionId,
+                );
+            }
+        }
+
+        for (const pendingCreate of pendingSubagentCreates) {
+            void this.#handleRuntimeSessionUpdate(liveConnection, pendingCreate);
         }
     }
 
@@ -4260,6 +4336,13 @@ function isSameEmbeddedResource(
     );
 }
 
+function isInternalUserInputResponseEcho(content: ContentBlock): boolean {
+    return (
+        content.type === "text" &&
+        content.text.trimStart().startsWith(CODEX_ACP_USER_INPUT_RESPONSE_PREFIX)
+    );
+}
+
 function normalizeEchoText(value: string): string {
     return value.trim().replace(/\s+/g, " ");
 }
@@ -4346,14 +4429,6 @@ function appendMirroredSubagentMessage(
     }
 
     if (snapshot.messages.some((message) => message.id === id)) {
-        return snapshot;
-    }
-
-    const latestMessage = snapshot.messages[snapshot.messages.length - 1] ?? null;
-    if (
-        latestMessage?.kind === kind &&
-        latestMessage.content.trim() === trimmedContent
-    ) {
         return snapshot;
     }
 

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -228,6 +228,23 @@ function shouldSuppressSessionToolActivityUpdate(
     return shouldSuppressToolActivityUpdate(update, title);
 }
 
+function suppressSubagentToolActivityRows(
+    liveSession: LiveAcpSession,
+    previousSnapshot: AiSessionSnapshot,
+    nextSnapshot: AiSessionSnapshot,
+): AiSessionSnapshot {
+    if (!isSubagentLiveSession(liveSession)) {
+        return nextSnapshot;
+    }
+
+    // Subagent tool calls are implementation details; keep their side effects
+    // such as tracked files and pending input without rendering tool rows.
+    return {
+        ...nextSnapshot,
+        toolActivity: previousSnapshot.toolActivity,
+    };
+}
+
 function isDirectStreamingSessionUpdate(
     update: SessionNotification["update"],
 ): boolean {
@@ -1769,34 +1786,52 @@ export class AiWorkerRuntime {
                 break;
             case "tool_call":
                 nextSnapshot = finalizeStreamingMessages(nextSnapshot);
-                nextSnapshot = isImageGenerationToolUpdate(update)
-                    ? mapImageGenerationToolUpdate(nextSnapshot, update, now)
-                    : mapToolCallUpdate(
-                          liveSession,
-                          nextSnapshot,
-                          update,
-                          "tool_call",
-                          now,
-                          {
-                              readOpenFileBuffer: (absolutePath) =>
-                                  this.#fileBuffers.get(absolutePath) ?? null,
-                          },
-                      );
+                {
+                    const previousSnapshot = nextSnapshot;
+                    const mappedSnapshot = isImageGenerationToolUpdate(update)
+                        ? mapImageGenerationToolUpdate(nextSnapshot, update, now)
+                        : mapToolCallUpdate(
+                              liveSession,
+                              nextSnapshot,
+                              update,
+                              "tool_call",
+                              now,
+                              {
+                                  readOpenFileBuffer: (absolutePath) =>
+                                      this.#fileBuffers.get(absolutePath) ??
+                                      null,
+                              },
+                          );
+                    nextSnapshot = suppressSubagentToolActivityRows(
+                        liveSession,
+                        previousSnapshot,
+                        mappedSnapshot,
+                    );
+                }
                 break;
             case "tool_call_update":
-                nextSnapshot = isImageGenerationToolUpdate(update)
-                    ? mapImageGenerationToolUpdate(nextSnapshot, update, now)
-                    : mapToolCallUpdate(
-                          liveSession,
-                          nextSnapshot,
-                          update,
-                          "tool_call_update",
-                          now,
-                          {
-                              readOpenFileBuffer: (absolutePath) =>
-                                  this.#fileBuffers.get(absolutePath) ?? null,
-                          },
-                      );
+                {
+                    const previousSnapshot = nextSnapshot;
+                    const mappedSnapshot = isImageGenerationToolUpdate(update)
+                        ? mapImageGenerationToolUpdate(nextSnapshot, update, now)
+                        : mapToolCallUpdate(
+                              liveSession,
+                              nextSnapshot,
+                              update,
+                              "tool_call_update",
+                              now,
+                              {
+                                  readOpenFileBuffer: (absolutePath) =>
+                                      this.#fileBuffers.get(absolutePath) ??
+                                      null,
+                              },
+                          );
+                    nextSnapshot = suppressSubagentToolActivityRows(
+                        liveSession,
+                        previousSnapshot,
+                        mappedSnapshot,
+                    );
+                }
                 break;
             case "plan":
                 nextSnapshot = {

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -23,6 +23,7 @@ import {
     type TerminalExitStatus,
     type TerminalOutputRequest,
     type TerminalOutputResponse,
+    type ToolCallContent,
     type WaitForTerminalExitRequest,
     type WaitForTerminalExitResponse,
     type WriteTextFileRequest,
@@ -145,6 +146,11 @@ interface PendingUserTextEcho {
     textMatched: boolean;
 }
 
+interface SuppressedInternalUserInputEcho {
+    bufferedText: string;
+    readonly messageId: string | null;
+}
+
 interface SubagentMirrorTurnState {
     assistantOutputSeen: boolean;
     suppressedAssistantEchoText: string;
@@ -248,6 +254,10 @@ export class AiWorkerRuntime {
     readonly #fileBuffers = new Map<string, string>();
     readonly #pendingUserTextEchoes = new Map<string, PendingUserTextEcho>();
     readonly #sessions = new Map<string, LiveAcpSession>();
+    readonly #suppressedInternalUserInputEchoes = new Map<
+        string,
+        SuppressedInternalUserInputEcho
+    >();
     readonly #subagentMirrorTurns = new Map<string, SubagentMirrorTurnState>();
     readonly #startedAt = new Date().toISOString();
 
@@ -1666,8 +1676,12 @@ export class AiWorkerRuntime {
 
         if (
             update.sessionUpdate === "user_message_chunk" &&
-            isInternalUserInputResponseEcho(update.content) &&
-            !this.#pendingUserTextEchoes.has(liveSession.snapshot.sessionId)
+            !this.#pendingUserTextEchoes.has(liveSession.snapshot.sessionId) &&
+            this.#shouldSuppressInternalUserInputResponseEcho(
+                liveSession,
+                update.content,
+                update.messageId ?? null,
+            )
         ) {
             return Promise.resolve();
         }
@@ -1711,7 +1725,13 @@ export class AiWorkerRuntime {
                 );
                 nextSnapshot = echoResult.snapshot;
                 if (!echoResult.handled) {
-                    if (!isInternalUserInputResponseEcho(update.content)) {
+                    if (
+                        !this.#shouldSuppressInternalUserInputResponseEcho(
+                            liveSession,
+                            update.content,
+                            update.messageId ?? null,
+                        )
+                    ) {
                         nextSnapshot = appendContentBlockToSnapshot(
                             nextSnapshot,
                             "user",
@@ -1921,6 +1941,49 @@ export class AiWorkerRuntime {
 
     #clearPendingUserTextEcho(liveSession: LiveAcpSession): void {
         this.#pendingUserTextEchoes.delete(liveSession.snapshot.sessionId);
+    }
+
+    #shouldSuppressInternalUserInputResponseEcho(
+        liveSession: LiveAcpSession,
+        content: ContentBlock,
+        messageId: string | null,
+    ): boolean {
+        if (content.type !== "text") {
+            return false;
+        }
+
+        const sessionId = liveSession.snapshot.sessionId;
+        const existing =
+            this.#suppressedInternalUserInputEchoes.get(sessionId) ?? null;
+        if (existing) {
+            if (
+                existing.messageId &&
+                messageId &&
+                existing.messageId !== messageId
+            ) {
+                this.#suppressedInternalUserInputEchoes.delete(sessionId);
+                return false;
+            }
+
+            existing.bufferedText = `${existing.bufferedText}${content.text}`;
+            if (isCompleteInternalUserInputResponseEcho(existing.bufferedText)) {
+                this.#suppressedInternalUserInputEchoes.delete(sessionId);
+            }
+            return true;
+        }
+
+        if (!isInternalUserInputResponseEcho(content)) {
+            return false;
+        }
+
+        const suppressedEcho: SuppressedInternalUserInputEcho = {
+            bufferedText: content.text,
+            messageId,
+        };
+        if (!isCompleteInternalUserInputResponseEcho(suppressedEcho.bufferedText)) {
+            this.#suppressedInternalUserInputEchoes.set(sessionId, suppressedEcho);
+        }
+        return true;
     }
 
     #applyPendingUserTextEcho(
@@ -4045,6 +4108,7 @@ export class AiWorkerRuntime {
             const sessionId = liveSession.snapshot.sessionId;
             this.#sessions.delete(sessionId);
             this.#pendingUserTextEchoes.delete(sessionId);
+            this.#suppressedInternalUserInputEchoes.delete(sessionId);
             this.#subagentMirrorTurns.delete(sessionId);
             this.#releaseAllTerminals(liveSession);
             if (liveSession.closing || liveConnection.closing) {
@@ -4079,6 +4143,7 @@ export class AiWorkerRuntime {
         const liveConnection = liveSession.runtimeConnection;
         this.#sessions.delete(sessionId);
         this.#pendingUserTextEchoes.delete(sessionId);
+        this.#suppressedInternalUserInputEchoes.delete(sessionId);
         this.#subagentMirrorTurns.delete(sessionId);
         liveConnection.sessionsByAppSessionId.delete(sessionId);
         if (liveSession.snapshot.runtimeSessionId) {
@@ -4133,6 +4198,7 @@ export class AiWorkerRuntime {
             const sessionId = liveSession.snapshot.sessionId;
             this.#sessions.delete(sessionId);
             this.#pendingUserTextEchoes.delete(sessionId);
+            this.#suppressedInternalUserInputEchoes.delete(sessionId);
             this.#subagentMirrorTurns.delete(sessionId);
             liveSession.closing = true;
             this.#flushSnapshotEvent(liveSession);
@@ -4463,6 +4529,27 @@ function isInternalUserInputResponseEcho(content: ContentBlock): boolean {
     );
 }
 
+function isCompleteInternalUserInputResponseEcho(value: string): boolean {
+    const trimmedValue = value.trimStart();
+    if (!trimmedValue.startsWith(CODEX_ACP_USER_INPUT_RESPONSE_PREFIX)) {
+        return false;
+    }
+
+    const payloadText = trimmedValue.slice(
+        CODEX_ACP_USER_INPUT_RESPONSE_PREFIX.length,
+    );
+    if (!payloadText.trim()) {
+        return false;
+    }
+
+    try {
+        JSON.parse(payloadText);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 function normalizeEchoText(value: string): string {
     return value.trim().replace(/\s+/g, " ");
 }
@@ -4578,7 +4665,51 @@ function readSubagentTurnPrompt(
         return null;
     }
 
-    return readRecordString(update.rawInput, "prompt");
+    return (
+        readRecordString(update.rawInput, "prompt") ??
+        readRecordString(update.rawInput, "message") ??
+        readRecordString(update.rawInput, "input") ??
+        readPromptFromToolCallContent(update.content)
+    );
+}
+
+function readPromptFromToolCallContent(
+    content: readonly ToolCallContent[] | null | undefined,
+): string | null {
+    if (!Array.isArray(content)) {
+        return null;
+    }
+
+    for (const entry of content) {
+        if (!isRecordValue(entry) || entry.type !== "content") {
+            continue;
+        }
+
+        const block = entry.content;
+        if (!isRecordValue(block) || block.type !== "text") {
+            continue;
+        }
+
+        const text = typeof block.text === "string" ? block.text : "";
+        const prompt = readPromptLineFromText(text);
+        if (prompt) {
+            return prompt;
+        }
+    }
+
+    return null;
+}
+
+function readPromptLineFromText(value: string): string | null {
+    for (const line of value.split(/\r?\n/)) {
+        const match = /^Prompt:\s*(.+)$/i.exec(line.trim());
+        const prompt = match ? match[1].trim() : "";
+        if (prompt) {
+            return prompt;
+        }
+    }
+
+    return null;
 }
 
 function readSubagentTurnResponse(

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -147,6 +147,8 @@ interface PendingUserTextEcho {
 
 interface SubagentMirrorTurnState {
     assistantOutputSeen: boolean;
+    suppressedAssistantEchoText: string;
+    terminalAssistantContent: string | null;
     readonly toolCallId: string;
 }
 
@@ -1721,6 +1723,14 @@ export class AiWorkerRuntime {
                 break;
             }
             case "agent_message_chunk":
+                if (
+                    this.#shouldSuppressMirroredSubagentAssistantEcho(
+                        liveSession,
+                        update.content,
+                    )
+                ) {
+                    break;
+                }
                 this.#markSubagentAssistantOutputSeen(liveSession);
                 nextSnapshot = appendContentBlockToSnapshot(
                     nextSnapshot,
@@ -2016,6 +2026,8 @@ export class AiWorkerRuntime {
     ): void {
         this.#subagentMirrorTurns.set(liveSession.snapshot.sessionId, {
             assistantOutputSeen: false,
+            suppressedAssistantEchoText: "",
+            terminalAssistantContent: null,
             toolCallId,
         });
     }
@@ -2035,6 +2047,50 @@ export class AiWorkerRuntime {
         if (state) {
             state.assistantOutputSeen = true;
         }
+    }
+
+    #rememberMirroredSubagentTerminalResponse(
+        liveSession: LiveAcpSession,
+        response: string,
+    ): void {
+        const state = this.#subagentMirrorTurns.get(
+            liveSession.snapshot.sessionId,
+        );
+        if (state) {
+            state.assistantOutputSeen = true;
+            state.terminalAssistantContent = response;
+            state.suppressedAssistantEchoText = "";
+        }
+    }
+
+    #shouldSuppressMirroredSubagentAssistantEcho(
+        liveSession: LiveAcpSession,
+        content: ContentBlock,
+    ): boolean {
+        if (!isSubagentLiveSession(liveSession) || content.type !== "text") {
+            return false;
+        }
+
+        const state = this.#subagentMirrorTurns.get(
+            liveSession.snapshot.sessionId,
+        );
+        const terminalContent = state?.terminalAssistantContent;
+        if (!state || !terminalContent) {
+            return false;
+        }
+
+        const nextEchoText = `${state.suppressedAssistantEchoText}${content.text}`;
+        const normalizedEchoText = normalizeEchoText(nextEchoText);
+        const normalizedTerminalContent = normalizeEchoText(terminalContent);
+        if (
+            normalizedEchoText.length === 0 ||
+            normalizedTerminalContent.startsWith(normalizedEchoText)
+        ) {
+            state.suppressedAssistantEchoText = nextEchoText;
+            return true;
+        }
+
+        return false;
     }
 
     #getSubagentMirrorTurn(
@@ -2420,7 +2476,7 @@ export class AiWorkerRuntime {
             `subagent:${update.toolCallId}:assistant`,
             updatedAt,
         );
-        this.#markSubagentAssistantOutputSeen(childSession);
+        this.#rememberMirroredSubagentTerminalResponse(childSession, response);
         this.#queueSnapshotFlush(childSession);
         this.#schedulePendingScopeRefresh(childSession.snapshot.sessionId);
     }

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -4726,7 +4726,7 @@ function readPromptFromToolCallContent(
         }
 
         const text = typeof block.text === "string" ? block.text : "";
-        const prompt = readPromptLineFromText(text);
+        const prompt = readPromptBlockFromText(text);
         if (prompt) {
             return prompt;
         }
@@ -4735,16 +4735,35 @@ function readPromptFromToolCallContent(
     return null;
 }
 
-function readPromptLineFromText(value: string): string | null {
+function readPromptBlockFromText(value: string): string | null {
+    const promptLines: string[] = [];
+    let isReadingPrompt = false;
+
     for (const line of value.split(/\r?\n/)) {
-        const match = /^Prompt:\s*(.+)$/i.exec(line.trim());
-        const prompt = match ? match[1].trim() : "";
-        if (prompt) {
-            return prompt;
+        const match = /^\s*Prompt:\s*(.*)$/i.exec(line);
+        if (match) {
+            isReadingPrompt = true;
+            promptLines.push(match[1]);
+            continue;
         }
+
+        if (!isReadingPrompt) {
+            continue;
+        }
+
+        if (isSubagentPromptDetailMetadataLine(line)) {
+            break;
+        }
+
+        promptLines.push(line);
     }
 
-    return null;
+    const prompt = promptLines.join("\n").trim();
+    return prompt || null;
+}
+
+function isSubagentPromptDetailMetadataLine(line: string): boolean {
+    return /^\s*(?:Model|Reasoning effort):\s*/i.test(line);
 }
 
 function readSubagentTurnResponse(

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -67,6 +67,7 @@ import {
     CODEX_ACP_CWD_KEY,
     CODEX_ACP_MODEL_KEY,
     CODEX_ACP_PARENT_SESSION_ID_KEY,
+    CODEX_ACP_PARENT_THREAD_ID_KEY,
     CODEX_ACP_REASONING_EFFORT_KEY,
     CODEX_ACP_SHUTDOWN_COMPLETE_EVENT_TYPE,
     CODEX_ACP_STATUS_EVENT_TYPE_KEY,
@@ -1393,10 +1394,8 @@ export class AiWorkerRuntime {
                 readMetaString(meta, CODEX_ACP_STATUS_EVENT_TYPE_KEY) ===
                 CODEX_ACP_SUBAGENT_SESSION_CREATED_EVENT_TYPE
             ) {
-                const runtimeParentSessionId = readMetaString(
-                    meta,
-                    CODEX_ACP_PARENT_SESSION_ID_KEY,
-                );
+                const runtimeParentSessionId =
+                    readSubagentParentRuntimeSessionId(meta);
                 const parentAppSessionId = runtimeParentSessionId
                     ? (liveConnection.appSessionIdByRuntimeSessionId.get(
                           runtimeParentSessionId,
@@ -1460,12 +1459,8 @@ export class AiWorkerRuntime {
         meta: Record<string, unknown>,
     ): LiveAcpSession | null {
         const runtimeChildSessionId =
-            readMetaString(meta, CODEX_ACP_CHILD_SESSION_ID_KEY) ??
-            params.sessionId;
-        const runtimeParentSessionId = readMetaString(
-            meta,
-            CODEX_ACP_PARENT_SESSION_ID_KEY,
-        );
+            readSubagentChildRuntimeSessionId(meta) ?? params.sessionId;
+        const runtimeParentSessionId = readSubagentParentRuntimeSessionId(meta);
         if (!runtimeParentSessionId) {
             this.#emitLog("warn", "Ignoring subagent session without parent.", {
                 runtimeChildSessionId,
@@ -2164,10 +2159,7 @@ export class AiWorkerRuntime {
             return snapshot;
         }
 
-        const runtimeChildSessionId = readMetaString(
-            meta,
-            CODEX_ACP_CHILD_SESSION_ID_KEY,
-        );
+        const runtimeChildSessionId = readSubagentChildRuntimeSessionId(meta);
         if (!runtimeChildSessionId) {
             return snapshot;
         }
@@ -2245,10 +2237,7 @@ export class AiWorkerRuntime {
             return;
         }
 
-        const runtimeChildSessionId = readMetaString(
-            meta,
-            CODEX_ACP_CHILD_SESSION_ID_KEY,
-        );
+        const runtimeChildSessionId = readSubagentChildRuntimeSessionId(meta);
         if (!runtimeChildSessionId) {
             return;
         }
@@ -2291,6 +2280,16 @@ export class AiWorkerRuntime {
                 isTerminalSubagentBreadcrumb(meta, update)
             ) {
                 this.#mirrorSubagentTurnEnd(childSession, update, updatedAt);
+            } else if (
+                childSession.activeTurnId &&
+                mirrorTurn?.toolCallId === update.toolCallId &&
+                isTerminalSubagentBreadcrumb(meta, update)
+            ) {
+                this.#mirrorSubagentTerminalResponse(
+                    childSession,
+                    update,
+                    updatedAt,
+                );
             }
         }
     }
@@ -2389,6 +2388,39 @@ export class AiWorkerRuntime {
         this.#clearPendingUserTextEcho(childSession);
         this.#clearSubagentMirrorTurn(childSession);
         childSession.snapshot = nextSnapshot;
+        this.#queueSnapshotFlush(childSession);
+        this.#schedulePendingScopeRefresh(childSession.snapshot.sessionId);
+    }
+
+    #mirrorSubagentTerminalResponse(
+        childSession: LiveAcpSession,
+        update: SessionNotification["update"],
+        updatedAt: string,
+    ): void {
+        if (
+            update.sessionUpdate !== "tool_call" &&
+            update.sessionUpdate !== "tool_call_update"
+        ) {
+            return;
+        }
+
+        const response = readSubagentTurnResponse(update);
+        const mirrorTurn = this.#getSubagentMirrorTurn(childSession);
+        if (!response || mirrorTurn?.assistantOutputSeen) {
+            return;
+        }
+
+        childSession.snapshot = appendMirroredSubagentMessage(
+            {
+                ...childSession.snapshot,
+                updatedAt,
+            },
+            "assistant",
+            response,
+            `subagent:${update.toolCallId}:assistant`,
+            updatedAt,
+        );
+        this.#markSubagentAssistantOutputSeen(childSession);
         this.#queueSnapshotFlush(childSession);
         this.#schedulePendingScopeRefresh(childSession.snapshot.sessionId);
     }
@@ -3704,7 +3736,11 @@ export class AiWorkerRuntime {
             ) ?? [];
 
         if (pending.length >= MAX_PENDING_SESSION_UPDATES_PER_RUNTIME_SESSION) {
-            pending.shift();
+            const dropIndex = pending.findIndex(
+                (pendingUpdate) =>
+                    !isSubagentSessionCreatedNotification(pendingUpdate),
+            );
+            pending.splice(dropIndex >= 0 ? dropIndex : 0, 1);
             this.#emitLog(
                 "warn",
                 "Dropping the oldest pending ACP update for an unmapped runtime session.",
@@ -3765,7 +3801,7 @@ export class AiWorkerRuntime {
                 const shouldRetry =
                     readMetaString(meta, CODEX_ACP_STATUS_EVENT_TYPE_KEY) ===
                         CODEX_ACP_SUBAGENT_SESSION_CREATED_EVENT_TYPE &&
-                    readMetaString(meta, CODEX_ACP_PARENT_SESSION_ID_KEY) ===
+                    readSubagentParentRuntimeSessionId(meta) ===
                         runtimeParentSessionId;
                 if (shouldRetry) {
                     pendingSubagentCreates.push(pendingUpdate);
@@ -4336,6 +4372,34 @@ function isSameEmbeddedResource(
     );
 }
 
+function readSubagentParentRuntimeSessionId(
+    meta: Record<string, unknown>,
+): string | null {
+    return (
+        readMetaString(meta, CODEX_ACP_PARENT_SESSION_ID_KEY) ??
+        readMetaString(meta, CODEX_ACP_PARENT_THREAD_ID_KEY)
+    );
+}
+
+function readSubagentChildRuntimeSessionId(
+    meta: Record<string, unknown>,
+): string | null {
+    return (
+        readMetaString(meta, CODEX_ACP_CHILD_SESSION_ID_KEY) ??
+        readMetaString(meta, CODEX_ACP_CHILD_THREAD_ID_KEY)
+    );
+}
+
+function isSubagentSessionCreatedNotification(
+    params: SessionNotification,
+): boolean {
+    const meta = getSessionNotificationMeta(params);
+    return (
+        readMetaString(meta, CODEX_ACP_STATUS_EVENT_TYPE_KEY) ===
+        CODEX_ACP_SUBAGENT_SESSION_CREATED_EVENT_TYPE
+    );
+}
+
 function isInternalUserInputResponseEcho(content: ContentBlock): boolean {
     return (
         content.type === "text" &&
@@ -4535,10 +4599,7 @@ function readSubagentStatusRecords(
         records.push(...metaStatuses.filter(isRecordValue));
     }
 
-    const runtimeChildSessionId = readMetaString(
-        meta,
-        CODEX_ACP_CHILD_SESSION_ID_KEY,
-    );
+    const runtimeChildSessionId = readSubagentChildRuntimeSessionId(meta);
     if (runtimeChildSessionId && meta[CODEX_ACP_AGENT_STATUS_KEY] !== undefined) {
         records.push({
             [CODEX_ACP_AGENT_STATUS_KEY]: meta[CODEX_ACP_AGENT_STATUS_KEY],

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -211,6 +211,72 @@ describe("ai-store queue", () => {
         ).toEqual(availableCommands);
     });
 
+    it("does not let stale session hydration overwrite a newer snapshot", async () => {
+        const prepareDeferred = createDeferred<AiSessionSnapshot>();
+        const getAiRuntimeStatus = vi
+            .fn()
+            .mockResolvedValue(createRuntimeStatus());
+        const prepareAiSession = vi.fn(() => prepareDeferred.promise);
+
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    getAiRuntimeStatus,
+                    prepareAiSession,
+                },
+            },
+            writable: true,
+        });
+
+        const ensurePromise = useAiStore.getState().ensureSession(TAB);
+
+        await vi.waitFor(() => {
+            expect(prepareAiSession).toHaveBeenCalledTimes(1);
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                messages: [
+                    {
+                        attachments: [],
+                        content: "hello from backend",
+                        createdAt: "2026-04-14T00:00:02.000Z",
+                        id: "msg-1",
+                        kind: "user",
+                        status: "completed",
+                    },
+                ],
+                status: "streaming",
+                updatedAt: "2026-04-14T00:00:02.000Z",
+            }),
+        );
+        prepareDeferred.resolve(
+            createSnapshot({
+                messages: [],
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+
+        await ensurePromise;
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot,
+        ).toEqual(
+            expect.objectContaining({
+                messages: [
+                    expect.objectContaining({
+                        content: "hello from backend",
+                        id: "msg-1",
+                    }),
+                ],
+                status: "streaming",
+                updatedAt: "2026-04-14T00:00:02.000Z",
+            }),
+        );
+    });
+
     it("keeps commands from an early catalog patch even before the session is registered", () => {
         const availableCommands = [
             {

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -277,6 +277,97 @@ describe("ai-store queue", () => {
         );
     });
 
+    it("does not let a stale full snapshot overwrite a newer transcript", () => {
+        useAiStore.getState().registerSessionTab(TAB);
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                messages: [
+                    {
+                        attachments: [],
+                        content: "newer message",
+                        createdAt: "2026-04-14T00:00:02.000Z",
+                        id: "msg-newer",
+                        kind: "assistant",
+                        status: "completed",
+                    },
+                ],
+                status: "streaming",
+                updatedAt: "2026-04-14T00:00:02.000Z",
+            }),
+        );
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                messages: [],
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot,
+        ).toEqual(
+            expect.objectContaining({
+                messages: [
+                    expect.objectContaining({
+                        content: "newer message",
+                        id: "msg-newer",
+                    }),
+                ],
+                status: "streaming",
+                updatedAt: "2026-04-14T00:00:02.000Z",
+            }),
+        );
+    });
+
+    it("does not let a stale patch overwrite a newer transcript", () => {
+        useAiStore.getState().registerSessionTab(TAB);
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                messages: [
+                    {
+                        attachments: [],
+                        content: "newer patch message",
+                        createdAt: "2026-04-14T00:00:02.000Z",
+                        id: "msg-newer-patch",
+                        kind: "assistant",
+                        status: "completed",
+                    },
+                ],
+                status: "streaming",
+                updatedAt: "2026-04-14T00:00:02.000Z",
+            }),
+        );
+
+        useAiStore.getState().applySessionUpdate({
+            kind: "patch",
+            patch: {
+                changes: {
+                    messages: [],
+                    status: "idle",
+                    updatedAt: "2026-04-14T00:00:01.000Z",
+                },
+                runtimeId: TAB.runtimeId,
+                sessionId: TAB.sessionId,
+            },
+        });
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot,
+        ).toEqual(
+            expect.objectContaining({
+                messages: [
+                    expect.objectContaining({
+                        content: "newer patch message",
+                        id: "msg-newer-patch",
+                    }),
+                ],
+                status: "streaming",
+                updatedAt: "2026-04-14T00:00:02.000Z",
+            }),
+        );
+    });
+
     it("keeps commands from an early catalog patch even before the session is registered", () => {
         const availableCommands = [
             {

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -503,9 +503,13 @@ export const useAiStore = create<AiStore>((set, get) => ({
                           existingCatalog,
                       )
                     : baseSnapshot;
-            const nextSnapshot = applySessionPatch(
+            const incomingSnapshot = applySessionPatch(
                 snapshotForPatch,
                 update.patch,
+            );
+            const nextSnapshot = resolveIncomingSessionSnapshot(
+                incomingSnapshot,
+                session,
             );
             const nextCatalog = hasCatalogChanges(update.patch.changes)
                 ? extractRuntimeCatalog(nextSnapshot)
@@ -552,7 +556,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
     },
 
     applySessionSnapshot: (snapshot) => {
-        let titleChanged = false;
+        let syncedTitle: string | null = null;
         set((state) => {
             const session =
                 state.sessions[snapshot.sessionId] ?? createSessionState();
@@ -565,13 +569,19 @@ export const useAiStore = create<AiStore>((set, get) => ({
                           existingCatalog,
                       )
                     : snapshot;
+            const resolvedSnapshot = resolveIncomingSessionSnapshot(
+                nextSnapshot,
+                session,
+            );
             const nextMeta = session.meta
-                ? session.meta.title === nextSnapshot.title
+                ? session.meta.title === resolvedSnapshot.title
                     ? session.meta
-                    : { ...session.meta, title: nextSnapshot.title }
+                    : { ...session.meta, title: resolvedSnapshot.title }
                 : session.meta;
-            titleChanged = nextMeta !== session.meta;
-            const nextCatalog = extractRuntimeCatalog(nextSnapshot);
+            if (nextMeta !== session.meta) {
+                syncedTitle = resolvedSnapshot.title;
+            }
+            const nextCatalog = extractRuntimeCatalog(resolvedSnapshot);
 
             return {
                 runtimeCatalogById: hasRuntimeCatalog(nextCatalog)
@@ -587,21 +597,18 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         hydrated: true,
                         isDispatching: false,
                         isHydrating: false,
-                        localError: nextSnapshot.lastError,
+                        localError: resolvedSnapshot.lastError,
                         meta: nextMeta,
-                        snapshot: nextSnapshot,
+                        snapshot: resolvedSnapshot,
                     },
                 },
             };
         });
 
-        if (titleChanged) {
+        if (syncedTitle !== null) {
             void useWorkspaceStore
                 .getState()
-                .updateSessionTabTitles(
-                    snapshot.sessionId,
-                    snapshot.title,
-                );
+                .updateSessionTabTitles(snapshot.sessionId, syncedTitle);
         }
 
         void drainQueueIfNeeded(snapshot.sessionId, get, set);
@@ -1802,10 +1809,10 @@ function resolveIncomingSessionSnapshot(
         return incomingSnapshot;
     }
 
-    const shouldPreserveCurrent =
-        hasMoreTranscript(currentSnapshot, incomingSnapshot) ||
-        (currentSession?.hydrated === true &&
-            isSnapshotUpdatedAfter(currentSnapshot, incomingSnapshot));
+    const shouldPreserveCurrent = hasMoreTranscript(
+        currentSnapshot,
+        incomingSnapshot,
+    );
     if (!shouldPreserveCurrent) {
         return incomingSnapshot;
     }
@@ -1836,19 +1843,6 @@ function mergeHydrationMetadataIntoCurrent(
         ...snapshotWithCatalog,
         runtimeSessionId: incomingSnapshot.runtimeSessionId,
     };
-}
-
-function isSnapshotUpdatedAfter(
-    currentSnapshot: Pick<AiSessionSnapshot, "updatedAt">,
-    incomingSnapshot: Pick<AiSessionSnapshot, "updatedAt">,
-): boolean {
-    const currentUpdatedAt = Date.parse(currentSnapshot.updatedAt);
-    const incomingUpdatedAt = Date.parse(incomingSnapshot.updatedAt);
-    return (
-        Number.isFinite(currentUpdatedAt) &&
-        Number.isFinite(incomingUpdatedAt) &&
-        currentUpdatedAt > incomingUpdatedAt
-    );
 }
 
 function hasMoreTranscript(

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -748,12 +748,17 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         ? runtimeCatalog
                         : (state.runtimeCatalogById[tab.runtimeId] ??
                           extractRuntimeCatalog(resolvedSnapshot));
-                const nextSnapshot = hasRuntimeCatalog(nextCatalog)
+                const incomingSnapshot = hasRuntimeCatalog(nextCatalog)
                     ? mergeRuntimeCatalogIntoSnapshot(
                           resolvedSnapshot,
                           nextCatalog,
                       )
                     : resolvedSnapshot;
+                const currentSession = state.sessions[tab.sessionId];
+                const nextSnapshot = resolveIncomingSessionSnapshot(
+                    incomingSnapshot,
+                    currentSession,
+                );
 
                 return {
                     runtimeCatalogById: hasRuntimeCatalog(nextCatalog)
@@ -1783,6 +1788,119 @@ function mergeRuntimeCatalogIntoSnapshot(
         modelId: snapshot.modelId ?? catalog.modelId,
         models: snapshot.models.length > 0 ? snapshot.models : catalog.models,
     };
+}
+
+function resolveIncomingSessionSnapshot(
+    incomingSnapshot: AiSessionSnapshot,
+    currentSession: AiSessionClientState | null | undefined,
+): AiSessionSnapshot {
+    const currentSnapshot = currentSession?.snapshot ?? null;
+    if (
+        !currentSnapshot ||
+        currentSnapshot.sessionId !== incomingSnapshot.sessionId
+    ) {
+        return incomingSnapshot;
+    }
+
+    const shouldPreserveCurrent =
+        hasMoreTranscript(currentSnapshot, incomingSnapshot) ||
+        (currentSession?.hydrated === true &&
+            isSnapshotUpdatedAfter(currentSnapshot, incomingSnapshot));
+    if (!shouldPreserveCurrent) {
+        return incomingSnapshot;
+    }
+
+    return mergeHydrationMetadataIntoCurrent(
+        currentSnapshot,
+        incomingSnapshot,
+    );
+}
+
+function mergeHydrationMetadataIntoCurrent(
+    currentSnapshot: AiSessionSnapshot,
+    incomingSnapshot: AiSessionSnapshot,
+): AiSessionSnapshot {
+    const incomingCatalog = extractRuntimeCatalog(incomingSnapshot);
+    const snapshotWithCatalog = hasRuntimeCatalog(incomingCatalog)
+        ? mergeRuntimeCatalogIntoSnapshot(currentSnapshot, incomingCatalog)
+        : currentSnapshot;
+
+    if (
+        snapshotWithCatalog.runtimeSessionId ||
+        !incomingSnapshot.runtimeSessionId
+    ) {
+        return snapshotWithCatalog;
+    }
+
+    return {
+        ...snapshotWithCatalog,
+        runtimeSessionId: incomingSnapshot.runtimeSessionId,
+    };
+}
+
+function isSnapshotUpdatedAfter(
+    currentSnapshot: Pick<AiSessionSnapshot, "updatedAt">,
+    incomingSnapshot: Pick<AiSessionSnapshot, "updatedAt">,
+): boolean {
+    const currentUpdatedAt = Date.parse(currentSnapshot.updatedAt);
+    const incomingUpdatedAt = Date.parse(incomingSnapshot.updatedAt);
+    return (
+        Number.isFinite(currentUpdatedAt) &&
+        Number.isFinite(incomingUpdatedAt) &&
+        currentUpdatedAt > incomingUpdatedAt
+    );
+}
+
+function hasMoreTranscript(
+    currentSnapshot: Pick<AiSessionSnapshot, "messages">,
+    incomingSnapshot: Pick<AiSessionSnapshot, "messages">,
+): boolean {
+    if (
+        currentSnapshot.messages.length < incomingSnapshot.messages.length ||
+        !hasCompatibleTranscriptPrefix(incomingSnapshot, currentSnapshot)
+    ) {
+        return false;
+    }
+
+    if (currentSnapshot.messages.length > incomingSnapshot.messages.length) {
+        return true;
+    }
+
+    return (
+        getTranscriptWeight(currentSnapshot) >
+        getTranscriptWeight(incomingSnapshot)
+    );
+}
+
+function hasCompatibleTranscriptPrefix(
+    prefixSnapshot: Pick<AiSessionSnapshot, "messages">,
+    candidateSnapshot: Pick<AiSessionSnapshot, "messages">,
+): boolean {
+    return prefixSnapshot.messages.every((message, index) => {
+        const candidate = candidateSnapshot.messages[index];
+        if (!candidate || candidate.kind !== message.kind) {
+            return false;
+        }
+
+        if (message.id && candidate.id && message.id !== candidate.id) {
+            return false;
+        }
+
+        return (
+            candidate.content.startsWith(message.content) &&
+            candidate.attachments.length >= message.attachments.length
+        );
+    });
+}
+
+function getTranscriptWeight(
+    snapshot: Pick<AiSessionSnapshot, "messages">,
+): number {
+    return snapshot.messages.reduce(
+        (total, message) =>
+            total + message.content.length + message.attachments.length,
+        0,
+    );
 }
 
 function applyCatalogPatchToCatalog(


### PR DESCRIPTION
## Summary

Fixes races that could hide, overwrite, or fail to attach messages while interacting with subagent sessions.

## Root Cause

Subagent and session events can arrive out of order around session hydration, ACP echo handling, child-session registration, and turn lifecycle breadcrumbs. In those windows, newer transcript state could be overwritten by stale data, internal guided-input payloads could leak into visible chat history, repeated prompts could be deduped too aggressively, early child-session creation could be lost, or a terminal subagent response could arrive before the lifecycle completion that idles the child session.

## Changes

- Preserve richer/newer transcript state when late hydration, full snapshots, or patches would otherwise replace it with stale transcript data.
- Suppress internal guided-input response echoes while keeping the human-readable answer summary visible.
- Avoid suppressing legitimate user content that reuses a prompt message ID.
- Preserve repeated subagent prompts with distinct tool call IDs.
- Retry buffered subagent creation events once the parent runtime session mapping is registered.
- Preserve `subagent_session_created` events even when early child updates overflow the pending update buffer.
- Keep terminal `interaction_end` / `resume_end` responses visible even if they arrive before the child `turn_complete` lifecycle event.
- Add fallback support for `codexAcpParentThreadId` / `codexAcpChildThreadId` metadata when session IDs are absent.
- Add focused regression coverage for renderer stale state and worker subagent lifecycle races.

## Validation

- `pnpm vitest run src/renderer/src/app/store/ai-store.test.ts src/main/ai/worker-runtime.test.ts` — 97 tests passed.
- `pnpm run typecheck` — passed.
- `pnpm eslint src/renderer/src/app/store/ai-store.ts src/renderer/src/app/store/ai-store.test.ts src/main/ai/worker-runtime.ts src/main/ai/worker-runtime.test.ts` — 0 errors, 8 existing warnings in `worker-runtime.ts`.
- `git diff --check` — passed.
