### PR TITLE
Update Claude runtime to 2.1.154

### DIFF
--- a/Copyright.md
+++ b/Copyright.md
@@ -173,10 +173,10 @@ was checked with `cargo metadata --format-version=1 --locked`.
 | Vendored path | `vendor/Claude-agent-acp-upstream` |
 | Staged path | `resources/ai/embedded/claude-agent-acp` |
 | Upstream package | `@agentclientprotocol/claude-agent-acp` |
-| Upstream baseline | `0.33.1`, commit `e0ea9d8` |
+| Upstream baseline | `0.37.0`, commit `36822c2b75b6e1cd5406a5ab40fe603fc380ee10` |
 | Package license | Apache-2.0 |
-| ACP SDK dependency | `@agentclientprotocol/sdk` `0.21.0`, Apache-2.0 |
-| Claude Agent SDK dependency | `@anthropic-ai/claude-agent-sdk` `0.2.132`, Anthropic legal terms |
+| ACP SDK dependency | `@agentclientprotocol/sdk` `0.22.1`, Apache-2.0 |
+| Claude Agent SDK dependency | `@anthropic-ai/claude-agent-sdk` `0.3.154`, Anthropic legal terms |
 
 The Claude ACP adapter itself is Apache-2.0. Its runtime dependency
 `@anthropic-ai/claude-agent-sdk` and the platform-specific
@@ -237,7 +237,7 @@ The currently tracked local delta includes:
 ### `vendor/Claude-agent-acp-upstream` - Agent Client Protocol Claude ACP
 
 The vendored Claude ACP runtime is based on upstream
-`@agentclientprotocol/claude-agent-acp` `0.33.1`. The Claude vendor source does
+`@agentclientprotocol/claude-agent-acp` `0.37.0`. The Claude vendor source does
 not carry Comando-specific review metadata. Claude PostToolUse structured patch
 responses are translated inside Comando's internal review adapter so review
 snippets can retain real line anchors while keeping the vendored runtime aligned
@@ -245,7 +245,8 @@ with upstream source.
 
 | File | Nature of changes |
 | ---- | ----------------- |
-| N/A | No Comando source delta for Claude review metadata |
+| `package.json`, `package-lock.json` | Updated `@anthropic-ai/claude-agent-sdk` to `0.3.154` to embed Claude Code `2.1.154` |
+| `src/acp-agent.ts` | Added no-op handling for the SDK `thinking_tokens` system event introduced by the newer runtime |
 
 This vendor directory should be reviewed intentionally whenever syncing against
 upstream.

--- a/src/main/ai/ACP.md
+++ b/src/main/ai/ACP.md
@@ -16,7 +16,7 @@ All five communicate with the app over ACP / JSON-RPC on stdio.
 
 | | Claude | Codex | Gemini | Kilo | OpenCode |
 |---|---|---|---|---|---|
-| **Source** | TypeScript (`@agentclientprotocol/claude-agent-acp` `0.35.0`, vendored upstream snapshot) | Rust (`codex-acp` `0.15.0`, vendored on top of `openai/codex` `rust-v0.133.0` + local patches) | External Gemini CLI binary | External Kilo CLI binary | External OpenCode CLI binary |
+| **Source** | TypeScript (`@agentclientprotocol/claude-agent-acp` `0.37.0`, vendored upstream snapshot) | Rust (`codex-acp` `0.15.0`, vendored on top of `openai/codex` `rust-v0.133.0` + local patches) | External Gemini CLI binary | External Kilo CLI binary | External OpenCode CLI binary |
 | **Runtime command** | `node .../claude-agent-acp/dist/index.js` or `claude-agent-acp` | `codex-acp` | `gemini --acp` | `kilo acp` | `opencode acp` |
 | **Release packaging** | Embedded Node runtime + embedded vendor JS project | Bundled native binary under `resources/ai/binaries/` | Not bundled today | Not bundled today | Not bundled today |
 | **Auth methods exposed by Comando** | `claude-ai-login`, `claude-login`, `console-login`, `gateway` | `chatgpt`, `codex-api-key`, `openai-api-key` | `login_with_google`, `use_gemini` | `kilo-login` | `opencode-login` |
@@ -27,7 +27,7 @@ Notes:
 
 - Comando persists runtime catalogs such as available commands, config options, modes and models, then rehydrates status from the latest stored catalog on startup.
 - The vendored Claude ACP snapshot follows upstream reasoning support. Comando maps upstream `thought_level` and legacy `effort` config options into the UI's reasoning controls and keeps compatibility with older saved `effort_level` preferences.
-- The current Claude vendor is `@agentclientprotocol/claude-agent-acp` `0.35.0`, with `@anthropic-ai/claude-agent-sdk` `0.3.143`. Compared with the previous Comando baseline (`0.31.4`), it honors `availableModels` from Claude settings, emits real diffs when `Write` overwrites existing files, preserves task-notification result origins so autonomous followups do not incorrectly drive the user-turn lifecycle, resolves defaults through the Claude SDK settings engine, mirrors SDK task hooks into ACP plan updates, and renders local command stdout messages instead of dropping them.
+- The current Claude vendor is `@agentclientprotocol/claude-agent-acp` `0.37.0`, with `@anthropic-ai/claude-agent-sdk` `0.3.154` (Claude Code `2.1.154`). It honors `availableModels` from Claude settings, emits real diffs when `Write` overwrites existing files, preserves task-notification result origins so autonomous followups do not incorrectly drive the user-turn lifecycle, resolves defaults through the Claude SDK settings engine, mirrors SDK task hooks into ACP plan updates, renders local command stdout messages instead of dropping them, and treats the SDK `thinking_tokens` telemetry event as a no-op.
 - The vendored Codex ACP snapshot is currently kept at `codex-acp` `0.15.0`, with its Rust runtime dependencies pinned to `openai/codex` `rust-v0.133.0` and `agent-client-protocol` `0.12.1`.
 - The vendored Codex ACP snapshot currently includes a local Fast Mode patch carried over into Comando. It exposes the ACP session config option `service_tier`, the `/fast` slash command, and rehydrates `service_tier` when a session is resumed.
 - The vendored Codex ACP snapshot also carries a local image-generation bridge: live Codex `ImageGenerationBegin` / `ImageGenerationEnd` events and replayed `ResponseItem::ImageGenerationCall` items are emitted as ACP tool updates with `codexAcpEventType = "image_generation"` and `codex-acp:image:` IDs so Comando can render generated images inline instead of as generic status activity. `TurnItem::ImageGeneration` is intentionally ignored for the live bridge because Codex also emits the begin/end events, and handling both would duplicate image cards.
@@ -253,7 +253,7 @@ This means Claude is staged as an embedded project, not as a freshly built stand
 
 Current local snapshot note:
 
-- `vendor/Claude-agent-acp-upstream/` is synced to upstream `@agentclientprotocol/claude-agent-acp` `0.35.0` at commit `f6e12d4`.
+- `vendor/Claude-agent-acp-upstream/` is synced to upstream `@agentclientprotocol/claude-agent-acp` `0.37.0` at commit `36822c2b75b6e1cd5406a5ab40fe603fc380ee10`, with a local runtime bump to `@anthropic-ai/claude-agent-sdk` `0.3.154` (Claude Code `2.1.154`).
 - `vendor/Claude-agent-acp-upstream/` uses the upstream Claude ACP reasoning implementation.
 - Upstream exposes model-specific reasoning values through the `thought_level` ACP session config option when the selected Claude model reports support for them.
 - Comando still accepts older saved `effort_level` and `effort` preferences and applies them to upstream's reasoning option.
@@ -263,6 +263,7 @@ Current local snapshot note:
 - Claude settings are now resolved through the Claude SDK settings engine, matching upstream defaults and trust filtering more closely than Comando's previous local merge.
 - Claude SDK task hooks (`TaskCreated` and `TaskCompleted`) now populate ACP plan updates, so newer SDK task state should remain visible in Comando's plan UI.
 - Upstream now renders local command stdout messages after stripping Claude command metadata, which lets slash-command and skill output reach the chat stream.
+- The local Claude compatibility delta treats the SDK `thinking_tokens` telemetry event as a no-op so newer Claude Code runtimes do not trip ACP event exhaustiveness handling.
 - Upstream added a `gateway-bedrock` auth method for Bedrock-style gateways, but Comando's persisted Claude gateway settings still model the existing Anthropic-compatible `gateway` path.
 
 ### macOS packaging (`scripts/package-macos-app.mjs`)

--- a/vendor/Claude-agent-acp-upstream/package-lock.json
+++ b/vendor/Claude-agent-acp-upstream/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.22.1",
-        "@anthropic-ai/claude-agent-sdk": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk": "0.3.154",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "bin": {
@@ -41,22 +41,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.146",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.146.tgz",
-      "integrity": "sha512-hK9/Ng+hOyexUemTxdIUsSWJ9o2LFi2YNWzHwz8/YMCohUYOnFMZkBiENvUAb0WIc5hieOyBZrOIlg5OewuJMg==",
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.154.tgz",
+      "integrity": "sha512-iEn25urI2QrMPFIhId3h7v/7EG5gsmF7ooe+6EvsAosePeLmpVVerp5nXtHnlmBkMinLecurcPA+OddKw76jYw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.146",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.146",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.146",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.146",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.146",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.146",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.146",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.146"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.154"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.146",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.146.tgz",
-      "integrity": "sha512-0IIvlEaenq2CRSVx5Bo5BaCtHQXS87GancM35WKEYveGVLn6DI+5G7ikYuTE4AKRPkMnogFtY4BJt6LulWGj+A==",
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.154.tgz",
+      "integrity": "sha512-oFW3LD5lYrKAU+AKu27Z8hrzqkrh362qQrwi/i3DxGcud9BXUycsXYjShpDj3D3JZu169UzZuSPhx1Wajmbiwg==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.146",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.146.tgz",
-      "integrity": "sha512-Dk5xJ03Ff1JXbMRP1t2wc/TyfY6xF/2Ysp31wMhFPjoNiKSPHMWaIg242+T3CHdxLWmJ8plWHL1HL5cyZ/LCkw==",
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.154.tgz",
+      "integrity": "sha512-5BgWEueP+cqoctWjZYhCbyltuaV/N2DmKDXD3/69cKaVmJp8XL9OCzlq/HEirA/+Ssjskx6hDUBaOcpuZ3iwQA==",
       "cpu": [
         "x64"
       ],
@@ -91,9 +91,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.146",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.146.tgz",
-      "integrity": "sha512-mzBXDDWWBAC/vDtAYpO1G/dq5QvJtYSPXsqcb+sNdcDhiuf4IYnYp7ytRncYlsUNDkLmX6Gk2jkWAHUUA2Lozg==",
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.154.tgz",
+      "integrity": "sha512-rRkW4SBL3W7zQvKscCIfIGlmoeuTbMV6dXFbPdmpRGvmYZIs79RpzO6xrGBnnhmm+B7znQ9oHAnffi/2FBgJbA==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.146",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.146.tgz",
-      "integrity": "sha512-QlCid0ucdrmhUAOewfQjaofN2wlokWcfFTxSFePTSj1umk35JO7TDFP700F7jU49r1fPWIdvJpPwWGyB0DeFPA==",
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.154.tgz",
+      "integrity": "sha512-o2bCQN4Xn3UqCLErC5m4T7u0yYArJYmgFCUFnA6K96DdW2RERvx+gTKXxWuHEBkDO+eMoHLHLxk0u2jGES00Ng==",
       "cpu": [
         "arm64"
       ],
@@ -117,9 +117,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.146",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.146.tgz",
-      "integrity": "sha512-B2baXU1tCBT5CVlD7jJMKjpC4xdO45NUIWpqImmwuOfKvlM/PITjyTXyTY662mGZf1dBmdqBBsqirwFH/jhi8Q==",
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.154.tgz",
+      "integrity": "sha512-GpiFF8Ez6PbM3m0gqtCo/FKM346qyRdP7VhbmJzdnbNKTiiUZ66vDQyEUPZPCG24ZkrG4m96KpRIUwY08rHiNg==",
       "cpu": [
         "x64"
       ],
@@ -130,9 +130,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.146",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.146.tgz",
-      "integrity": "sha512-E3coK1ThQT08KIX80RLcsq7DWXFllCKOzoOe32it/bdtY56TBgPY9xemwXhIJ+cVBHTI9/MpBSIlKBcFCt+yQA==",
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.154.tgz",
+      "integrity": "sha512-zA7S8Lm6O4QBsUpbhiOht8BgiXHOBBFUIo8ZLK6r5wAatK3Q44syWVxICeyCnR6wqfnkf3cugCw27ycS6vVgaA==",
       "cpu": [
         "x64"
       ],
@@ -143,9 +143,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.146",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.146.tgz",
-      "integrity": "sha512-CIwQxGX2r/yWpjCJ6ahB3smKXhghWgGTxL98+LGW52TUwqTiBnlNrH9DPqqgv1/+Hyquw6xfLrKU+StyfMgiLw==",
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.154.tgz",
+      "integrity": "sha512-cDW1YFbU/PJFlrGXhlAGcbkXt80sEO6WtnH8nN8YHXLn5NWduy2q7o/qC6i8XozgvRGf6t/eMoH7IasGIEDhDw==",
       "cpu": [
         "arm64"
       ],
@@ -156,9 +156,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.146",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.146.tgz",
-      "integrity": "sha512-qmxrsyaqA8s4HShqJls7ZCRjdoqN66Jo/hbjQNB3uHepD8tEO1iD19aPV4+osdLT7feMkhDBfLT07Q30R2NB5w==",
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.154.tgz",
+      "integrity": "sha512-tSKaIIpL72OPg3WfzZTCIl8OJgcbq4qieu8/fDWjsdeQuari9gQMIuEflFphk9HqNsxpSmDqKi8Sm5mW2V566Q==",
       "cpu": [
         "x64"
       ],

--- a/vendor/Claude-agent-acp-upstream/package.json
+++ b/vendor/Claude-agent-acp-upstream/package.json
@@ -61,7 +61,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agentclientprotocol/sdk": "0.22.1",
-    "@anthropic-ai/claude-agent-sdk": "0.3.146",
+    "@anthropic-ai/claude-agent-sdk": "0.3.154",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/vendor/Claude-agent-acp-upstream/src/acp-agent.ts
+++ b/vendor/Claude-agent-acp-upstream/src/acp-agent.ts
@@ -926,6 +926,7 @@ export class ClaudeAcpAgent implements Agent {
               case "api_retry":
               case "mirror_error":
               case "permission_denied":
+              case "thinking_tokens":
                 // Todo: process via status api: https://docs.claude.com/en/docs/claude-code/hooks#hook-output
                 break;
               default:

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -25,10 +25,10 @@ Current scope in Comando:
     - `vendor/codex-acp/src/subagents.rs`
     - `vendor/codex-acp/src/thread.rs`
 - `Claude-agent-acp-upstream/`
-  - vendored snapshot is currently based on `@agentclientprotocol/claude-agent-acp` `0.33.1`
-  - synced against upstream commit `e0ea9d8` (`chore(main): release 0.33.1 (#638)`)
-  - uses `@anthropic-ai/claude-agent-sdk` `0.2.132`
-  - includes upstream fixes for `availableModels` allowlists, real `Write` overwrite diffs, and task-notification result origins
+  - vendored snapshot is currently based on `@agentclientprotocol/claude-agent-acp` `0.37.0`
+  - synced against upstream commit `36822c2b75b6e1cd5406a5ab40fe603fc380ee10`
+  - local runtime update keeps `@agentclientprotocol/sdk` at `0.22.1` and updates `@anthropic-ai/claude-agent-sdk` to `0.3.154` (Claude Code `2.1.154`)
+  - includes upstream fixes for `availableModels` allowlists, real `Write` overwrite diffs, task-notification result origins, SDK settings defaults, task-hook mirroring and local command stdout rendering
 
 ## Current Codex Delta
 
@@ -53,6 +53,17 @@ The remaining Comando-specific delta exists to preserve desktop product behavior
 When updating Codex again, treat `863d433` plus the current OpenAI Codex crate tag as the comparison base, and review those files intentionally instead of replacing the whole directory blindly.
 
 Comando's ACP client lives in TypeScript/Electron under `src/main/ai/` and currently uses `@agentclientprotocol/sdk` from npm. Do not copy a Rust workspace ACP client migration unless Comando gains an equivalent Rust backend.
+
+## Current Claude Delta
+
+The Claude vendor is based on upstream `@agentclientprotocol/claude-agent-acp`
+`0.37.0`, with a narrow local runtime bump to `@anthropic-ai/claude-agent-sdk`
+`0.3.154` so the embedded Claude Code runtime is `2.1.154`.
+
+The only source-level compatibility delta is treating the SDK's
+`thinking_tokens` system event as a no-op. The event is streaming telemetry for
+thinking-token estimates, not assistant content, tool calls, file edits, or final
+usage. `dist/` is rebuilt from the vendored source after applying that delta.
 
 ## Updating Vendored Runtimes
 


### PR DESCRIPTION
## Summary

Updates the vendored Claude ACP runtime dependency so Comando embeds `@anthropic-ai/claude-agent-sdk` `0.3.154`, matching Claude Code `2.1.154` and enabling the newer Opus 4.8 runtime support path.

Adds compatibility handling for the SDK `thinking_tokens` system event by treating it as telemetry/no-op activity, so newer Claude Code runtimes do not trip ACP event exhaustiveness handling.

Also refreshes the vendor and ACP architecture notes to reflect the current Claude ACP `0.37.0` baseline and local Claude runtime delta.

## Validation

- `npm run build` in `vendor/Claude-agent-acp-upstream`
- `npm test -- --run` in `vendor/Claude-agent-acp-upstream`
- `node scripts/ai/stage-claude-runtime.mjs`
- `pnpm run verify:ai-runtimes`
- `git diff --check`