### PR TITLE
Fix subagent child timelines and project worker event routing

### DIFF
--- a/src/main/ai/session-core.ts
+++ b/src/main/ai/session-core.ts
@@ -180,8 +180,10 @@ function mapSessionModes(
     state: SessionModeState | null | undefined,
     configOptions: readonly AiSessionConfigOption[],
 ): readonly AiSessionMode[] {
-    if (state && state.availableModes.length > 0) {
-        return state.availableModes.map((mode) => ({
+    const availableModes =
+        state && Array.isArray(state.availableModes) ? state.availableModes : [];
+    if (availableModes.length > 0) {
+        return availableModes.map((mode) => ({
             description: mode.description ?? null,
             id: mode.id,
             name: mode.name,
@@ -195,8 +197,12 @@ function mapSessionModels(
     state: SessionModelState | null | undefined,
     configOptions: readonly AiSessionConfigOption[],
 ): readonly AiSessionModel[] {
-    if (state && state.availableModels.length > 0) {
-        return state.availableModels.map((model) => ({
+    const availableModels =
+        state && Array.isArray(state.availableModels)
+            ? state.availableModels
+            : [];
+    if (availableModels.length > 0) {
+        return availableModels.map((model) => ({
             description: model.description ?? null,
             id: model.modelId,
             name: model.name,
@@ -298,8 +304,12 @@ function deriveModeId(
         return modeConfig.value;
     }
 
-    if (state && state.currentModeId.trim()) {
-        return state.currentModeId;
+    const currentModeId =
+        state && typeof state.currentModeId === "string"
+            ? state.currentModeId.trim()
+            : "";
+    if (currentModeId) {
+        return currentModeId;
     }
 
     return fallback;
@@ -312,10 +322,11 @@ function deriveModelId(
 ): string | null {
     if (
         state &&
+        typeof state.currentModelId === "string" &&
         state.currentModelId.trim() &&
         !state.currentModelId.includes("/")
     ) {
-        return state.currentModelId;
+        return state.currentModelId.trim();
     }
 
     const modelConfig = getModelConfigOption(configOptions);

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -1851,9 +1851,9 @@ describe("AiWorkerRuntime prepareSession", () => {
         ]);
     });
 
-    it("hides internal tool activity rows from Codex subagent child sessions", async () => {
+    it("renders subagent child tool activity while keeping parent timeline isolated", async () => {
         const { client, emittedEvents, tempDir } =
-            await setupPreparedRuntimeWithClient("Subagent hidden tools parent");
+            await setupPreparedRuntimeWithClient("Subagent visible tools parent");
         const childSnapshot = await registerSubagentSession(
             client,
             emittedEvents,
@@ -1897,6 +1897,19 @@ describe("AiWorkerRuntime prepareSession", () => {
         await client.sessionUpdate({
             sessionId: "runtime-subagent-1",
             update: {
+                kind: "read",
+                rawInput: {
+                    filePath: path.join(tempDir, "src/input.ts"),
+                },
+                sessionUpdate: "tool_call",
+                status: "completed",
+                title: "read_file",
+                toolCallId: "child-read",
+            },
+        });
+        await client.sessionUpdate({
+            sessionId: "runtime-subagent-1",
+            update: {
                 kind: "plan",
                 sessionUpdate: "tool_call",
                 status: "completed",
@@ -1914,17 +1927,26 @@ describe("AiWorkerRuntime prepareSession", () => {
                 ),
             ).toBe(true);
         });
-        expect(
-            hasToolActivityMatching(
-                emittedEvents,
-                childSnapshot.sessionId,
-                (activity) =>
-                    activity.id === "child-exec" ||
-                    activity.id === "child-plan" ||
-                    activity.title === "exec_command" ||
-                    activity.title === "update_plan",
-            ),
-        ).toBe(false);
+        for (const expectedToolId of [
+            "child-exec",
+            "child-read",
+            "child-plan",
+        ]) {
+            expect(
+                hasToolActivityMatching(
+                    emittedEvents,
+                    childSnapshot.sessionId,
+                    (activity) => activity.id === expectedToolId,
+                ),
+            ).toBe(true);
+            expect(
+                hasToolActivityMatching(
+                    emittedEvents,
+                    "session-1",
+                    (activity) => activity.id === expectedToolId,
+                ),
+            ).toBe(false);
+        }
 
         emittedEvents.length = 0;
         await client.sessionUpdate({
@@ -1961,6 +1983,16 @@ describe("AiWorkerRuntime prepareSession", () => {
                 childSnapshot.sessionId,
                 (activity) => activity.id === "child-edit",
             ),
+        ).toBe(true);
+        expect(
+            hasToolActivityMatching(
+                emittedEvents,
+                "session-1",
+                (activity) => activity.id === "child-edit",
+            ),
+        ).toBe(false);
+        expect(
+            hasTrackedFileEvent(emittedEvents, "session-1", "src/subagent-tool.ts"),
         ).toBe(false);
     });
 

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -228,23 +228,6 @@ function shouldSuppressSessionToolActivityUpdate(
     return shouldSuppressToolActivityUpdate(update, title);
 }
 
-function suppressSubagentToolActivityRows(
-    liveSession: LiveAcpSession,
-    previousSnapshot: AiSessionSnapshot,
-    nextSnapshot: AiSessionSnapshot,
-): AiSessionSnapshot {
-    if (!isSubagentLiveSession(liveSession)) {
-        return nextSnapshot;
-    }
-
-    // Subagent tool calls are implementation details; keep their side effects
-    // such as tracked files and pending input without rendering tool rows.
-    return {
-        ...nextSnapshot,
-        toolActivity: previousSnapshot.toolActivity,
-    };
-}
-
 function isDirectStreamingSessionUpdate(
     update: SessionNotification["update"],
 ): boolean {
@@ -1786,52 +1769,34 @@ export class AiWorkerRuntime {
                 break;
             case "tool_call":
                 nextSnapshot = finalizeStreamingMessages(nextSnapshot);
-                {
-                    const previousSnapshot = nextSnapshot;
-                    const mappedSnapshot = isImageGenerationToolUpdate(update)
-                        ? mapImageGenerationToolUpdate(nextSnapshot, update, now)
-                        : mapToolCallUpdate(
-                              liveSession,
-                              nextSnapshot,
-                              update,
-                              "tool_call",
-                              now,
-                              {
-                                  readOpenFileBuffer: (absolutePath) =>
-                                      this.#fileBuffers.get(absolutePath) ??
-                                      null,
-                              },
-                          );
-                    nextSnapshot = suppressSubagentToolActivityRows(
-                        liveSession,
-                        previousSnapshot,
-                        mappedSnapshot,
-                    );
-                }
+                nextSnapshot = isImageGenerationToolUpdate(update)
+                    ? mapImageGenerationToolUpdate(nextSnapshot, update, now)
+                    : mapToolCallUpdate(
+                          liveSession,
+                          nextSnapshot,
+                          update,
+                          "tool_call",
+                          now,
+                          {
+                              readOpenFileBuffer: (absolutePath) =>
+                                  this.#fileBuffers.get(absolutePath) ?? null,
+                          },
+                      );
                 break;
             case "tool_call_update":
-                {
-                    const previousSnapshot = nextSnapshot;
-                    const mappedSnapshot = isImageGenerationToolUpdate(update)
-                        ? mapImageGenerationToolUpdate(nextSnapshot, update, now)
-                        : mapToolCallUpdate(
-                              liveSession,
-                              nextSnapshot,
-                              update,
-                              "tool_call_update",
-                              now,
-                              {
-                                  readOpenFileBuffer: (absolutePath) =>
-                                      this.#fileBuffers.get(absolutePath) ??
-                                      null,
-                              },
-                          );
-                    nextSnapshot = suppressSubagentToolActivityRows(
-                        liveSession,
-                        previousSnapshot,
-                        mappedSnapshot,
-                    );
-                }
+                nextSnapshot = isImageGenerationToolUpdate(update)
+                    ? mapImageGenerationToolUpdate(nextSnapshot, update, now)
+                    : mapToolCallUpdate(
+                          liveSession,
+                          nextSnapshot,
+                          update,
+                          "tool_call_update",
+                          now,
+                          {
+                              readOpenFileBuffer: (absolutePath) =>
+                                  this.#fileBuffers.get(absolutePath) ?? null,
+                          },
+                      );
                 break;
             case "plan":
                 nextSnapshot = {

--- a/src/main/projects/client.test.ts
+++ b/src/main/projects/client.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./worker?modulePath", () => ({
+    default: "/test/project-worker.js",
+}));
+
+const { __testing } = await import("./client");
+
+describe("project worker client event routing", () => {
+    it("lets RPC responses pass through to the supervisor", () => {
+        const onProjectTreeInvalidated = vi.fn();
+
+        const handled = __testing.handleProjectWorkerMessage(
+            {
+                id: 1,
+                result: null,
+            },
+            onProjectTreeInvalidated,
+        );
+
+        expect(handled).toBe(false);
+        expect(onProjectTreeInvalidated).not.toHaveBeenCalled();
+    });
+
+    it("handles project invalidation events", () => {
+        const onProjectTreeInvalidated = vi.fn();
+        const payload = {
+            occurredAt: "2026-05-29T00:00:00.000Z",
+            projectId: "project-1",
+            relativePaths: ["src/main.ts"],
+            worktreeId: null,
+        };
+
+        const handled = __testing.handleProjectWorkerMessage(
+            {
+                event: "project.invalidated",
+                payload,
+                type: "event",
+            },
+            onProjectTreeInvalidated,
+        );
+
+        expect(handled).toBe(true);
+        expect(onProjectTreeInvalidated).toHaveBeenCalledWith(payload);
+    });
+
+    it("consumes malformed project invalidation events without crashing", () => {
+        const onProjectTreeInvalidated = vi.fn();
+
+        const handled = __testing.handleProjectWorkerMessage(
+            {
+                event: "project.invalidated",
+                type: "event",
+            },
+            onProjectTreeInvalidated,
+        );
+
+        expect(handled).toBe(true);
+        expect(onProjectTreeInvalidated).not.toHaveBeenCalled();
+    });
+});

--- a/src/main/projects/client.ts
+++ b/src/main/projects/client.ts
@@ -32,12 +32,6 @@ interface ProjectWorkerFatalMessage {
     readonly type: "fatal";
 }
 
-interface ProjectWorkerEventMessage {
-    readonly event: "project.invalidated";
-    readonly payload: ProjectTreeInvalidation;
-    readonly type: "event";
-}
-
 interface SerializedError {
     readonly message: string;
     readonly name: string;
@@ -296,17 +290,63 @@ export async function createProjectWorkerClient(
                 options.onWorkerRestarted?.();
             }
         },
-        onMessage: (message) => {
-            const payload = message as ProjectWorkerEventMessage;
-            options.onProjectTreeInvalidated(payload.payload);
-            return true;
-        },
+        onMessage: (message) =>
+            handleProjectWorkerMessage(
+                message,
+                options.onProjectTreeInvalidated,
+            ),
         timeoutMs: WORKER_TIMEOUTS_MS.projects,
     });
     const rpc = new ProjectRpcClient(supervisor);
 
     await rpc.ready();
     return new RemoteProjectWorkerClient(rpc);
+}
+
+function handleProjectWorkerMessage(
+    message: unknown,
+    onProjectTreeInvalidated: (payload: ProjectTreeInvalidation) => void,
+): boolean {
+    if (!isRecord(message) || message.type !== "event") {
+        return false;
+    }
+
+    if (message.event !== "project.invalidated") {
+        return true;
+    }
+
+    const payload = message.payload;
+    if (!isProjectTreeInvalidation(payload)) {
+        return true;
+    }
+
+    onProjectTreeInvalidated(payload);
+    return true;
+}
+
+function isProjectTreeInvalidation(
+    payload: unknown,
+): payload is ProjectTreeInvalidation {
+    if (!isRecord(payload)) {
+        return false;
+    }
+
+    const { occurredAt, projectId, relativePaths, worktreeId } = payload;
+    return (
+        typeof projectId === "string" &&
+        typeof occurredAt === "string" &&
+        (relativePaths === undefined ||
+            relativePaths === null ||
+            (Array.isArray(relativePaths) &&
+                relativePaths.every((entry) => typeof entry === "string"))) &&
+        (worktreeId === undefined ||
+            worktreeId === null ||
+            typeof worktreeId === "string")
+    );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
 }
 
 function waitForWorkerReady(worker: Worker, port: MessagePort): Promise<void> {
@@ -354,6 +394,10 @@ function waitForWorkerReady(worker: Worker, port: MessagePort): Promise<void> {
         port.start();
     });
 }
+
+export const __testing = {
+    handleProjectWorkerMessage,
+};
 
 function deserializeWorkerError(input: SerializedError): Error {
     const error = new Error(input.message);


### PR DESCRIPTION
## Summary
- Restores normal tool activity cards inside subagent child timelines while keeping parent timelines isolated to breadcrumbs/open-session activity.
- Hardens ACP session catalog mapping for partial or legacy mode/model payloads.
- Fixes project worker message routing so RPC responses are not treated as project invalidation events.

## Root Cause
Subagent child sessions were explicitly preserving the previous `toolActivity` array, so their own read/execute/plan/edit cards were discarded even though side effects like tracked files still arrived.

The packaged-app crash came from the project worker client consuming every worker message as a `project.invalidated` event. Normal RPC responses like `{ id, result }` have no `payload`, which eventually sent `undefined` into `broadcastProjectGitInvalidation` and crashed on `payload.worktreeId`.

## Verification
- `pnpm exec vitest run src/main/ai/worker-runtime.test.ts`
- `pnpm exec vitest run src/main/projects/client.test.ts src/main/projects/service.test.ts src/main/workers/supervisor.test.ts`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run build`
