### PR TITLE
Polish and harden file tree interactions

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1533,8 +1533,12 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
                 input.relativePath,
                 input.worktreeId ?? null,
             );
-            options.projectService.touchProject(input.projectId);
             await shell.trashItem(absolutePath);
+            await options.projectService.recordProjectEntryMutation(
+                input.projectId,
+                input.relativePath,
+                input.worktreeId ?? null,
+            );
         },
     );
     ipcMain.handle(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import fs from "node:fs";
 
 import {
     IPC_CHANNELS,
@@ -119,6 +120,7 @@ import {
     type ListAiSessionHistoryInput,
     type ListProjectEntriesInput,
     type ListProjectTreeInput,
+    type OpenProjectEntryExternallyInput,
     type OpenProjectFileInput,
     type OpenProjectWindowInput,
     type OpenSettingsWindowInput,
@@ -139,6 +141,7 @@ import {
     type SettingsSnapshot,
     type SystemTheme,
     type ThemeMode,
+    type TrashProjectEntryInput,
     type TsconfigResolutionSnapshot,
     type WindowContextSnapshot,
     type WriteTerminalInput,
@@ -307,6 +310,8 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.copyProjectEntries);
     ipcMain.removeHandler(IPC_CHANNELS.renameProjectEntry);
     ipcMain.removeHandler(IPC_CHANNELS.deleteProjectEntry);
+    ipcMain.removeHandler(IPC_CHANNELS.trashProjectEntry);
+    ipcMain.removeHandler(IPC_CHANNELS.openProjectEntryExternally);
     ipcMain.removeHandler(IPC_CHANNELS.revealProjectEntry);
     ipcMain.removeHandler(IPC_CHANNELS.listProjectEntries);
     ipcMain.removeHandler(IPC_CHANNELS.searchProjectEntries);
@@ -1506,6 +1511,37 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             deleteProjectEntryLimiter(() =>
                 options.projectService.deleteProjectEntry(input),
             ),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.trashProjectEntry,
+        async (_event, input: TrashProjectEntryInput) => {
+            const absolutePath = options.projectService.resolveProjectEntryPath(
+                input.projectId,
+                input.relativePath,
+                input.worktreeId ?? null,
+            );
+            options.projectService.touchProject(input.projectId);
+            await shell.trashItem(absolutePath);
+        },
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.openProjectEntryExternally,
+        async (_event, input: OpenProjectEntryExternallyInput) => {
+            const absolutePath = options.projectService.resolveProjectEntryPath(
+                input.projectId,
+                input.relativePath,
+                input.worktreeId ?? null,
+            );
+            const stats = await fs.promises.stat(absolutePath);
+            if (!stats.isFile()) {
+                throw new Error("Only files can be opened externally.");
+            }
+
+            const errorMessage = await shell.openPath(absolutePath);
+            if (errorMessage) {
+                throw new Error(errorMessage);
+            }
+        },
     );
     ipcMain.handle(
         IPC_CHANNELS.revealProjectEntry,

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -26,6 +26,7 @@ import {
     type CloneRepositoryInput,
     type CloneRepositoryResult,
     type CodexRuntimeSettingsInput,
+    type CopyProjectEntriesInput,
     type CreateProjectEntryInput,
     type CreateTerminalSessionInput,
     type DeleteProjectEntryInput,
@@ -303,6 +304,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.openProjectFile);
     ipcMain.removeHandler(IPC_CHANNELS.saveProjectFile);
     ipcMain.removeHandler(IPC_CHANNELS.createProjectEntry);
+    ipcMain.removeHandler(IPC_CHANNELS.copyProjectEntries);
     ipcMain.removeHandler(IPC_CHANNELS.renameProjectEntry);
     ipcMain.removeHandler(IPC_CHANNELS.deleteProjectEntry);
     ipcMain.removeHandler(IPC_CHANNELS.revealProjectEntry);
@@ -1437,6 +1439,10 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         IPC_CHANNELS.createProjectEntry,
         4,
     );
+    const copyProjectEntriesLimiter = createIpcInFlightLimiter(
+        IPC_CHANNELS.copyProjectEntries,
+        2,
+    );
     const renameProjectEntryLimiter = createIpcInFlightLimiter(
         IPC_CHANNELS.renameProjectEntry,
         4,
@@ -1478,6 +1484,13 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         (_event, input: CreateProjectEntryInput) =>
             createProjectEntryLimiter(() =>
                 options.projectService.createProjectEntry(input),
+            ),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.copyProjectEntries,
+        (_event, input: CopyProjectEntriesInput) =>
+            copyProjectEntriesLimiter(() =>
+                options.projectService.copyProjectEntries(input),
             ),
     );
     ipcMain.handle(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -27,6 +27,7 @@ import {
     type CloneRepositoryInput,
     type CloneRepositoryResult,
     type CodexRuntimeSettingsInput,
+    type CopyExternalProjectEntriesInput,
     type CopyProjectEntriesInput,
     type CreateProjectEntryInput,
     type CreateTerminalSessionInput,
@@ -308,6 +309,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.saveProjectFile);
     ipcMain.removeHandler(IPC_CHANNELS.createProjectEntry);
     ipcMain.removeHandler(IPC_CHANNELS.copyProjectEntries);
+    ipcMain.removeHandler(IPC_CHANNELS.copyExternalProjectEntries);
     ipcMain.removeHandler(IPC_CHANNELS.renameProjectEntry);
     ipcMain.removeHandler(IPC_CHANNELS.deleteProjectEntry);
     ipcMain.removeHandler(IPC_CHANNELS.trashProjectEntry);
@@ -1448,6 +1450,10 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         IPC_CHANNELS.copyProjectEntries,
         2,
     );
+    const copyExternalProjectEntriesLimiter = createIpcInFlightLimiter(
+        IPC_CHANNELS.copyExternalProjectEntries,
+        2,
+    );
     const renameProjectEntryLimiter = createIpcInFlightLimiter(
         IPC_CHANNELS.renameProjectEntry,
         4,
@@ -1496,6 +1502,13 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         (_event, input: CopyProjectEntriesInput) =>
             copyProjectEntriesLimiter(() =>
                 options.projectService.copyProjectEntries(input),
+            ),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.copyExternalProjectEntries,
+        (_event, input: CopyExternalProjectEntriesInput) =>
+            copyExternalProjectEntriesLimiter(() =>
+                options.projectService.copyExternalProjectEntries(input),
             ),
     );
     ipcMain.handle(

--- a/src/main/projects/client.ts
+++ b/src/main/projects/client.ts
@@ -9,6 +9,7 @@ import type {
 
 import {
     ProjectRuntime,
+    type ProjectRuntimeCopyEntriesInput,
     type ProjectRuntimeCreateEntryInput,
     type ProjectRuntimeDeleteEntryInput,
     type ProjectRuntimeListEntriesInput,
@@ -64,6 +65,9 @@ export interface ProjectWorkerGateway {
     createProjectEntry(
         input: ProjectRuntimeCreateEntryInput,
     ): Promise<ProjectEntryMutationResult>;
+    copyProjectEntries(
+        input: ProjectRuntimeCopyEntriesInput,
+    ): Promise<readonly ProjectEntryMutationResult[]>;
     renameProjectEntry(
         input: ProjectRuntimeRenameEntryInput,
     ): Promise<ProjectEntryMutationResult>;
@@ -145,6 +149,12 @@ class RemoteProjectWorkerClient implements ProjectWorkerGateway {
         return await this.#rpc.call("projects.createProjectEntry", input);
     }
 
+    async copyProjectEntries(
+        input: ProjectRuntimeCopyEntriesInput,
+    ): Promise<readonly ProjectEntryMutationResult[]> {
+        return await this.#rpc.call("projects.copyProjectEntries", input);
+    }
+
     async renameProjectEntry(
         input: ProjectRuntimeRenameEntryInput,
     ): Promise<ProjectEntryMutationResult> {
@@ -223,6 +233,12 @@ class LocalProjectWorkerClient implements ProjectWorkerGateway {
         input: ProjectRuntimeCreateEntryInput,
     ): Promise<ProjectEntryMutationResult> {
         return await this.#runtime.createProjectEntry(input);
+    }
+
+    async copyProjectEntries(
+        input: ProjectRuntimeCopyEntriesInput,
+    ): Promise<readonly ProjectEntryMutationResult[]> {
+        return await this.#runtime.copyProjectEntries(input);
     }
 
     async renameProjectEntry(

--- a/src/main/projects/client.ts
+++ b/src/main/projects/client.ts
@@ -9,6 +9,7 @@ import type {
 
 import {
     ProjectRuntime,
+    type ProjectRuntimeCopyExternalEntriesInput,
     type ProjectRuntimeCopyEntriesInput,
     type ProjectRuntimeCreateEntryInput,
     type ProjectRuntimeDeleteEntryInput,
@@ -67,6 +68,9 @@ export interface ProjectWorkerGateway {
     ): Promise<ProjectEntryMutationResult>;
     copyProjectEntries(
         input: ProjectRuntimeCopyEntriesInput,
+    ): Promise<readonly ProjectEntryMutationResult[]>;
+    copyExternalProjectEntries(
+        input: ProjectRuntimeCopyExternalEntriesInput,
     ): Promise<readonly ProjectEntryMutationResult[]>;
     renameProjectEntry(
         input: ProjectRuntimeRenameEntryInput,
@@ -155,6 +159,15 @@ class RemoteProjectWorkerClient implements ProjectWorkerGateway {
         return await this.#rpc.call("projects.copyProjectEntries", input);
     }
 
+    async copyExternalProjectEntries(
+        input: ProjectRuntimeCopyExternalEntriesInput,
+    ): Promise<readonly ProjectEntryMutationResult[]> {
+        return await this.#rpc.call(
+            "projects.copyExternalProjectEntries",
+            input,
+        );
+    }
+
     async renameProjectEntry(
         input: ProjectRuntimeRenameEntryInput,
     ): Promise<ProjectEntryMutationResult> {
@@ -239,6 +252,12 @@ class LocalProjectWorkerClient implements ProjectWorkerGateway {
         input: ProjectRuntimeCopyEntriesInput,
     ): Promise<readonly ProjectEntryMutationResult[]> {
         return await this.#runtime.copyProjectEntries(input);
+    }
+
+    async copyExternalProjectEntries(
+        input: ProjectRuntimeCopyExternalEntriesInput,
+    ): Promise<readonly ProjectEntryMutationResult[]> {
+        return await this.#runtime.copyExternalProjectEntries(input);
     }
 
     async renameProjectEntry(

--- a/src/main/projects/client.ts
+++ b/src/main/projects/client.ts
@@ -13,6 +13,7 @@ import {
     type ProjectRuntimeCopyEntriesInput,
     type ProjectRuntimeCreateEntryInput,
     type ProjectRuntimeDeleteEntryInput,
+    type ProjectRuntimeEntryMutationInput,
     type ProjectRuntimeListEntriesInput,
     type ProjectRuntimeOpenFileInput,
     type ProjectRuntimeRegistrySnapshot,
@@ -76,6 +77,9 @@ export interface ProjectWorkerGateway {
         input: ProjectRuntimeRenameEntryInput,
     ): Promise<ProjectEntryMutationResult>;
     deleteProjectEntry(input: ProjectRuntimeDeleteEntryInput): Promise<void>;
+    recordProjectEntryMutation(
+        input: ProjectRuntimeEntryMutationInput,
+    ): Promise<void>;
     searchProjectEntries(
         input: ProjectRuntimeSearchInput,
     ): Promise<ProjectRuntimeSearchResponse>;
@@ -180,6 +184,12 @@ class RemoteProjectWorkerClient implements ProjectWorkerGateway {
         await this.#rpc.call("projects.deleteProjectEntry", input);
     }
 
+    async recordProjectEntryMutation(
+        input: ProjectRuntimeEntryMutationInput,
+    ): Promise<void> {
+        await this.#rpc.call("projects.recordProjectEntryMutation", input);
+    }
+
     async searchProjectEntries(
         input: ProjectRuntimeSearchInput,
     ): Promise<ProjectRuntimeSearchResponse> {
@@ -270,6 +280,13 @@ class LocalProjectWorkerClient implements ProjectWorkerGateway {
         input: ProjectRuntimeDeleteEntryInput,
     ): Promise<void> {
         await this.#runtime.deleteProjectEntry(input);
+    }
+
+    recordProjectEntryMutation(
+        input: ProjectRuntimeEntryMutationInput,
+    ): Promise<void> {
+        this.#runtime.recordProjectEntryMutation(input);
+        return Promise.resolve();
     }
 
     async searchProjectEntries(

--- a/src/main/projects/runtime.ts
+++ b/src/main/projects/runtime.ts
@@ -132,6 +132,11 @@ export interface ProjectRuntimeDeleteEntryInput extends ProjectRuntimeScopeInput
     readonly relativePath: string;
 }
 
+export interface ProjectRuntimeEntryMutationInput
+    extends ProjectRuntimeScopeInput {
+    readonly relativePaths: readonly string[];
+}
+
 export interface ProjectRuntimeSearchInput extends ProjectRuntimeScopeInput {
     readonly limit?: number;
     readonly query: string;
@@ -318,6 +323,11 @@ export class ProjectRuntime {
         });
 
         this.#handleRootMutation(input, [input.relativePath]);
+    }
+
+    recordProjectEntryMutation(input: ProjectRuntimeEntryMutationInput): void {
+        this.#ensureRootContext(input);
+        this.#handleRootMutation(input, input.relativePaths);
     }
 
     async searchProjectEntries(

--- a/src/main/projects/runtime.ts
+++ b/src/main/projects/runtime.ts
@@ -22,6 +22,7 @@ import {
 import { debugBenignError } from "../observability/logging";
 import { shouldIgnoreEntry } from "./ignore";
 import {
+    copyExternalProjectEntries,
     copyProjectEntries,
     createProjectEntry,
     deleteProjectEntry,
@@ -113,6 +114,12 @@ export interface ProjectRuntimeCreateEntryInput extends ProjectRuntimeScopeInput
 export interface ProjectRuntimeCopyEntriesInput extends ProjectRuntimeScopeInput {
     readonly destinationParentRelativePath: string | null;
     readonly sourceRelativePaths: readonly string[];
+}
+
+export interface ProjectRuntimeCopyExternalEntriesInput
+    extends ProjectRuntimeScopeInput {
+    readonly destinationParentRelativePath: string | null;
+    readonly sourcePaths: readonly string[];
 }
 
 export interface ProjectRuntimeRenameEntryInput extends ProjectRuntimeScopeInput {
@@ -257,6 +264,23 @@ export class ProjectRuntime {
             destinationParentRelativePath: input.destinationParentRelativePath,
             rootPath: input.rootPath,
             sourceRelativePaths: input.sourceRelativePaths,
+        });
+
+        this.#handleRootMutation(
+            input,
+            entries.map((entry) => entry.relativePath),
+        );
+        return entries;
+    }
+
+    async copyExternalProjectEntries(
+        input: ProjectRuntimeCopyExternalEntriesInput,
+    ): Promise<readonly ProjectEntryMutationResult[]> {
+        this.#ensureRootContext(input);
+        const entries = await copyExternalProjectEntries({
+            destinationParentRelativePath: input.destinationParentRelativePath,
+            rootPath: input.rootPath,
+            sourcePaths: input.sourcePaths,
         });
 
         this.#handleRootMutation(

--- a/src/main/projects/runtime.ts
+++ b/src/main/projects/runtime.ts
@@ -22,6 +22,7 @@ import {
 import { debugBenignError } from "../observability/logging";
 import { shouldIgnoreEntry } from "./ignore";
 import {
+    copyProjectEntries,
     createProjectEntry,
     deleteProjectEntry,
     listProjectTreeChildren,
@@ -107,6 +108,11 @@ export interface ProjectRuntimeCreateEntryInput extends ProjectRuntimeScopeInput
     readonly kind: CreateProjectEntryInput["kind"];
     readonly name: string;
     readonly parentRelativePath: string | null;
+}
+
+export interface ProjectRuntimeCopyEntriesInput extends ProjectRuntimeScopeInput {
+    readonly destinationParentRelativePath: string | null;
+    readonly sourceRelativePaths: readonly string[];
 }
 
 export interface ProjectRuntimeRenameEntryInput extends ProjectRuntimeScopeInput {
@@ -241,6 +247,23 @@ export class ProjectRuntime {
 
         this.#handleRootMutation(input, [entry.relativePath]);
         return entry;
+    }
+
+    async copyProjectEntries(
+        input: ProjectRuntimeCopyEntriesInput,
+    ): Promise<readonly ProjectEntryMutationResult[]> {
+        this.#ensureRootContext(input);
+        const entries = await copyProjectEntries({
+            destinationParentRelativePath: input.destinationParentRelativePath,
+            rootPath: input.rootPath,
+            sourceRelativePaths: input.sourceRelativePaths,
+        });
+
+        this.#handleRootMutation(
+            input,
+            entries.map((entry) => entry.relativePath),
+        );
+        return entries;
     }
 
     async renameProjectEntry(

--- a/src/main/projects/service.ts
+++ b/src/main/projects/service.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 
 import type {
+    CopyExternalProjectEntriesInput,
+    CopyExternalProjectEntriesResult,
     CopyProjectEntriesInput,
     CopyProjectEntriesResult,
     CreateProjectEntryInput,
@@ -391,6 +393,35 @@ export class ProjectService {
                     projectId: input.projectId,
                     rootPath: project.rootPath,
                     sourceRelativePaths: input.sourceRelativePaths,
+                    worktreeId: project.worktreeId,
+                }),
+        );
+
+        return { entries: [...entries] };
+    }
+
+    async copyExternalProjectEntries(
+        input: CopyExternalProjectEntriesInput,
+    ): Promise<CopyExternalProjectEntriesResult> {
+        await this.#ensureWorkerRegistry();
+        const project = this.#resolveProjectScope(
+            input.projectId,
+            input.worktreeId ?? null,
+        );
+        this.touchProject(input.projectId);
+
+        const entries = await this.#trackFilesystemAccess(
+            resolveProjectPath(
+                project.rootPath,
+                input.destinationParentRelativePath,
+            ),
+            async () =>
+                await this.#worker.copyExternalProjectEntries({
+                    destinationParentRelativePath:
+                        input.destinationParentRelativePath,
+                    projectId: input.projectId,
+                    rootPath: project.rootPath,
+                    sourcePaths: input.sourcePaths,
                     worktreeId: project.worktreeId,
                 }),
         );

--- a/src/main/projects/service.ts
+++ b/src/main/projects/service.ts
@@ -474,6 +474,22 @@ export class ProjectService {
         );
     }
 
+    async recordProjectEntryMutation(
+        projectId: string,
+        relativePath: string,
+        worktreeId: string | null = null,
+    ): Promise<void> {
+        await this.#ensureWorkerRegistry();
+        const project = this.#resolveProjectScope(projectId, worktreeId);
+        this.touchProject(projectId);
+        await this.#worker.recordProjectEntryMutation({
+            projectId,
+            relativePaths: [relativePath],
+            rootPath: project.rootPath,
+            worktreeId: project.worktreeId,
+        });
+    }
+
     getProjectRootPath(
         projectId: string,
         worktreeId: string | null = null,

--- a/src/main/projects/service.ts
+++ b/src/main/projects/service.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 
 import type {
+    CopyProjectEntriesInput,
+    CopyProjectEntriesResult,
     CreateProjectEntryInput,
     DeleteProjectEntryInput,
     ListProjectEntriesInput,
@@ -365,6 +367,35 @@ export class ProjectService {
                     worktreeId: project.worktreeId,
                 }),
         );
+    }
+
+    async copyProjectEntries(
+        input: CopyProjectEntriesInput,
+    ): Promise<CopyProjectEntriesResult> {
+        await this.#ensureWorkerRegistry();
+        const project = this.#resolveProjectScope(
+            input.projectId,
+            input.worktreeId ?? null,
+        );
+        this.touchProject(input.projectId);
+
+        const entries = await this.#trackFilesystemAccess(
+            resolveProjectPath(
+                project.rootPath,
+                input.destinationParentRelativePath,
+            ),
+            async () =>
+                await this.#worker.copyProjectEntries({
+                    destinationParentRelativePath:
+                        input.destinationParentRelativePath,
+                    projectId: input.projectId,
+                    rootPath: project.rootPath,
+                    sourceRelativePaths: input.sourceRelativePaths,
+                    worktreeId: project.worktreeId,
+                }),
+        );
+
+        return { entries: [...entries] };
     }
 
     async renameProjectEntry(

--- a/src/main/projects/tree.test.ts
+++ b/src/main/projects/tree.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+    copyExternalProjectEntries,
     copyProjectEntries,
     createProjectEntry,
     deleteProjectEntry,
@@ -337,6 +338,84 @@ describe("project tree helpers", () => {
                 destinationParentRelativePath: "src/components",
                 rootPath,
                 sourceRelativePaths: ["src"],
+            }),
+        ).rejects.toThrow(/inside itself/i);
+    });
+
+    it("copies external files and folders into a destination folder", async () => {
+        const rootPath = createProjectFixture();
+        const externalRoot = createProjectFixture();
+        fs.mkdirSync(path.join(rootPath, "imports"));
+        fs.mkdirSync(path.join(externalRoot, "assets"), { recursive: true });
+        fs.writeFileSync(path.join(externalRoot, "notes.md"), "external\n");
+        fs.writeFileSync(
+            path.join(externalRoot, "assets", "logo.svg"),
+            "<svg />\n",
+        );
+
+        const copiedEntries = await copyExternalProjectEntries({
+            destinationParentRelativePath: "imports",
+            rootPath,
+            sourcePaths: [
+                path.join(externalRoot, "notes.md"),
+                path.join(externalRoot, "assets"),
+            ],
+        });
+
+        expect(copiedEntries).toEqual([
+            {
+                kind: "file",
+                name: "notes.md",
+                parentRelativePath: "imports",
+                relativePath: "imports/notes.md",
+            },
+            {
+                kind: "directory",
+                name: "assets",
+                parentRelativePath: "imports",
+                relativePath: "imports/assets",
+            },
+        ]);
+        expect(
+            fs.readFileSync(path.join(rootPath, "imports", "notes.md"), "utf8"),
+        ).toBe("external\n");
+        expect(
+            fs.readFileSync(
+                path.join(rootPath, "imports", "assets", "logo.svg"),
+                "utf8",
+            ),
+        ).toBe("<svg />\n");
+    });
+
+    it("resolves duplicate names when copying external entries", async () => {
+        const rootPath = createProjectFixture();
+        const externalRoot = createProjectFixture();
+        fs.writeFileSync(path.join(rootPath, "notes.md"), "one\n");
+        fs.writeFileSync(path.join(externalRoot, "notes.md"), "two\n");
+
+        const copiedEntries = await copyExternalProjectEntries({
+            destinationParentRelativePath: null,
+            rootPath,
+            sourcePaths: [path.join(externalRoot, "notes.md")],
+        });
+
+        expect(copiedEntries[0]?.relativePath).toBe("notes copy.md");
+        expect(
+            fs.readFileSync(path.join(rootPath, "notes copy.md"), "utf8"),
+        ).toBe("two\n");
+    });
+
+    it("rejects copying an external folder into itself", async () => {
+        const rootPath = createProjectFixture();
+        fs.mkdirSync(path.join(rootPath, "src", "components"), {
+            recursive: true,
+        });
+
+        await expect(
+            copyExternalProjectEntries({
+                destinationParentRelativePath: "src/components",
+                rootPath,
+                sourcePaths: [path.join(rootPath, "src")],
             }),
         ).rejects.toThrow(/inside itself/i);
     });

--- a/src/main/projects/tree.test.ts
+++ b/src/main/projects/tree.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+    copyProjectEntries,
     createProjectEntry,
     deleteProjectEntry,
     listProjectTreeChildren,
@@ -232,6 +233,110 @@ describe("project tree helpers", () => {
                 nextParentRelativePath: "src/components",
                 relativePath: "src",
                 rootPath,
+            }),
+        ).rejects.toThrow(/inside itself/i);
+    });
+
+    it("copies a file into a destination folder", async () => {
+        const rootPath = createProjectFixture();
+        fs.mkdirSync(path.join(rootPath, "src"));
+        fs.mkdirSync(path.join(rootPath, "docs"));
+        fs.writeFileSync(path.join(rootPath, "src/notes.md"), "hello\n");
+
+        const copiedEntries = await copyProjectEntries({
+            destinationParentRelativePath: "docs",
+            rootPath,
+            sourceRelativePaths: ["src/notes.md"],
+        });
+
+        expect(copiedEntries).toEqual([
+            {
+                kind: "file",
+                name: "notes.md",
+                parentRelativePath: "docs",
+                relativePath: "docs/notes.md",
+            },
+        ]);
+        expect(fs.readFileSync(path.join(rootPath, "docs/notes.md"), "utf8")).toBe(
+            "hello\n",
+        );
+    });
+
+    it("copies a folder recursively", async () => {
+        const rootPath = createProjectFixture();
+        fs.mkdirSync(path.join(rootPath, "src/components"), {
+            recursive: true,
+        });
+        fs.mkdirSync(path.join(rootPath, "backup"));
+        fs.writeFileSync(
+            path.join(rootPath, "src/components/Button.tsx"),
+            "export const Button = () => null;\n",
+        );
+
+        const copiedEntries = await copyProjectEntries({
+            destinationParentRelativePath: "backup",
+            rootPath,
+            sourceRelativePaths: ["src"],
+        });
+
+        expect(copiedEntries[0]).toMatchObject({
+            kind: "directory",
+            name: "src",
+            parentRelativePath: "backup",
+            relativePath: "backup/src",
+        });
+        expect(
+            fs.readFileSync(
+                path.join(rootPath, "backup/src/components/Button.tsx"),
+                "utf8",
+            ),
+        ).toContain("Button");
+    });
+
+    it("resolves duplicate copied names like Finder", async () => {
+        const rootPath = createProjectFixture();
+        fs.mkdirSync(path.join(rootPath, "docs"));
+        fs.writeFileSync(path.join(rootPath, "notes.md"), "one\n");
+        fs.writeFileSync(path.join(rootPath, "notes copy.md"), "two\n");
+
+        const firstCopy = await copyProjectEntries({
+            destinationParentRelativePath: null,
+            rootPath,
+            sourceRelativePaths: ["notes.md"],
+        });
+        const secondCopy = await copyProjectEntries({
+            destinationParentRelativePath: null,
+            rootPath,
+            sourceRelativePaths: ["docs"],
+        });
+
+        expect(firstCopy[0]?.relativePath).toBe("notes copy 2.md");
+        expect(secondCopy[0]?.relativePath).toBe("docs copy");
+        expect(fs.existsSync(path.join(rootPath, "notes copy 2.md"))).toBe(
+            true,
+        );
+        expect(fs.existsSync(path.join(rootPath, "docs copy"))).toBe(true);
+    });
+
+    it("rejects copying a folder into itself or a descendant", async () => {
+        const rootPath = createProjectFixture();
+        fs.mkdirSync(path.join(rootPath, "src/components"), {
+            recursive: true,
+        });
+
+        await expect(
+            copyProjectEntries({
+                destinationParentRelativePath: "src",
+                rootPath,
+                sourceRelativePaths: ["src"],
+            }),
+        ).rejects.toThrow(/inside itself/i);
+
+        await expect(
+            copyProjectEntries({
+                destinationParentRelativePath: "src/components",
+                rootPath,
+                sourceRelativePaths: ["src"],
             }),
         ).rejects.toThrow(/inside itself/i);
     });

--- a/src/main/projects/tree.ts
+++ b/src/main/projects/tree.ts
@@ -298,6 +298,81 @@ export async function copyProjectEntries(options: {
     return copiedEntries;
 }
 
+export async function copyExternalProjectEntries(options: {
+    readonly destinationParentRelativePath: string | null;
+    readonly rootPath: string;
+    readonly sourcePaths: readonly string[];
+}): Promise<ProjectEntryMutationResult[]> {
+    const destinationParentRelativePath = normalizeOptionalRelativePath(
+        options.destinationParentRelativePath,
+    );
+    const absoluteDestinationParentPath = resolveProjectPath(
+        options.rootPath,
+        destinationParentRelativePath,
+    );
+    const destinationParentStats = await fs.promises.stat(
+        absoluteDestinationParentPath,
+    );
+
+    if (!destinationParentStats.isDirectory()) {
+        throw new Error("Drop files into a folder or the project root.");
+    }
+
+    const sourceEntries = await resolveExternalCopySourceEntries(
+        options.sourcePaths,
+    );
+    const compactedSourceEntries =
+        compactCopySourceEntriesByAbsoluteAncestor(sourceEntries);
+    const reservedNames = new Set(
+        (
+            await fs.promises.readdir(absoluteDestinationParentPath, {
+                withFileTypes: true,
+            })
+        ).map((entry) => entry.name.toLowerCase()),
+    );
+    const copiedEntries: ProjectEntryMutationResult[] = [];
+
+    for (const sourceEntry of compactedSourceEntries) {
+        if (
+            sourceEntry.kind === "directory" &&
+            isSameOrChildPath(
+                absoluteDestinationParentPath,
+                sourceEntry.absolutePath,
+            )
+        ) {
+            throw new Error("A folder cannot be copied inside itself.");
+        }
+
+        const destinationName = resolveCopyDestinationName(
+            sourceEntry.name,
+            sourceEntry.kind,
+            reservedNames,
+        );
+        const absoluteDestinationPath = path.join(
+            absoluteDestinationParentPath,
+            destinationName,
+        );
+
+        await fs.promises.cp(sourceEntry.absolutePath, absoluteDestinationPath, {
+            errorOnExist: true,
+            force: false,
+            preserveTimestamps: true,
+            recursive: sourceEntry.kind === "directory",
+        });
+
+        copiedEntries.push({
+            kind: sourceEntry.kind,
+            name: destinationName,
+            parentRelativePath: destinationParentRelativePath,
+            relativePath: normalizeRelativePath(
+                path.relative(options.rootPath, absoluteDestinationPath),
+            ),
+        });
+    }
+
+    return copiedEntries;
+}
+
 export async function renameProjectEntry(options: {
     readonly nextName: string;
     readonly nextParentRelativePath?: string | null;
@@ -590,6 +665,34 @@ async function resolveCopySourceEntries(
     return entries;
 }
 
+async function resolveExternalCopySourceEntries(
+    sourcePaths: readonly string[],
+): Promise<CopySourceEntry[]> {
+    const entries: CopySourceEntry[] = [];
+    const seenPaths = new Set<string>();
+
+    for (const sourcePath of sourcePaths) {
+        const absolutePath = path.resolve(sourcePath);
+        const normalizedKey = normalizeComparableAbsolutePath(absolutePath);
+        if (!normalizedKey || seenPaths.has(normalizedKey)) {
+            continue;
+        }
+
+        const stats = await fs.promises.stat(absolutePath);
+        const name = validateEntryName(path.basename(absolutePath));
+
+        entries.push({
+            absolutePath,
+            kind: stats.isDirectory() ? "directory" : "file",
+            name,
+            relativePath: normalizedKey,
+        });
+        seenPaths.add(normalizedKey);
+    }
+
+    return entries;
+}
+
 function compactCopySourceEntriesByAncestor(
     entries: readonly CopySourceEntry[],
 ): CopySourceEntry[] {
@@ -604,6 +707,39 @@ function compactCopySourceEntriesByAncestor(
                     ),
             ),
     );
+}
+
+function compactCopySourceEntriesByAbsoluteAncestor(
+    entries: readonly CopySourceEntry[],
+): CopySourceEntry[] {
+    return entries.filter(
+        (entry) =>
+            !entries.some(
+                (candidate) =>
+                    candidate.kind === "directory" &&
+                    candidate.absolutePath !== entry.absolutePath &&
+                    isChildPath(entry.absolutePath, candidate.absolutePath),
+            ),
+    );
+}
+
+function isSameOrChildPath(candidatePath: string, parentPath: string): boolean {
+    const candidate = normalizeComparableAbsolutePath(candidatePath);
+    const parent = normalizeComparableAbsolutePath(parentPath);
+    return candidate === parent || isChildPath(candidate, parent);
+}
+
+function isChildPath(candidatePath: string, parentPath: string): boolean {
+    const candidate = normalizeComparableAbsolutePath(candidatePath);
+    const parent = normalizeComparableAbsolutePath(parentPath);
+    return candidate.startsWith(`${parent}/`);
+}
+
+function normalizeComparableAbsolutePath(candidatePath: string): string {
+    const normalizedPath = path.resolve(candidatePath).replaceAll("\\", "/");
+    return process.platform === "win32"
+        ? normalizedPath.toLowerCase()
+        : normalizedPath;
 }
 
 function resolveCopyDestinationName(

--- a/src/main/projects/tree.ts
+++ b/src/main/projects/tree.ts
@@ -221,6 +221,83 @@ export async function createProjectEntry(options: {
     };
 }
 
+export async function copyProjectEntries(options: {
+    readonly destinationParentRelativePath: string | null;
+    readonly rootPath: string;
+    readonly sourceRelativePaths: readonly string[];
+}): Promise<ProjectEntryMutationResult[]> {
+    const destinationParentRelativePath = normalizeOptionalRelativePath(
+        options.destinationParentRelativePath,
+    );
+    const absoluteDestinationParentPath = resolveProjectPath(
+        options.rootPath,
+        destinationParentRelativePath,
+    );
+    const destinationParentStats = await fs.promises.stat(
+        absoluteDestinationParentPath,
+    );
+
+    if (!destinationParentStats.isDirectory()) {
+        throw new Error("Paste into a folder or the project root.");
+    }
+
+    const sourceEntries = await resolveCopySourceEntries(
+        options.rootPath,
+        options.sourceRelativePaths,
+    );
+    const compactedSourceEntries =
+        compactCopySourceEntriesByAncestor(sourceEntries);
+    const reservedNames = new Set(
+        (
+            await fs.promises.readdir(absoluteDestinationParentPath, {
+                withFileTypes: true,
+            })
+        ).map((entry) => entry.name.toLowerCase()),
+    );
+    const copiedEntries: ProjectEntryMutationResult[] = [];
+
+    for (const sourceEntry of compactedSourceEntries) {
+        if (
+            sourceEntry.kind === "directory" &&
+            destinationParentRelativePath &&
+            (destinationParentRelativePath === sourceEntry.relativePath ||
+                destinationParentRelativePath.startsWith(
+                    `${sourceEntry.relativePath}/`,
+                ))
+        ) {
+            throw new Error("A folder cannot be pasted inside itself.");
+        }
+
+        const destinationName = resolveCopyDestinationName(
+            sourceEntry.name,
+            sourceEntry.kind,
+            reservedNames,
+        );
+        const absoluteDestinationPath = path.join(
+            absoluteDestinationParentPath,
+            destinationName,
+        );
+
+        await fs.promises.cp(sourceEntry.absolutePath, absoluteDestinationPath, {
+            errorOnExist: true,
+            force: false,
+            preserveTimestamps: true,
+            recursive: sourceEntry.kind === "directory",
+        });
+
+        copiedEntries.push({
+            kind: sourceEntry.kind,
+            name: destinationName,
+            parentRelativePath: destinationParentRelativePath,
+            relativePath: normalizeRelativePath(
+                path.relative(options.rootPath, absoluteDestinationPath),
+            ),
+        });
+    }
+
+    return copiedEntries;
+}
+
 export async function renameProjectEntry(options: {
     readonly nextName: string;
     readonly nextParentRelativePath?: string | null;
@@ -470,6 +547,100 @@ function normalizeOptionalRelativePath(
     }
 
     return normalizeRelativePath(relativePath);
+}
+
+interface CopySourceEntry {
+    readonly absolutePath: string;
+    readonly kind: ProjectEntryKind;
+    readonly name: string;
+    readonly relativePath: string;
+}
+
+async function resolveCopySourceEntries(
+    rootPath: string,
+    relativePaths: readonly string[],
+): Promise<CopySourceEntry[]> {
+    const entries: CopySourceEntry[] = [];
+    const seenRelativePaths = new Set<string>();
+
+    for (const relativePath of relativePaths) {
+        const normalizedRelativePath = normalizeRelativePath(relativePath);
+        if (
+            !normalizedRelativePath ||
+            seenRelativePaths.has(normalizedRelativePath)
+        ) {
+            continue;
+        }
+
+        const absolutePath = resolveProjectPath(
+            rootPath,
+            normalizedRelativePath,
+        );
+        const stats = await fs.promises.stat(absolutePath);
+
+        entries.push({
+            absolutePath,
+            kind: stats.isDirectory() ? "directory" : "file",
+            name: path.basename(absolutePath),
+            relativePath: normalizedRelativePath,
+        });
+        seenRelativePaths.add(normalizedRelativePath);
+    }
+
+    return entries;
+}
+
+function compactCopySourceEntriesByAncestor(
+    entries: readonly CopySourceEntry[],
+): CopySourceEntry[] {
+    return entries.filter(
+        (entry) =>
+            !entries.some(
+                (candidate) =>
+                    candidate.kind === "directory" &&
+                    candidate.relativePath !== entry.relativePath &&
+                    entry.relativePath.startsWith(
+                        `${candidate.relativePath}/`,
+                    ),
+            ),
+    );
+}
+
+function resolveCopyDestinationName(
+    sourceName: string,
+    kind: ProjectEntryKind,
+    reservedNames: Set<string>,
+): string {
+    const sourceKey = sourceName.toLowerCase();
+    if (!reservedNames.has(sourceKey)) {
+        reservedNames.add(sourceKey);
+        return sourceName;
+    }
+
+    const extension =
+        kind === "file" && path.extname(sourceName) !== sourceName
+            ? path.extname(sourceName)
+            : "";
+    const baseName = extension
+        ? sourceName.slice(0, -extension.length)
+        : sourceName;
+
+    for (
+        let copyIndex = 1;
+        copyIndex < Number.MAX_SAFE_INTEGER;
+        copyIndex += 1
+    ) {
+        const suffix = copyIndex === 1 ? " copy" : ` copy ${copyIndex}`;
+        const candidateName = `${baseName}${suffix}${extension}`;
+        const candidateKey = candidateName.toLowerCase();
+
+        if (!reservedNames.has(candidateKey)) {
+            reservedNames.add(candidateKey);
+            return candidateName;
+        }
+    }
+
+    throw new Error("Could not resolve a unique copy name.");
 }
 
 async function statIfExists(targetPath: string): Promise<fs.Stats | null> {

--- a/src/main/projects/worker.ts
+++ b/src/main/projects/worker.ts
@@ -144,6 +144,10 @@ async function dispatchMethod(method: string, params: unknown): Promise<unknown>
             return await projectRuntime.createProjectEntry(
                 params as Parameters<ProjectRuntime["createProjectEntry"]>[0],
             );
+        case "projects.copyProjectEntries":
+            return await projectRuntime.copyProjectEntries(
+                params as Parameters<ProjectRuntime["copyProjectEntries"]>[0],
+            );
         case "projects.renameProjectEntry":
             return await projectRuntime.renameProjectEntry(
                 params as Parameters<ProjectRuntime["renameProjectEntry"]>[0],

--- a/src/main/projects/worker.ts
+++ b/src/main/projects/worker.ts
@@ -148,6 +148,12 @@ async function dispatchMethod(method: string, params: unknown): Promise<unknown>
             return await projectRuntime.copyProjectEntries(
                 params as Parameters<ProjectRuntime["copyProjectEntries"]>[0],
             );
+        case "projects.copyExternalProjectEntries":
+            return await projectRuntime.copyExternalProjectEntries(
+                params as Parameters<
+                    ProjectRuntime["copyExternalProjectEntries"]
+                >[0],
+            );
         case "projects.renameProjectEntry":
             return await projectRuntime.renameProjectEntry(
                 params as Parameters<ProjectRuntime["renameProjectEntry"]>[0],

--- a/src/main/projects/worker.ts
+++ b/src/main/projects/worker.ts
@@ -163,6 +163,13 @@ async function dispatchMethod(method: string, params: unknown): Promise<unknown>
                 params as Parameters<ProjectRuntime["deleteProjectEntry"]>[0],
             );
             return;
+        case "projects.recordProjectEntryMutation":
+            projectRuntime.recordProjectEntryMutation(
+                params as Parameters<
+                    ProjectRuntime["recordProjectEntryMutation"]
+                >[0],
+            );
+            return;
         case "projects.searchProjectEntries":
             return await projectRuntime.searchProjectEntries(
                 params as Parameters<ProjectRuntime["searchProjectEntries"]>[0],

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -35,6 +35,8 @@ import {
     type CloneRepositoryResult,
     type ComandoApi,
     type CodexRuntimeSettingsInput,
+    type CopyProjectEntriesInput,
+    type CopyProjectEntriesResult,
     type CreateProjectEntryInput,
     type CreateTerminalSessionInput,
     type DeleteProjectEntryInput,
@@ -664,6 +666,11 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.saveProjectFile, input),
     createProjectEntry: (input: CreateProjectEntryInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.createProjectEntry, input),
+    copyProjectEntries: async (input: CopyProjectEntriesInput) =>
+        assertIpcObject<CopyProjectEntriesResult>(
+            IPC_CHANNELS.copyProjectEntries,
+            await ipcRenderer.invoke(IPC_CHANNELS.copyProjectEntries, input),
+        ),
     renameProjectEntry: (input: RenameProjectEntryInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.renameProjectEntry, input),
     deleteProjectEntry: (input: DeleteProjectEntryInput) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -35,6 +35,8 @@ import {
     type CloneRepositoryResult,
     type ComandoApi,
     type CodexRuntimeSettingsInput,
+    type CopyExternalProjectEntriesInput,
+    type CopyExternalProjectEntriesResult,
     type CopyProjectEntriesInput,
     type CopyProjectEntriesResult,
     type CreateProjectEntryInput,
@@ -672,6 +674,16 @@ const comandoApi: ComandoApi = {
         assertIpcObject<CopyProjectEntriesResult>(
             IPC_CHANNELS.copyProjectEntries,
             await ipcRenderer.invoke(IPC_CHANNELS.copyProjectEntries, input),
+        ),
+    copyExternalProjectEntries: async (
+        input: CopyExternalProjectEntriesInput,
+    ) =>
+        assertIpcObject<CopyExternalProjectEntriesResult>(
+            IPC_CHANNELS.copyExternalProjectEntries,
+            await ipcRenderer.invoke(
+                IPC_CHANNELS.copyExternalProjectEntries,
+                input,
+            ),
         ),
     renameProjectEntry: (input: RenameProjectEntryInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.renameProjectEntry, input),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -45,6 +45,7 @@ import {
     type ListAiSessionHistoryInput,
     type ListProjectTreeInput,
     type OpenProjectWindowInput,
+    type OpenProjectEntryExternallyInput,
     type OpenProjectFileInput,
     type OpenSettingsWindowInput,
     type AiSessionSnapshot,
@@ -152,6 +153,7 @@ import {
     type SystemTheme,
     type TerminalDataEvent,
     type TerminalExitEvent,
+    type TrashProjectEntryInput,
     type TsconfigResolutionSnapshot,
     type WriteTerminalInput,
     type WorkspaceSnapshot,
@@ -675,6 +677,10 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.renameProjectEntry, input),
     deleteProjectEntry: (input: DeleteProjectEntryInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.deleteProjectEntry, input),
+    trashProjectEntry: (input: TrashProjectEntryInput) =>
+        ipcRenderer.invoke(IPC_CHANNELS.trashProjectEntry, input),
+    openProjectEntryExternally: (input: OpenProjectEntryExternallyInput) =>
+        ipcRenderer.invoke(IPC_CHANNELS.openProjectEntryExternally, input),
     revealProjectEntry: (input: RevealProjectEntryInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.revealProjectEntry, input),
     saveSettingsSnapshot: (snapshot: SettingsSnapshot) =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -63,11 +63,15 @@ import { useShellStore } from "./app/store/shell-store";
 import { useWorkspaceStore } from "./app/store/workspace-store";
 import { findPaneById, type RuntimeWorkspaceTab } from "./app/workspace/tree";
 import {
+    compactGitTreeEntriesByAncestor,
+    compactGitTreeEntriesForDeletion,
     flattenVisibleGitTreeNodes,
     getProjectEntryParentRelativePath,
     GitTreeView,
+    normalizeGitTreeDragPayload,
     resolveGitTreeDragPaths,
     type GitTreeDragData,
+    type GitTreeDragPayload,
     type GitTreeNode,
     type GitTreeNodeActivationEvent,
 } from "./components/git";
@@ -229,9 +233,6 @@ export function App() {
     );
     const createChatTab = useWorkspaceStore((state) => state.createChatTab);
     const openFileTab = useWorkspaceStore((state) => state.openFileTab);
-    const closeTabsForProjectPath = useWorkspaceStore(
-        (state) => state.closeTabsForProjectPath,
-    );
     const closeTabsForProjectPaths = useWorkspaceStore(
         (state) => state.closeTabsForProjectPaths,
     );
@@ -1324,7 +1325,6 @@ export function App() {
     }, [quickOpenResults.length]);
     const isProjectRootExpanded =
         projectRootExpandedByContext[activeProjectContextKey] ?? true;
-    void closeTabsForProjectPath;
     void renameTabsForProjectPath;
     const activeFilePath = useMemo(
         () =>
@@ -1531,7 +1531,10 @@ export function App() {
     );
 
     const handleMoveTreeNode = useCallback(
-        async (draggedEntry: GitTreeDragData, destinationNode: GitTreeNode) => {
+        async (
+            draggedPayload: GitTreeDragPayload,
+            destinationNode: GitTreeNode,
+        ) => {
             if (!activeProjectId) {
                 return;
             }
@@ -1539,8 +1542,11 @@ export function App() {
             const nextParentRelativePath = destinationNode.isProjectRoot
                 ? null
                 : destinationNode.path;
-            const currentParentRelativePath = getProjectEntryParentRelativePath(
-                draggedEntry.relativePath,
+            const draggedEntries = compactGitTreeEntriesByAncestor(
+                normalizeGitTreeDragPayload(draggedPayload).map((entry) => ({
+                    ...entry,
+                    path: entry.relativePath,
+                })),
             );
             const destinationProjectTreeNode =
                 destinationNode.isProjectRoot || !destinationNode.path
@@ -1553,25 +1559,33 @@ export function App() {
                 Boolean(destinationProjectTreeNode) &&
                 !activeExpandedDirectories.includes(destinationNode.path);
 
-            if (currentParentRelativePath === nextParentRelativePath) {
+            const movableEntries = draggedEntries.filter(
+                (entry) =>
+                    getProjectEntryParentRelativePath(entry.relativePath) !==
+                    nextParentRelativePath,
+            );
+
+            if (movableEntries.length === 0) {
                 return;
             }
 
             try {
-                const movedEntry = await renameEntry(
-                    activeProjectId,
-                    draggedEntry.relativePath,
-                    draggedEntry.name,
-                    nextParentRelativePath,
-                    activeWorktreeId,
-                );
-                await renameTabsForProjectPath(
-                    activeProjectId,
-                    activeWorktreeId,
-                    draggedEntry.relativePath,
-                    movedEntry.relativePath,
-                    draggedEntry.kind,
-                );
+                for (const entry of movableEntries) {
+                    const movedEntry = await renameEntry(
+                        activeProjectId,
+                        entry.relativePath,
+                        entry.name,
+                        nextParentRelativePath,
+                        activeWorktreeId,
+                    );
+                    await renameTabsForProjectPath(
+                        activeProjectId,
+                        activeWorktreeId,
+                        entry.relativePath,
+                        movedEntry.relativePath,
+                        entry.kind,
+                    );
+                }
                 if (destinationProjectTreeNode && shouldExpandDestination) {
                     await toggleDirectory(
                         activeProjectId,
@@ -1598,30 +1612,61 @@ export function App() {
         ],
     );
 
-    const handleDeleteTreeNode = useCallback(
-        async (node: GitTreeNode) => {
+    const handleDeleteTreeNodes = useCallback(
+        async (nodes: readonly GitTreeNode[]) => {
             if (!activeProjectId) {
                 return;
             }
 
+            const deletableNodes = nodes.filter((node) => !node.isProjectRoot);
+            if (deletableNodes.length === 0) {
+                return;
+            }
+
             const confirmed = window.confirm(
-                node.kind === "directory"
-                    ? `Delete folder "${node.name}" and all its contents?`
-                    : `Delete file "${node.name}"?`,
+                deletableNodes.length === 1
+                    ? deletableNodes[0].kind === "directory"
+                        ? `Delete folder "${deletableNodes[0].name}" and all its contents?`
+                        : `Delete file "${deletableNodes[0].name}"?`
+                    : `Delete ${deletableNodes.length} selected items?`,
             );
             if (!confirmed) {
                 return;
             }
 
+            const entriesToDelete =
+                compactGitTreeEntriesForDeletion(deletableNodes);
+            const deletedEntries: {
+                readonly kind: "directory" | "file";
+                readonly relativePath: string;
+            }[] = [];
+
             try {
-                await deleteEntry(activeProjectId, node.path, activeWorktreeId);
-                await closeTabsForProjectPath(
+                for (const entry of entriesToDelete) {
+                    await deleteEntry(
+                        activeProjectId,
+                        entry.path,
+                        activeWorktreeId,
+                    );
+                    deletedEntries.push({
+                        kind: entry.kind,
+                        relativePath: entry.path,
+                    });
+                }
+
+                await closeTabsForProjectPaths(
                     activeProjectId,
                     activeWorktreeId,
-                    node.path,
-                    node.kind,
+                    deletedEntries,
                 );
             } catch (error) {
+                if (deletedEntries.length > 0) {
+                    await closeTabsForProjectPaths(
+                        activeProjectId,
+                        activeWorktreeId,
+                        deletedEntries,
+                    );
+                }
                 window.alert(
                     error instanceof Error
                         ? error.message
@@ -1632,7 +1677,7 @@ export function App() {
         [
             activeProjectId,
             activeWorktreeId,
-            closeTabsForProjectPath,
+            closeTabsForProjectPaths,
             deleteEntry,
         ],
     );
@@ -1660,14 +1705,21 @@ export function App() {
         [activeProjectId, activeWorktreeId, revealEntry],
     );
 
-    const handleCopyTreePath = useCallback(
-        async (relativePath: string, mode: "absolute" | "relative") => {
-            const text =
-                mode === "absolute"
-                    ? activeProject
-                        ? joinProjectPath(activeProject.rootPath, relativePath)
-                        : null
-                    : relativePath;
+    const handleCopyTreePaths = useCallback(
+        async (
+            nodes: readonly GitTreeNode[],
+            mode: "absolute" | "relative",
+        ) => {
+            const text = nodes
+                .map((node) =>
+                    mode === "absolute"
+                        ? activeProject
+                            ? joinProjectPath(activeProject.rootPath, node.path)
+                            : null
+                        : node.path,
+                )
+                .filter((path): path is string => path !== null)
+                .join("\n");
 
             if (!text) {
                 return;
@@ -1682,9 +1734,17 @@ export function App() {
         [activeProject],
     );
 
-    const handleAddFileToChat = useCallback(
-        async (node: GitTreeNode) => {
-            if (!activeProjectId || node.kind !== "file") {
+    const handleAddFilesToChat = useCallback(
+        async (
+            nodes: readonly GitTreeNode[],
+            options: { readonly forceNewChat?: boolean } = {},
+        ) => {
+            if (!activeProjectId) {
+                return;
+            }
+
+            const fileNodes = nodes.filter((node) => node.kind === "file");
+            if (fileNodes.length === 0) {
                 return;
             }
 
@@ -1698,19 +1758,21 @@ export function App() {
             );
 
             const attachContext = (sessionId: string) => {
-                addDraftFileContext(sessionId, {
-                    extension: node.path.split(".").pop() ?? null,
-                    id: `file-ctx:${crypto.randomUUID()}`,
-                    languageId: resolveEditorLanguage({
-                        filePath: node.path,
-                    }).id,
-                    name: node.name,
-                    projectId: activeProjectId,
-                    relativePath: node.path,
+                fileNodes.forEach((node) => {
+                    addDraftFileContext(sessionId, {
+                        extension: node.path.split(".").pop() ?? null,
+                        id: `file-ctx:${crypto.randomUUID()}`,
+                        languageId: resolveEditorLanguage({
+                            filePath: node.path,
+                        }).id,
+                        name: node.name,
+                        projectId: activeProjectId,
+                        relativePath: node.path,
+                    });
                 });
             };
 
-            if (existingChatTab?.kind === "chat") {
+            if (!options.forceNewChat && existingChatTab?.kind === "chat") {
                 attachContext(existingChatTab.sessionId);
                 return;
             }
@@ -1932,11 +1994,10 @@ export function App() {
                 kind: entry.kind,
                 name: entry.name,
                 relativePath: entry.path,
-            }));
+            })) satisfies GitTreeDragData[];
 
             dataTransfer.clearData();
-            dataTransfer.effectAllowed =
-                composerEntries.length > 1 ? "copy" : "copyMove";
+            dataTransfer.effectAllowed = "copyMove";
             dataTransfer.setData(
                 COMPOSER_PROJECT_ENTRY_LIST_MIME,
                 serializeComposerProjectEntryListDragData({
@@ -1963,6 +2024,10 @@ export function App() {
                           .map((entry) => entry.relativePath)
                           .join("\n"),
             );
+
+            return composerEntries.length === 1
+                ? composerEntries[0]
+                : composerEntries;
         },
         [
             effectiveFileTreeSelectedPaths,
@@ -2050,9 +2115,58 @@ export function App() {
 
         const node = fileTreeContextMenu.payload.node;
         const contextSelection = getFileTreeContextSelection(node);
+        const contextSelectionFileCount = contextSelection.filter(
+            (entry) => entry.kind === "file",
+        ).length;
+        const addToChatLabel =
+            contextSelectionFileCount === 0
+                ? "Add Files to Chat"
+                : contextSelection.length > 1
+                ? `Add ${contextSelectionFileCount} ${
+                      contextSelectionFileCount === 1 ? "File" : "Files"
+                  } to Chat`
+                : "Add to Chat";
+        const addToNewChatLabel =
+            contextSelectionFileCount === 0
+                ? "Add Files to New Chat"
+                : contextSelection.length > 1
+                ? `Add ${contextSelectionFileCount} ${
+                      contextSelectionFileCount === 1 ? "File" : "Files"
+                  } to New Chat`
+                : "Add to New Chat";
+        const copyRelativePathLabel =
+            contextSelection.length > 1
+                ? `Copy ${contextSelection.length} Relative Paths`
+                : "Copy Relative Path";
+        const copyAbsolutePathLabel =
+            contextSelection.length > 1
+                ? `Copy ${contextSelection.length} Absolute Paths`
+                : "Copy Absolute Path";
+        const deleteLabel =
+            contextSelection.length > 1
+                ? `Delete ${contextSelection.length} Selected Items`
+                : "Delete";
         const multiSelectionEntries =
             contextSelection.length > 1
                 ? ([
+                      {
+                          label: addToChatLabel,
+                          action: () =>
+                              void handleAddFilesToChat(contextSelection),
+                          disabled:
+                              !activeProjectId ||
+                              contextSelectionFileCount === 0,
+                      },
+                      {
+                          label: addToNewChatLabel,
+                          action: () =>
+                              void handleAddFilesToChat(contextSelection, {
+                                  forceNewChat: true,
+                              }),
+                          disabled:
+                              !activeProjectId ||
+                              contextSelectionFileCount === 0,
+                      },
                       {
                           label: `Close ${contextSelection.length} Selected Tabs`,
                           action: () =>
@@ -2084,7 +2198,7 @@ export function App() {
                 },
                 {
                     label: "Copy Absolute Path",
-                    action: () => void handleCopyTreePath("", "absolute"),
+                    action: () => void handleCopyTreePaths([node], "absolute"),
                     disabled: !activeProject,
                 },
                 {
@@ -2116,11 +2230,24 @@ export function App() {
                             : undefined,
                     disabled: !activeProjectId,
                 },
-                {
-                    label: "Add to Chat",
-                    action: () => void handleAddFileToChat(node),
-                    disabled: !activeProjectId,
-                },
+                ...(contextSelection.length === 1
+                    ? ([
+                          {
+                              label: addToChatLabel,
+                              action: () =>
+                                  void handleAddFilesToChat(contextSelection),
+                              disabled: !activeProjectId,
+                          },
+                          {
+                              label: addToNewChatLabel,
+                              action: () =>
+                                  void handleAddFilesToChat(contextSelection, {
+                                      forceNewChat: true,
+                                  }),
+                              disabled: !activeProjectId,
+                          },
+                      ] satisfies ContextMenuEntry[])
+                    : ([] satisfies ContextMenuEntry[])),
                 { type: "separator" },
                 {
                     label: "Rename",
@@ -2133,20 +2260,20 @@ export function App() {
                     disabled: !activeProjectId,
                 },
                 {
-                    label: "Copy Relative Path",
+                    label: copyRelativePathLabel,
                     action: () =>
-                        void handleCopyTreePath(node.path, "relative"),
+                        void handleCopyTreePaths(contextSelection, "relative"),
                 },
                 {
-                    label: "Copy Absolute Path",
+                    label: copyAbsolutePathLabel,
                     action: () =>
-                        void handleCopyTreePath(node.path, "absolute"),
+                        void handleCopyTreePaths(contextSelection, "absolute"),
                     disabled: !activeProject,
                 },
                 { type: "separator" },
                 {
-                    label: "Delete",
-                    action: () => void handleDeleteTreeNode(node),
+                    label: deleteLabel,
+                    action: () => void handleDeleteTreeNodes(contextSelection),
                     danger: true,
                     disabled: !activeProjectId,
                 },
@@ -2178,18 +2305,20 @@ export function App() {
                 disabled: !activeProjectId,
             },
             {
-                label: "Copy Relative Path",
-                action: () => void handleCopyTreePath(node.path, "relative"),
+                label: copyRelativePathLabel,
+                action: () =>
+                    void handleCopyTreePaths(contextSelection, "relative"),
             },
             {
-                label: "Copy Absolute Path",
-                action: () => void handleCopyTreePath(node.path, "absolute"),
+                label: copyAbsolutePathLabel,
+                action: () =>
+                    void handleCopyTreePaths(contextSelection, "absolute"),
                 disabled: !activeProject,
             },
             { type: "separator" },
             {
-                label: "Delete",
-                action: () => void handleDeleteTreeNode(node),
+                label: deleteLabel,
+                action: () => void handleDeleteTreeNodes(contextSelection),
                 danger: true,
                 disabled: !activeProjectId,
             },
@@ -2200,11 +2329,11 @@ export function App() {
         activeWorktreeId,
         fileTreeContextMenu,
         getFileTreeContextSelection,
-        handleAddFileToChat,
+        handleAddFilesToChat,
         handleCloseFileTreeTabs,
-        handleCopyTreePath,
+        handleCopyTreePaths,
         handleCreateTreeEntry,
-        handleDeleteTreeNode,
+        handleDeleteTreeNodes,
         handleRenameTreeNode,
         handleRevealTreeEntry,
         openFileTab,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -376,6 +376,10 @@ export function App() {
     >([]);
     const [fileTreeSelectionAnchorPath, setFileTreeSelectionAnchorPath] =
         useState<string | null>(null);
+    const [
+        isFileTreeSelectionSuppressed,
+        setIsFileTreeSelectionSuppressed,
+    ] = useState(false);
     const [fileTreeRevealSignal, setFileTreeRevealSignal] = useState<
         number | null
     >(null);
@@ -1398,10 +1402,26 @@ export function App() {
         setFileTreeInlineEditor(null);
     }, []);
 
-    const clearFileTreeSelection = useCallback(() => {
-        setFileTreeSelectedPaths([]);
-        setFileTreeSelectionAnchorPath(null);
-    }, []);
+    const clearFileTreeSelection = useCallback(
+        (
+            options: {
+                readonly suppressActivePathFallback?: boolean;
+            } = {},
+        ) => {
+            setIsFileTreeSelectionSuppressed(
+                options.suppressActivePathFallback === true,
+            );
+            setFileTreeSelectedPaths([]);
+            setFileTreeSelectionAnchorPath(null);
+        },
+        [],
+    );
+
+    const focusWorkspaceSurface = useCallback(() => {
+        focusSurface("workspace");
+        clearFileTreeSelection({ suppressActivePathFallback: true });
+        setFileTreeContextMenu(null);
+    }, [clearFileTreeSelection, focusSurface]);
 
     const closeFileTreeContextMenu = useCallback(() => {
         const transientSelectionPath =
@@ -2263,9 +2283,15 @@ export function App() {
             reconcileFileTreeSelection({
                 activeFileTreePath: activeFilePath,
                 anchorPath: fileTreeSelectionAnchorPath,
+                includeActivePathFallback: !isFileTreeSelectionSuppressed,
                 selectedPaths: fileTreeSelectedPaths,
             }),
-        [activeFilePath, fileTreeSelectionAnchorPath, fileTreeSelectedPaths],
+        [
+            activeFilePath,
+            fileTreeSelectionAnchorPath,
+            fileTreeSelectedPaths,
+            isFileTreeSelectionSuppressed,
+        ],
     );
     const effectiveFileTreeSelectedPaths =
         effectiveFileTreeSelection.selectedPaths;
@@ -2348,6 +2374,8 @@ export function App() {
 
     const handleFileTreeNodeClick = useCallback(
         (node: GitTreeNode, event: GitTreeNodeActivationEvent) => {
+            setIsFileTreeSelectionSuppressed(false);
+
             const isRangeSelection = event.shiftKey;
             const isToggleSelection = event.metaKey || event.ctrlKey;
 
@@ -2390,6 +2418,8 @@ export function App() {
             if (!dataTransfer) {
                 return;
             }
+
+            setIsFileTreeSelectionSuppressed(false);
 
             const dragPaths = resolveGitTreeDragPaths(
                 node.path,
@@ -3701,7 +3731,9 @@ export function App() {
                                 return;
                             }
 
-                            clearFileTreeSelection();
+                            clearFileTreeSelection({
+                                suppressActivePathFallback: true,
+                            });
                         }}
                         onScroll={handleFileTreeScroll}
                     >
@@ -3762,7 +3794,11 @@ export function App() {
                                     />
                                 ) : null}
                                 <GitTreeView
-                                    activePath={activeFilePath}
+                                    activePath={
+                                        isFileTreeSelectionSuppressed
+                                            ? null
+                                            : activeFilePath
+                                    }
                                     editingDraftName={
                                         fileTreeInlineEditor?.draftName ?? null
                                     }
@@ -3796,11 +3832,16 @@ export function App() {
                                     }}
                                     stickyFolderPaths={stickyFolderPaths}
                                     selectedPaths={selectedFileTreePathSet}
+                                    suppressKeyboardCursor={
+                                        isFileTreeSelectionSuppressed
+                                    }
                                     scrollToActivePathSignal={
                                         fileTreeRevealSignal ?? undefined
                                     }
                                     onBackgroundContextMenu={({ x, y }) => {
-                                        clearFileTreeSelection();
+                                        clearFileTreeSelection({
+                                            suppressActivePathFallback: true,
+                                        });
                                         setFileTreeContextMenu({
                                             x,
                                             y,
@@ -3840,6 +3881,7 @@ export function App() {
                                     }
                                     onNodeClick={handleFileTreeNodeClick}
                                     onNodeContextMenu={(node, { x, y }) => {
+                                        setIsFileTreeSelectionSuppressed(false);
                                         const isNodeSelected =
                                             selectedFileTreePathSet.has(
                                                 node.path,
@@ -4021,8 +4063,8 @@ export function App() {
                         <main
                             className="surface-focus min-h-0 bg-bg-primary"
                             data-active={activeSurface === "workspace"}
-                            onClick={() => focusSurface("workspace")}
-                            onFocus={() => focusSurface("workspace")}
+                            onFocus={focusWorkspaceSurface}
+                            onPointerDown={focusWorkspaceSurface}
                             tabIndex={0}
                         >
                             <WorkspaceView

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -9,6 +9,7 @@ import {
     type MouseEvent as ReactMouseEvent,
     type PointerEvent as ReactPointerEvent,
 } from "react";
+import { createPortal } from "react-dom";
 
 import type {
     ComandoApi,
@@ -65,10 +66,10 @@ import { findPaneById, type RuntimeWorkspaceTab } from "./app/workspace/tree";
 import {
     compactGitTreeEntriesByAncestor,
     compactGitTreeEntriesForDeletion,
+    compactGitTreeDragEntriesByAncestor,
     flattenVisibleGitTreeNodes,
-    getProjectEntryParentRelativePath,
+    getProjectEntryMoveValidation,
     GitTreeView,
-    normalizeGitTreeDragPayload,
     resolveGitTreeDragPaths,
     type GitTreeDragData,
     type GitTreeDragPayload,
@@ -77,6 +78,7 @@ import {
 } from "./components/git";
 import { StickyFolderOverlay } from "./components/git/StickyFolderOverlay";
 import { useStickyFolders } from "./components/git/useStickyFolders";
+import { FolderTypeIcon } from "./components/icons/FolderTypeIcon";
 import {
     ContextMenu,
     type ContextMenuEntry,
@@ -149,6 +151,15 @@ interface FileTreeClipboardState {
     readonly operation: "copy";
     readonly projectId: string;
     readonly worktreeId: string | null;
+}
+
+interface FileTreeMoveDestination {
+    readonly canMove: boolean;
+    readonly depth: number;
+    readonly invalidReason: string | null;
+    readonly name: string;
+    readonly path: string | null;
+    readonly pathLabel: string;
 }
 
 function getProjectSearchDelayMs(query: string): number {
@@ -342,6 +353,12 @@ export function App() {
         useState<FileTreeInlineEditorState | null>(null);
     const [fileTreeClipboard, setFileTreeClipboard] =
         useState<FileTreeClipboardState | null>(null);
+    const [fileTreeMovePickerEntries, setFileTreeMovePickerEntries] = useState<
+        readonly GitTreeDragData[] | null
+    >(null);
+    const [fileTreeMovePickerQuery, setFileTreeMovePickerQuery] = useState("");
+    const [fileTreeMovePickerSelectedIndex, setFileTreeMovePickerSelectedIndex] =
+        useState(0);
     const [persistenceReady, setPersistenceReady] = useState(false);
     const [sidebarOverlayVisible, setSidebarOverlayVisible] = useState(false);
     const [sidebarOverlayClosing, setSidebarOverlayClosing] = useState(false);
@@ -1543,6 +1560,35 @@ export function App() {
         [activeProjectId, beginFileTreeInlineRename],
     );
 
+    const closeFileTreeMovePicker = useCallback(() => {
+        setFileTreeMovePickerEntries(null);
+        setFileTreeMovePickerQuery("");
+        setFileTreeMovePickerSelectedIndex(0);
+    }, []);
+
+    const openFileTreeMovePicker = useCallback(
+        (nodes: readonly GitTreeNode[]) => {
+            const entries = compactGitTreeDragEntriesByAncestor(
+                nodes
+                    .filter((node) => !node.isProjectRoot)
+                    .map((node) => ({
+                        kind: node.kind,
+                        name: node.name,
+                        relativePath: node.path,
+                    })),
+            );
+
+            if (entries.length === 0) {
+                return;
+            }
+
+            setFileTreeMovePickerEntries(entries);
+            setFileTreeMovePickerQuery("");
+            setFileTreeMovePickerSelectedIndex(0);
+        },
+        [],
+    );
+
     const handleMoveTreeNode = useCallback(
         async (
             draggedPayload: GitTreeDragPayload,
@@ -1555,12 +1601,22 @@ export function App() {
             const nextParentRelativePath = destinationNode.isProjectRoot
                 ? null
                 : destinationNode.path;
-            const draggedEntries = compactGitTreeEntriesByAncestor(
-                normalizeGitTreeDragPayload(draggedPayload).map((entry) => ({
-                    ...entry,
-                    path: entry.relativePath,
-                })),
+            const validation = getProjectEntryMoveValidation(
+                draggedPayload,
+                nextParentRelativePath,
             );
+            if (!validation.canMove) {
+                if (
+                    validation.reason === "directory-self" ||
+                    validation.reason === "directory-descendant"
+                ) {
+                    window.alert(
+                        getFileTreeMoveValidationMessage(validation.reason),
+                    );
+                }
+                return;
+            }
+
             const destinationProjectTreeNode =
                 destinationNode.isProjectRoot || !destinationNode.path
                     ? null
@@ -1572,18 +1628,8 @@ export function App() {
                 Boolean(destinationProjectTreeNode) &&
                 !activeExpandedDirectories.includes(destinationNode.path);
 
-            const movableEntries = draggedEntries.filter(
-                (entry) =>
-                    getProjectEntryParentRelativePath(entry.relativePath) !==
-                    nextParentRelativePath,
-            );
-
-            if (movableEntries.length === 0) {
-                return;
-            }
-
             try {
-                for (const entry of movableEntries) {
+                for (const entry of validation.entries) {
                     const movedEntry = await renameEntry(
                         activeProjectId,
                         entry.relativePath,
@@ -1610,7 +1656,9 @@ export function App() {
                 window.alert(
                     error instanceof Error
                         ? error.message
-                        : "Could not move the selected entry.",
+                        : validation.entries.length > 1
+                          ? "Could not move the selected items."
+                          : "Could not move the selected item.",
                 );
             }
         },
@@ -2027,6 +2075,54 @@ export function App() {
         () => new Map(visibleSidebarNodes.map((node) => [node.path, node])),
         [visibleSidebarNodes],
     );
+    const fileTreeMoveDestinations = useMemo(
+        () =>
+            buildFileTreeMoveDestinations({
+                activeProjectName: activeProject?.name ?? null,
+                entries: fileTreeMovePickerEntries,
+                projectEntryIndex: cachedFileTreeEntryIndex,
+                query: fileTreeMovePickerQuery,
+                treeNodesByParent: activeTreeNodesByParent,
+            }),
+        [
+            activeProject?.name,
+            activeTreeNodesByParent,
+            cachedFileTreeEntryIndex,
+            fileTreeMovePickerEntries,
+            fileTreeMovePickerQuery,
+        ],
+    );
+    const resolvedFileTreeMovePickerSelectedIndex = useMemo(
+        () =>
+            resolveFileTreeMovePickerSelectedIndex(
+                fileTreeMoveDestinations,
+                fileTreeMovePickerSelectedIndex,
+            ),
+        [fileTreeMoveDestinations, fileTreeMovePickerSelectedIndex],
+    );
+
+    const handleFileTreeMoveDestinationSelect = useCallback(
+        (destination: FileTreeMoveDestination) => {
+            if (!fileTreeMovePickerEntries || !destination.canMove) {
+                return;
+            }
+
+            closeFileTreeMovePicker();
+            void handleMoveTreeNode(fileTreeMovePickerEntries, {
+                id: destination.path ?? ROOT_NODE_KEY,
+                isProjectRoot: destination.path === null,
+                kind: "directory",
+                name: destination.name,
+                path: destination.path ?? "",
+                status: null,
+            });
+        },
+        [
+            closeFileTreeMovePicker,
+            fileTreeMovePickerEntries,
+            handleMoveTreeNode,
+        ],
+    );
 
     useEffect(() => {
         return scheduleEffectStateUpdate(() => {
@@ -2274,6 +2370,10 @@ export function App() {
             copyableContextSelection.length > 1
                 ? `Copy ${copyableContextSelection.length} Selected Items`
                 : "Copy";
+        const moveEntryLabel =
+            copyableContextSelection.length > 1
+                ? "Move Selected Items to..."
+                : "Move to...";
         const deleteLabel =
             contextSelection.length > 1
                 ? `Delete ${contextSelection.length} Selected Items`
@@ -2396,6 +2496,13 @@ export function App() {
                     disabled: !activeProjectId,
                 },
                 {
+                    label: moveEntryLabel,
+                    action: () =>
+                        void openFileTreeMovePicker(copyableContextSelection),
+                    disabled:
+                        !activeProjectId || copyableContextSelection.length === 0,
+                },
+                {
                     label: "Reveal in Finder",
                     action: () => void handleRevealTreeEntry(node.path),
                     disabled: !activeProjectId,
@@ -2456,6 +2563,11 @@ export function App() {
                 disabled: !activeProjectId,
             },
             {
+                label: moveEntryLabel,
+                action: () => void openFileTreeMovePicker(copyableContextSelection),
+                disabled: !activeProjectId || copyableContextSelection.length === 0,
+            },
+            {
                 label: "Reveal in Finder",
                 action: () => void handleRevealTreeEntry(node.path),
                 disabled: !activeProjectId,
@@ -2502,6 +2614,7 @@ export function App() {
         handleRevealTreeEntry,
         isFileTreeClipboardCompatible,
         openFileTab,
+        openFileTreeMovePicker,
         refreshProjectTree,
     ]);
 
@@ -3708,8 +3821,440 @@ export function App() {
                 results={quickOpenResults}
                 selectedIndex={quickOpenSelectedIndex}
             />
+
+            <FileTreeMoveDestinationPicker
+                destinations={fileTreeMoveDestinations}
+                entries={fileTreeMovePickerEntries ?? []}
+                onChangeQuery={setFileTreeMovePickerQuery}
+                onClose={closeFileTreeMovePicker}
+                onHoverIndex={setFileTreeMovePickerSelectedIndex}
+                onSelect={handleFileTreeMoveDestinationSelect}
+                open={fileTreeMovePickerEntries !== null}
+                query={fileTreeMovePickerQuery}
+                selectedIndex={resolvedFileTreeMovePickerSelectedIndex}
+            />
         </div>
     );
+}
+
+function FileTreeMoveDestinationPicker({
+    destinations,
+    entries,
+    onChangeQuery,
+    onClose,
+    onHoverIndex,
+    onSelect,
+    open,
+    query,
+    selectedIndex,
+}: {
+    readonly destinations: readonly FileTreeMoveDestination[];
+    readonly entries: readonly GitTreeDragData[];
+    readonly onChangeQuery: (value: string) => void;
+    readonly onClose: () => void;
+    readonly onHoverIndex: (index: number) => void;
+    readonly onSelect: (destination: FileTreeMoveDestination) => void;
+    readonly open: boolean;
+    readonly query: string;
+    readonly selectedIndex: number;
+}) {
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const listRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        const frameId = window.requestAnimationFrame(() => {
+            inputRef.current?.focus();
+            inputRef.current?.select();
+        });
+
+        return () => window.cancelAnimationFrame(frameId);
+    }, [open]);
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        const selectedElement = listRef.current?.querySelector<HTMLElement>(
+            "[data-move-destination-selected='true']",
+        );
+        selectedElement?.scrollIntoView({ block: "nearest" });
+    }, [open, selectedIndex]);
+
+    if (!open) {
+        return null;
+    }
+
+    const selectedDestination = destinations[selectedIndex] ?? null;
+    const itemCountLabel =
+        entries.length === 1 ? "1 item" : `${entries.length} items`;
+
+    const handleKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Escape") {
+            event.preventDefault();
+            onClose();
+            return;
+        }
+
+        if (destinations.length === 0) {
+            return;
+        }
+
+        if (event.key === "ArrowDown") {
+            event.preventDefault();
+            onHoverIndex(
+                findNextFileTreeMoveDestinationIndex(
+                    destinations,
+                    selectedIndex,
+                    1,
+                ),
+            );
+            return;
+        }
+
+        if (event.key === "ArrowUp") {
+            event.preventDefault();
+            onHoverIndex(
+                findNextFileTreeMoveDestinationIndex(
+                    destinations,
+                    selectedIndex,
+                    -1,
+                ),
+            );
+            return;
+        }
+
+        if (event.key === "Home") {
+            event.preventDefault();
+            onHoverIndex(resolveFileTreeMovePickerSelectedIndex(destinations, 0));
+            return;
+        }
+
+        if (event.key === "End") {
+            event.preventDefault();
+            onHoverIndex(
+                resolveFileTreeMovePickerSelectedIndex(
+                    destinations,
+                    destinations.length - 1,
+                ),
+            );
+            return;
+        }
+
+        if (event.key === "Enter") {
+            event.preventDefault();
+            if (selectedDestination?.canMove) {
+                onSelect(selectedDestination);
+            }
+        }
+    };
+
+    return createPortal(
+        <div
+            className="app-no-drag fixed inset-0 z-10030 flex items-start justify-center px-5 pt-[min(14vh,104px)]"
+            onMouseDown={(event) => {
+                if (event.target === event.currentTarget) {
+                    onClose();
+                }
+            }}
+            style={{
+                background:
+                    "color-mix(in srgb, var(--color-bg-primary) 70%, transparent)",
+                backdropFilter: "blur(10px)",
+            }}
+        >
+            <div
+                className="app-no-drag flex w-full max-w-[520px] flex-col overflow-hidden rounded-lg border"
+                style={{
+                    background: "var(--color-bg-elevated)",
+                    borderColor:
+                        "color-mix(in srgb, var(--color-border) 80%, transparent)",
+                    boxShadow:
+                        "0 24px 80px rgba(0, 0, 0, 0.22), 0 0 0 1px color-mix(in srgb, var(--color-border) 40%, transparent)",
+                }}
+            >
+                <div
+                    className="border-b px-3.5 py-2.5"
+                    style={{
+                        borderColor:
+                            "color-mix(in srgb, var(--color-border) 60%, transparent)",
+                    }}
+                >
+                    <div className="mb-2 flex items-center justify-between gap-3">
+                        <div className="min-w-0">
+                            <div className="truncate text-[13px] font-medium text-text-primary">
+                                Move to Folder
+                            </div>
+                            <div className="truncate text-[11px] text-text-secondary/75">
+                                {itemCountLabel}
+                            </div>
+                        </div>
+                    </div>
+                    <input
+                        autoCapitalize="off"
+                        autoComplete="off"
+                        autoCorrect="off"
+                        className="w-full rounded-md border bg-bg-primary px-2.5 py-1.75 text-[13px] text-text-primary outline-none placeholder:text-text-secondary/60"
+                        onChange={(event) => onChangeQuery(event.target.value)}
+                        onKeyDown={handleKeyDown}
+                        placeholder="Search folders..."
+                        ref={inputRef}
+                        spellCheck={false}
+                        style={{
+                            borderColor:
+                                "color-mix(in srgb, var(--color-border) 60%, transparent)",
+                        }}
+                        type="text"
+                        value={query}
+                    />
+                </div>
+
+                <div
+                    className="shell-scrollbar max-h-[min(48vh,380px)] overflow-y-auto py-1"
+                    ref={listRef}
+                >
+                    {destinations.length > 0 ? (
+                        destinations.map((destination, index) => {
+                            const isSelected = index === selectedIndex;
+
+                            return (
+                                <button
+                                    className={[
+                                        "flex w-full items-center gap-2.5 px-3.5 py-1.5 text-left transition",
+                                        destination.canMove
+                                            ? "text-text-primary"
+                                            : "text-text-secondary/45",
+                                    ].join(" ")}
+                                    data-move-destination-selected={isSelected}
+                                    disabled={!destination.canMove}
+                                    key={destination.path ?? ROOT_NODE_KEY}
+                                    onClick={() => onSelect(destination)}
+                                    onMouseEnter={() => onHoverIndex(index)}
+                                    style={{
+                                        background: isSelected
+                                            ? "color-mix(in srgb, var(--color-accent) 14%, var(--color-bg-primary))"
+                                            : "transparent",
+                                        paddingLeft: 14 + destination.depth * 14,
+                                    }}
+                                    title={
+                                        destination.invalidReason ??
+                                        destination.pathLabel
+                                    }
+                                    type="button"
+                                >
+                                    <FolderTypeIcon
+                                        folderName={destination.name}
+                                        opacity={
+                                            destination.canMove ? 0.9 : 0.45
+                                        }
+                                        open={isSelected}
+                                        size={15}
+                                    />
+                                    <span className="min-w-0 flex-1 truncate text-[13px]">
+                                        {destination.name}
+                                    </span>
+                                    <span className="min-w-0 truncate font-mono text-[11px] text-text-secondary/70">
+                                        {destination.invalidReason ??
+                                            destination.pathLabel}
+                                    </span>
+                                </button>
+                            );
+                        })
+                    ) : (
+                        <div className="px-3.5 py-6 text-center text-[12px] text-text-secondary">
+                            No matching folders
+                        </div>
+                    )}
+                </div>
+
+                <div
+                    className="flex items-center justify-between border-t px-3.5 py-1.5 text-[11px] text-text-secondary/70"
+                    style={{
+                        borderColor:
+                            "color-mix(in srgb, var(--color-border) 50%, transparent)",
+                    }}
+                >
+                    <span>
+                        {selectedDestination?.invalidReason ??
+                            "Select a destination"}
+                    </span>
+                    <span>↑↓ Navigate · Enter Move · Esc Close</span>
+                </div>
+            </div>
+        </div>,
+        document.body,
+    );
+}
+
+function buildFileTreeMoveDestinations({
+    activeProjectName,
+    entries,
+    projectEntryIndex,
+    query,
+    treeNodesByParent,
+}: {
+    readonly activeProjectName: string | null;
+    readonly entries: readonly GitTreeDragData[] | null;
+    readonly projectEntryIndex: readonly ProjectTreeNode[] | null;
+    readonly query: string;
+    readonly treeNodesByParent: Record<string, readonly ProjectTreeNode[]>;
+}): readonly FileTreeMoveDestination[] {
+    if (!entries || !activeProjectName) {
+        return [];
+    }
+
+    const normalizedQuery = query.trim().toLowerCase();
+    const directoryCandidates = collectFileTreeDirectoryCandidates({
+        activeProjectName,
+        projectEntryIndex,
+        treeNodesByParent,
+    });
+
+    return directoryCandidates
+        .filter((destination) => {
+            if (!normalizedQuery) {
+                return true;
+            }
+
+            return `${destination.name} ${destination.pathLabel}`
+                .toLowerCase()
+                .includes(normalizedQuery);
+        })
+        .map((destination) => {
+            const validation = getProjectEntryMoveValidation(
+                entries,
+                destination.path,
+            );
+
+            return {
+                ...destination,
+                canMove: validation.canMove,
+                invalidReason: validation.canMove
+                    ? null
+                    : getFileTreeMoveValidationMessage(validation.reason),
+            };
+        });
+}
+
+function collectFileTreeDirectoryCandidates({
+    activeProjectName,
+    projectEntryIndex,
+    treeNodesByParent,
+}: {
+    readonly activeProjectName: string;
+    readonly projectEntryIndex: readonly ProjectTreeNode[] | null;
+    readonly treeNodesByParent: Record<string, readonly ProjectTreeNode[]>;
+}): readonly Omit<FileTreeMoveDestination, "canMove" | "invalidReason">[] {
+    const seenPaths = new Set<string>();
+    const destinations: Omit<
+        FileTreeMoveDestination,
+        "canMove" | "invalidReason"
+    >[] = [
+        {
+            depth: 0,
+            name: activeProjectName,
+            path: null,
+            pathLabel: "Project root",
+        },
+    ];
+
+    const pushDirectory = (relativePath: string) => {
+        if (!relativePath || seenPaths.has(relativePath)) {
+            return;
+        }
+
+        seenPaths.add(relativePath);
+        const segments = relativePath.split("/").filter(Boolean);
+        destinations.push({
+            depth: segments.length,
+            name: segments.at(-1) ?? relativePath,
+            path: relativePath,
+            pathLabel: relativePath,
+        });
+    };
+
+    if (projectEntryIndex) {
+        projectEntryIndex
+            .filter((entry) => entry.kind === "directory")
+            .map((entry) => entry.relativePath)
+            .sort((left, right) =>
+                left.localeCompare(right, undefined, { sensitivity: "base" }),
+            )
+            .forEach(pushDirectory);
+        return destinations;
+    }
+
+    Object.values(treeNodesByParent)
+        .flat()
+        .filter((entry) => entry.kind === "directory")
+        .map((entry) => entry.relativePath)
+        .sort((left, right) =>
+            left.localeCompare(right, undefined, { sensitivity: "base" }),
+        )
+        .forEach(pushDirectory);
+
+    return destinations;
+}
+
+function getFileTreeMoveValidationMessage(
+    reason: ReturnType<typeof getProjectEntryMoveValidation>["reason"],
+): string {
+    switch (reason) {
+        case "directory-descendant":
+            return "Cannot move a folder into one of its subfolders.";
+        case "directory-self":
+            return "Cannot move a folder into itself.";
+        case "empty":
+            return "No items selected.";
+        case "same-parent":
+            return "Already in this folder.";
+        default:
+            return "Cannot move to this folder.";
+    }
+}
+
+function resolveFileTreeMovePickerSelectedIndex(
+    destinations: readonly FileTreeMoveDestination[],
+    index: number,
+): number {
+    if (destinations.length === 0) {
+        return 0;
+    }
+
+    const clampedIndex = Math.min(Math.max(index, 0), destinations.length - 1);
+    if (destinations[clampedIndex]?.canMove) {
+        return clampedIndex;
+    }
+
+    const firstMovableIndex = destinations.findIndex(
+        (destination) => destination.canMove,
+    );
+    return firstMovableIndex >= 0 ? firstMovableIndex : clampedIndex;
+}
+
+function findNextFileTreeMoveDestinationIndex(
+    destinations: readonly FileTreeMoveDestination[],
+    selectedIndex: number,
+    direction: 1 | -1,
+): number {
+    if (destinations.length === 0) {
+        return 0;
+    }
+
+    for (let offset = 1; offset <= destinations.length; offset += 1) {
+        const nextIndex =
+            (selectedIndex + offset * direction + destinations.length) %
+            destinations.length;
+        if (destinations[nextIndex]?.canMove) {
+            return nextIndex;
+        }
+    }
+
+    return Math.min(Math.max(selectedIndex, 0), destinations.length - 1);
 }
 
 function ProjectSwitcher({

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -138,6 +138,19 @@ type FileTreeInlineEditorState = {
     readonly path: string;
 };
 
+interface FileTreeClipboardEntry {
+    readonly kind: "directory" | "file";
+    readonly name: string;
+    readonly path: string;
+}
+
+interface FileTreeClipboardState {
+    readonly entries: readonly FileTreeClipboardEntry[];
+    readonly operation: "copy";
+    readonly projectId: string;
+    readonly worktreeId: string | null;
+}
+
 function getProjectSearchDelayMs(query: string): number {
     return query.trim().length <= 1 ? 0 : PROJECT_SEARCH_FOLLOWUP_DEBOUNCE_MS;
 }
@@ -198,6 +211,7 @@ export function App() {
     );
     const removeProject = useProjectsStore((state) => state.removeProject);
     const createEntry = useProjectsStore((state) => state.createEntry);
+    const copyEntries = useProjectsStore((state) => state.copyEntries);
     const deleteEntry = useProjectsStore((state) => state.deleteEntry);
     const renameEntry = useProjectsStore((state) => state.renameEntry);
     const revealEntry = useProjectsStore((state) => state.revealEntry);
@@ -220,9 +234,6 @@ export function App() {
     void loadingNodeKeys;
     void removeProject;
     void createEntry;
-    void deleteEntry;
-    void renameEntry;
-    void revealEntry;
 
     const workspaceHydrate = useWorkspaceStore((state) => state.hydrate);
     const appendTerminalOutput = useWorkspaceStore(
@@ -329,6 +340,8 @@ export function App() {
     const [quickOpenSelectedIndex, setQuickOpenSelectedIndex] = useState(0);
     const [fileTreeInlineEditor, setFileTreeInlineEditor] =
         useState<FileTreeInlineEditorState | null>(null);
+    const [fileTreeClipboard, setFileTreeClipboard] =
+        useState<FileTreeClipboardState | null>(null);
     const [persistenceReady, setPersistenceReady] = useState(false);
     const [sidebarOverlayVisible, setSidebarOverlayVisible] = useState(false);
     const [sidebarOverlayClosing, setSidebarOverlayClosing] = useState(false);
@@ -1734,6 +1747,109 @@ export function App() {
         [activeProject],
     );
 
+    const isFileTreeClipboardCompatible = useMemo(
+        () =>
+            Boolean(
+                activeProjectId &&
+                    fileTreeClipboard &&
+                    fileTreeClipboard.operation === "copy" &&
+                    fileTreeClipboard.projectId === activeProjectId &&
+                    normalizeFileTreeClipboardWorktreeId(
+                        fileTreeClipboard.worktreeId,
+                    ) ===
+                        normalizeFileTreeClipboardWorktreeId(
+                            activeWorktreeId,
+                        ) &&
+                    fileTreeClipboard.entries.length > 0,
+            ),
+        [activeProjectId, activeWorktreeId, fileTreeClipboard],
+    );
+
+    const fileTreePasteLabel = useMemo(() => {
+        const count = fileTreeClipboard?.entries.length ?? 0;
+        return count > 1 ? `Paste ${count} Items` : "Paste";
+    }, [fileTreeClipboard]);
+
+    const handleCopyTreeEntries = useCallback(
+        (nodes: readonly GitTreeNode[]) => {
+            if (!activeProjectId) {
+                return;
+            }
+
+            const entries = compactGitTreeEntriesByAncestor(
+                nodes
+                    .filter((node) => !node.isProjectRoot)
+                    .map((node) => ({
+                        kind: node.kind,
+                        name: node.name,
+                        path: node.path,
+                    })),
+            );
+
+            if (entries.length === 0) {
+                return;
+            }
+
+            setFileTreeClipboard({
+                entries,
+                operation: "copy",
+                projectId: activeProjectId,
+                worktreeId: activeWorktreeId ?? null,
+            });
+        },
+        [activeProjectId, activeWorktreeId],
+    );
+
+    const handlePasteTreeEntries = useCallback(
+        async (destinationParentRelativePath: string | null) => {
+            if (
+                !activeProjectId ||
+                !fileTreeClipboard ||
+                !isFileTreeClipboardCompatible
+            ) {
+                return;
+            }
+
+            try {
+                const result = await copyEntries(
+                    activeProjectId,
+                    fileTreeClipboard.entries.map((entry) => entry.path),
+                    destinationParentRelativePath,
+                    activeWorktreeId,
+                );
+                const firstCopiedEntry = result.entries[0] ?? null;
+
+                if (firstCopiedEntry) {
+                    await revealPathInTree(
+                        activeProjectId,
+                        firstCopiedEntry.relativePath,
+                        activeWorktreeId,
+                    );
+                } else if (destinationParentRelativePath) {
+                    await revealPathInTree(
+                        activeProjectId,
+                        destinationParentRelativePath,
+                        activeWorktreeId,
+                    );
+                }
+            } catch (error) {
+                window.alert(
+                    error instanceof Error
+                        ? error.message
+                        : "Could not paste the selected entries.",
+                );
+            }
+        },
+        [
+            activeProjectId,
+            activeWorktreeId,
+            copyEntries,
+            fileTreeClipboard,
+            isFileTreeClipboardCompatible,
+            revealPathInTree,
+        ],
+    );
+
     const handleAddFilesToChat = useCallback(
         async (
             nodes: readonly GitTreeNode[],
@@ -2093,6 +2209,15 @@ export function App() {
                     action: () => void handleCreateTreeEntry("directory", null),
                     disabled: !activeProjectId,
                 },
+                ...(isFileTreeClipboardCompatible
+                    ? ([
+                          {
+                              label: fileTreePasteLabel,
+                              action: () => void handlePasteTreeEntries(null),
+                              disabled: !activeProjectId,
+                          },
+                      ] satisfies ContextMenuEntry[])
+                    : ([] satisfies ContextMenuEntry[])),
                 { type: "separator" },
                 {
                     label: "Reveal Project Root",
@@ -2115,6 +2240,9 @@ export function App() {
 
         const node = fileTreeContextMenu.payload.node;
         const contextSelection = getFileTreeContextSelection(node);
+        const copyableContextSelection = contextSelection.filter(
+            (entry) => !entry.isProjectRoot,
+        );
         const contextSelectionFileCount = contextSelection.filter(
             (entry) => entry.kind === "file",
         ).length;
@@ -2142,6 +2270,10 @@ export function App() {
             contextSelection.length > 1
                 ? `Copy ${contextSelection.length} Absolute Paths`
                 : "Copy Absolute Path";
+        const copyEntryLabel =
+            copyableContextSelection.length > 1
+                ? `Copy ${copyableContextSelection.length} Selected Items`
+                : "Copy";
         const deleteLabel =
             contextSelection.length > 1
                 ? `Delete ${contextSelection.length} Selected Items`
@@ -2190,6 +2322,15 @@ export function App() {
                     action: () => void handleCreateTreeEntry("directory", null),
                     disabled: !activeProjectId,
                 },
+                ...(isFileTreeClipboardCompatible
+                    ? ([
+                          {
+                              label: fileTreePasteLabel,
+                              action: () => void handlePasteTreeEntries(null),
+                              disabled: !activeProjectId,
+                          },
+                      ] satisfies ContextMenuEntry[])
+                    : ([] satisfies ContextMenuEntry[])),
                 { type: "separator" },
                 {
                     label: "Reveal in Finder",
@@ -2260,6 +2401,12 @@ export function App() {
                     disabled: !activeProjectId,
                 },
                 {
+                    label: copyEntryLabel,
+                    action: () => void handleCopyTreeEntries(contextSelection),
+                    disabled:
+                        !activeProjectId || copyableContextSelection.length === 0,
+                },
+                {
                     label: copyRelativePathLabel,
                     action: () =>
                         void handleCopyTreePaths(contextSelection, "relative"),
@@ -2293,6 +2440,15 @@ export function App() {
                     void handleCreateTreeEntry("directory", node.path),
                 disabled: !activeProjectId,
             },
+            ...(isFileTreeClipboardCompatible
+                ? ([
+                      {
+                          label: fileTreePasteLabel,
+                          action: () => void handlePasteTreeEntries(node.path),
+                          disabled: !activeProjectId,
+                      },
+                  ] satisfies ContextMenuEntry[])
+                : ([] satisfies ContextMenuEntry[])),
             { type: "separator" },
             {
                 label: "Rename",
@@ -2303,6 +2459,11 @@ export function App() {
                 label: "Reveal in Finder",
                 action: () => void handleRevealTreeEntry(node.path),
                 disabled: !activeProjectId,
+            },
+            {
+                label: copyEntryLabel,
+                action: () => void handleCopyTreeEntries(contextSelection),
+                disabled: !activeProjectId || copyableContextSelection.length === 0,
             },
             {
                 label: copyRelativePathLabel,
@@ -2328,14 +2489,18 @@ export function App() {
         activeProjectId,
         activeWorktreeId,
         fileTreeContextMenu,
+        fileTreePasteLabel,
         getFileTreeContextSelection,
         handleAddFilesToChat,
         handleCloseFileTreeTabs,
+        handleCopyTreeEntries,
         handleCopyTreePaths,
         handleCreateTreeEntry,
         handleDeleteTreeNodes,
+        handlePasteTreeEntries,
         handleRenameTreeNode,
         handleRevealTreeEntry,
+        isFileTreeClipboardCompatible,
         openFileTab,
         refreshProjectTree,
     ]);
@@ -3917,6 +4082,12 @@ function joinProjectPath(rootPath: string, relativePath: string): string {
     return `${rootPath.replace(/[\\/]+$/, "")}${separator}${relativePath
         .split("/")
         .join(separator)}`;
+}
+
+function normalizeFileTreeClipboardWorktreeId(
+    worktreeId: string | null | undefined,
+): string {
+    return worktreeId ?? "__primary__";
 }
 
 function getComandoApi(): ComandoApi | null {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1973,6 +1973,57 @@ export function App() {
         ],
     );
 
+    const handleImportExternalTreeEntries = useCallback(
+        async (
+            sourcePaths: readonly string[],
+            destinationNode: GitTreeNode | null,
+        ) => {
+            if (!activeProjectId) {
+                return;
+            }
+
+            const destinationParentRelativePath = destinationNode?.isProjectRoot
+                ? null
+                : (destinationNode?.path ?? null);
+
+            try {
+                const result = await copyExternalEntries(
+                    activeProjectId,
+                    sourcePaths,
+                    destinationParentRelativePath,
+                    activeWorktreeId,
+                );
+                const firstImportedEntry = result.entries[0] ?? null;
+
+                if (firstImportedEntry) {
+                    await revealPathInTree(
+                        activeProjectId,
+                        firstImportedEntry.relativePath,
+                        activeWorktreeId,
+                    );
+                } else if (destinationParentRelativePath) {
+                    await revealPathInTree(
+                        activeProjectId,
+                        destinationParentRelativePath,
+                        activeWorktreeId,
+                    );
+                }
+            } catch (error) {
+                window.alert(
+                    error instanceof Error
+                        ? error.message
+                        : "Could not import the dropped entries.",
+                );
+            }
+        },
+        [
+            activeProjectId,
+            activeWorktreeId,
+            copyExternalEntries,
+            revealPathInTree,
+        ],
+    );
+
     const handleDuplicateTreeEntries = useCallback(
         async (nodes: readonly GitTreeNode[]) => {
             if (!activeProjectId) {
@@ -3702,18 +3753,9 @@ export function App() {
                                             sourcePaths,
                                             destinationNode,
                                         ) => {
-                                            if (!activeProjectId) {
-                                                return;
-                                            }
-
-                                            void copyExternalEntries(
-                                                activeProjectId,
+                                            void handleImportExternalTreeEntries(
                                                 sourcePaths,
-                                                destinationNode?.isProjectRoot
-                                                    ? null
-                                                    : (destinationNode?.path ??
-                                                      null),
-                                                activeWorktreeId,
+                                                destinationNode,
                                             );
                                         }}
                                         selectedPaths={selectedFileTreePathSet}
@@ -3790,18 +3832,9 @@ export function App() {
                                         isFilteringFileTree
                                             ? undefined
                                             : (sourcePaths, destinationNode) => {
-                                                  if (!activeProjectId) {
-                                                      return;
-                                                  }
-
-                                                  void copyExternalEntries(
-                                                      activeProjectId,
+                                                  void handleImportExternalTreeEntries(
                                                       sourcePaths,
-                                                      destinationNode?.isProjectRoot
-                                                          ? null
-                                                          : (destinationNode?.path ??
-                                                            null),
-                                                      activeWorktreeId,
+                                                      destinationNode,
                                                   );
                                               }
                                     }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1861,18 +1861,13 @@ export function App() {
         [activeProjectId, activeWorktreeId, revealEntry],
     );
 
-    const handleCopyTreePaths = useCallback(
-        async (
-            nodes: readonly GitTreeNode[],
-            mode: "absolute" | "relative",
-        ) => {
+    const handleCopyTreeFullPaths = useCallback(
+        async (nodes: readonly GitTreeNode[]) => {
             const text = nodes
                 .map((node) =>
-                    mode === "absolute"
-                        ? activeProject
-                            ? joinProjectPath(activeProject.rootPath, node.path)
-                            : null
-                        : node.path,
+                    activeProject
+                        ? joinProjectPath(activeProject.rootPath, node.path)
+                        : null,
                 )
                 .filter((path): path is string => path !== null)
                 .join("\n");
@@ -2592,10 +2587,6 @@ export function App() {
                       contextSelectionFileCount === 1 ? "File" : "Files"
                   } to New Chat`
                 : "Add to New Chat";
-        const copyRelativePathLabel =
-            contextSelection.length > 1
-                ? `Copy ${contextSelection.length} Relative Paths`
-                : "Copy Relative Path";
         const copyAbsolutePathLabel =
             contextSelection.length > 1
                 ? `Copy ${contextSelection.length} Full Paths`
@@ -2683,7 +2674,7 @@ export function App() {
                 },
                 {
                     label: "Copy Full Path",
-                    action: () => void handleCopyTreePaths([node], "absolute"),
+                    action: () => void handleCopyTreeFullPaths([node]),
                     disabled: !activeProject,
                 },
                 {
@@ -2780,14 +2771,9 @@ export function App() {
                         !activeProjectId || copyableContextSelection.length === 0,
                 },
                 {
-                    label: copyRelativePathLabel,
-                    action: () =>
-                        void handleCopyTreePaths(contextSelection, "relative"),
-                },
-                {
                     label: copyAbsolutePathLabel,
                     action: () =>
-                        void handleCopyTreePaths(contextSelection, "absolute"),
+                        void handleCopyTreeFullPaths(contextSelection),
                     disabled: !activeProject,
                 },
                 { type: "separator" },
@@ -2863,14 +2849,9 @@ export function App() {
                 disabled: !activeProjectId || copyableContextSelection.length === 0,
             },
             {
-                label: copyRelativePathLabel,
-                action: () =>
-                    void handleCopyTreePaths(contextSelection, "relative"),
-            },
-            {
                 label: copyAbsolutePathLabel,
                 action: () =>
-                    void handleCopyTreePaths(contextSelection, "absolute"),
+                    void handleCopyTreeFullPaths(contextSelection),
                 disabled: !activeProject,
             },
             { type: "separator" },
@@ -2897,7 +2878,7 @@ export function App() {
         handleAddFilesToChat,
         handleCloseFileTreeTabs,
         handleCopyTreeEntries,
-        handleCopyTreePaths,
+        handleCopyTreeFullPaths,
         handleCreateTreeEntry,
         handleDeleteTreeNodes,
         handleDuplicateTreeEntries,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3775,11 +3775,7 @@ export function App() {
                                     />
                                 ) : null}
                                 <GitTreeView
-                                    activePath={
-                                        isFileTreeSelectionSuppressed
-                                            ? null
-                                            : activeFilePath
-                                    }
+                                    activePath={activeFilePath}
                                     editingDraftName={
                                         fileTreeInlineEditor?.draftName ?? null
                                     }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -33,6 +33,13 @@ import {
     resolveFileTreeNodeClickSelection,
 } from "./app/projects/file-tree-selection";
 import {
+    buildFileTreeMoveDestinations,
+    findNextFileTreeMoveDestinationIndex,
+    getFileTreeMoveValidationMessage,
+    resolveFileTreeMovePickerSelectedIndex,
+    type FileTreeMoveDestination,
+} from "./app/projects/file-tree-move-destinations";
+import {
     searchProjectQuickOpenEntries,
     type ProjectQuickOpenMatch,
 } from "./app/projects/quick-open";
@@ -151,15 +158,6 @@ interface FileTreeClipboardState {
     readonly operation: "copy";
     readonly projectId: string;
     readonly worktreeId: string | null;
-}
-
-interface FileTreeMoveDestination {
-    readonly canMove: boolean;
-    readonly depth: number;
-    readonly invalidReason: string | null;
-    readonly name: string;
-    readonly path: string | null;
-    readonly pathLabel: string;
 }
 
 function getProjectSearchDelayMs(query: string): number {
@@ -4369,173 +4367,6 @@ function FileTreeMoveDestinationPicker({
         </div>,
         document.body,
     );
-}
-
-function buildFileTreeMoveDestinations({
-    activeProjectName,
-    entries,
-    projectEntryIndex,
-    query,
-    treeNodesByParent,
-}: {
-    readonly activeProjectName: string | null;
-    readonly entries: readonly GitTreeDragData[] | null;
-    readonly projectEntryIndex: readonly ProjectTreeNode[] | null;
-    readonly query: string;
-    readonly treeNodesByParent: Record<string, readonly ProjectTreeNode[]>;
-}): readonly FileTreeMoveDestination[] {
-    if (!entries || !activeProjectName) {
-        return [];
-    }
-
-    const normalizedQuery = query.trim().toLowerCase();
-    const directoryCandidates = collectFileTreeDirectoryCandidates({
-        activeProjectName,
-        projectEntryIndex,
-        treeNodesByParent,
-    });
-
-    return directoryCandidates
-        .filter((destination) => {
-            if (!normalizedQuery) {
-                return true;
-            }
-
-            return `${destination.name} ${destination.pathLabel}`
-                .toLowerCase()
-                .includes(normalizedQuery);
-        })
-        .map((destination) => {
-            const validation = getProjectEntryMoveValidation(
-                entries,
-                destination.path,
-            );
-
-            return {
-                ...destination,
-                canMove: validation.canMove,
-                invalidReason: validation.canMove
-                    ? null
-                    : getFileTreeMoveValidationMessage(validation.reason),
-            };
-        });
-}
-
-function collectFileTreeDirectoryCandidates({
-    activeProjectName,
-    projectEntryIndex,
-    treeNodesByParent,
-}: {
-    readonly activeProjectName: string;
-    readonly projectEntryIndex: readonly ProjectTreeNode[] | null;
-    readonly treeNodesByParent: Record<string, readonly ProjectTreeNode[]>;
-}): readonly Omit<FileTreeMoveDestination, "canMove" | "invalidReason">[] {
-    const seenPaths = new Set<string>();
-    const destinations: Omit<
-        FileTreeMoveDestination,
-        "canMove" | "invalidReason"
-    >[] = [
-        {
-            depth: 0,
-            name: activeProjectName,
-            path: null,
-            pathLabel: "Project root",
-        },
-    ];
-
-    const pushDirectory = (relativePath: string) => {
-        if (!relativePath || seenPaths.has(relativePath)) {
-            return;
-        }
-
-        seenPaths.add(relativePath);
-        const segments = relativePath.split("/").filter(Boolean);
-        destinations.push({
-            depth: segments.length,
-            name: segments.at(-1) ?? relativePath,
-            path: relativePath,
-            pathLabel: relativePath,
-        });
-    };
-
-    if (projectEntryIndex) {
-        projectEntryIndex
-            .filter((entry) => entry.kind === "directory")
-            .map((entry) => entry.relativePath)
-            .sort((left, right) =>
-                left.localeCompare(right, undefined, { sensitivity: "base" }),
-            )
-            .forEach(pushDirectory);
-        return destinations;
-    }
-
-    Object.values(treeNodesByParent)
-        .flat()
-        .filter((entry) => entry.kind === "directory")
-        .map((entry) => entry.relativePath)
-        .sort((left, right) =>
-            left.localeCompare(right, undefined, { sensitivity: "base" }),
-        )
-        .forEach(pushDirectory);
-
-    return destinations;
-}
-
-function getFileTreeMoveValidationMessage(
-    reason: ReturnType<typeof getProjectEntryMoveValidation>["reason"],
-): string {
-    switch (reason) {
-        case "directory-descendant":
-            return "Cannot move a folder into one of its subfolders.";
-        case "directory-self":
-            return "Cannot move a folder into itself.";
-        case "empty":
-            return "No items selected.";
-        case "same-parent":
-            return "Already in this folder.";
-        default:
-            return "Cannot move to this folder.";
-    }
-}
-
-function resolveFileTreeMovePickerSelectedIndex(
-    destinations: readonly FileTreeMoveDestination[],
-    index: number,
-): number {
-    if (destinations.length === 0) {
-        return 0;
-    }
-
-    const clampedIndex = Math.min(Math.max(index, 0), destinations.length - 1);
-    if (destinations[clampedIndex]?.canMove) {
-        return clampedIndex;
-    }
-
-    const firstMovableIndex = destinations.findIndex(
-        (destination) => destination.canMove,
-    );
-    return firstMovableIndex >= 0 ? firstMovableIndex : clampedIndex;
-}
-
-function findNextFileTreeMoveDestinationIndex(
-    destinations: readonly FileTreeMoveDestination[],
-    selectedIndex: number,
-    direction: 1 | -1,
-): number {
-    if (destinations.length === 0) {
-        return 0;
-    }
-
-    for (let offset = 1; offset <= destinations.length; offset += 1) {
-        const nextIndex =
-            (selectedIndex + offset * direction + destinations.length) %
-            destinations.length;
-        if (destinations[nextIndex]?.canMove) {
-            return nextIndex;
-        }
-    }
-
-    return Math.min(Math.max(selectedIndex, 0), destinations.length - 1);
 }
 
 function ProjectSwitcher({

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -69,6 +69,7 @@ import {
     resolveGitTreeDragPaths,
     type GitTreeDragData,
     type GitTreeNode,
+    type GitTreeNodeActivationEvent,
 } from "./components/git";
 import { StickyFolderOverlay } from "./components/git/StickyFolderOverlay";
 import { useStickyFolders } from "./components/git/useStickyFolders";
@@ -1868,7 +1869,7 @@ export function App() {
     }, [visibleSidebarNodePathSet]);
 
     const handleFileTreeNodeClick = useCallback(
-        (node: GitTreeNode, event: ReactMouseEvent<HTMLDivElement>) => {
+        (node: GitTreeNode, event: GitTreeNodeActivationEvent) => {
             const isRangeSelection = event.shiftKey;
             const isToggleSelection = event.metaKey || event.ctrlKey;
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -223,6 +223,9 @@ export function App() {
     const removeProject = useProjectsStore((state) => state.removeProject);
     const createEntry = useProjectsStore((state) => state.createEntry);
     const copyEntries = useProjectsStore((state) => state.copyEntries);
+    const copyExternalEntries = useProjectsStore(
+        (state) => state.copyExternalEntries,
+    );
     const deleteEntry = useProjectsStore((state) => state.deleteEntry);
     const trashEntry = useProjectsStore((state) => state.trashEntry);
     const openEntryExternally = useProjectsStore(
@@ -3697,6 +3700,24 @@ export function App() {
                                                 destinationNode,
                                             );
                                         }}
+                                        onExternalFilesDrop={(
+                                            sourcePaths,
+                                            destinationNode,
+                                        ) => {
+                                            if (!activeProjectId) {
+                                                return;
+                                            }
+
+                                            void copyExternalEntries(
+                                                activeProjectId,
+                                                sourcePaths,
+                                                destinationNode?.isProjectRoot
+                                                    ? null
+                                                    : (destinationNode?.path ??
+                                                      null),
+                                                activeWorktreeId,
+                                            );
+                                        }}
                                         selectedPaths={selectedFileTreePathSet}
                                     />
                                 ) : null}
@@ -3764,6 +3785,25 @@ export function App() {
                                                   void handleMoveTreeNode(
                                                       dragData,
                                                       rootNode,
+                                                  );
+                                              }
+                                    }
+                                    onExternalFilesDrop={
+                                        isFilteringFileTree
+                                            ? undefined
+                                            : (sourcePaths, destinationNode) => {
+                                                  if (!activeProjectId) {
+                                                      return;
+                                                  }
+
+                                                  void copyExternalEntries(
+                                                      activeProjectId,
+                                                      sourcePaths,
+                                                      destinationNode?.isProjectRoot
+                                                          ? null
+                                                          : (destinationNode?.path ??
+                                                            null),
+                                                      activeWorktreeId,
                                                   );
                                               }
                                     }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -224,6 +224,10 @@ export function App() {
     const createEntry = useProjectsStore((state) => state.createEntry);
     const copyEntries = useProjectsStore((state) => state.copyEntries);
     const deleteEntry = useProjectsStore((state) => state.deleteEntry);
+    const trashEntry = useProjectsStore((state) => state.trashEntry);
+    const openEntryExternally = useProjectsStore(
+        (state) => state.openEntryExternally,
+    );
     const renameEntry = useProjectsStore((state) => state.renameEntry);
     const revealEntry = useProjectsStore((state) => state.revealEntry);
     const setActiveProject = useProjectsStore(
@@ -1743,6 +1747,76 @@ export function App() {
         ],
     );
 
+    const handleTrashTreeNodes = useCallback(
+        async (nodes: readonly GitTreeNode[]) => {
+            if (!activeProjectId) {
+                return;
+            }
+
+            const trashableNodes = nodes.filter((node) => !node.isProjectRoot);
+            if (trashableNodes.length === 0) {
+                return;
+            }
+
+            const confirmed = window.confirm(
+                trashableNodes.length === 1
+                    ? trashableNodes[0].kind === "directory"
+                        ? `Move folder "${trashableNodes[0].name}" and all its contents to Trash?`
+                        : `Move file "${trashableNodes[0].name}" to Trash?`
+                    : `Move ${trashableNodes.length} selected items to Trash?`,
+            );
+            if (!confirmed) {
+                return;
+            }
+
+            const entriesToTrash =
+                compactGitTreeEntriesForDeletion(trashableNodes);
+            const trashedEntries: {
+                readonly kind: "directory" | "file";
+                readonly relativePath: string;
+            }[] = [];
+
+            try {
+                for (const entry of entriesToTrash) {
+                    await trashEntry(
+                        activeProjectId,
+                        entry.path,
+                        activeWorktreeId,
+                    );
+                    trashedEntries.push({
+                        kind: entry.kind,
+                        relativePath: entry.path,
+                    });
+                }
+
+                await closeTabsForProjectPaths(
+                    activeProjectId,
+                    activeWorktreeId,
+                    trashedEntries,
+                );
+            } catch (error) {
+                if (trashedEntries.length > 0) {
+                    await closeTabsForProjectPaths(
+                        activeProjectId,
+                        activeWorktreeId,
+                        trashedEntries,
+                    );
+                }
+                window.alert(
+                    error instanceof Error
+                        ? error.message
+                        : "Could not move the selected entry to Trash.",
+                );
+            }
+        },
+        [
+            activeProjectId,
+            activeWorktreeId,
+            closeTabsForProjectPaths,
+            trashEntry,
+        ],
+    );
+
     const handleRevealTreeEntry = useCallback(
         async (relativePath: string | null) => {
             if (!activeProjectId) {
@@ -1815,7 +1889,7 @@ export function App() {
 
     const fileTreePasteLabel = useMemo(() => {
         const count = fileTreeClipboard?.entries.length ?? 0;
-        return count > 1 ? `Paste ${count} Items` : "Paste";
+        return count > 1 ? `Paste ${count} Items Here` : "Paste Here";
     }, [fileTreeClipboard]);
 
     const handleCopyTreeEntries = useCallback(
@@ -1896,6 +1970,84 @@ export function App() {
             isFileTreeClipboardCompatible,
             revealPathInTree,
         ],
+    );
+
+    const handleDuplicateTreeEntries = useCallback(
+        async (nodes: readonly GitTreeNode[]) => {
+            if (!activeProjectId) {
+                return;
+            }
+
+            const entries = compactGitTreeEntriesByAncestor(
+                nodes
+                    .filter((node) => !node.isProjectRoot)
+                    .map((node) => ({
+                        kind: node.kind,
+                        name: node.name,
+                        path: node.path,
+                    })),
+            );
+            const firstEntry = entries[0] ?? null;
+            if (!firstEntry) {
+                return;
+            }
+
+            const destinationParentRelativePath =
+                firstEntry.path.split("/").slice(0, -1).join("/") || null;
+
+            try {
+                const result = await copyEntries(
+                    activeProjectId,
+                    entries.map((entry) => entry.path),
+                    destinationParentRelativePath,
+                    activeWorktreeId,
+                );
+                const firstDuplicatedEntry = result.entries[0] ?? null;
+
+                if (firstDuplicatedEntry) {
+                    await revealPathInTree(
+                        activeProjectId,
+                        firstDuplicatedEntry.relativePath,
+                        activeWorktreeId,
+                    );
+                }
+            } catch (error) {
+                window.alert(
+                    error instanceof Error
+                        ? error.message
+                        : "Could not duplicate the selected entry.",
+                );
+            }
+        },
+        [
+            activeProjectId,
+            activeWorktreeId,
+            copyEntries,
+            revealPathInTree,
+        ],
+    );
+
+    const handleOpenTreeEntryExternally = useCallback(
+        async (relativePath: string) => {
+            if (!activeProjectId) {
+                return;
+            }
+
+            try {
+                await openEntryExternally(
+                    activeProjectId,
+                    relativePath,
+                    activeWorktreeId,
+                );
+            } catch (error) {
+                window.alert(
+                    error instanceof Error
+                        ? error.message
+                        : "Could not open the selected file externally.",
+                );
+            }
+        },
+        [activeProjectId, activeWorktreeId, openEntryExternally],
     );
 
     const handleAddFilesToChat = useCallback(
@@ -2364,12 +2516,14 @@ export function App() {
                 : "Copy Relative Path";
         const copyAbsolutePathLabel =
             contextSelection.length > 1
-                ? `Copy ${contextSelection.length} Absolute Paths`
-                : "Copy Absolute Path";
+                ? `Copy ${contextSelection.length} Full Paths`
+                : "Copy Full Path";
         const copyEntryLabel =
             copyableContextSelection.length > 1
                 ? `Copy ${copyableContextSelection.length} Selected Items`
                 : "Copy";
+        const canDuplicateContextSelection =
+            copyableContextSelection.length === 1;
         const moveEntryLabel =
             copyableContextSelection.length > 1
                 ? "Move Selected Items to..."
@@ -2377,7 +2531,15 @@ export function App() {
         const deleteLabel =
             contextSelection.length > 1
                 ? `Delete ${contextSelection.length} Selected Items`
-                : "Delete";
+                : node.kind === "directory"
+                  ? "Delete Folder"
+                  : "Delete File";
+        const trashLabel =
+            copyableContextSelection.length > 1
+                ? `Move ${copyableContextSelection.length} Selected Items to Trash`
+                : copyableContextSelection[0]?.kind === "directory"
+                  ? "Move Folder to Trash"
+                  : "Move File to Trash";
         const multiSelectionEntries =
             contextSelection.length > 1
                 ? ([
@@ -2438,7 +2600,7 @@ export function App() {
                     disabled: !activeProjectId,
                 },
                 {
-                    label: "Copy Absolute Path",
+                    label: "Copy Full Path",
                     action: () => void handleCopyTreePaths([node], "absolute"),
                     disabled: !activeProject,
                 },
@@ -2474,6 +2636,16 @@ export function App() {
                 ...(contextSelection.length === 1
                     ? ([
                           {
+                              label: "Open Externally",
+                              action: () =>
+                                  void handleOpenTreeEntryExternally(node.path),
+                              disabled: !activeProjectId,
+                          },
+                      ] satisfies ContextMenuEntry[])
+                    : ([] satisfies ContextMenuEntry[])),
+                ...(contextSelection.length === 1
+                    ? ([
+                          {
                               label: addToChatLabel,
                               action: () =>
                                   void handleAddFilesToChat(contextSelection),
@@ -2495,6 +2667,18 @@ export function App() {
                     action: () => void handleRenameTreeNode(node),
                     disabled: !activeProjectId,
                 },
+                ...(canDuplicateContextSelection
+                    ? ([
+                          {
+                              label: "Duplicate",
+                              action: () =>
+                                  void handleDuplicateTreeEntries(
+                                      copyableContextSelection,
+                                  ),
+                              disabled: !activeProjectId,
+                          },
+                      ] satisfies ContextMenuEntry[])
+                    : ([] satisfies ContextMenuEntry[])),
                 {
                     label: moveEntryLabel,
                     action: () =>
@@ -2525,6 +2709,13 @@ export function App() {
                     disabled: !activeProject,
                 },
                 { type: "separator" },
+                {
+                    label: trashLabel,
+                    action: () => void handleTrashTreeNodes(contextSelection),
+                    danger: true,
+                    disabled:
+                        !activeProjectId || copyableContextSelection.length === 0,
+                },
                 {
                     label: deleteLabel,
                     action: () => void handleDeleteTreeNodes(contextSelection),
@@ -2562,6 +2753,18 @@ export function App() {
                 action: () => void handleRenameTreeNode(node),
                 disabled: !activeProjectId,
             },
+            ...(canDuplicateContextSelection
+                ? ([
+                      {
+                          label: "Duplicate",
+                          action: () =>
+                              void handleDuplicateTreeEntries(
+                                  copyableContextSelection,
+                              ),
+                          disabled: !activeProjectId,
+                      },
+                  ] satisfies ContextMenuEntry[])
+                : ([] satisfies ContextMenuEntry[])),
             {
                 label: moveEntryLabel,
                 action: () => void openFileTreeMovePicker(copyableContextSelection),
@@ -2590,6 +2793,12 @@ export function App() {
             },
             { type: "separator" },
             {
+                label: trashLabel,
+                action: () => void handleTrashTreeNodes(contextSelection),
+                danger: true,
+                disabled: !activeProjectId || copyableContextSelection.length === 0,
+            },
+            {
                 label: deleteLabel,
                 action: () => void handleDeleteTreeNodes(contextSelection),
                 danger: true,
@@ -2609,9 +2818,12 @@ export function App() {
         handleCopyTreePaths,
         handleCreateTreeEntry,
         handleDeleteTreeNodes,
+        handleDuplicateTreeEntries,
+        handleOpenTreeEntryExternally,
         handlePasteTreeEntries,
         handleRenameTreeNode,
         handleRevealTreeEntry,
+        handleTrashTreeNodes,
         isFileTreeClipboardCompatible,
         openFileTab,
         openFileTreeMovePicker,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3738,6 +3738,35 @@ export function App() {
                                     scrollToActivePathSignal={
                                         fileTreeRevealSignal ?? undefined
                                     }
+                                    onBackgroundContextMenu={({ x, y }) => {
+                                        clearFileTreeSelection();
+                                        setFileTreeContextMenu({
+                                            x,
+                                            y,
+                                            payload: {
+                                                kind: "background",
+                                            },
+                                        });
+                                    }}
+                                    onBackgroundDrop={
+                                        isFilteringFileTree
+                                            ? undefined
+                                            : (dragData) => {
+                                                  const rootNode =
+                                                      sidebarTreeNodes.find(
+                                                          (node) =>
+                                                              node.isProjectRoot,
+                                                      );
+                                                  if (!rootNode) {
+                                                      return;
+                                                  }
+
+                                                  void handleMoveTreeNode(
+                                                      dragData,
+                                                      rootNode,
+                                                  );
+                                              }
+                                    }
                                     onNodeClick={handleFileTreeNodeClick}
                                     onNodeContextMenu={(node, { x, y }) => {
                                         const isNodeSelected =

--- a/src/renderer/src/app/drag-and-drop.test.ts
+++ b/src/renderer/src/app/drag-and-drop.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
     getExternalComposerDropItems,
+    getExternalProjectDropData,
+    hasExternalProjectDropPayload,
     inferMimeTypeFromPath,
     parseComposerProjectEntryListDragData,
     serializeComposerProjectEntryListDragData,
@@ -139,5 +141,50 @@ describe("drag-and-drop", () => {
                 mimeType: "application/pdf",
             },
         ]);
+    });
+
+    it("detects native file payloads before paths are resolved", () => {
+        const dataTransfer = {
+            files: [],
+            types: ["Files"],
+        } as unknown as DataTransfer;
+
+        expect(hasExternalProjectDropPayload(dataTransfer)).toBe(true);
+    });
+
+    it("extracts external project drop paths without duplicates", () => {
+        const specFile = {
+            path: "/tmp/spec.pdf",
+            size: 42,
+            type: "application/pdf",
+        } as unknown as File;
+        const readmeFile = {
+            path: "/tmp/README.md",
+            size: 12,
+            type: "text/markdown",
+        } as unknown as File;
+
+        const dataTransfer = {
+            files: [specFile, readmeFile],
+            items: [
+                {
+                    getAsFile: () => specFile,
+                    kind: "file",
+                },
+                {
+                    getAsFile: () => specFile,
+                    kind: "file",
+                },
+                {
+                    getAsFile: () => readmeFile,
+                    kind: "file",
+                },
+            ],
+            types: ["Files"],
+        } as unknown as DataTransfer;
+
+        expect(getExternalProjectDropData(dataTransfer)).toEqual({
+            sourcePaths: ["/tmp/spec.pdf", "/tmp/README.md"],
+        });
     });
 });

--- a/src/renderer/src/app/drag-and-drop.ts
+++ b/src/renderer/src/app/drag-and-drop.ts
@@ -52,6 +52,10 @@ export type ExternalComposerDropItem =
           readonly label: string;
       };
 
+export interface ExternalProjectDropData {
+    readonly sourcePaths: readonly string[];
+}
+
 export type WorkspaceTabComposerDragItem = {
     readonly kind: "file_mention";
     readonly label: string;
@@ -274,6 +278,28 @@ export function getExternalComposerDropItems(
     return items;
 }
 
+export function hasExternalProjectDropPayload(
+    dataTransfer: DataTransfer | null,
+): boolean {
+    if (!dataTransfer) {
+        return false;
+    }
+
+    const types = Array.from(dataTransfer.types ?? []);
+    return types.includes("Files") || dataTransfer.files.length > 0;
+}
+
+export function getExternalProjectDropData(
+    dataTransfer: DataTransfer | null,
+): ExternalProjectDropData | null {
+    if (!dataTransfer || !hasExternalProjectDropPayload(dataTransfer)) {
+        return null;
+    }
+
+    const sourcePaths = collectExternalProjectDropPaths(dataTransfer);
+    return sourcePaths.length > 0 ? { sourcePaths } : null;
+}
+
 export function inferMimeTypeFromPath(filePath: string): string {
     const fileName = getPathBaseName(filePath);
     const dotIndex = fileName.lastIndexOf(".");
@@ -294,6 +320,48 @@ function getDroppedFilePath(file: File | null): string | null {
 
     const trimmed = candidate.trim();
     return trimmed.length > 0 ? trimmed : null;
+}
+
+function collectExternalProjectDropPaths(
+    dataTransfer: DataTransfer,
+): readonly string[] {
+    const sourcePaths: string[] = [];
+    const seenPaths = new Set<string>();
+
+    const pushPath = (filePath: string | null) => {
+        if (!filePath) {
+            return;
+        }
+
+        const normalizedKey = filePath.replaceAll("\\", "/");
+        if (!normalizedKey || seenPaths.has(normalizedKey)) {
+            return;
+        }
+
+        seenPaths.add(normalizedKey);
+        sourcePaths.push(filePath);
+    };
+
+    const dragItems = Array.from(dataTransfer.items);
+    if (dragItems.length > 0) {
+        for (const item of dragItems) {
+            if (item.kind !== "file") {
+                continue;
+            }
+
+            pushPath(getDroppedFilePath(item.getAsFile()));
+        }
+
+        if (sourcePaths.length > 0) {
+            return sourcePaths;
+        }
+    }
+
+    for (const file of Array.from(dataTransfer.files)) {
+        pushPath(getDroppedFilePath(file));
+    }
+
+    return sourcePaths;
 }
 
 function getFileSystemPath(file: File | null): string | null {

--- a/src/renderer/src/app/projects/file-tree-move-destinations.test.ts
+++ b/src/renderer/src/app/projects/file-tree-move-destinations.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProjectTreeNode } from "@shared/ipc";
+
+import type { GitTreeDragData } from "../../components/git/types";
+import {
+    buildFileTreeMoveDestinations,
+    findNextFileTreeMoveDestinationIndex,
+    resolveFileTreeMovePickerSelectedIndex,
+    type FileTreeMoveDestination,
+} from "./file-tree-move-destinations";
+
+function makeProjectTreeNode(
+    relativePath: string,
+    kind: "directory" | "file",
+): ProjectTreeNode {
+    const parentRelativePath = relativePath.includes("/")
+        ? relativePath.split("/").slice(0, -1).join("/")
+        : null;
+
+    return {
+        extension:
+            kind === "file" ? (relativePath.split(".").at(-1) ?? null) : null,
+        gitStatus: null,
+        hasChildren: kind === "directory",
+        id: `project:${relativePath}`,
+        kind,
+        name: relativePath.split("/").at(-1) ?? relativePath,
+        parentRelativePath,
+        relativePath,
+    };
+}
+
+function makeDragEntry(
+    relativePath: string,
+    kind: "directory" | "file",
+): GitTreeDragData {
+    return {
+        kind,
+        name: relativePath.split("/").at(-1) ?? relativePath,
+        relativePath,
+    };
+}
+
+function makeDestination(
+    canMove: boolean,
+    path: string,
+): FileTreeMoveDestination {
+    return {
+        canMove,
+        depth: 1,
+        invalidReason: canMove ? null : "Cannot move to this folder.",
+        name: path,
+        path,
+        pathLabel: path,
+    };
+}
+
+describe("buildFileTreeMoveDestinations", () => {
+    it("includes the project root and sorted directories", () => {
+        const destinations = buildFileTreeMoveDestinations({
+            activeProjectName: "Comando",
+            entries: [makeDragEntry("notes/todo.md", "file")],
+            projectEntryIndex: [
+                makeProjectTreeNode("src/components", "directory"),
+                makeProjectTreeNode("README.md", "file"),
+                makeProjectTreeNode("docs", "directory"),
+                makeProjectTreeNode("src", "directory"),
+            ],
+            query: "",
+            treeNodesByParent: {},
+        });
+
+        expect(
+            destinations.map(({ depth, name, path, pathLabel }) => ({
+                depth,
+                name,
+                path,
+                pathLabel,
+            })),
+        ).toEqual([
+            {
+                depth: 0,
+                name: "Comando",
+                path: null,
+                pathLabel: "Project root",
+            },
+            { depth: 1, name: "docs", path: "docs", pathLabel: "docs" },
+            { depth: 1, name: "src", path: "src", pathLabel: "src" },
+            {
+                depth: 2,
+                name: "components",
+                path: "src/components",
+                pathLabel: "src/components",
+            },
+        ]);
+    });
+
+    it("falls back to loaded tree nodes when the full project index is unavailable", () => {
+        const destinations = buildFileTreeMoveDestinations({
+            activeProjectName: "Comando",
+            entries: [makeDragEntry("notes/todo.md", "file")],
+            projectEntryIndex: null,
+            query: "",
+            treeNodesByParent: {
+                __root__: [
+                    makeProjectTreeNode("src", "directory"),
+                    makeProjectTreeNode("README.md", "file"),
+                ],
+                src: [
+                    makeProjectTreeNode("src/components", "directory"),
+                    makeProjectTreeNode("src/App.tsx", "file"),
+                ],
+            },
+        });
+
+        expect(destinations.map((destination) => destination.path)).toEqual([
+            null,
+            "src",
+            "src/components",
+        ]);
+    });
+
+    it("filters by query against name and path label", () => {
+        const options = {
+            activeProjectName: "Comando",
+            entries: [makeDragEntry("notes/todo.md", "file")],
+            projectEntryIndex: [
+                makeProjectTreeNode("docs", "directory"),
+                makeProjectTreeNode("src/components", "directory"),
+            ],
+            treeNodesByParent: {},
+        };
+
+        expect(
+            buildFileTreeMoveDestinations({
+                ...options,
+                query: "Project root",
+            }).map((destination) => destination.path),
+        ).toEqual([null]);
+
+        expect(
+            buildFileTreeMoveDestinations({
+                ...options,
+                query: "src/",
+            }).map((destination) => destination.path),
+        ).toEqual(["src/components"]);
+    });
+
+    it("marks invalid destinations for self, descendant, and same-parent moves", () => {
+        const destinations = buildFileTreeMoveDestinations({
+            activeProjectName: "Comando",
+            entries: [makeDragEntry("src", "directory")],
+            projectEntryIndex: [
+                makeProjectTreeNode("docs", "directory"),
+                makeProjectTreeNode("src", "directory"),
+                makeProjectTreeNode("src/components", "directory"),
+            ],
+            query: "",
+            treeNodesByParent: {},
+        });
+
+        expect(destinations.find((destination) => destination.path === "src"))
+            .toMatchObject({
+                canMove: false,
+                invalidReason: "Cannot move a folder into itself.",
+            });
+        expect(
+            destinations.find(
+                (destination) => destination.path === "src/components",
+            ),
+        ).toMatchObject({
+            canMove: false,
+            invalidReason: "Cannot move a folder into one of its subfolders.",
+        });
+
+        const sameParentDestination = buildFileTreeMoveDestinations({
+            activeProjectName: "Comando",
+            entries: [makeDragEntry("docs/guide.md", "file")],
+            projectEntryIndex: [makeProjectTreeNode("docs", "directory")],
+            query: "",
+            treeNodesByParent: {},
+        }).find((destination) => destination.path === "docs");
+
+        expect(sameParentDestination).toMatchObject({
+            canMove: false,
+            invalidReason: "Already in this folder.",
+        });
+    });
+});
+
+describe("resolveFileTreeMovePickerSelectedIndex", () => {
+    it("uses the first movable destination when the current selection is invalid", () => {
+        expect(
+            resolveFileTreeMovePickerSelectedIndex(
+                [
+                    makeDestination(false, "docs"),
+                    makeDestination(true, "src"),
+                    makeDestination(true, "tests"),
+                ],
+                0,
+            ),
+        ).toBe(1);
+    });
+});
+
+describe("findNextFileTreeMoveDestinationIndex", () => {
+    it("skips invalid destinations while navigating to the next movable one", () => {
+        expect(
+            findNextFileTreeMoveDestinationIndex(
+                [
+                    makeDestination(true, "docs"),
+                    makeDestination(false, "src"),
+                    makeDestination(true, "tests"),
+                ],
+                0,
+                1,
+            ),
+        ).toBe(2);
+    });
+});

--- a/src/renderer/src/app/projects/file-tree-move-destinations.ts
+++ b/src/renderer/src/app/projects/file-tree-move-destinations.ts
@@ -1,0 +1,183 @@
+import type { ProjectTreeNode } from "@shared/ipc";
+
+import {
+    getProjectEntryMoveValidation,
+    type ProjectEntryMoveValidationReason,
+} from "../../components/git/tree-dnd";
+import type { GitTreeDragData } from "../../components/git/types";
+
+export interface FileTreeMoveDestination {
+    readonly canMove: boolean;
+    readonly depth: number;
+    readonly invalidReason: string | null;
+    readonly name: string;
+    readonly path: string | null;
+    readonly pathLabel: string;
+}
+
+export function buildFileTreeMoveDestinations({
+    activeProjectName,
+    entries,
+    projectEntryIndex,
+    query,
+    treeNodesByParent,
+}: {
+    readonly activeProjectName: string | null;
+    readonly entries: readonly GitTreeDragData[] | null;
+    readonly projectEntryIndex: readonly ProjectTreeNode[] | null;
+    readonly query: string;
+    readonly treeNodesByParent: Record<string, readonly ProjectTreeNode[]>;
+}): readonly FileTreeMoveDestination[] {
+    if (!entries || !activeProjectName) {
+        return [];
+    }
+
+    const normalizedQuery = query.trim().toLowerCase();
+    const directoryCandidates = collectFileTreeDirectoryCandidates({
+        activeProjectName,
+        projectEntryIndex,
+        treeNodesByParent,
+    });
+
+    return directoryCandidates
+        .filter((destination) => {
+            if (!normalizedQuery) {
+                return true;
+            }
+
+            return `${destination.name} ${destination.pathLabel}`
+                .toLowerCase()
+                .includes(normalizedQuery);
+        })
+        .map((destination) => {
+            const validation = getProjectEntryMoveValidation(
+                entries,
+                destination.path,
+            );
+
+            return {
+                ...destination,
+                canMove: validation.canMove,
+                invalidReason: validation.canMove
+                    ? null
+                    : getFileTreeMoveValidationMessage(validation.reason),
+            };
+        });
+}
+
+function collectFileTreeDirectoryCandidates({
+    activeProjectName,
+    projectEntryIndex,
+    treeNodesByParent,
+}: {
+    readonly activeProjectName: string;
+    readonly projectEntryIndex: readonly ProjectTreeNode[] | null;
+    readonly treeNodesByParent: Record<string, readonly ProjectTreeNode[]>;
+}): readonly Omit<FileTreeMoveDestination, "canMove" | "invalidReason">[] {
+    const seenPaths = new Set<string>();
+    const destinations: Omit<
+        FileTreeMoveDestination,
+        "canMove" | "invalidReason"
+    >[] = [
+        {
+            depth: 0,
+            name: activeProjectName,
+            path: null,
+            pathLabel: "Project root",
+        },
+    ];
+
+    const pushDirectory = (relativePath: string) => {
+        if (!relativePath || seenPaths.has(relativePath)) {
+            return;
+        }
+
+        seenPaths.add(relativePath);
+        const segments = relativePath.split("/").filter(Boolean);
+        destinations.push({
+            depth: segments.length,
+            name: segments.at(-1) ?? relativePath,
+            path: relativePath,
+            pathLabel: relativePath,
+        });
+    };
+
+    if (projectEntryIndex) {
+        projectEntryIndex
+            .filter((entry) => entry.kind === "directory")
+            .map((entry) => entry.relativePath)
+            .sort((left, right) =>
+                left.localeCompare(right, undefined, { sensitivity: "base" }),
+            )
+            .forEach(pushDirectory);
+        return destinations;
+    }
+
+    Object.values(treeNodesByParent)
+        .flat()
+        .filter((entry) => entry.kind === "directory")
+        .map((entry) => entry.relativePath)
+        .sort((left, right) =>
+            left.localeCompare(right, undefined, { sensitivity: "base" }),
+        )
+        .forEach(pushDirectory);
+
+    return destinations;
+}
+
+export function getFileTreeMoveValidationMessage(
+    reason: ProjectEntryMoveValidationReason | null,
+): string {
+    switch (reason) {
+        case "directory-descendant":
+            return "Cannot move a folder into one of its subfolders.";
+        case "directory-self":
+            return "Cannot move a folder into itself.";
+        case "empty":
+            return "No items selected.";
+        case "same-parent":
+            return "Already in this folder.";
+        default:
+            return "Cannot move to this folder.";
+    }
+}
+
+export function resolveFileTreeMovePickerSelectedIndex(
+    destinations: readonly FileTreeMoveDestination[],
+    index: number,
+): number {
+    if (destinations.length === 0) {
+        return 0;
+    }
+
+    const clampedIndex = Math.min(Math.max(index, 0), destinations.length - 1);
+    if (destinations[clampedIndex]?.canMove) {
+        return clampedIndex;
+    }
+
+    const firstMovableIndex = destinations.findIndex(
+        (destination) => destination.canMove,
+    );
+    return firstMovableIndex >= 0 ? firstMovableIndex : clampedIndex;
+}
+
+export function findNextFileTreeMoveDestinationIndex(
+    destinations: readonly FileTreeMoveDestination[],
+    selectedIndex: number,
+    direction: 1 | -1,
+): number {
+    if (destinations.length === 0) {
+        return 0;
+    }
+
+    for (let offset = 1; offset <= destinations.length; offset += 1) {
+        const nextIndex =
+            (selectedIndex + offset * direction + destinations.length) %
+            destinations.length;
+        if (destinations[nextIndex]?.canMove) {
+            return nextIndex;
+        }
+    }
+
+    return Math.min(Math.max(selectedIndex, 0), destinations.length - 1);
+}

--- a/src/renderer/src/app/projects/file-tree-selection.test.ts
+++ b/src/renderer/src/app/projects/file-tree-selection.test.ts
@@ -78,6 +78,20 @@ describe("file tree selection", () => {
         });
     });
 
+    it("can suppress the active file fallback after focus leaves the tree", () => {
+        expect(
+            reconcileFileTreeSelection({
+                activeFileTreePath: "docs/todo.md",
+                anchorPath: null,
+                includeActivePathFallback: false,
+                selectedPaths: [],
+            }),
+        ).toEqual({
+            anchorPath: null,
+            selectedPaths: [],
+        });
+    });
+
     it("preserves manual selection while an active file exists", () => {
         const selection = ["docs/guide.md", "docs/todo.md"];
 

--- a/src/renderer/src/app/projects/file-tree-selection.ts
+++ b/src/renderer/src/app/projects/file-tree-selection.ts
@@ -13,6 +13,7 @@ interface ResolveActiveFileTreePathInput {
 interface ReconcileFileTreeSelectionInput {
     readonly activeFileTreePath: string | null;
     readonly anchorPath: string | null;
+    readonly includeActivePathFallback?: boolean;
     readonly selectedPaths: readonly string[];
 }
 
@@ -50,9 +51,14 @@ export function resolveActiveFileTreePath({
 export function reconcileFileTreeSelection({
     activeFileTreePath,
     anchorPath,
+    includeActivePathFallback = true,
     selectedPaths,
 }: ReconcileFileTreeSelectionInput): FileTreeSelectionState {
-    if (selectedPaths.length > 0 || activeFileTreePath === null) {
+    if (
+        selectedPaths.length > 0 ||
+        activeFileTreePath === null ||
+        !includeActivePathFallback
+    ) {
         return {
             anchorPath,
             selectedPaths,

--- a/src/renderer/src/app/store/projects-store.ts
+++ b/src/renderer/src/app/store/projects-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 import type {
+    CopyProjectEntriesResult,
     ProjectAppDataSummary,
     ProjectEntryKind,
     ProjectEntryMutationResult,
@@ -34,6 +35,12 @@ interface ProjectsState {
         kind: ProjectEntryKind,
         worktreeId?: string | null,
     ) => Promise<ProjectEntryMutationResult>;
+    copyEntries: (
+        projectId: string,
+        sourceRelativePaths: readonly string[],
+        destinationParentRelativePath: string | null,
+        worktreeId?: string | null,
+    ) => Promise<CopyProjectEntriesResult>;
     deleteEntry: (
         projectId: string,
         relativePath: string,
@@ -312,6 +319,45 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
                     ? error.message
                     : `Could not create the ${kind}.`;
             set({ error: message });
+            throw error;
+        }
+    },
+
+    copyEntries: async (
+        projectId,
+        sourceRelativePaths,
+        destinationParentRelativePath,
+        worktreeId = null,
+    ) => {
+        const contextKey = getTreeContextKey(projectId, worktreeId);
+        try {
+            const result = await getComandoApi().copyProjectEntries({
+                destinationParentRelativePath,
+                projectId,
+                sourceRelativePaths,
+                worktreeId,
+            });
+
+            set((state) => ({
+                error: null,
+                fullyLoadedTreeProjects: {
+                    ...state.fullyLoadedTreeProjects,
+                    [contextKey]: false,
+                },
+                treeNodes: {
+                    ...state.treeNodes,
+                    [contextKey]: {},
+                },
+            }));
+            await get().refreshProjectTree(projectId, worktreeId);
+            return result;
+        } catch (error) {
+            set({
+                error:
+                    error instanceof Error
+                        ? error.message
+                        : "Could not paste the selected entries.",
+            });
             throw error;
         }
     },

--- a/src/renderer/src/app/store/projects-store.ts
+++ b/src/renderer/src/app/store/projects-store.ts
@@ -46,6 +46,16 @@ interface ProjectsState {
         relativePath: string,
         worktreeId?: string | null,
     ) => Promise<void>;
+    trashEntry: (
+        projectId: string,
+        relativePath: string,
+        worktreeId?: string | null,
+    ) => Promise<void>;
+    openEntryExternally: (
+        projectId: string,
+        relativePath: string,
+        worktreeId?: string | null,
+    ) => Promise<void>;
     getProjectAppDataSummary: (
         projectId: string,
     ) => Promise<ProjectAppDataSummary>;
@@ -397,6 +407,63 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
                         ? error.message
                         : "Could not delete the selected entry.",
             });
+            throw error;
+        }
+    },
+
+    trashEntry: async (projectId, relativePath, worktreeId = null) => {
+        const contextKey = getTreeContextKey(projectId, worktreeId);
+        try {
+            await getComandoApi().trashProjectEntry({
+                projectId,
+                relativePath,
+                worktreeId,
+            });
+
+            set((state) => ({
+                error: null,
+                expandedDirectories: {
+                    ...state.expandedDirectories,
+                    [contextKey]: removeMatchingPaths(
+                        state.expandedDirectories[contextKey] ?? [],
+                        relativePath,
+                    ),
+                },
+                fullyLoadedTreeProjects: {
+                    ...state.fullyLoadedTreeProjects,
+                    [contextKey]: false,
+                },
+                treeNodes: {
+                    ...state.treeNodes,
+                    [contextKey]: {},
+                },
+            }));
+            void get().refreshProjectTree(projectId, worktreeId);
+        } catch (error) {
+            set({
+                error:
+                    error instanceof Error
+                        ? error.message
+                        : "Could not move the selected entry to Trash.",
+            });
+            throw error;
+        }
+    },
+
+    openEntryExternally: async (projectId, relativePath, worktreeId = null) => {
+        try {
+            await getComandoApi().openProjectEntryExternally({
+                projectId,
+                relativePath,
+                worktreeId,
+            });
+            set({ error: null });
+        } catch (error) {
+            const message =
+                error instanceof Error
+                    ? error.message
+                    : "Could not open the selected file externally.";
+            set({ error: message });
             throw error;
         }
     },

--- a/src/renderer/src/app/store/projects-store.ts
+++ b/src/renderer/src/app/store/projects-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 import type {
+    CopyExternalProjectEntriesResult,
     CopyProjectEntriesResult,
     ProjectAppDataSummary,
     ProjectEntryKind,
@@ -41,6 +42,12 @@ interface ProjectsState {
         destinationParentRelativePath: string | null,
         worktreeId?: string | null,
     ) => Promise<CopyProjectEntriesResult>;
+    copyExternalEntries: (
+        projectId: string,
+        sourcePaths: readonly string[],
+        destinationParentRelativePath: string | null,
+        worktreeId?: string | null,
+    ) => Promise<CopyExternalProjectEntriesResult>;
     deleteEntry: (
         projectId: string,
         relativePath: string,
@@ -367,6 +374,45 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
                     error instanceof Error
                         ? error.message
                         : "Could not paste the selected entries.",
+            });
+            throw error;
+        }
+    },
+
+    copyExternalEntries: async (
+        projectId,
+        sourcePaths,
+        destinationParentRelativePath,
+        worktreeId = null,
+    ) => {
+        const contextKey = getTreeContextKey(projectId, worktreeId);
+        try {
+            const result = await getComandoApi().copyExternalProjectEntries({
+                destinationParentRelativePath,
+                projectId,
+                sourcePaths,
+                worktreeId,
+            });
+
+            set((state) => ({
+                error: null,
+                fullyLoadedTreeProjects: {
+                    ...state.fullyLoadedTreeProjects,
+                    [contextKey]: false,
+                },
+                treeNodes: {
+                    ...state.treeNodes,
+                    [contextKey]: {},
+                },
+            }));
+            await get().refreshProjectTree(projectId, worktreeId);
+            return result;
+        } catch (error) {
+            set({
+                error:
+                    error instanceof Error
+                        ? error.message
+                        : "Could not import the dropped entries.",
             });
             throw error;
         }

--- a/src/renderer/src/components/git/GitChangesView.tsx
+++ b/src/renderer/src/components/git/GitChangesView.tsx
@@ -1,10 +1,11 @@
-import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { GitActionButton } from "./GitUi";
 import { GitTreeView } from "./GitTreeView";
 import type {
     GitChangeGroup,
     GitChangeGroupId,
+    GitTreeNodeActivationEvent,
     GitChangesViewProps,
     GitTreeNode,
 } from "./types";
@@ -88,7 +89,7 @@ function GitChangeGroupSection({
     readonly layout: "list" | "tree";
     readonly onNodeClick?: (
         node: GitTreeNode,
-        event: ReactMouseEvent<HTMLDivElement>,
+        event: GitTreeNodeActivationEvent,
     ) => void;
     readonly onToggleDirectory?: (node: GitTreeNode) => void;
     readonly onToggleGroup?: (groupId: GitChangeGroupId) => void;

--- a/src/renderer/src/components/git/GitTreeView.test.tsx
+++ b/src/renderer/src/components/git/GitTreeView.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { GitTreeView } from "./GitTreeView";
+import { getGitTreeDragLabel, GitTreeView } from "./GitTreeView";
 import type { GitTreeNode } from "./types";
 
 function createFileNode(overrides: Partial<GitTreeNode> = {}): GitTreeNode {
@@ -191,5 +191,66 @@ describe("GitTreeView", () => {
         expect(markup).toMatch(
             /data-keyboard-cursor="true"[^>]*data-path="todo\.md"[^>]*data-selected="true"/,
         );
+    });
+
+    it("exposes root drag and context state hooks for background interactions", () => {
+        const markup = renderToStaticMarkup(
+            <GitTreeView
+                nodes={[createFileNode()]}
+                onBackgroundContextMenu={() => undefined}
+                onBackgroundDrop={() => undefined}
+            />,
+        );
+
+        expect(markup).toContain("git-tree-root");
+        expect(markup).toContain('data-background-drop-target="false"');
+        expect(markup).toContain('data-dragging="false"');
+        expect(markup).toContain('data-context-target="false"');
+    });
+
+    it("keeps row interaction states distinct in markup", () => {
+        const markup = renderToStaticMarkup(
+            <GitTreeView
+                activePath="notes.md"
+                nodes={[createFileNode()]}
+                selectedPaths={new Set(["notes.md"])}
+            />,
+        );
+
+        expect(markup).toContain('data-active="true"');
+        expect(markup).toContain('data-selected="true"');
+        expect(markup).toContain('data-drop-target="false"');
+        expect(markup).toContain('data-dragging="false"');
+        expect(markup).toContain('data-context-target="false"');
+    });
+
+    it("builds useful drag ghost labels for single and multi-entry drags", () => {
+        expect(
+            getGitTreeDragLabel({
+                kind: "file",
+                name: "notes.md",
+                relativePath: "notes.md",
+            }),
+        ).toBe("notes.md");
+
+        expect(
+            getGitTreeDragLabel([
+                {
+                    kind: "directory",
+                    name: "src",
+                    relativePath: "src",
+                },
+                {
+                    kind: "file",
+                    name: "App.tsx",
+                    relativePath: "src/App.tsx",
+                },
+                {
+                    kind: "file",
+                    name: "README.md",
+                    relativePath: "README.md",
+                },
+            ]),
+        ).toBe("1 folder, 2 files");
     });
 });

--- a/src/renderer/src/components/git/GitTreeView.test.tsx
+++ b/src/renderer/src/components/git/GitTreeView.test.tsx
@@ -155,10 +155,15 @@ describe("GitTreeView", () => {
 
     it("can suppress the keyboard cursor while focus is outside the tree", () => {
         const markup = renderToStaticMarkup(
-            <GitTreeView nodes={[createFileNode()]} suppressKeyboardCursor />,
+            <GitTreeView
+                activePath="notes.md"
+                nodes={[createFileNode()]}
+                suppressKeyboardCursor
+            />,
         );
 
         expect(markup).toContain('role="tree"');
+        expect(markup).toContain('data-active="true"');
         expect(markup).not.toContain('aria-activedescendant=');
         expect(markup).not.toContain('data-keyboard-cursor="true"');
     });

--- a/src/renderer/src/components/git/GitTreeView.test.tsx
+++ b/src/renderer/src/components/git/GitTreeView.test.tsx
@@ -153,6 +153,16 @@ describe("GitTreeView", () => {
         expect(markup).toContain('data-keyboard-cursor="true"');
     });
 
+    it("can suppress the keyboard cursor while focus is outside the tree", () => {
+        const markup = renderToStaticMarkup(
+            <GitTreeView nodes={[createFileNode()]} suppressKeyboardCursor />,
+        );
+
+        expect(markup).toContain('role="tree"');
+        expect(markup).not.toContain('aria-activedescendant=');
+        expect(markup).not.toContain('data-keyboard-cursor="true"');
+    });
+
     it("initializes the keyboard cursor from the active path when visible", () => {
         const markup = renderToStaticMarkup(
             <GitTreeView

--- a/src/renderer/src/components/git/GitTreeView.test.tsx
+++ b/src/renderer/src/components/git/GitTreeView.test.tsx
@@ -16,6 +16,64 @@ function createFileNode(overrides: Partial<GitTreeNode> = {}): GitTreeNode {
 }
 
 describe("GitTreeView", () => {
+    it("renders children for expanded directories", () => {
+        const markup = renderToStaticMarkup(
+            <GitTreeView
+                expandedPaths={["src"]}
+                nodes={[
+                    createFileNode({
+                        children: [
+                            createFileNode({
+                                id: "file-2",
+                                name: "App.tsx",
+                                path: "src/App.tsx",
+                            }),
+                        ],
+                        hasChildren: true,
+                        id: "dir-1",
+                        kind: "directory",
+                        name: "src",
+                        path: "src",
+                        status: "modified",
+                    }),
+                ]}
+            />,
+        );
+
+        expect(markup).toContain("src");
+        expect(markup).toContain("App.tsx");
+        expect(markup).toContain('data-path="src/App.tsx"');
+    });
+
+    it("does not render children for collapsed directories", () => {
+        const markup = renderToStaticMarkup(
+            <GitTreeView
+                expandedPaths={[]}
+                nodes={[
+                    createFileNode({
+                        children: [
+                            createFileNode({
+                                id: "file-2",
+                                name: "App.tsx",
+                                path: "src/App.tsx",
+                            }),
+                        ],
+                        hasChildren: true,
+                        id: "dir-1",
+                        kind: "directory",
+                        name: "src",
+                        path: "src",
+                        status: "modified",
+                    }),
+                ]}
+            />,
+        );
+
+        expect(markup).toContain("src");
+        expect(markup).not.toContain("App.tsx");
+        expect(markup).not.toContain('data-path="src/App.tsx"');
+    });
+
     it("uses git status color on file title without rendering the status letter when disabled", () => {
         const markup = renderToStaticMarkup(
             <GitTreeView

--- a/src/renderer/src/components/git/GitTreeView.test.tsx
+++ b/src/renderer/src/components/git/GitTreeView.test.tsx
@@ -140,4 +140,56 @@ describe("GitTreeView", () => {
         expect(markup).toContain('data-active="true"');
         expect(markup).toContain('data-selected="true"');
     });
+
+    it("renders a focusable tree with an initial keyboard cursor", () => {
+        const markup = renderToStaticMarkup(
+            <GitTreeView nodes={[createFileNode()]} />,
+        );
+
+        expect(markup).toContain('role="tree"');
+        expect(markup).toContain('tabindex="0"');
+        expect(markup).toContain('aria-activedescendant=');
+        expect(markup).toContain('role="treeitem"');
+        expect(markup).toContain('data-keyboard-cursor="true"');
+    });
+
+    it("initializes the keyboard cursor from the active path when visible", () => {
+        const markup = renderToStaticMarkup(
+            <GitTreeView
+                activePath="todo.md"
+                nodes={[
+                    createFileNode(),
+                    createFileNode({
+                        id: "file-2",
+                        name: "todo.md",
+                        path: "todo.md",
+                    }),
+                ]}
+            />,
+        );
+
+        expect(markup).toMatch(
+            /data-keyboard-cursor="true"[^>]*data-path="todo\.md"/,
+        );
+    });
+
+    it("initializes the keyboard cursor from selection when no active path is visible", () => {
+        const markup = renderToStaticMarkup(
+            <GitTreeView
+                nodes={[
+                    createFileNode(),
+                    createFileNode({
+                        id: "file-2",
+                        name: "todo.md",
+                        path: "todo.md",
+                    }),
+                ]}
+                selectedPaths={new Set(["todo.md"])}
+            />,
+        );
+
+        expect(markup).toMatch(
+            /data-keyboard-cursor="true"[^>]*data-path="todo\.md"[^>]*data-selected="true"/,
+        );
+    });
 });

--- a/src/renderer/src/components/git/GitTreeView.tsx
+++ b/src/renderer/src/components/git/GitTreeView.tsx
@@ -14,6 +14,8 @@ import {
 import {
     COMPOSER_PROJECT_ENTRY_LIST_MIME,
     COMPOSER_PROJECT_ENTRY_MIME,
+    getExternalProjectDropData,
+    hasExternalProjectDropPayload,
     parseComposerProjectEntryListDragData,
     parseComposerProjectEntryDragData,
 } from "@renderer/app/drag-and-drop";
@@ -406,6 +408,7 @@ export function GitTreeView({
     onEditingSubmit,
     onBackgroundContextMenu,
     onBackgroundDrop,
+    onExternalFilesDrop,
     onNodeContextMenu,
     onNodeClick,
     onNodeDrop,
@@ -710,6 +713,12 @@ export function GitTreeView({
         Boolean(onBackgroundDrop) &&
         canDropProjectEntriesIntoDirectory(dragData, null);
 
+    const canDropExternalFilesOnBackground = (
+        dataTransfer: DataTransfer | null,
+    ): boolean =>
+        Boolean(onExternalFilesDrop) &&
+        hasExternalProjectDropPayload(dataTransfer);
+
     const scheduleHoverExpand = (
         node: GitTreeNode,
         isExpanded: boolean,
@@ -851,13 +860,19 @@ export function GitTreeView({
                 }
 
                 const dragData = getEventDragData(event.dataTransfer);
-                if (!canDropOnBackground(dragData)) {
+                const canDropInternal = canDropOnBackground(dragData);
+                const canDropExternal = canDropExternalFilesOnBackground(
+                    event.dataTransfer,
+                );
+                if (!canDropInternal && !canDropExternal) {
                     setIsBackgroundDropTarget(false);
                     return;
                 }
 
                 event.preventDefault();
-                event.dataTransfer.dropEffect = "move";
+                event.dataTransfer.dropEffect = canDropExternal
+                    ? "copy"
+                    : "move";
                 setDropTargetPath(null);
                 setIsBackgroundDropTarget(true);
             }}
@@ -867,7 +882,16 @@ export function GitTreeView({
                 }
 
                 const dragData = getEventDragData(event.dataTransfer);
+                const externalDropData = getExternalProjectDropData(
+                    event.dataTransfer,
+                );
                 clearDragState();
+                if (externalDropData && onExternalFilesDrop) {
+                    event.preventDefault();
+                    onExternalFilesDrop(externalDropData.sourcePaths, null);
+                    return;
+                }
+
                 if (!canDropOnBackground(dragData)) {
                     return;
                 }
@@ -913,6 +937,7 @@ export function GitTreeView({
                         onNodeClick={onNodeClick}
                         onNodeDrop={onNodeDrop}
                         onNodeDragStart={onNodeDragStart}
+                        onExternalFilesDrop={onExternalFilesDrop}
                         onSetKeyboardCursor={setKeyboardCursorPath}
                         scheduleHoverExpand={scheduleHoverExpand}
                         onToggleDirectory={onToggleDirectory}
@@ -921,6 +946,7 @@ export function GitTreeView({
                         setActiveDragData={setActiveDragData}
                         setContextTargetPath={setContextTargetPath}
                         clearHoverExpand={clearHoverExpand}
+                        setIsBackgroundDropTarget={setIsBackgroundDropTarget}
                         setDropTargetPath={setDropTargetPath}
                         showStatusIndicator={showStatusIndicator}
                         stickyFolderPaths={stickyFolderPaths}
@@ -955,6 +981,7 @@ function GitTreeNodeRow({
     onNodeClick,
     onNodeDrop,
     onNodeDragStart,
+    onExternalFilesDrop,
     onSetKeyboardCursor,
     scheduleHoverExpand,
     onToggleDirectory,
@@ -963,6 +990,7 @@ function GitTreeNodeRow({
     setActiveDragData,
     setContextTargetPath,
     clearHoverExpand,
+    setIsBackgroundDropTarget,
     setDropTargetPath,
     showStatusIndicator,
     stickyFolderPaths,
@@ -1004,6 +1032,10 @@ function GitTreeNodeRow({
         node: GitTreeNode,
         dataTransfer: DataTransfer | null,
     ) => GitTreeDragPayload | void;
+    readonly onExternalFilesDrop?: (
+        sourcePaths: readonly string[],
+        node: GitTreeNode | null,
+    ) => void;
     readonly onSetKeyboardCursor: (path: string) => void;
     readonly scheduleHoverExpand: (
         node: GitTreeNode,
@@ -1016,6 +1048,7 @@ function GitTreeNodeRow({
     readonly setActiveDragData: (dragData: GitTreeDragPayload | null) => void;
     readonly setContextTargetPath: (path: string | null) => void;
     readonly clearHoverExpand: () => void;
+    readonly setIsBackgroundDropTarget: (isDropTarget: boolean) => void;
     readonly setDropTargetPath: (path: string | null) => void;
     readonly showStatusIndicator: boolean;
     readonly stickyFolderPaths?: ReadonlySet<string>;
@@ -1097,6 +1130,7 @@ function GitTreeNodeRow({
                 clearHoverExpand();
                 setActiveDragData(null);
                 setDropTargetPath(null);
+                setIsBackgroundDropTarget(false);
             }}
             onDragLeave={(event) => {
                 if (
@@ -1115,22 +1149,31 @@ function GitTreeNodeRow({
             onDragOver={(event) => {
                 const dragData =
                     getTreeDragData(event.dataTransfer) ?? activeDragData;
-                const canAcceptDrop =
+                const canAcceptInternalDrop =
                     isDirectory &&
                     Boolean(onNodeDrop) &&
                     canDropProjectEntriesIntoDirectory(
                         dragData,
                         node.isProjectRoot ? null : node.path,
                     );
+                const canAcceptExternalDrop =
+                    isDirectory &&
+                    Boolean(onExternalFilesDrop) &&
+                    hasExternalProjectDropPayload(event.dataTransfer);
+                const canAcceptDrop =
+                    canAcceptInternalDrop || canAcceptExternalDrop;
 
                 scheduleHoverExpand(node, isExpanded, canAcceptDrop);
 
-                if (!isDirectory || !onNodeDrop || !canAcceptDrop) {
+                if (!isDirectory || !canAcceptDrop) {
                     return;
                 }
 
                 event.preventDefault();
-                event.dataTransfer.dropEffect = "move";
+                event.dataTransfer.dropEffect = canAcceptExternalDrop
+                    ? "copy"
+                    : "move";
+                setIsBackgroundDropTarget(false);
                 if (dropTargetPath !== node.path) {
                     setDropTargetPath(node.path);
                 }
@@ -1154,9 +1197,19 @@ function GitTreeNodeRow({
             onDrop={(event) => {
                 const dragData =
                     getTreeDragData(event.dataTransfer) ?? activeDragData;
+                const externalDropData = getExternalProjectDropData(
+                    event.dataTransfer,
+                );
                 clearHoverExpand();
                 setActiveDragData(null);
                 setDropTargetPath(null);
+                setIsBackgroundDropTarget(false);
+
+                if (isDirectory && externalDropData && onExternalFilesDrop) {
+                    event.preventDefault();
+                    onExternalFilesDrop(externalDropData.sourcePaths, node);
+                    return;
+                }
 
                 if (
                     !isDirectory ||

--- a/src/renderer/src/components/git/GitTreeView.tsx
+++ b/src/renderer/src/components/git/GitTreeView.tsx
@@ -1,10 +1,12 @@
 import {
     useCallback,
     useEffect,
+    useId,
     useMemo,
     useRef,
     useState,
     type CSSProperties,
+    type KeyboardEvent as ReactKeyboardEvent,
     type MouseEvent as ReactMouseEvent,
     type ReactNode,
 } from "react";
@@ -27,6 +29,7 @@ import type {
     GitTreeDragData,
     GitNodeStatus,
     GitTreeNode,
+    GitTreeNodeActivationEvent,
     GitTreeViewProps,
     GitViewLayout,
 } from "./types";
@@ -57,6 +60,16 @@ interface FlatGitTreeRow {
     readonly key: string;
     readonly node: GitTreeNode;
 }
+
+type KeyboardNavigationKey =
+    | "ArrowDown"
+    | "ArrowLeft"
+    | "ArrowRight"
+    | "ArrowUp"
+    | "End"
+    | "Enter"
+    | "Home"
+    | " ";
 
 export function scalePx(value: number): string {
     return `calc(${value}px * var(--file-tree-scale, 1))`;
@@ -128,6 +141,134 @@ function flattenGitTreeRows({
     return rows;
 }
 
+function findRowIndexByPath(
+    rows: readonly FlatGitTreeRow[],
+    path: string | null,
+): number {
+    if (!path) {
+        return -1;
+    }
+
+    return rows.findIndex((row) => row.node.path === path);
+}
+
+function findFirstSelectedRowIndex(
+    rows: readonly FlatGitTreeRow[],
+    selectedPaths: ReadonlySet<string> | undefined,
+): number {
+    if (!selectedPaths || selectedPaths.size === 0) {
+        return -1;
+    }
+
+    return rows.findIndex((row) => selectedPaths.has(row.node.path));
+}
+
+function findNearestVisibleAncestorIndex(
+    rows: readonly FlatGitTreeRow[],
+    path: string | null,
+): number {
+    if (!path) {
+        return -1;
+    }
+
+    const parts = path.split("/");
+    for (let length = parts.length - 1; length > 0; length -= 1) {
+        const ancestorPath = parts.slice(0, length).join("/");
+        const index = findRowIndexByPath(rows, ancestorPath);
+        if (index >= 0) {
+            return index;
+        }
+    }
+
+    return -1;
+}
+
+function resolveKeyboardCursorIndex({
+    activePath,
+    cursorPath,
+    rows,
+    selectedPaths,
+}: {
+    readonly activePath: string | null;
+    readonly cursorPath: string | null;
+    readonly rows: readonly FlatGitTreeRow[];
+    readonly selectedPaths: ReadonlySet<string> | undefined;
+}): number {
+    if (rows.length === 0) {
+        return -1;
+    }
+
+    const cursorIndex = findRowIndexByPath(rows, cursorPath);
+    if (cursorIndex >= 0) {
+        return cursorIndex;
+    }
+
+    const ancestorIndex = findNearestVisibleAncestorIndex(rows, cursorPath);
+    if (ancestorIndex >= 0) {
+        return ancestorIndex;
+    }
+
+    const activeIndex = findRowIndexByPath(rows, activePath);
+    if (activeIndex >= 0) {
+        return activeIndex;
+    }
+
+    const selectedIndex = findFirstSelectedRowIndex(rows, selectedPaths);
+    if (selectedIndex >= 0) {
+        return selectedIndex;
+    }
+
+    return 0;
+}
+
+function findParentRowIndex(
+    rows: readonly FlatGitTreeRow[],
+    rowIndex: number,
+): number {
+    const row = rows[rowIndex];
+    if (!row || row.depth === 0) {
+        return -1;
+    }
+
+    for (let index = rowIndex - 1; index >= 0; index -= 1) {
+        if (rows[index]?.depth === row.depth - 1) {
+            return index;
+        }
+    }
+
+    return -1;
+}
+
+function isKeyboardNavigationKey(
+    key: string,
+): key is KeyboardNavigationKey {
+    return (
+        key === "ArrowDown" ||
+        key === "ArrowLeft" ||
+        key === "ArrowRight" ||
+        key === "ArrowUp" ||
+        key === "End" ||
+        key === "Enter" ||
+        key === "Home" ||
+        key === " "
+    );
+}
+
+function isInteractiveTreeEventTarget(
+    event: ReactKeyboardEvent<HTMLDivElement>,
+): boolean {
+    if (event.target === event.currentTarget) {
+        return false;
+    }
+
+    return (
+        event.target instanceof HTMLElement &&
+        event.target.closest(
+            'button,input,select,textarea,[contenteditable="true"],[data-inline-tree-editor="true"]',
+        ) !== null
+    );
+}
+
 function findScrollContainer(node: HTMLElement): HTMLElement | null {
     if (typeof window === "undefined") {
         return null;
@@ -191,7 +332,11 @@ export function GitTreeView({
     showStatusIndicator = true,
     stickyFolderPaths,
 }: GitTreeViewProps) {
+    const treeId = useId();
     const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
+    const [keyboardCursorPath, setKeyboardCursorPath] = useState<string | null>(
+        null,
+    );
     const [activeDragData, setActiveDragData] =
         useState<GitTreeDragData | null>(null);
     const hoverExpandPathRef = useRef<string | null>(null);
@@ -215,6 +360,17 @@ export function GitTreeView({
             }),
         [expandedPathSet, expandedPaths, layout, nodes],
     );
+    const keyboardCursorIndex = resolveKeyboardCursorIndex({
+        activePath,
+        cursorPath: keyboardCursorPath,
+        rows: flatRows,
+        selectedPaths,
+    });
+    const keyboardCursorRow =
+        keyboardCursorIndex >= 0 ? flatRows[keyboardCursorIndex] : null;
+    const activeDescendantId = keyboardCursorRow
+        ? `${treeId}-row-${keyboardCursorIndex}`
+        : undefined;
 
     const refreshVirtualizationTarget = useCallback(() => {
         const container = containerRef.current;
@@ -252,6 +408,184 @@ export function GitTreeView({
             virtualListRef.current = handle;
         },
         [],
+    );
+
+    const scrollKeyboardCursorIntoView = useCallback(
+        (index: number) => {
+            if (index < 0) {
+                return;
+            }
+
+            if (shouldVirtualize) {
+                virtualListRef.current?.scrollToIndex(index, {
+                    align: "center",
+                    offset: treeScrollOffsetRef.current,
+                });
+            }
+
+            if (typeof window === "undefined") {
+                return;
+            }
+
+            window.requestAnimationFrame(() => {
+                const row = document.getElementById(`${treeId}-row-${index}`);
+                row?.scrollIntoView({
+                    block: "nearest",
+                    inline: "nearest",
+                });
+            });
+        },
+        [shouldVirtualize, treeId],
+    );
+
+    const moveKeyboardCursor = useCallback(
+        (index: number) => {
+            const row = flatRows[index];
+            if (!row) {
+                return;
+            }
+
+            setKeyboardCursorPath(row.node.path);
+            scrollKeyboardCursorIntoView(index);
+        },
+        [flatRows, scrollKeyboardCursorIntoView],
+    );
+
+    const activateKeyboardCursor = useCallback(
+        (event: ReactKeyboardEvent<HTMLDivElement>) => {
+            if (!keyboardCursorRow) {
+                return;
+            }
+
+            const { node } = keyboardCursorRow;
+
+            if (node.kind === "file") {
+                onNodeClick?.(node, event);
+                return;
+            }
+
+            if (node.kind === "directory") {
+                onNodeClick?.(node, event);
+                onToggleDirectory?.(node);
+            }
+        },
+        [keyboardCursorRow, onNodeClick, onToggleDirectory],
+    );
+
+    const handleTreeKeyDown = useCallback(
+        (event: ReactKeyboardEvent<HTMLDivElement>) => {
+            if (editingPath || flatRows.length === 0) {
+                return;
+            }
+
+            if (isInteractiveTreeEventTarget(event)) {
+                return;
+            }
+
+            if (!isKeyboardNavigationKey(event.key)) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+
+            const currentIndex = keyboardCursorIndex >= 0
+                ? keyboardCursorIndex
+                : 0;
+            const currentRow = flatRows[currentIndex];
+
+            switch (event.key) {
+                case "ArrowDown":
+                    moveKeyboardCursor(
+                        Math.min(currentIndex + 1, flatRows.length - 1),
+                    );
+                    return;
+                case "ArrowUp":
+                    moveKeyboardCursor(Math.max(currentIndex - 1, 0));
+                    return;
+                case "Home":
+                    moveKeyboardCursor(0);
+                    return;
+                case "End":
+                    moveKeyboardCursor(flatRows.length - 1);
+                    return;
+                case "ArrowRight": {
+                    if (
+                        !currentRow ||
+                        layout !== "tree" ||
+                        currentRow.node.kind !== "directory"
+                    ) {
+                        return;
+                    }
+
+                    const isExpanded = isTreeNodeExpanded({
+                        expandedPathSet,
+                        expandedPaths,
+                        layout,
+                        node: currentRow.node,
+                    });
+                    const firstChildIndex =
+                        flatRows[currentIndex + 1]?.depth >
+                        currentRow.depth
+                            ? currentIndex + 1
+                            : -1;
+
+                    if (!isExpanded) {
+                        onToggleDirectory?.(currentRow.node);
+                        return;
+                    }
+
+                    if (firstChildIndex >= 0) {
+                        moveKeyboardCursor(firstChildIndex);
+                    }
+                    return;
+                }
+                case "ArrowLeft": {
+                    if (!currentRow) {
+                        return;
+                    }
+
+                    const isExpanded =
+                        layout === "tree" &&
+                        currentRow.node.kind === "directory" &&
+                        isTreeNodeExpanded({
+                            expandedPathSet,
+                            expandedPaths,
+                            layout,
+                            node: currentRow.node,
+                        });
+
+                    if (isExpanded) {
+                        onToggleDirectory?.(currentRow.node);
+                        return;
+                    }
+
+                    const parentIndex = findParentRowIndex(
+                        flatRows,
+                        currentIndex,
+                    );
+                    if (parentIndex >= 0) {
+                        moveKeyboardCursor(parentIndex);
+                    }
+                    return;
+                }
+                case "Enter":
+                case " ":
+                    activateKeyboardCursor(event);
+                    return;
+            }
+        },
+        [
+            activateKeyboardCursor,
+            editingPath,
+            expandedPathSet,
+            expandedPaths,
+            flatRows,
+            keyboardCursorIndex,
+            layout,
+            moveKeyboardCursor,
+            onToggleDirectory,
+        ],
     );
 
     const clearHoverExpand = () => {
@@ -357,7 +691,14 @@ export function GitTreeView({
     }
 
     return (
-        <div className={className} ref={setContainerRef}>
+        <div
+            aria-activedescendant={activeDescendantId}
+            className={className}
+            onKeyDown={handleTreeKeyDown}
+            ref={setContainerRef}
+            role="tree"
+            tabIndex={0}
+        >
             <MeasuredVirtualList
                 defaultViewportHeight={900}
                 enabled={shouldVirtualize}
@@ -366,7 +707,7 @@ export function GitTreeView({
                 items={flatRows}
                 onReady={handleVirtualListReady}
                 overscan={8}
-                renderItem={({ item }) => (
+                renderItem={({ index, item }) => (
                     <GitTreeNodeRow
                         activePath={activePath}
                         constrainWidth={constrainWidth}
@@ -378,6 +719,8 @@ export function GitTreeView({
                         enableNodeDrag={enableNodeDrag}
                         expandedPathSet={expandedPathSet}
                         expandedPaths={expandedPaths}
+                        id={`${treeId}-row-${index}`}
+                        isKeyboardCursor={index === keyboardCursorIndex}
                         key={item.key}
                         layout={layout}
                         node={item.node}
@@ -388,6 +731,7 @@ export function GitTreeView({
                         onNodeClick={onNodeClick}
                         onNodeDrop={onNodeDrop}
                         onNodeDragStart={onNodeDragStart}
+                        onSetKeyboardCursor={setKeyboardCursorPath}
                         scheduleHoverExpand={scheduleHoverExpand}
                         onToggleDirectory={onToggleDirectory}
                         renderNodeMeta={renderNodeMeta}
@@ -416,6 +760,8 @@ function GitTreeNodeRow({
     enableNodeDrag,
     expandedPathSet,
     expandedPaths,
+    id,
+    isKeyboardCursor,
     layout,
     node,
     onEditingCancel,
@@ -425,6 +771,7 @@ function GitTreeNodeRow({
     onNodeClick,
     onNodeDrop,
     onNodeDragStart,
+    onSetKeyboardCursor,
     scheduleHoverExpand,
     onToggleDirectory,
     renderNodeMeta,
@@ -445,6 +792,8 @@ function GitTreeNodeRow({
     readonly enableNodeDrag: boolean;
     readonly expandedPathSet: ReadonlySet<string> | null;
     readonly expandedPaths: readonly string[] | undefined;
+    readonly id: string;
+    readonly isKeyboardCursor: boolean;
     readonly layout: GitViewLayout;
     readonly node: GitTreeNode;
     readonly onEditingCancel?: () => void;
@@ -459,7 +808,7 @@ function GitTreeNodeRow({
     ) => void;
     readonly onNodeClick?: (
         node: GitTreeNode,
-        event: ReactMouseEvent<HTMLDivElement>,
+        event: GitTreeNodeActivationEvent,
     ) => void;
     readonly onNodeDrop?: (
         dragData: GitTreeDragData,
@@ -469,6 +818,7 @@ function GitTreeNodeRow({
         node: GitTreeNode,
         dataTransfer: DataTransfer | null,
     ) => void;
+    readonly onSetKeyboardCursor: (path: string) => void;
     readonly scheduleHoverExpand: (
         node: GitTreeNode,
         isExpanded: boolean,
@@ -511,6 +861,8 @@ function GitTreeNodeRow({
         isDirectory && stickyFolderPaths?.has(node.path) === true;
 
     const handleRowClick = (event: ReactMouseEvent<HTMLDivElement>) => {
+        onSetKeyboardCursor(node.path);
+
         const hasSelectionModifier =
             event.metaKey || event.ctrlKey || event.shiftKey;
 
@@ -544,9 +896,11 @@ function GitTreeNodeRow({
             className="git-tree-row"
             data-active={isActive ? "true" : "false"}
             data-drop-target={isDropTarget ? "true" : "false"}
+            data-keyboard-cursor={isKeyboardCursor ? "true" : "false"}
             data-path={node.path}
             data-selected={isSelected ? "true" : "false"}
             draggable={isDraggable}
+            id={id}
             onDragEnd={() => {
                 clearHoverExpand();
                 setActiveDragData(null);
@@ -668,8 +1022,20 @@ function GitTreeNodeRow({
                           }
                         : {}),
                 ...(constrainWidth ? ROW_BOX_CONSTRAINED : ROW_BOX),
+                ...(isKeyboardCursor
+                    ? {
+                          outline:
+                              "1px solid color-mix(in srgb, var(--color-accent) 58%, transparent)",
+                          outlineOffset: scalePx(-1),
+                      }
+                    : {}),
             }}
             onClick={handleRowClick}
+            role="treeitem"
+            aria-expanded={
+                isDirectory && layout === "tree" ? isExpanded : undefined
+            }
+            aria-selected={isSelected || isActive ? true : undefined}
         >
             <TreeIndentGuides depth={depth} />
 

--- a/src/renderer/src/components/git/GitTreeView.tsx
+++ b/src/renderer/src/components/git/GitTreeView.tsx
@@ -58,6 +58,31 @@ const ROW_BOX_CONSTRAINED: CSSProperties = {
     boxSizing: "border-box",
 };
 
+export const ROW_DROP_TARGET_STYLE: CSSProperties = {
+    backgroundColor: "color-mix(in srgb, var(--color-accent) 16%, transparent)",
+    boxShadow:
+        "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 62%, transparent)",
+};
+
+export const ROW_ACTIVE_STYLE: CSSProperties = {
+    backgroundColor: "color-mix(in srgb, var(--color-accent) 22%, transparent)",
+    boxShadow:
+        "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 40%, transparent)",
+};
+
+export const ROW_SELECTED_STYLE: CSSProperties = {
+    backgroundColor: "color-mix(in srgb, var(--color-accent) 10%, transparent)",
+    boxShadow:
+        "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 22%, transparent)",
+};
+
+export const ROW_CONTEXT_TARGET_STYLE: CSSProperties = {
+    backgroundColor:
+        "color-mix(in srgb, var(--color-bg-tertiary) 76%, var(--color-accent) 8%)",
+    boxShadow:
+        "inset 0 0 0 1px color-mix(in srgb, var(--color-text-secondary) 24%, transparent)",
+};
+
 interface FlatGitTreeRow {
     readonly depth: number;
     readonly key: string;
@@ -76,6 +101,62 @@ type KeyboardNavigationKey =
 
 export function scalePx(value: number): string {
     return `calc(${value}px * var(--file-tree-scale, 1))`;
+}
+
+function toGitTreeDragEntries(
+    dragData: GitTreeDragPayload,
+): readonly GitTreeDragData[] {
+    if (isGitTreeDragDataList(dragData)) {
+        return dragData;
+    }
+
+    return [dragData];
+}
+
+function isGitTreeDragDataList(
+    dragData: GitTreeDragPayload,
+): dragData is readonly GitTreeDragData[] {
+    return Array.isArray(dragData);
+}
+
+export function getGitTreeRowStateStyle({
+    isActive = false,
+    isContextTarget = false,
+    isDragging = false,
+    isDropTarget = false,
+    isKeyboardCursor = false,
+    isSelected = false,
+}: {
+    readonly isActive?: boolean;
+    readonly isContextTarget?: boolean;
+    readonly isDragging?: boolean;
+    readonly isDropTarget?: boolean;
+    readonly isKeyboardCursor?: boolean;
+    readonly isSelected?: boolean;
+}): CSSProperties {
+    return {
+        ...(isDropTarget
+            ? ROW_DROP_TARGET_STYLE
+            : isActive
+              ? ROW_ACTIVE_STYLE
+              : isContextTarget
+                ? ROW_CONTEXT_TARGET_STYLE
+                : isSelected
+                  ? ROW_SELECTED_STYLE
+                  : {}),
+        ...(isKeyboardCursor
+            ? {
+                  outline:
+                      "1px solid color-mix(in srgb, var(--color-accent) 58%, transparent)",
+                  outlineOffset: scalePx(-1),
+              }
+            : {}),
+        ...(isDragging
+            ? {
+                  opacity: 0.62,
+              }
+            : {}),
+    };
 }
 
 function isTreeNodeExpanded({
@@ -323,6 +404,8 @@ export function GitTreeView({
     onEditingCancel,
     onEditingDraftNameChange,
     onEditingSubmit,
+    onBackgroundContextMenu,
+    onBackgroundDrop,
     onNodeContextMenu,
     onNodeClick,
     onNodeDrop,
@@ -337,6 +420,11 @@ export function GitTreeView({
 }: GitTreeViewProps) {
     const treeId = useId();
     const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
+    const [isBackgroundDropTarget, setIsBackgroundDropTarget] =
+        useState(false);
+    const [contextTargetPath, setContextTargetPath] = useState<string | null>(
+        null,
+    );
     const [keyboardCursorPath, setKeyboardCursorPath] = useState<string | null>(
         null,
     );
@@ -374,6 +462,9 @@ export function GitTreeView({
     const activeDescendantId = keyboardCursorRow
         ? `${treeId}-row-${keyboardCursorIndex}`
         : undefined;
+    const rootClassName = ["git-tree-root", className]
+        .filter(Boolean)
+        .join(" ");
 
     const refreshVirtualizationTarget = useCallback(() => {
         const container = containerRef.current;
@@ -599,6 +690,26 @@ export function GitTreeView({
         }
     };
 
+    const isTreeRowEvent = (target: EventTarget | null): boolean =>
+        target instanceof HTMLElement &&
+        target.closest(".git-tree-row") !== null;
+
+    const clearDragState = () => {
+        clearHoverExpand();
+        setActiveDragData(null);
+        setDropTargetPath(null);
+        setIsBackgroundDropTarget(false);
+    };
+
+    const getEventDragData = (dataTransfer: DataTransfer | null) =>
+        getTreeDragData(dataTransfer) ?? activeDragData;
+
+    const canDropOnBackground = (
+        dragData: GitTreeDragPayload | null,
+    ): dragData is GitTreeDragPayload =>
+        Boolean(onBackgroundDrop) &&
+        canDropProjectEntriesIntoDirectory(dragData, null);
+
     const scheduleHoverExpand = (
         node: GitTreeNode,
         isExpanded: boolean,
@@ -696,7 +807,74 @@ export function GitTreeView({
     return (
         <div
             aria-activedescendant={activeDescendantId}
-            className={className}
+            className={rootClassName}
+            data-background-drop-target={
+                isBackgroundDropTarget ? "true" : "false"
+            }
+            data-context-target={
+                contextTargetPath === "" ? "background" : undefined
+            }
+            data-dragging={activeDragData ? "true" : "false"}
+            onClick={(event) => {
+                if (isTreeRowEvent(event.target)) {
+                    return;
+                }
+                setContextTargetPath(null);
+            }}
+            onContextMenu={(event) => {
+                if (!onBackgroundContextMenu || isTreeRowEvent(event.target)) {
+                    return;
+                }
+
+                event.preventDefault();
+                setContextTargetPath("");
+                onBackgroundContextMenu({
+                    x: event.clientX,
+                    y: event.clientY,
+                });
+            }}
+            onDragEnd={clearDragState}
+            onDragLeave={(event) => {
+                if (
+                    event.currentTarget.contains(
+                        event.relatedTarget as Node | null,
+                    )
+                ) {
+                    return;
+                }
+
+                setIsBackgroundDropTarget(false);
+            }}
+            onDragOver={(event) => {
+                if (isTreeRowEvent(event.target)) {
+                    return;
+                }
+
+                const dragData = getEventDragData(event.dataTransfer);
+                if (!canDropOnBackground(dragData)) {
+                    setIsBackgroundDropTarget(false);
+                    return;
+                }
+
+                event.preventDefault();
+                event.dataTransfer.dropEffect = "move";
+                setDropTargetPath(null);
+                setIsBackgroundDropTarget(true);
+            }}
+            onDrop={(event) => {
+                if (isTreeRowEvent(event.target)) {
+                    return;
+                }
+
+                const dragData = getEventDragData(event.dataTransfer);
+                clearDragState();
+                if (!canDropOnBackground(dragData)) {
+                    return;
+                }
+
+                event.preventDefault();
+                onBackgroundDrop?.(dragData);
+            }}
             onKeyDown={handleTreeKeyDown}
             ref={setContainerRef}
             role="tree"
@@ -716,6 +894,7 @@ export function GitTreeView({
                         constrainWidth={constrainWidth}
                         depth={item.depth}
                         dropTargetPath={dropTargetPath}
+                        contextTargetPath={contextTargetPath}
                         activeDragData={activeDragData}
                         editingDraftName={editingDraftName}
                         editingPath={editingPath}
@@ -740,6 +919,7 @@ export function GitTreeView({
                         renderNodeMeta={renderNodeMeta}
                         selectedPaths={selectedPaths}
                         setActiveDragData={setActiveDragData}
+                        setContextTargetPath={setContextTargetPath}
                         clearHoverExpand={clearHoverExpand}
                         setDropTargetPath={setDropTargetPath}
                         showStatusIndicator={showStatusIndicator}
@@ -756,6 +936,7 @@ function GitTreeNodeRow({
     activePath,
     activeDragData,
     constrainWidth = false,
+    contextTargetPath,
     depth,
     dropTargetPath,
     editingDraftName,
@@ -780,6 +961,7 @@ function GitTreeNodeRow({
     renderNodeMeta,
     selectedPaths,
     setActiveDragData,
+    setContextTargetPath,
     clearHoverExpand,
     setDropTargetPath,
     showStatusIndicator,
@@ -788,6 +970,7 @@ function GitTreeNodeRow({
     readonly activePath: string | null;
     readonly activeDragData: GitTreeDragPayload | null;
     readonly constrainWidth?: boolean;
+    readonly contextTargetPath: string | null;
     readonly depth: number;
     readonly dropTargetPath: string | null;
     readonly editingDraftName: string | null;
@@ -831,6 +1014,7 @@ function GitTreeNodeRow({
     readonly renderNodeMeta?: (node: GitTreeNode) => ReactNode;
     readonly selectedPaths?: ReadonlySet<string>;
     readonly setActiveDragData: (dragData: GitTreeDragPayload | null) => void;
+    readonly setContextTargetPath: (path: string | null) => void;
     readonly clearHoverExpand: () => void;
     readonly setDropTargetPath: (path: string | null) => void;
     readonly showStatusIndicator: boolean;
@@ -846,12 +1030,14 @@ function GitTreeNodeRow({
     const isEditing = editingPath === node.path;
     const isActive = activePath === node.path;
     const isSelected = selectedPaths?.has(node.path) === true;
+    const isContextTarget = contextTargetPath === node.path;
     const canOpen = !isEditing && Boolean(onNodeClick && node.kind === "file");
     const canToggle = !isEditing && Boolean(isDirectory && onToggleDirectory);
     const isDraggable =
         !isEditing && enableNodeDrag === true && !node.isProjectRoot;
     const dragStartHandler = onNodeDragStart;
     const isDropTarget = dropTargetPath === node.path;
+    const isDragging = containsGitTreeDragPath(activeDragData, node.path);
     const statusTint = node.status ? statusColor(node.status) : null;
     const titleColor = statusTint
         ? statusTint
@@ -864,6 +1050,7 @@ function GitTreeNodeRow({
         isDirectory && stickyFolderPaths?.has(node.path) === true;
 
     const handleRowClick = (event: ReactMouseEvent<HTMLDivElement>) => {
+        setContextTargetPath(null);
         onSetKeyboardCursor(node.path);
 
         const hasSelectionModifier =
@@ -898,7 +1085,9 @@ function GitTreeNodeRow({
         <div
             className="git-tree-row"
             data-active={isActive ? "true" : "false"}
+            data-context-target={isContextTarget ? "true" : "false"}
             data-drop-target={isDropTarget ? "true" : "false"}
+            data-dragging={isDragging ? "true" : "false"}
             data-keyboard-cursor={isKeyboardCursor ? "true" : "false"}
             data-path={node.path}
             data-selected={isSelected ? "true" : "false"}
@@ -960,6 +1149,7 @@ function GitTreeNodeRow({
                     dragStartHandler?.(node, event.dataTransfer ?? null) ??
                     fallbackDragData;
                 setActiveDragData(dragData);
+                setTreeDragImage(event.dataTransfer ?? null, dragData);
             }}
             onDrop={(event) => {
                 const dragData =
@@ -988,6 +1178,7 @@ function GitTreeNodeRow({
                 }
 
                 event.preventDefault();
+                setContextTargetPath(node.path);
                 onNodeContextMenu(node, {
                     x: event.clientX,
                     y: event.clientY,
@@ -1005,36 +1196,15 @@ function GitTreeNodeRow({
                 borderRadius: scalePx(4),
                 cursor: canOpen || canToggle ? "pointer" : "default",
                 color: "var(--color-text-primary)",
-                ...(isActive
-                    ? {
-                          backgroundColor:
-                              "color-mix(in srgb, var(--color-accent) 22%, transparent)",
-                          boxShadow:
-                              "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 40%, transparent)",
-                      }
-                    : isDropTarget
-                      ? {
-                            backgroundColor:
-                                "color-mix(in srgb, var(--color-accent) 14%, transparent)",
-                            boxShadow:
-                                "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 55%, transparent)",
-                        }
-                      : isSelected
-                        ? {
-                              backgroundColor:
-                                  "color-mix(in srgb, var(--color-accent) 10%, transparent)",
-                              boxShadow:
-                                  "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 22%, transparent)",
-                          }
-                        : {}),
+                ...getGitTreeRowStateStyle({
+                    isActive,
+                    isContextTarget,
+                    isDragging,
+                    isDropTarget,
+                    isKeyboardCursor,
+                    isSelected,
+                }),
                 ...(constrainWidth ? ROW_BOX_CONSTRAINED : ROW_BOX),
-                ...(isKeyboardCursor
-                    ? {
-                          outline:
-                              "1px solid color-mix(in srgb, var(--color-accent) 58%, transparent)",
-                          outlineOffset: scalePx(-1),
-                      }
-                    : {}),
             }}
             onClick={handleRowClick}
             role="treeitem"
@@ -1135,6 +1305,65 @@ function GitTreeNodeRow({
             </div>
         </div>
     );
+}
+
+export function getGitTreeDragLabel(dragData: GitTreeDragPayload): string {
+    const entries = toGitTreeDragEntries(dragData);
+    if (entries.length === 0) {
+        return "Move item";
+    }
+
+    if (entries.length === 1) {
+        const [entry] = entries;
+        return entry?.name ?? "Move item";
+    }
+
+    const fileCount = entries.filter((entry) => entry.kind === "file").length;
+    const folderCount = entries.length - fileCount;
+    const parts = [
+        folderCount > 0
+            ? `${folderCount} ${folderCount === 1 ? "folder" : "folders"}`
+            : null,
+        fileCount > 0
+            ? `${fileCount} ${fileCount === 1 ? "file" : "files"}`
+            : null,
+    ].filter((part): part is string => Boolean(part));
+
+    return parts.join(", ");
+}
+
+function containsGitTreeDragPath(
+    dragData: GitTreeDragPayload | null,
+    path: string,
+): boolean {
+    if (!dragData) {
+        return false;
+    }
+
+    const entries = toGitTreeDragEntries(dragData);
+    return entries.some((entry) => entry.relativePath === path);
+}
+
+export function setTreeDragImage(
+    dataTransfer: DataTransfer | null,
+    dragData: GitTreeDragPayload,
+): void {
+    if (
+        !dataTransfer ||
+        typeof dataTransfer.setDragImage !== "function" ||
+        typeof document === "undefined"
+    ) {
+        return;
+    }
+
+    const dragImage = document.createElement("div");
+    dragImage.className = "git-tree-drag-ghost";
+    dragImage.textContent = getGitTreeDragLabel(dragData);
+    document.body.appendChild(dragImage);
+    dataTransfer.setDragImage(dragImage, 12, 12);
+    globalThis.setTimeout(() => {
+        dragImage.remove();
+    }, 0);
 }
 
 function TreeInlineNameInput({

--- a/src/renderer/src/components/git/GitTreeView.tsx
+++ b/src/renderer/src/components/git/GitTreeView.tsx
@@ -12,7 +12,9 @@ import {
 } from "react";
 
 import {
+    COMPOSER_PROJECT_ENTRY_LIST_MIME,
     COMPOSER_PROJECT_ENTRY_MIME,
+    parseComposerProjectEntryListDragData,
     parseComposerProjectEntryDragData,
 } from "@renderer/app/drag-and-drop";
 
@@ -24,9 +26,10 @@ import {
 } from "@renderer/components/virtual/MeasuredVirtualList";
 
 import { GitActionButton, GitEmptyState } from "./GitUi";
-import { canDropProjectEntryIntoDirectory } from "./tree-dnd";
+import { canDropProjectEntriesIntoDirectory } from "./tree-dnd";
 import type {
     GitTreeDragData,
+    GitTreeDragPayload,
     GitNodeStatus,
     GitTreeNode,
     GitTreeNodeActivationEvent,
@@ -338,7 +341,7 @@ export function GitTreeView({
         null,
     );
     const [activeDragData, setActiveDragData] =
-        useState<GitTreeDragData | null>(null);
+        useState<GitTreeDragPayload | null>(null);
     const hoverExpandPathRef = useRef<string | null>(null);
     const hoverExpandTimeoutRef = useRef<number | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
@@ -783,7 +786,7 @@ function GitTreeNodeRow({
     stickyFolderPaths,
 }: {
     readonly activePath: string | null;
-    readonly activeDragData: GitTreeDragData | null;
+    readonly activeDragData: GitTreeDragPayload | null;
     readonly constrainWidth?: boolean;
     readonly depth: number;
     readonly dropTargetPath: string | null;
@@ -811,13 +814,13 @@ function GitTreeNodeRow({
         event: GitTreeNodeActivationEvent,
     ) => void;
     readonly onNodeDrop?: (
-        dragData: GitTreeDragData,
+        dragData: GitTreeDragPayload,
         node: GitTreeNode,
     ) => void;
     readonly onNodeDragStart?: (
         node: GitTreeNode,
         dataTransfer: DataTransfer | null,
-    ) => void;
+    ) => GitTreeDragPayload | void;
     readonly onSetKeyboardCursor: (path: string) => void;
     readonly scheduleHoverExpand: (
         node: GitTreeNode,
@@ -827,7 +830,7 @@ function GitTreeNodeRow({
     readonly onToggleDirectory?: (node: GitTreeNode) => void;
     readonly renderNodeMeta?: (node: GitTreeNode) => ReactNode;
     readonly selectedPaths?: ReadonlySet<string>;
-    readonly setActiveDragData: (dragData: GitTreeDragData | null) => void;
+    readonly setActiveDragData: (dragData: GitTreeDragPayload | null) => void;
     readonly clearHoverExpand: () => void;
     readonly setDropTargetPath: (path: string | null) => void;
     readonly showStatusIndicator: boolean;
@@ -922,11 +925,11 @@ function GitTreeNodeRow({
             }}
             onDragOver={(event) => {
                 const dragData =
-                    activeDragData ?? getTreeDragData(event.dataTransfer);
+                    getTreeDragData(event.dataTransfer) ?? activeDragData;
                 const canAcceptDrop =
                     isDirectory &&
                     Boolean(onNodeDrop) &&
-                    canDropProjectEntryIntoDirectory(
+                    canDropProjectEntriesIntoDirectory(
                         dragData,
                         node.isProjectRoot ? null : node.path,
                     );
@@ -948,16 +951,19 @@ function GitTreeNodeRow({
                     return;
                 }
 
-                setActiveDragData({
+                const fallbackDragData = {
                     kind: node.kind,
                     name: node.name,
                     relativePath: node.path,
-                });
-                dragStartHandler?.(node, event.dataTransfer ?? null);
+                } satisfies GitTreeDragData;
+                const dragData =
+                    dragStartHandler?.(node, event.dataTransfer ?? null) ??
+                    fallbackDragData;
+                setActiveDragData(dragData);
             }}
             onDrop={(event) => {
                 const dragData =
-                    activeDragData ?? getTreeDragData(event.dataTransfer);
+                    getTreeDragData(event.dataTransfer) ?? activeDragData;
                 clearHoverExpand();
                 setActiveDragData(null);
                 setDropTargetPath(null);
@@ -965,7 +971,7 @@ function GitTreeNodeRow({
                 if (
                     !isDirectory ||
                     !onNodeDrop ||
-                    !canDropProjectEntryIntoDirectory(
+                    !canDropProjectEntriesIntoDirectory(
                         dragData,
                         node.isProjectRoot ? null : node.path,
                     )
@@ -1208,9 +1214,20 @@ function TreeInlineNameInput({
 
 function getTreeDragData(
     dataTransfer: DataTransfer | null,
-): GitTreeDragData | null {
+): GitTreeDragPayload | null {
     if (!dataTransfer) {
         return null;
+    }
+
+    const parsedList = parseComposerProjectEntryListDragData(
+        dataTransfer.getData(COMPOSER_PROJECT_ENTRY_LIST_MIME),
+    );
+    if (parsedList) {
+        return parsedList.entries.map((entry) => ({
+            kind: entry.kind,
+            name: entry.name,
+            relativePath: entry.relativePath,
+        }));
     }
 
     const parsed = parseComposerProjectEntryDragData(

--- a/src/renderer/src/components/git/GitTreeView.tsx
+++ b/src/renderer/src/components/git/GitTreeView.tsx
@@ -274,12 +274,18 @@ function resolveKeyboardCursorIndex({
     cursorPath,
     rows,
     selectedPaths,
+    suppressKeyboardCursor = false,
 }: {
     readonly activePath: string | null;
     readonly cursorPath: string | null;
     readonly rows: readonly FlatGitTreeRow[];
     readonly selectedPaths: ReadonlySet<string> | undefined;
+    readonly suppressKeyboardCursor?: boolean;
 }): number {
+    if (suppressKeyboardCursor) {
+        return -1;
+    }
+
     if (rows.length === 0) {
         return -1;
     }
@@ -420,6 +426,7 @@ export function GitTreeView({
     selectedPaths,
     showStatusIndicator = true,
     stickyFolderPaths,
+    suppressKeyboardCursor = false,
 }: GitTreeViewProps) {
     const treeId = useId();
     const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
@@ -459,6 +466,7 @@ export function GitTreeView({
         cursorPath: keyboardCursorPath,
         rows: flatRows,
         selectedPaths,
+        suppressKeyboardCursor,
     });
     const keyboardCursorRow =
         keyboardCursorIndex >= 0 ? flatRows[keyboardCursorIndex] : null;

--- a/src/renderer/src/components/git/GitTreeView.tsx
+++ b/src/renderer/src/components/git/GitTreeView.tsx
@@ -1,5 +1,7 @@
 import {
+    useCallback,
     useEffect,
+    useMemo,
     useRef,
     useState,
     type CSSProperties,
@@ -14,6 +16,10 @@ import {
 
 import { FileTypeIcon } from "@renderer/components/icons/FileTypeIcon";
 import { FolderTypeIcon } from "@renderer/components/icons/FolderTypeIcon";
+import {
+    MeasuredVirtualList,
+    type MeasuredVirtualListHandle,
+} from "@renderer/components/virtual/MeasuredVirtualList";
 
 import { GitActionButton, GitEmptyState } from "./GitUi";
 import { canDropProjectEntryIntoDirectory } from "./tree-dnd";
@@ -46,8 +52,117 @@ const ROW_BOX_CONSTRAINED: CSSProperties = {
     boxSizing: "border-box",
 };
 
+interface FlatGitTreeRow {
+    readonly depth: number;
+    readonly key: string;
+    readonly node: GitTreeNode;
+}
+
 export function scalePx(value: number): string {
     return `calc(${value}px * var(--file-tree-scale, 1))`;
+}
+
+function isTreeNodeExpanded({
+    expandedPathSet,
+    expandedPaths,
+    layout,
+    node,
+}: {
+    readonly expandedPathSet: ReadonlySet<string> | null;
+    readonly expandedPaths: readonly string[] | undefined;
+    readonly layout: GitViewLayout;
+    readonly node: GitTreeNode;
+}): boolean {
+    if (layout !== "tree" || node.kind !== "directory") {
+        return false;
+    }
+
+    if (node.isProjectRoot) {
+        return Boolean(node.children);
+    }
+
+    return expandedPaths ? expandedPathSet?.has(node.path) === true : true;
+}
+
+function flattenGitTreeRows({
+    expandedPathSet,
+    expandedPaths,
+    layout,
+    nodes,
+}: {
+    readonly expandedPathSet: ReadonlySet<string> | null;
+    readonly expandedPaths: readonly string[] | undefined;
+    readonly layout: GitViewLayout;
+    readonly nodes: readonly GitTreeNode[];
+}): FlatGitTreeRow[] {
+    const rows: FlatGitTreeRow[] = [];
+
+    const appendNode = (node: GitTreeNode, depth: number) => {
+        rows.push({
+            depth,
+            key: `${node.id}:${node.path}`,
+            node,
+        });
+
+        if (
+            !isTreeNodeExpanded({
+                expandedPathSet,
+                expandedPaths,
+                layout,
+                node,
+            }) ||
+            !node.children?.length
+        ) {
+            return;
+        }
+
+        for (const child of node.children) {
+            appendNode(child, depth + 1);
+        }
+    };
+
+    for (const node of nodes) {
+        appendNode(node, 0);
+    }
+
+    return rows;
+}
+
+function findScrollContainer(node: HTMLElement): HTMLElement | null {
+    if (typeof window === "undefined") {
+        return null;
+    }
+
+    let current: HTMLElement | null = node;
+
+    while (current) {
+        const { overflowY } = window.getComputedStyle(current);
+
+        if (overflowY === "auto" || overflowY === "scroll") {
+            return current;
+        }
+
+        current = current.parentElement;
+    }
+
+    return document.scrollingElement instanceof HTMLElement
+        ? document.scrollingElement
+        : null;
+}
+
+function getTreeOffsetWithinScrollContainer(
+    treeRoot: HTMLElement,
+    scrollContainer: HTMLElement,
+): number {
+    if (treeRoot === scrollContainer) {
+        return 0;
+    }
+
+    return (
+        treeRoot.getBoundingClientRect().top -
+        scrollContainer.getBoundingClientRect().top +
+        scrollContainer.scrollTop
+    );
 }
 
 export function GitTreeView({
@@ -82,6 +197,62 @@ export function GitTreeView({
     const hoverExpandPathRef = useRef<string | null>(null);
     const hoverExpandTimeoutRef = useRef<number | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
+    const scrollContainerRef = useRef<HTMLElement | null>(null);
+    const virtualListRef = useRef<MeasuredVirtualListHandle | null>(null);
+    const treeScrollOffsetRef = useRef(0);
+    const [shouldVirtualize, setShouldVirtualize] = useState(false);
+    const expandedPathSet = useMemo(
+        () => (expandedPaths ? new Set(expandedPaths) : null),
+        [expandedPaths],
+    );
+    const flatRows = useMemo(
+        () =>
+            flattenGitTreeRows({
+                expandedPathSet,
+                expandedPaths,
+                layout,
+                nodes,
+            }),
+        [expandedPathSet, expandedPaths, layout, nodes],
+    );
+
+    const refreshVirtualizationTarget = useCallback(() => {
+        const container = containerRef.current;
+        const scrollContainer = container
+            ? findScrollContainer(container)
+            : null;
+
+        scrollContainerRef.current = scrollContainer;
+
+        if (!container || !scrollContainer) {
+            treeScrollOffsetRef.current = 0;
+            setShouldVirtualize(false);
+            return;
+        }
+
+        const treeOffset = Math.max(
+            0,
+            getTreeOffsetWithinScrollContainer(container, scrollContainer),
+        );
+
+        treeScrollOffsetRef.current = treeOffset;
+        setShouldVirtualize(treeOffset <= ROW_HEIGHT);
+    }, []);
+
+    const setContainerRef = useCallback(
+        (node: HTMLDivElement | null) => {
+            containerRef.current = node;
+            refreshVirtualizationTarget();
+        },
+        [refreshVirtualizationTarget],
+    );
+
+    const handleVirtualListReady = useCallback(
+        (handle: MeasuredVirtualListHandle | null) => {
+            virtualListRef.current = handle;
+        },
+        [],
+    );
 
     const clearHoverExpand = () => {
         hoverExpandPathRef.current = null;
@@ -131,11 +302,26 @@ export function GitTreeView({
     }, []);
 
     useEffect(() => {
+        refreshVirtualizationTarget();
+    }, [flatRows.length, refreshVirtualizationTarget]);
+
+    useEffect(() => {
         if (scrollToActivePathSignal === undefined || !activePath) {
             return;
         }
 
         const frameId = window.requestAnimationFrame(() => {
+            const activeIndex = flatRows.findIndex(
+                (row) => row.node.path === activePath,
+            );
+
+            if (activeIndex >= 0 && shouldVirtualize) {
+                virtualListRef.current?.scrollToIndex(activeIndex, {
+                    align: "center",
+                    offset: treeScrollOffsetRef.current,
+                });
+            }
+
             const activeRow =
                 containerRef.current?.querySelector<HTMLElement>(
                     '[data-active="true"]',
@@ -150,7 +336,13 @@ export function GitTreeView({
         return () => {
             window.cancelAnimationFrame(frameId);
         };
-    }, [activePath, nodes, onScrollToActivePathConsumed, scrollToActivePathSignal]);
+    }, [
+        activePath,
+        flatRows,
+        onScrollToActivePathConsumed,
+        scrollToActivePathSignal,
+        shouldVirtualize,
+    ]);
 
     if (nodes.length === 0) {
         if (emptyState === null) {
@@ -165,39 +357,50 @@ export function GitTreeView({
     }
 
     return (
-        <div className={className} ref={containerRef}>
-            {nodes.map((node) => (
-                <GitTreeNodeRow
-                    activePath={activePath}
-                    constrainWidth={constrainWidth}
-                    depth={0}
-                    dropTargetPath={dropTargetPath}
-                    activeDragData={activeDragData}
-                    editingDraftName={editingDraftName}
-                    editingPath={editingPath}
-                    enableNodeDrag={enableNodeDrag}
-                    expandedPaths={expandedPaths}
-                    key={node.id}
-                    layout={layout}
-                    node={node}
-                    onEditingCancel={onEditingCancel}
-                    onEditingDraftNameChange={onEditingDraftNameChange}
-                    onEditingSubmit={onEditingSubmit}
-                    onNodeContextMenu={onNodeContextMenu}
-                    onNodeClick={onNodeClick}
-                    onNodeDrop={onNodeDrop}
-                    onNodeDragStart={onNodeDragStart}
-                    scheduleHoverExpand={scheduleHoverExpand}
-                    onToggleDirectory={onToggleDirectory}
-                    renderNodeMeta={renderNodeMeta}
-                    selectedPaths={selectedPaths}
-                    setActiveDragData={setActiveDragData}
-                    clearHoverExpand={clearHoverExpand}
-                    setDropTargetPath={setDropTargetPath}
-                    showStatusIndicator={showStatusIndicator}
-                    stickyFolderPaths={stickyFolderPaths}
-                />
-            ))}
+        <div className={className} ref={setContainerRef}>
+            <MeasuredVirtualList
+                defaultViewportHeight={900}
+                enabled={shouldVirtualize}
+                estimateSize={() => ROW_HEIGHT}
+                getItemKey={(row) => row.key}
+                items={flatRows}
+                onReady={handleVirtualListReady}
+                overscan={8}
+                renderItem={({ item }) => (
+                    <GitTreeNodeRow
+                        activePath={activePath}
+                        constrainWidth={constrainWidth}
+                        depth={item.depth}
+                        dropTargetPath={dropTargetPath}
+                        activeDragData={activeDragData}
+                        editingDraftName={editingDraftName}
+                        editingPath={editingPath}
+                        enableNodeDrag={enableNodeDrag}
+                        expandedPathSet={expandedPathSet}
+                        expandedPaths={expandedPaths}
+                        key={item.key}
+                        layout={layout}
+                        node={item.node}
+                        onEditingCancel={onEditingCancel}
+                        onEditingDraftNameChange={onEditingDraftNameChange}
+                        onEditingSubmit={onEditingSubmit}
+                        onNodeContextMenu={onNodeContextMenu}
+                        onNodeClick={onNodeClick}
+                        onNodeDrop={onNodeDrop}
+                        onNodeDragStart={onNodeDragStart}
+                        scheduleHoverExpand={scheduleHoverExpand}
+                        onToggleDirectory={onToggleDirectory}
+                        renderNodeMeta={renderNodeMeta}
+                        selectedPaths={selectedPaths}
+                        setActiveDragData={setActiveDragData}
+                        clearHoverExpand={clearHoverExpand}
+                        setDropTargetPath={setDropTargetPath}
+                        showStatusIndicator={showStatusIndicator}
+                        stickyFolderPaths={stickyFolderPaths}
+                    />
+                )}
+                scrollContainerRef={scrollContainerRef}
+            />
         </div>
     );
 }
@@ -211,6 +414,7 @@ function GitTreeNodeRow({
     editingDraftName,
     editingPath,
     enableNodeDrag,
+    expandedPathSet,
     expandedPaths,
     layout,
     node,
@@ -239,6 +443,7 @@ function GitTreeNodeRow({
     readonly editingDraftName: string | null;
     readonly editingPath: string | null;
     readonly enableNodeDrag: boolean;
+    readonly expandedPathSet: ReadonlySet<string> | null;
     readonly expandedPaths: readonly string[] | undefined;
     readonly layout: GitViewLayout;
     readonly node: GitTreeNode;
@@ -279,14 +484,12 @@ function GitTreeNodeRow({
     readonly stickyFolderPaths?: ReadonlySet<string>;
 }) {
     const isDirectory = node.kind === "directory";
-    const isExpanded =
-        layout === "tree" && isDirectory
-            ? node.isProjectRoot
-                ? Boolean(node.children)
-                : expandedPaths
-                  ? expandedPaths.includes(node.path)
-                  : true
-            : false;
+    const isExpanded = isTreeNodeExpanded({
+        expandedPathSet,
+        expandedPaths,
+        layout,
+        node,
+    });
     const isEditing = editingPath === node.path;
     const isActive = activePath === node.path;
     const isSelected = selectedPaths?.has(node.path) === true;
@@ -327,286 +530,238 @@ function GitTreeNodeRow({
         }
     };
 
+    if (isStickyHidden) {
+        return (
+            <div
+                aria-hidden="true"
+                style={{ height: scalePx(ROW_HEIGHT) }}
+            />
+        );
+    }
+
     return (
-        <>
-            {isStickyHidden ? (
-                <div
-                    aria-hidden="true"
-                    style={{ height: scalePx(ROW_HEIGHT) }}
+        <div
+            className="git-tree-row"
+            data-active={isActive ? "true" : "false"}
+            data-drop-target={isDropTarget ? "true" : "false"}
+            data-path={node.path}
+            data-selected={isSelected ? "true" : "false"}
+            draggable={isDraggable}
+            onDragEnd={() => {
+                clearHoverExpand();
+                setActiveDragData(null);
+                setDropTargetPath(null);
+            }}
+            onDragLeave={(event) => {
+                if (
+                    event.currentTarget.contains(
+                        event.relatedTarget as Node | null,
+                    )
+                ) {
+                    return;
+                }
+
+                if (dropTargetPath === node.path) {
+                    clearHoverExpand();
+                    setDropTargetPath(null);
+                }
+            }}
+            onDragOver={(event) => {
+                const dragData =
+                    activeDragData ?? getTreeDragData(event.dataTransfer);
+                const canAcceptDrop =
+                    isDirectory &&
+                    Boolean(onNodeDrop) &&
+                    canDropProjectEntryIntoDirectory(
+                        dragData,
+                        node.isProjectRoot ? null : node.path,
+                    );
+
+                scheduleHoverExpand(node, isExpanded, canAcceptDrop);
+
+                if (!isDirectory || !onNodeDrop || !canAcceptDrop) {
+                    return;
+                }
+
+                event.preventDefault();
+                event.dataTransfer.dropEffect = "move";
+                if (dropTargetPath !== node.path) {
+                    setDropTargetPath(node.path);
+                }
+            }}
+            onDragStart={(event) => {
+                if (!isDraggable) {
+                    return;
+                }
+
+                setActiveDragData({
+                    kind: node.kind,
+                    name: node.name,
+                    relativePath: node.path,
+                });
+                dragStartHandler?.(node, event.dataTransfer ?? null);
+            }}
+            onDrop={(event) => {
+                const dragData =
+                    activeDragData ?? getTreeDragData(event.dataTransfer);
+                clearHoverExpand();
+                setActiveDragData(null);
+                setDropTargetPath(null);
+
+                if (
+                    !isDirectory ||
+                    !onNodeDrop ||
+                    !canDropProjectEntryIntoDirectory(
+                        dragData,
+                        node.isProjectRoot ? null : node.path,
+                    )
+                ) {
+                    return;
+                }
+
+                event.preventDefault();
+                onNodeDrop(dragData, node);
+            }}
+            onContextMenu={(event) => {
+                if (!onNodeContextMenu || isEditing) {
+                    return;
+                }
+
+                event.preventDefault();
+                onNodeContextMenu(node, {
+                    x: event.clientX,
+                    y: event.clientY,
+                });
+            }}
+            style={{
+                position: "relative",
+                display: "flex",
+                alignItems: "center",
+                gap: scalePx(6),
+                height: scalePx(ROW_HEIGHT),
+                paddingLeft,
+                paddingRight: scalePx(8),
+                fontSize: scalePx(FONT_SIZE),
+                borderRadius: scalePx(4),
+                cursor: canOpen || canToggle ? "pointer" : "default",
+                color: "var(--color-text-primary)",
+                ...(isActive
+                    ? {
+                          backgroundColor:
+                              "color-mix(in srgb, var(--color-accent) 22%, transparent)",
+                          boxShadow:
+                              "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 40%, transparent)",
+                      }
+                    : isDropTarget
+                      ? {
+                            backgroundColor:
+                                "color-mix(in srgb, var(--color-accent) 14%, transparent)",
+                            boxShadow:
+                                "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 55%, transparent)",
+                        }
+                      : isSelected
+                        ? {
+                              backgroundColor:
+                                  "color-mix(in srgb, var(--color-accent) 10%, transparent)",
+                              boxShadow:
+                                  "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 22%, transparent)",
+                          }
+                        : {}),
+                ...(constrainWidth ? ROW_BOX_CONSTRAINED : ROW_BOX),
+            }}
+            onClick={handleRowClick}
+        >
+            <TreeIndentGuides depth={depth} />
+
+            {isDirectory && layout === "tree" ? (
+                <ChevronIcon open={isExpanded} />
+            ) : (
+                <span style={{ width: scalePx(ICON_SM), flexShrink: 0 }} />
+            )}
+
+            {isDirectory ? (
+                <FolderIcon folderName={node.name} open={isExpanded} />
+            ) : (
+                <FileTypeIcon
+                    color={statusTint ?? undefined}
+                    fileName={node.name}
+                    scaled
+                    size={ICON_SM}
+                />
+            )}
+
+            {isEditing ? (
+                <TreeInlineNameInput
+                    constrainWidth={constrainWidth}
+                    titleColor={titleColor}
+                    value={editingDraftName ?? node.name}
+                    onCancel={onEditingCancel}
+                    onChange={onEditingDraftNameChange}
+                    onSubmit={onEditingSubmit}
                 />
             ) : (
-                <div
-                    className="git-tree-row"
-                    data-active={isActive ? "true" : "false"}
-                    data-drop-target={isDropTarget ? "true" : "false"}
-                    data-path={node.path}
-                    data-selected={isSelected ? "true" : "false"}
-                    draggable={isDraggable}
-                    onDragEnd={() => {
-                        clearHoverExpand();
-                        setActiveDragData(null);
-                        setDropTargetPath(null);
-                    }}
-                    onDragLeave={(event) => {
-                        if (
-                            event.currentTarget.contains(
-                                event.relatedTarget as Node | null,
-                            )
-                        ) {
-                            return;
-                        }
-
-                        if (dropTargetPath === node.path) {
-                            clearHoverExpand();
-                            setDropTargetPath(null);
-                        }
-                    }}
-                    onDragOver={(event) => {
-                        const dragData =
-                            activeDragData ??
-                            getTreeDragData(event.dataTransfer);
-                        const canAcceptDrop =
-                            isDirectory &&
-                            Boolean(onNodeDrop) &&
-                            canDropProjectEntryIntoDirectory(
-                                dragData,
-                                node.isProjectRoot ? null : node.path,
-                            );
-
-                        scheduleHoverExpand(node, isExpanded, canAcceptDrop);
-
-                        if (!isDirectory || !onNodeDrop || !canAcceptDrop) {
-                            return;
-                        }
-
-                        event.preventDefault();
-                        event.dataTransfer.dropEffect = "move";
-                        if (dropTargetPath !== node.path) {
-                            setDropTargetPath(node.path);
-                        }
-                    }}
-                    onDragStart={(event) => {
-                        if (!isDraggable) {
-                            return;
-                        }
-
-                        setActiveDragData({
-                            kind: node.kind,
-                            name: node.name,
-                            relativePath: node.path,
-                        });
-                        dragStartHandler?.(node, event.dataTransfer ?? null);
-                    }}
-                    onDrop={(event) => {
-                        const dragData =
-                            activeDragData ??
-                            getTreeDragData(event.dataTransfer);
-                        clearHoverExpand();
-                        setActiveDragData(null);
-                        setDropTargetPath(null);
-
-                        if (
-                            !isDirectory ||
-                            !onNodeDrop ||
-                            !canDropProjectEntryIntoDirectory(
-                                dragData,
-                                node.isProjectRoot ? null : node.path,
-                            )
-                        ) {
-                            return;
-                        }
-
-                        event.preventDefault();
-                        onNodeDrop(dragData, node);
-                    }}
-                    onContextMenu={(event) => {
-                        if (!onNodeContextMenu || isEditing) {
-                            return;
-                        }
-
-                        event.preventDefault();
-                        onNodeContextMenu(node, {
-                            x: event.clientX,
-                            y: event.clientY,
-                        });
-                    }}
+                <span
                     style={{
-                        position: "relative",
-                        display: "flex",
-                        alignItems: "center",
-                        gap: scalePx(6),
-                        height: scalePx(ROW_HEIGHT),
-                        paddingLeft,
-                        paddingRight: scalePx(8),
-                        fontSize: scalePx(FONT_SIZE),
-                        borderRadius: scalePx(4),
-                        cursor: canOpen || canToggle ? "pointer" : "default",
-                        color: "var(--color-text-primary)",
-                        ...(isActive
-                            ? {
-                                  backgroundColor:
-                                      "color-mix(in srgb, var(--color-accent) 22%, transparent)",
-                                  boxShadow:
-                                      "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 40%, transparent)",
-                              }
-                            : isDropTarget
-                              ? {
-                                    backgroundColor:
-                                        "color-mix(in srgb, var(--color-accent) 14%, transparent)",
-                                    boxShadow:
-                                        "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 55%, transparent)",
-                                }
-                              : isSelected
-                                ? {
-                                      backgroundColor:
-                                          "color-mix(in srgb, var(--color-accent) 10%, transparent)",
-                                      boxShadow:
-                                          "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 22%, transparent)",
-                                  }
-                              : {}),
-                        ...(constrainWidth ? ROW_BOX_CONSTRAINED : ROW_BOX),
+                        flexShrink: constrainWidth ? 1 : 0,
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        minWidth: constrainWidth ? scalePx(40) : 0,
+                        flex: 1,
+                        color: titleColor,
                     }}
-                    onClick={handleRowClick}
                 >
-                    <TreeIndentGuides depth={depth} />
+                    {node.name}
+                </span>
+            )}
 
-                    {isDirectory && layout === "tree" ? (
-                        <ChevronIcon open={isExpanded} />
-                    ) : (
-                        <span
-                            style={{ width: scalePx(ICON_SM), flexShrink: 0 }}
-                        />
-                    )}
+            {!constrainWidth && node.secondaryText ? (
+                <span
+                    style={{
+                        fontSize: scalePx(11),
+                        color: "var(--color-text-secondary)",
+                        whiteSpace: "nowrap",
+                        flexShrink: 0,
+                    }}
+                >
+                    {node.secondaryText}
+                </span>
+            ) : null}
 
-                    {isDirectory ? (
-                        <FolderIcon
-                            folderName={node.name}
-                            open={isExpanded}
-                        />
-                    ) : (
-                        <FileTypeIcon
-                            color={statusTint ?? undefined}
-                            fileName={node.name}
-                            scaled
-                            size={ICON_SM}
-                        />
-                    )}
+            <div
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: scalePx(4),
+                    flexShrink: 0,
+                    marginLeft: "auto",
+                }}
+            >
+                {renderNodeMeta ? renderNodeMeta(node) : node.meta}
 
-                    {isEditing ? (
-                        <TreeInlineNameInput
-                            constrainWidth={constrainWidth}
-                            titleColor={titleColor}
-                            value={editingDraftName ?? node.name}
-                            onCancel={onEditingCancel}
-                            onChange={onEditingDraftNameChange}
-                            onSubmit={onEditingSubmit}
-                        />
-                    ) : (
-                        <span
-                            style={{
-                                flexShrink: constrainWidth ? 1 : 0,
-                                whiteSpace: "nowrap",
-                                overflow: "hidden",
-                                textOverflow: "ellipsis",
-                                minWidth: constrainWidth ? scalePx(40) : 0,
-                                flex: 1,
-                                color: titleColor,
-                            }}
-                        >
-                            {node.name}
-                        </span>
-                    )}
+                {showStatusIndicator &&
+                !constrainWidth &&
+                node.status &&
+                !isDirectory ? (
+                    <StatusIndicator status={node.status} />
+                ) : null}
 
-                    {!constrainWidth && node.secondaryText ? (
-                        <span
-                            style={{
-                                fontSize: scalePx(11),
-                                color: "var(--color-text-secondary)",
-                                whiteSpace: "nowrap",
-                                flexShrink: 0,
-                            }}
-                        >
-                            {node.secondaryText}
-                        </span>
-                    ) : null}
-
+                {!constrainWidth && node.actions?.length ? (
                     <div
+                        className="git-tree-row-actions"
                         style={{
                             display: "flex",
                             alignItems: "center",
                             gap: scalePx(4),
-                            flexShrink: 0,
-                            marginLeft: "auto",
                         }}
                     >
-                        {renderNodeMeta ? renderNodeMeta(node) : node.meta}
-
-                        {showStatusIndicator &&
-                        !constrainWidth &&
-                        node.status &&
-                        !isDirectory ? (
-                            <StatusIndicator status={node.status} />
-                        ) : null}
-
-                        {!constrainWidth && node.actions?.length ? (
-                            <div
-                                className="git-tree-row-actions"
-                                style={{
-                                    display: "flex",
-                                    alignItems: "center",
-                                    gap: scalePx(4),
-                                }}
-                            >
-                                {node.actions.map((action) => (
-                                    <GitActionButton
-                                        action={action}
-                                        key={action.id}
-                                    />
-                                ))}
-                            </div>
-                        ) : null}
+                        {node.actions.map((action) => (
+                            <GitActionButton action={action} key={action.id} />
+                        ))}
                     </div>
-                </div>
-            )}
-
-            {layout === "tree" &&
-            isDirectory &&
-            isExpanded &&
-            node.children?.length
-                ? node.children.map((child) => (
-                      <GitTreeNodeRow
-                          activePath={activePath}
-                          activeDragData={activeDragData}
-                          constrainWidth={constrainWidth}
-                          depth={depth + 1}
-                          dropTargetPath={dropTargetPath}
-                          editingDraftName={editingDraftName}
-                          editingPath={editingPath}
-                          enableNodeDrag={enableNodeDrag}
-                          expandedPaths={expandedPaths}
-                          key={child.id}
-                          layout={layout}
-                          node={child}
-                          onEditingCancel={onEditingCancel}
-                          onEditingDraftNameChange={onEditingDraftNameChange}
-                          onEditingSubmit={onEditingSubmit}
-                          onNodeContextMenu={onNodeContextMenu}
-                          onNodeClick={onNodeClick}
-                          onNodeDrop={onNodeDrop}
-                          onNodeDragStart={dragStartHandler}
-                          scheduleHoverExpand={scheduleHoverExpand}
-                          onToggleDirectory={onToggleDirectory}
-                          renderNodeMeta={renderNodeMeta}
-                          selectedPaths={selectedPaths}
-                          setActiveDragData={setActiveDragData}
-                          clearHoverExpand={clearHoverExpand}
-                          setDropTargetPath={setDropTargetPath}
-                          showStatusIndicator={showStatusIndicator}
-                          stickyFolderPaths={stickyFolderPaths}
-                      />
-                  ))
-                : null}
-        </>
+                ) : null}
+            </div>
+        </div>
     );
 }
 

--- a/src/renderer/src/components/git/StickyFolderOverlay.tsx
+++ b/src/renderer/src/components/git/StickyFolderOverlay.tsx
@@ -7,6 +7,8 @@ import {
 import {
     COMPOSER_PROJECT_ENTRY_LIST_MIME,
     COMPOSER_PROJECT_ENTRY_MIME,
+    getExternalProjectDropData,
+    hasExternalProjectDropPayload,
     parseComposerProjectEntryListDragData,
     parseComposerProjectEntryDragData,
 } from "@renderer/app/drag-and-drop";
@@ -57,6 +59,7 @@ export function StickyFolderOverlay({
     onNodeClick,
     onNodeDragStart,
     onNodeDrop,
+    onExternalFilesDrop,
     selectedPaths,
 }: {
     readonly stickyFolders: readonly StickyFolder[];
@@ -74,6 +77,10 @@ export function StickyFolderOverlay({
     readonly onNodeDrop?: (
         dragData: GitTreeDragPayload,
         node: GitTreeNode,
+    ) => void;
+    readonly onExternalFilesDrop?: (
+        sourcePaths: readonly string[],
+        node: GitTreeNode | null,
     ) => void;
     readonly selectedPaths?: ReadonlySet<string>;
 }) {
@@ -110,6 +117,7 @@ export function StickyFolderOverlay({
                         onNodeClick={onNodeClick}
                         onDragStart={onNodeDragStart}
                         onDrop={onNodeDrop}
+                        onExternalFilesDrop={onExternalFilesDrop}
                         selectedPaths={selectedPaths}
                     />
                 </div>
@@ -126,6 +134,7 @@ function StickyFolderRow({
     onNodeClick,
     onDragStart,
     onDrop,
+    onExternalFilesDrop,
     selectedPaths,
 }: {
     readonly node: GitTreeNode;
@@ -141,6 +150,10 @@ function StickyFolderRow({
         dataTransfer: DataTransfer | null,
     ) => GitTreeDragPayload | void;
     readonly onDrop?: (dragData: GitTreeDragPayload, node: GitTreeNode) => void;
+    readonly onExternalFilesDrop?: (
+        sourcePaths: readonly string[],
+        node: GitTreeNode | null,
+    ) => void;
     readonly selectedPaths?: ReadonlySet<string>;
 }) {
     const [isDropTarget, setIsDropTarget] = useState(false);
@@ -199,17 +212,23 @@ function StickyFolderRow({
                 setTreeDragImage(event.dataTransfer ?? null, dragData);
             }}
             onDragOver={(event) => {
-                if (!onDrop) return;
-
                 const dragData = getStickyFolderDragData(event.dataTransfer);
-                const canAccept = canDropProjectEntriesIntoDirectory(
-                    dragData,
-                    node.isProjectRoot ? null : node.path,
-                );
+                const canAcceptInternal =
+                    Boolean(onDrop) &&
+                    canDropProjectEntriesIntoDirectory(
+                        dragData,
+                        node.isProjectRoot ? null : node.path,
+                    );
+                const canAcceptExternal =
+                    Boolean(onExternalFilesDrop) &&
+                    hasExternalProjectDropPayload(event.dataTransfer);
+                const canAccept = canAcceptInternal || canAcceptExternal;
                 if (!canAccept) return;
 
                 event.preventDefault();
-                event.dataTransfer.dropEffect = "move";
+                event.dataTransfer.dropEffect = canAcceptExternal
+                    ? "copy"
+                    : "move";
                 setIsDropTarget(true);
             }}
             onDragLeave={(event) => {
@@ -224,9 +243,19 @@ function StickyFolderRow({
             }}
             onDrop={(event) => {
                 setIsDropTarget(false);
-                if (!onDrop) return;
 
                 const dragData = getStickyFolderDragData(event.dataTransfer);
+                const externalDropData = getExternalProjectDropData(
+                    event.dataTransfer,
+                );
+                if (externalDropData && onExternalFilesDrop) {
+                    event.preventDefault();
+                    onExternalFilesDrop(externalDropData.sourcePaths, node);
+                    return;
+                }
+
+                if (!onDrop) return;
+
                 if (
                     !canDropProjectEntriesIntoDirectory(
                         dragData,

--- a/src/renderer/src/components/git/StickyFolderOverlay.tsx
+++ b/src/renderer/src/components/git/StickyFolderOverlay.tsx
@@ -11,16 +11,18 @@ import {
     parseComposerProjectEntryDragData,
 } from "@renderer/app/drag-and-drop";
 
-import type { GitTreeDragPayload, GitTreeNode } from "./types";
+import type { GitTreeDragData, GitTreeDragPayload, GitTreeNode } from "./types";
 import { canDropProjectEntriesIntoDirectory } from "./tree-dnd";
 import {
     BASE_PADDING,
     ChevronIcon,
     FONT_SIZE,
     FolderIcon,
+    getGitTreeRowStateStyle,
     INDENT_STEP,
     ROW_HEIGHT,
     scalePx,
+    setTreeDragImage,
     TreeIndentGuides,
 } from "./GitTreeView";
 import type { StickyFolder } from "./useStickyFolders";
@@ -44,6 +46,8 @@ function stickyChrome(scrollLeft: number): CSSProperties {
 }
 
 const STICKY_EDGE_SHADOW = "0 2px 6px rgba(0,0,0,0.18)";
+const STICKY_CHROME_BACKGROUND =
+    "color-mix(in srgb, var(--color-bg-primary) 94%, var(--color-bg-elevated) 6%)";
 
 export function StickyFolderOverlay({
     stickyFolders,
@@ -66,7 +70,7 @@ export function StickyFolderOverlay({
     readonly onNodeDragStart?: (
         node: GitTreeNode,
         dataTransfer: DataTransfer | null,
-    ) => void;
+    ) => GitTreeDragPayload | void;
     readonly onNodeDrop?: (
         dragData: GitTreeDragPayload,
         node: GitTreeNode,
@@ -87,10 +91,11 @@ export function StickyFolderOverlay({
                         top,
                         ...stickyChrome(scrollLeft),
                         zIndex: 20 - depth,
-                        background:
-                            "color-mix(in srgb, var(--color-bg-primary) var(--vibrancy-opacity, 88%), transparent)",
-                        backdropFilter: "blur(10px)",
-                        WebkitBackdropFilter: "blur(10px)",
+                        background: STICKY_CHROME_BACKGROUND,
+                        backdropFilter: "blur(14px) saturate(1.15)",
+                        WebkitBackdropFilter: "blur(14px) saturate(1.15)",
+                        borderBottom:
+                            "1px solid color-mix(in srgb, var(--color-border) 72%, transparent)",
                         pointerEvents: "auto",
                         ...(i === stickyFolders.length - 1 && {
                             boxShadow: STICKY_EDGE_SHADOW,
@@ -134,7 +139,7 @@ function StickyFolderRow({
     readonly onDragStart?: (
         node: GitTreeNode,
         dataTransfer: DataTransfer | null,
-    ) => void;
+    ) => GitTreeDragPayload | void;
     readonly onDrop?: (dragData: GitTreeDragPayload, node: GitTreeNode) => void;
     readonly selectedPaths?: ReadonlySet<string>;
 }) {
@@ -175,24 +180,23 @@ function StickyFolderRow({
                 width: "100%",
                 boxSizing: "border-box",
                 borderRadius: scalePx(4),
-                ...(isDropTarget && {
-                    backgroundColor:
-                        "color-mix(in srgb, var(--color-accent) 14%, transparent)",
-                    boxShadow:
-                        "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 55%, transparent)",
+                ...getGitTreeRowStateStyle({
+                    isDropTarget,
+                    isSelected,
                 }),
-                ...(!isDropTarget &&
-                    isSelected && {
-                        backgroundColor:
-                            "color-mix(in srgb, var(--color-accent) 10%, transparent)",
-                        boxShadow:
-                            "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 22%, transparent)",
-                    }),
             }}
             onClick={handleClick}
             onDragStart={(event) => {
                 if (!isDraggable) return;
-                onDragStart?.(node, event.dataTransfer ?? null);
+                const fallbackDragData = {
+                    kind: node.kind,
+                    name: node.name,
+                    relativePath: node.path,
+                } satisfies GitTreeDragData;
+                const dragData =
+                    onDragStart?.(node, event.dataTransfer ?? null) ??
+                    fallbackDragData;
+                setTreeDragImage(event.dataTransfer ?? null, dragData);
             }}
             onDragOver={(event) => {
                 if (!onDrop) return;

--- a/src/renderer/src/components/git/StickyFolderOverlay.tsx
+++ b/src/renderer/src/components/git/StickyFolderOverlay.tsx
@@ -5,12 +5,14 @@ import {
 } from "react";
 
 import {
+    COMPOSER_PROJECT_ENTRY_LIST_MIME,
     COMPOSER_PROJECT_ENTRY_MIME,
+    parseComposerProjectEntryListDragData,
     parseComposerProjectEntryDragData,
 } from "@renderer/app/drag-and-drop";
 
-import type { GitTreeDragData, GitTreeNode } from "./types";
-import { canDropProjectEntryIntoDirectory } from "./tree-dnd";
+import type { GitTreeDragPayload, GitTreeNode } from "./types";
+import { canDropProjectEntriesIntoDirectory } from "./tree-dnd";
 import {
     BASE_PADDING,
     ChevronIcon,
@@ -66,7 +68,7 @@ export function StickyFolderOverlay({
         dataTransfer: DataTransfer | null,
     ) => void;
     readonly onNodeDrop?: (
-        dragData: GitTreeDragData,
+        dragData: GitTreeDragPayload,
         node: GitTreeNode,
     ) => void;
     readonly selectedPaths?: ReadonlySet<string>;
@@ -133,7 +135,7 @@ function StickyFolderRow({
         node: GitTreeNode,
         dataTransfer: DataTransfer | null,
     ) => void;
-    readonly onDrop?: (dragData: GitTreeDragData, node: GitTreeNode) => void;
+    readonly onDrop?: (dragData: GitTreeDragPayload, node: GitTreeNode) => void;
     readonly selectedPaths?: ReadonlySet<string>;
 }) {
     const [isDropTarget, setIsDropTarget] = useState(false);
@@ -195,10 +197,8 @@ function StickyFolderRow({
             onDragOver={(event) => {
                 if (!onDrop) return;
 
-                const dragData = parseComposerProjectEntryDragData(
-                    event.dataTransfer.getData(COMPOSER_PROJECT_ENTRY_MIME),
-                );
-                const canAccept = canDropProjectEntryIntoDirectory(
+                const dragData = getStickyFolderDragData(event.dataTransfer);
+                const canAccept = canDropProjectEntriesIntoDirectory(
                     dragData,
                     node.isProjectRoot ? null : node.path,
                 );
@@ -222,11 +222,9 @@ function StickyFolderRow({
                 setIsDropTarget(false);
                 if (!onDrop) return;
 
-                const dragData = parseComposerProjectEntryDragData(
-                    event.dataTransfer.getData(COMPOSER_PROJECT_ENTRY_MIME),
-                );
+                const dragData = getStickyFolderDragData(event.dataTransfer);
                 if (
-                    !canDropProjectEntryIntoDirectory(
+                    !canDropProjectEntriesIntoDirectory(
                         dragData,
                         node.isProjectRoot ? null : node.path,
                     )
@@ -253,5 +251,20 @@ function StickyFolderRow({
                 {node.name}
             </span>
         </div>
+    );
+}
+
+function getStickyFolderDragData(
+    dataTransfer: DataTransfer,
+): GitTreeDragPayload | null {
+    const listData = parseComposerProjectEntryListDragData(
+        dataTransfer.getData(COMPOSER_PROJECT_ENTRY_LIST_MIME),
+    );
+    if (listData) {
+        return listData.entries;
+    }
+
+    return parseComposerProjectEntryDragData(
+        dataTransfer.getData(COMPOSER_PROJECT_ENTRY_MIME),
     );
 }

--- a/src/renderer/src/components/git/tree-dnd.test.ts
+++ b/src/renderer/src/components/git/tree-dnd.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+    canDropProjectEntriesIntoDirectory,
     canDropProjectEntryIntoDirectory,
     getProjectEntryParentRelativePath,
 } from "./tree-dnd";
@@ -69,6 +70,46 @@ describe("tree-dnd", () => {
                     name: "src",
                     relativePath: "src",
                 },
+                "src/components",
+            ),
+        ).toBe(false);
+    });
+
+    it("allows a multi-entry move when at least one selected item changes parent", () => {
+        expect(
+            canDropProjectEntriesIntoDirectory(
+                [
+                    {
+                        kind: "file",
+                        name: "intro.md",
+                        relativePath: "docs/intro.md",
+                    },
+                    {
+                        kind: "file",
+                        name: "App.tsx",
+                        relativePath: "src/App.tsx",
+                    },
+                ],
+                "docs",
+            ),
+        ).toBe(true);
+    });
+
+    it("rejects a multi-entry move into a selected folder descendant", () => {
+        expect(
+            canDropProjectEntriesIntoDirectory(
+                [
+                    {
+                        kind: "directory",
+                        name: "src",
+                        relativePath: "src",
+                    },
+                    {
+                        kind: "file",
+                        name: "README.md",
+                        relativePath: "README.md",
+                    },
+                ],
                 "src/components",
             ),
         ).toBe(false);

--- a/src/renderer/src/components/git/tree-dnd.test.ts
+++ b/src/renderer/src/components/git/tree-dnd.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
     canDropProjectEntriesIntoDirectory,
     canDropProjectEntryIntoDirectory,
+    compactGitTreeDragEntriesByAncestor,
+    getProjectEntryMoveValidation,
     getProjectEntryParentRelativePath,
 } from "./tree-dnd";
 
@@ -113,5 +115,103 @@ describe("tree-dnd", () => {
                 "src/components",
             ),
         ).toBe(false);
+    });
+
+    it("compacts nested drag entries before validating parent changes", () => {
+        expect(
+            getProjectEntryMoveValidation(
+                [
+                    {
+                        kind: "directory",
+                        name: "src",
+                        relativePath: "src",
+                    },
+                    {
+                        kind: "file",
+                        name: "App.tsx",
+                        relativePath: "src/App.tsx",
+                    },
+                ],
+                null,
+            ),
+        ).toMatchObject({
+            canMove: false,
+            reason: "same-parent",
+        });
+    });
+
+    it("returns only movable compacted entries for mixed parent moves", () => {
+        const validation = getProjectEntryMoveValidation(
+            [
+                {
+                    kind: "directory",
+                    name: "src",
+                    relativePath: "src",
+                },
+                {
+                    kind: "file",
+                    name: "App.tsx",
+                    relativePath: "src/App.tsx",
+                },
+                {
+                    kind: "file",
+                    name: "README.md",
+                    relativePath: "README.md",
+                },
+            ],
+            "docs",
+        );
+
+        expect(validation.canMove).toBe(true);
+        expect(validation.entries.map((entry) => entry.relativePath)).toEqual([
+            "src",
+            "README.md",
+        ]);
+    });
+
+    it("deduplicates drag entries while compacting ancestors", () => {
+        expect(
+            compactGitTreeDragEntriesByAncestor([
+                {
+                    kind: "directory",
+                    name: "src",
+                    relativePath: "src",
+                },
+                {
+                    kind: "directory",
+                    name: "src",
+                    relativePath: "src",
+                },
+                {
+                    kind: "file",
+                    name: "App.tsx",
+                    relativePath: "src/App.tsx",
+                },
+            ]).map((entry) => entry.relativePath),
+        ).toEqual(["src"]);
+    });
+
+    it("reports specific invalid folder move reasons", () => {
+        expect(
+            getProjectEntryMoveValidation(
+                {
+                    kind: "directory",
+                    name: "src",
+                    relativePath: "src",
+                },
+                "src",
+            ).reason,
+        ).toBe("directory-self");
+
+        expect(
+            getProjectEntryMoveValidation(
+                {
+                    kind: "directory",
+                    name: "src",
+                    relativePath: "src",
+                },
+                "src/components",
+            ).reason,
+        ).toBe("directory-descendant");
     });
 });

--- a/src/renderer/src/components/git/tree-dnd.ts
+++ b/src/renderer/src/components/git/tree-dnd.ts
@@ -1,5 +1,17 @@
 import type { GitTreeDragData, GitTreeDragPayload } from "./types";
 
+export type ProjectEntryMoveValidationReason =
+    | "directory-descendant"
+    | "directory-self"
+    | "empty"
+    | "same-parent";
+
+export interface ProjectEntryMoveValidation {
+    readonly canMove: boolean;
+    readonly entries: readonly GitTreeDragData[];
+    readonly reason: ProjectEntryMoveValidationReason | null;
+}
+
 export function normalizeGitTreeDragPayload(
     dragData: GitTreeDragPayload,
 ): readonly GitTreeDragData[] {
@@ -10,58 +22,105 @@ export function normalizeGitTreeDragPayload(
     return [dragData as GitTreeDragData];
 }
 
+export function compactGitTreeDragEntriesByAncestor(
+    entries: readonly GitTreeDragData[],
+): GitTreeDragData[] {
+    const seenPaths = new Set<string>();
+    const uniqueEntries = entries.filter((entry) => {
+        if (seenPaths.has(entry.relativePath)) {
+            return false;
+        }
+
+        seenPaths.add(entry.relativePath);
+        return true;
+    });
+
+    return uniqueEntries.filter((entry) => {
+        if (entry.relativePath === "") {
+            return true;
+        }
+
+        return !uniqueEntries.some(
+            (candidate) =>
+                candidate.kind === "directory" &&
+                candidate.relativePath !== "" &&
+                isProjectEntryDescendantPath(
+                    candidate.relativePath,
+                    entry.relativePath,
+                ),
+        );
+    });
+}
+
+export function getProjectEntryMoveValidation(
+    dragData: GitTreeDragPayload | null,
+    directoryPath: string | null,
+): ProjectEntryMoveValidation {
+    if (!dragData) {
+        return { canMove: false, entries: [], reason: "empty" };
+    }
+
+    const destinationPath = normalizeProjectDirectoryPath(directoryPath);
+    const compactedEntries = compactGitTreeDragEntriesByAncestor(
+        normalizeGitTreeDragPayload(dragData),
+    );
+    if (compactedEntries.length === 0) {
+        return { canMove: false, entries: [], reason: "empty" };
+    }
+
+    for (const entry of compactedEntries) {
+        if (entry.kind !== "directory") {
+            continue;
+        }
+
+        if (entry.relativePath === destinationPath) {
+            return {
+                canMove: false,
+                entries: compactedEntries,
+                reason: "directory-self",
+            };
+        }
+
+        if (
+            destinationPath &&
+            isProjectEntryDescendantPath(entry.relativePath, destinationPath)
+        ) {
+            return {
+                canMove: false,
+                entries: compactedEntries,
+                reason: "directory-descendant",
+            };
+        }
+    }
+
+    const movableEntries = compactedEntries.filter(
+        (entry) =>
+            getProjectEntryParentRelativePath(entry.relativePath) !==
+            destinationPath,
+    );
+    if (movableEntries.length === 0) {
+        return {
+            canMove: false,
+            entries: compactedEntries,
+            reason: "same-parent",
+        };
+    }
+
+    return { canMove: true, entries: movableEntries, reason: null };
+}
+
 export function canDropProjectEntryIntoDirectory(
     dragData: GitTreeDragData | null,
     directoryPath: string | null,
 ): dragData is GitTreeDragData {
-    if (!dragData) {
-        return false;
-    }
-
-    const currentParentPath = getProjectEntryParentRelativePath(
-        dragData.relativePath,
-    );
-    if (currentParentPath === directoryPath) {
-        return false;
-    }
-
-    if (dragData.kind === "directory") {
-        return (
-            dragData.relativePath !== directoryPath &&
-            !(directoryPath ?? "").startsWith(`${dragData.relativePath}/`)
-        );
-    }
-
-    return true;
+    return getProjectEntryMoveValidation(dragData, directoryPath).canMove;
 }
 
 export function canDropProjectEntriesIntoDirectory(
     dragData: GitTreeDragPayload | null,
     directoryPath: string | null,
 ): dragData is GitTreeDragPayload {
-    if (!dragData) {
-        return false;
-    }
-
-    const entries = normalizeGitTreeDragPayload(dragData);
-    return (
-        entries.length > 0 &&
-        entries.some(
-            (entry) =>
-                getProjectEntryParentRelativePath(entry.relativePath) !==
-                directoryPath,
-        ) &&
-        entries.every((entry) => {
-            if (entry.kind !== "directory") {
-                return true;
-            }
-
-            return (
-                entry.relativePath !== directoryPath &&
-                !(directoryPath ?? "").startsWith(`${entry.relativePath}/`)
-            );
-        })
-    );
+    return getProjectEntryMoveValidation(dragData, directoryPath).canMove;
 }
 
 export function getProjectEntryParentRelativePath(
@@ -73,4 +132,19 @@ export function getProjectEntryParentRelativePath(
     }
 
     return segments.slice(0, -1).join("/");
+}
+
+function normalizeProjectDirectoryPath(directoryPath: string | null): string | null {
+    const normalizedPath = directoryPath?.split("/").filter(Boolean).join("/");
+    return normalizedPath ? normalizedPath : null;
+}
+
+function isProjectEntryDescendantPath(
+    parentPath: string,
+    candidatePath: string,
+): boolean {
+    return (
+        candidatePath !== parentPath &&
+        candidatePath.startsWith(`${parentPath}/`)
+    );
 }

--- a/src/renderer/src/components/git/tree-dnd.ts
+++ b/src/renderer/src/components/git/tree-dnd.ts
@@ -1,4 +1,14 @@
-import type { GitTreeDragData } from "./types";
+import type { GitTreeDragData, GitTreeDragPayload } from "./types";
+
+export function normalizeGitTreeDragPayload(
+    dragData: GitTreeDragPayload,
+): readonly GitTreeDragData[] {
+    if (Array.isArray(dragData)) {
+        return dragData as readonly GitTreeDragData[];
+    }
+
+    return [dragData as GitTreeDragData];
+}
 
 export function canDropProjectEntryIntoDirectory(
     dragData: GitTreeDragData | null,
@@ -23,6 +33,35 @@ export function canDropProjectEntryIntoDirectory(
     }
 
     return true;
+}
+
+export function canDropProjectEntriesIntoDirectory(
+    dragData: GitTreeDragPayload | null,
+    directoryPath: string | null,
+): dragData is GitTreeDragPayload {
+    if (!dragData) {
+        return false;
+    }
+
+    const entries = normalizeGitTreeDragPayload(dragData);
+    return (
+        entries.length > 0 &&
+        entries.some(
+            (entry) =>
+                getProjectEntryParentRelativePath(entry.relativePath) !==
+                directoryPath,
+        ) &&
+        entries.every((entry) => {
+            if (entry.kind !== "directory") {
+                return true;
+            }
+
+            return (
+                entry.relativePath !== directoryPath &&
+                !(directoryPath ?? "").startsWith(`${entry.relativePath}/`)
+            );
+        })
+    );
 }
 
 export function getProjectEntryParentRelativePath(

--- a/src/renderer/src/components/git/treeSelection.test.ts
+++ b/src/renderer/src/components/git/treeSelection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { GitTreeNode } from "./types";
 import {
+    compactGitTreeEntriesForDeletion,
     flattenVisibleGitTreeNodes,
     orderGitTreePathsByVisibility,
     resolveGitTreeDragPaths,
@@ -107,5 +108,25 @@ describe("treeSelection", () => {
                 visiblePaths,
             ),
         ).toEqual(["src/lib.ts"]);
+    });
+
+    it("compacts deletion entries when a selected folder already contains selected children", () => {
+        const visibleNodes = flattenVisibleGitTreeNodes(TREE);
+
+        expect(
+            compactGitTreeEntriesForDeletion([
+                visibleNodes[0],
+                visibleNodes[1],
+                visibleNodes[3],
+            ]),
+        ).toEqual([visibleNodes[0], visibleNodes[3]]);
+    });
+
+    it("keeps sibling deletion entries in their input order", () => {
+        const visibleNodes = flattenVisibleGitTreeNodes(TREE);
+
+        expect(
+            compactGitTreeEntriesForDeletion([visibleNodes[1], visibleNodes[2]]),
+        ).toEqual([visibleNodes[1], visibleNodes[2]]);
     });
 });

--- a/src/renderer/src/components/git/treeSelection.ts
+++ b/src/renderer/src/components/git/treeSelection.ts
@@ -74,3 +74,38 @@ export function resolveGitTreeDragPaths(
     );
     return orderedSelectedPaths.length > 0 ? orderedSelectedPaths : [nodePath];
 }
+
+type GitTreeActionEntry = Pick<GitTreeNode, "kind" | "path">;
+
+function isGitTreeDescendantPath(
+    parentPath: string,
+    candidatePath: string,
+): boolean {
+    return (
+        candidatePath !== parentPath &&
+        candidatePath.startsWith(`${parentPath}/`)
+    );
+}
+
+export function compactGitTreeEntriesByAncestor<
+    Entry extends GitTreeActionEntry,
+>(entries: readonly Entry[]): Entry[] {
+    return entries.filter((entry) => {
+        if (entry.path === "") {
+            return true;
+        }
+
+        return !entries.some(
+            (candidate) =>
+                candidate.kind === "directory" &&
+                candidate.path !== "" &&
+                isGitTreeDescendantPath(candidate.path, entry.path),
+        );
+    });
+}
+
+export function compactGitTreeEntriesForDeletion<
+    Entry extends GitTreeActionEntry,
+>(entries: readonly Entry[]): Entry[] {
+    return compactGitTreeEntriesByAncestor(entries);
+}

--- a/src/renderer/src/components/git/types.ts
+++ b/src/renderer/src/components/git/types.ts
@@ -158,7 +158,7 @@ export interface GitTreeViewProps {
         readonly x: number;
         readonly y: number;
     }) => void;
-    readonly onBackgroundDrop?: (dragData: GitTreeDragData) => void;
+    readonly onBackgroundDrop?: (dragData: GitTreeDragPayload) => void;
     readonly onNodeClick?: (
         node: GitTreeNode,
         event: GitTreeNodeActivationEvent,

--- a/src/renderer/src/components/git/types.ts
+++ b/src/renderer/src/components/git/types.ts
@@ -191,6 +191,7 @@ export interface GitTreeViewProps {
     readonly scrollToActivePathSignal?: number;
     readonly showStatusIndicator?: boolean;
     readonly stickyFolderPaths?: ReadonlySet<string>;
+    readonly suppressKeyboardCursor?: boolean;
 }
 
 export interface GitChangesViewProps {

--- a/src/renderer/src/components/git/types.ts
+++ b/src/renderer/src/components/git/types.ts
@@ -1,4 +1,8 @@
-import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import type {
+    KeyboardEvent as ReactKeyboardEvent,
+    MouseEvent as ReactMouseEvent,
+    ReactNode,
+} from "react";
 
 export type GitPanelTabId = "changes" | "diffs";
 
@@ -67,6 +71,10 @@ export interface GitChangeGroup {
     readonly nodes: readonly GitTreeNode[];
     readonly actions?: readonly GitAction[];
 }
+
+export type GitTreeNodeActivationEvent =
+    | ReactMouseEvent<HTMLDivElement>
+    | ReactKeyboardEvent<HTMLDivElement>;
 
 export type GitDiffLineKind = "add" | "context" | "remove";
 
@@ -149,7 +157,7 @@ export interface GitTreeViewProps {
     readonly onBackgroundDrop?: (dragData: GitTreeDragData) => void;
     readonly onNodeClick?: (
         node: GitTreeNode,
-        event: ReactMouseEvent<HTMLDivElement>,
+        event: GitTreeNodeActivationEvent,
     ) => void;
     readonly onNodeContextMenu?: (
         node: GitTreeNode,
@@ -188,7 +196,7 @@ export interface GitChangesViewProps {
     readonly layout?: GitViewLayout;
     readonly onNodeClick?: (
         node: GitTreeNode,
-        event: ReactMouseEvent<HTMLDivElement>,
+        event: GitTreeNodeActivationEvent,
     ) => void;
     readonly onToggleDirectory?: (node: GitTreeNode) => void;
     readonly onToggleGroup?: (groupId: GitChangeGroupId) => void;

--- a/src/renderer/src/components/git/types.ts
+++ b/src/renderer/src/components/git/types.ts
@@ -48,6 +48,10 @@ export interface GitTreeDragData {
     readonly relativePath: string;
 }
 
+export type GitTreeDragPayload =
+    | GitTreeDragData
+    | readonly GitTreeDragData[];
+
 export interface GitTreeNode {
     readonly id: string;
     readonly name: string;
@@ -167,13 +171,13 @@ export interface GitTreeViewProps {
         },
     ) => void;
     readonly onNodeDrop?: (
-        dragData: GitTreeDragData,
+        dragData: GitTreeDragPayload,
         node: GitTreeNode,
     ) => void;
     readonly onNodeDragStart?: (
         node: GitTreeNode,
         dataTransfer: DataTransfer | null,
-    ) => void;
+    ) => GitTreeDragPayload | void;
     readonly onEditingCancel?: () => void;
     readonly onEditingDraftNameChange?: (value: string) => void;
     readonly onEditingSubmit?: () => void;

--- a/src/renderer/src/components/git/types.ts
+++ b/src/renderer/src/components/git/types.ts
@@ -174,6 +174,10 @@ export interface GitTreeViewProps {
         dragData: GitTreeDragPayload,
         node: GitTreeNode,
     ) => void;
+    readonly onExternalFilesDrop?: (
+        sourcePaths: readonly string[],
+        node: GitTreeNode | null,
+    ) => void;
     readonly onNodeDragStart?: (
         node: GitTreeNode,
         dataTransfer: DataTransfer | null,

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -542,6 +542,26 @@ button {
         box-shadow 100ms ease;
 }
 
+.git-tree-root {
+    border-radius: 6px;
+    transition:
+        background-color 120ms ease,
+        box-shadow 120ms ease;
+}
+
+.git-tree-root[data-background-drop-target="true"] {
+    background-color: color-mix(
+        in srgb,
+        var(--color-accent) 8%,
+        transparent
+    );
+    box-shadow:
+        inset 0 0 0 1px
+            color-mix(in srgb, var(--color-accent) 42%, transparent),
+        inset 0 0 0 999px
+            color-mix(in srgb, var(--color-accent) 3%, transparent);
+}
+
 .git-tree-row:hover {
     background-color: var(--color-bg-tertiary);
 }
@@ -551,7 +571,45 @@ button {
 }
 
 .git-tree-row:hover[data-drop-target="true"] {
-    background-color: color-mix(in srgb, var(--color-accent) 14%, transparent);
+    background-color: color-mix(in srgb, var(--color-accent) 16%, transparent);
+}
+
+.git-tree-row[data-context-target="true"] {
+    background-color: color-mix(
+        in srgb,
+        var(--color-bg-tertiary) 76%,
+        var(--color-accent) 8%
+    );
+}
+
+.git-tree-row[data-dragging="true"] {
+    cursor: grabbing;
+}
+
+.git-tree-drag-ghost {
+    position: fixed;
+    top: -9999px;
+    left: -9999px;
+    z-index: 2147483647;
+    max-width: 260px;
+    padding: 5px 8px;
+    border: 1px solid color-mix(in srgb, var(--color-accent) 42%, transparent);
+    border-radius: 6px;
+    background: color-mix(
+        in srgb,
+        var(--color-bg-elevated) 96%,
+        var(--color-accent) 4%
+    );
+    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.2);
+    color: var(--color-text-primary);
+    font:
+        12px/1.25 var(--font-sans),
+        system-ui,
+        sans-serif;
+    overflow: hidden;
+    pointer-events: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .git-tree-row-actions {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -549,6 +549,11 @@ button {
         box-shadow 120ms ease;
 }
 
+.app-sidebar:focus,
+.git-tree-root:focus {
+    outline: none;
+}
+
 .git-tree-root[data-background-drop-target="true"] {
     background-color: color-mix(
         in srgb,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -110,6 +110,8 @@ export const IPC_CHANNELS = {
     copyProjectEntries: "projects:copy-entries",
     renameProjectEntry: "projects:rename-entry",
     deleteProjectEntry: "projects:delete-entry",
+    trashProjectEntry: "projects:trash-entry",
+    openProjectEntryExternally: "projects:open-entry-externally",
     revealProjectEntry: "projects:reveal-entry",
     listProjectEntries: "projects:list-entries",
     searchProjectEntries: "projects:search-entries",
@@ -1743,6 +1745,18 @@ export interface DeleteProjectEntryInput {
     readonly worktreeId?: string | null;
 }
 
+export interface TrashProjectEntryInput {
+    readonly projectId: string;
+    readonly relativePath: string;
+    readonly worktreeId?: string | null;
+}
+
+export interface OpenProjectEntryExternallyInput {
+    readonly projectId: string;
+    readonly relativePath: string;
+    readonly worktreeId?: string | null;
+}
+
 export interface RevealProjectEntryInput {
     readonly projectId: string;
     readonly relativePath: string | null;
@@ -2715,6 +2729,10 @@ export interface ComandoApi {
         input: RenameProjectEntryInput,
     ) => Promise<ProjectEntryMutationResult>;
     deleteProjectEntry: (input: DeleteProjectEntryInput) => Promise<void>;
+    trashProjectEntry: (input: TrashProjectEntryInput) => Promise<void>;
+    openProjectEntryExternally: (
+        input: OpenProjectEntryExternallyInput,
+    ) => Promise<void>;
     revealProjectEntry: (input: RevealProjectEntryInput) => Promise<void>;
     getWorkspaceSnapshot: () => Promise<WorkspaceSnapshot>;
     saveWorkspaceSnapshot: (snapshot: WorkspaceSnapshot) => Promise<void>;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -107,6 +107,7 @@ export const IPC_CHANNELS = {
     openProjectFile: "projects:open-file",
     saveProjectFile: "projects:save-file",
     createProjectEntry: "projects:create-entry",
+    copyProjectEntries: "projects:copy-entries",
     renameProjectEntry: "projects:rename-entry",
     deleteProjectEntry: "projects:delete-entry",
     revealProjectEntry: "projects:reveal-entry",
@@ -1717,6 +1718,17 @@ export interface CreateProjectEntryInput {
     readonly worktreeId?: string | null;
 }
 
+export interface CopyProjectEntriesInput {
+    readonly destinationParentRelativePath: string | null;
+    readonly projectId: string;
+    readonly sourceRelativePaths: readonly string[];
+    readonly worktreeId?: string | null;
+}
+
+export interface CopyProjectEntriesResult {
+    readonly entries: readonly ProjectEntryMutationResult[];
+}
+
 export interface RenameProjectEntryInput {
     readonly projectId: string;
     readonly nextName: string;
@@ -2696,6 +2708,9 @@ export interface ComandoApi {
     createProjectEntry: (
         input: CreateProjectEntryInput,
     ) => Promise<ProjectEntryMutationResult>;
+    copyProjectEntries: (
+        input: CopyProjectEntriesInput,
+    ) => Promise<CopyProjectEntriesResult>;
     renameProjectEntry: (
         input: RenameProjectEntryInput,
     ) => Promise<ProjectEntryMutationResult>;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -108,6 +108,7 @@ export const IPC_CHANNELS = {
     saveProjectFile: "projects:save-file",
     createProjectEntry: "projects:create-entry",
     copyProjectEntries: "projects:copy-entries",
+    copyExternalProjectEntries: "projects:copy-external-entries",
     renameProjectEntry: "projects:rename-entry",
     deleteProjectEntry: "projects:delete-entry",
     trashProjectEntry: "projects:trash-entry",
@@ -1731,6 +1732,17 @@ export interface CopyProjectEntriesResult {
     readonly entries: readonly ProjectEntryMutationResult[];
 }
 
+export interface CopyExternalProjectEntriesInput {
+    readonly destinationParentRelativePath: string | null;
+    readonly projectId: string;
+    readonly sourcePaths: readonly string[];
+    readonly worktreeId?: string | null;
+}
+
+export interface CopyExternalProjectEntriesResult {
+    readonly entries: readonly ProjectEntryMutationResult[];
+}
+
 export interface RenameProjectEntryInput {
     readonly projectId: string;
     readonly nextName: string;
@@ -2725,6 +2737,9 @@ export interface ComandoApi {
     copyProjectEntries: (
         input: CopyProjectEntriesInput,
     ) => Promise<CopyProjectEntriesResult>;
+    copyExternalProjectEntries: (
+        input: CopyExternalProjectEntriesInput,
+    ) => Promise<CopyExternalProjectEntriesResult>;
     renameProjectEntry: (
         input: RenameProjectEntryInput,
     ) => Promise<ProjectEntryMutationResult>;


### PR DESCRIPTION
## Summary

- Flatten the expanded file tree before rendering rows.
- Render the shared tree view through the existing measured virtual list.
- Preserve row behavior for selection, active files, inline rename, drag/drop, sticky placeholders, status metadata, and scroll-to-active.
- Add focused coverage for expanded and collapsed directory rendering.

## Validation

- `pnpm vitest run src/renderer/src/components/git/GitTreeView.test.tsx`
- `pnpm run typecheck`
- `pnpm exec eslint src/renderer/src/components/git/GitTreeView.tsx src/renderer/src/components/git/GitTreeView.test.tsx`
- `git diff --check`