### PR TITLE
Fix GitHub panel worktree fallback

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.test.ts
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+    GitBranchSummary,
+    GitRemoteSummary,
+    GitRepositorySnapshot,
+    GitWorktreeSummary,
+} from "@shared/ipc";
+
+import {
+    getGitHubRepositorySnapshot,
+    getProjectSnapshot,
+} from "./SidebarGitHubPanel";
+
+function createBranch(
+    overrides: Partial<GitBranchSummary> = {},
+): GitBranchSummary {
+    return {
+        aheadBy: 0,
+        behindBy: 0,
+        commitSha: "abc1234567890",
+        isCurrent: true,
+        isDetached: false,
+        isRemote: false,
+        kind: "branch",
+        name: "main",
+        upstreamName: "origin/main",
+        ...overrides,
+    };
+}
+
+function createRemote(
+    overrides: Partial<GitRemoteSummary> = {},
+): GitRemoteSummary {
+    return {
+        aheadBy: 0,
+        behindBy: 0,
+        fetchUrl: "https://github.com/example/comando.git",
+        isDefault: true,
+        name: "origin",
+        pushUrl: "https://github.com/example/comando.git",
+        refName: "origin/main",
+        ...overrides,
+    };
+}
+
+function createWorktree(
+    overrides: Partial<GitWorktreeSummary> = {},
+): GitWorktreeSummary {
+    return {
+        branchName: "main",
+        commitSha: "abc1234567890",
+        id: "project-1:primary",
+        isBare: false,
+        isCurrent: true,
+        isLocked: false,
+        isPrimary: true,
+        lockedReason: null,
+        projectId: "project-1",
+        rootPath: "/tmp/Comando",
+        updatedAt: "2026-04-19T00:00:00.000Z",
+        ...overrides,
+    };
+}
+
+function createSnapshot(
+    overrides: Partial<GitRepositorySnapshot> = {},
+): GitRepositorySnapshot {
+    return {
+        aheadBy: 0,
+        behindBy: 0,
+        branch: createBranch(),
+        canonicalRootPath: "/tmp/Comando",
+        changedPaths: [],
+        changes: [],
+        currentWorktreeId: null,
+        defaultTreeViewMode: "tree",
+        headSha: "abc1234567890",
+        projectId: "project-1",
+        remotes: [createRemote()],
+        repositoryState: "ready",
+        rootPath: "/tmp/Comando",
+        selectedRemoteName: "origin",
+        status: {
+            changedCount: 0,
+            conflictedCount: 0,
+            stagedCount: 0,
+            unstagedCount: 0,
+            untrackedCount: 0,
+        },
+        syncStatus: "in_sync",
+        updatedAt: "2026-04-19T00:00:00.000Z",
+        worktrees: [createWorktree()],
+        ...overrides,
+    };
+}
+
+describe("SidebarGitHubPanel snapshot helpers", () => {
+    it("does not use a project fallback for the branch snapshot of a missing worktree", () => {
+        const primarySnapshot = createSnapshot({
+            branch: createBranch({ name: "main" }),
+            worktrees: [
+                createWorktree(),
+                createWorktree({
+                    branchName: "feature/github-panel",
+                    id: "worktree-feature",
+                    isCurrent: false,
+                    isPrimary: false,
+                    rootPath: "/tmp/Comando-feature",
+                }),
+            ],
+        });
+
+        const snapshots = {
+            "project-1::primary": primarySnapshot,
+        };
+
+        expect(
+            getProjectSnapshot(snapshots, "project-1", "worktree-feature"),
+        ).toBeNull();
+    });
+
+    it("uses a project snapshot fallback for GitHub repository identity", () => {
+        const primarySnapshot = createSnapshot({
+            remotes: [
+                createRemote({
+                    fetchUrl: "git@github.com:example/comando.git",
+                    pushUrl: "git@github.com:example/comando.git",
+                }),
+            ],
+            worktrees: [
+                createWorktree(),
+                createWorktree({
+                    branchName: "feature/github-panel",
+                    id: "worktree-feature",
+                    isCurrent: false,
+                    isPrimary: false,
+                    rootPath: "/tmp/Comando-feature",
+                }),
+            ],
+        });
+
+        const snapshots = {
+            "project-1::primary": primarySnapshot,
+        };
+
+        expect(
+            getGitHubRepositorySnapshot(
+                snapshots,
+                "project-1",
+                "worktree-feature",
+            ),
+        ).toBe(primarySnapshot);
+    });
+
+    it("prefers the direct worktree snapshot for GitHub repository identity", () => {
+        const primarySnapshot = createSnapshot({
+            branch: createBranch({ name: "main" }),
+        });
+        const worktreeSnapshot = createSnapshot({
+            branch: createBranch({ name: "feature/github-panel" }),
+            currentWorktreeId: "worktree-feature",
+            rootPath: "/tmp/Comando-feature",
+            worktrees: [
+                createWorktree({
+                    branchName: "feature/github-panel",
+                    id: "worktree-feature",
+                    rootPath: "/tmp/Comando-feature",
+                }),
+            ],
+        });
+
+        const snapshots = {
+            "project-1::primary": primarySnapshot,
+            "project-1::worktree-feature": worktreeSnapshot,
+        };
+
+        expect(
+            getGitHubRepositorySnapshot(
+                snapshots,
+                "project-1",
+                "worktree-feature",
+            ),
+        ).toBe(worktreeSnapshot);
+    });
+});

--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
@@ -102,9 +102,18 @@ export function SidebarGitHubPanel({
             ? getProjectSnapshot(state.snapshots, projectId, worktreeId)
             : null,
     );
+    const githubSnapshot = useGitStore((state) =>
+        projectId
+            ? getGitHubRepositorySnapshot(
+                  state.snapshots,
+                  projectId,
+                  worktreeId,
+              )
+            : null,
+    );
     const repoRef = useMemo(
-        () => resolveGitHubRepositoryRef(snapshot?.remotes ?? []),
-        [snapshot?.remotes],
+        () => resolveGitHubRepositoryRef(githubSnapshot?.remotes ?? []),
+        [githubSnapshot?.remotes],
     );
     const repoKey = repoRef ? getGitHubRepoKey(repoRef) : null;
     const authStatus = useGitHubStore((state) =>
@@ -217,7 +226,7 @@ export function SidebarGitHubPanel({
         isCheckingAuth,
         projectId,
         repoRef,
-        snapshot,
+        snapshot: githubSnapshot,
     });
 
     useEffect(() => {
@@ -1612,7 +1621,7 @@ function getContextKey(projectId: string, worktreeId: string | null): string {
     return getGitContextKey(projectId, worktreeId);
 }
 
-function getProjectSnapshot(
+export function getProjectSnapshot(
     snapshots: Record<string, GitRepositorySnapshot | null>,
     projectId: string,
     worktreeId: string | null,
@@ -1631,6 +1640,29 @@ function getProjectSnapshot(
             (snapshot) =>
                 snapshot?.projectId === projectId &&
                 snapshot.currentWorktreeId === null,
+        ) ?? null
+    );
+}
+
+export function getGitHubRepositorySnapshot(
+    snapshots: Record<string, GitRepositorySnapshot | null>,
+    projectId: string,
+    worktreeId: string | null,
+): GitRepositorySnapshot | null {
+    const directMatch = getProjectSnapshot(snapshots, projectId, worktreeId);
+    if (directMatch) {
+        return directMatch;
+    }
+
+    return (
+        Object.values(snapshots).find(
+            (snapshot) =>
+                snapshot?.projectId === projectId &&
+                (worktreeId === null ||
+                    snapshot.worktrees.some(
+                        (entry) => entry.id === worktreeId,
+                    ) ||
+                    snapshot.currentWorktreeId === null),
         ) ?? null
     );
 }


### PR DESCRIPTION
## Summary
- Keep the GitHub sidebar tied to repository identity when switching into a worktree before its direct git snapshot is available.
- Preserve branch-aware behavior by reading the active branch only from the direct worktree snapshot.
- Add focused coverage for the GitHub snapshot fallback helpers.

## Root Cause
The GitHub sidebar resolved both repository remotes and current branch from the same worktree-scoped snapshot. When switching to a worktree before that snapshot existed, the sidebar lost `repoRef` and showed no issues or pull requests.

## Validation
- `pnpm exec vitest run src/renderer/src/components/sidebar/SidebarGitHubPanel.test.ts`
- `pnpm exec eslint src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx src/renderer/src/components/sidebar/SidebarGitHubPanel.test.ts`
- `pnpm exec tsc --noEmit -p tsconfig.web.json --pretty false`
- `git diff --check`