### PR TITLE
Virtualize GitHub tables, diffs, and review history

### DIFF
--- a/src/renderer/src/components/git/GitDiffsView.test.tsx
+++ b/src/renderer/src/components/git/GitDiffsView.test.tsx
@@ -137,7 +137,9 @@ function createLargeDiffFile(index: number): GitDiffFile {
     });
 }
 
-function createLargeLineDiffFile(): GitDiffFile {
+function createLargeLineDiffFile(
+    overrides: Partial<GitDiffFile> = {},
+): GitDiffFile {
     return createDiffFile({
         hunks: [
             {
@@ -162,6 +164,7 @@ function createLargeLineDiffFile(): GitDiffFile {
         id: "src/giant-diff.ts",
         path: "src/giant-diff.ts",
         summary: `+${GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD} -0`,
+        ...overrides,
     });
 }
 
@@ -174,6 +177,7 @@ describe("GitDiffsView", () => {
             />,
         );
 
+        expect(markup).not.toContain('data-virtualized-diff-lines="true"');
         expect(markup).toContain('data-diff-line="true"');
         expect(markup).toContain('data-line-exact="true"');
         expect(markup).toContain('data-line-type="context"');
@@ -233,6 +237,66 @@ describe("GitDiffsView", () => {
 
         expect(markup).toContain('class="min-w-full w-max"');
         expect(markup).toContain("grid-template-columns:44px max-content");
+    });
+
+    it("virtualizes giant non-wrapping diff files by mounting visual blocks", () => {
+        const markup = renderToStaticMarkup(
+            <GitDiffsView
+                files={[createLargeLineDiffFile()]}
+                lineWrapping={false}
+                showFileSelector={false}
+            />,
+        );
+
+        expect(markup).toContain('data-virtualized-diff-lines="true"');
+        expect(markup).toContain('data-diff-hunk-header="true"');
+        expect(markup).toContain('data-measured-virtual-list="true"');
+        expect(markup).toContain("1–0 → 1–1000");
+        expect(markup).toContain("giant-diff-line-1");
+        expect(markup).not.toContain("giant-diff-line-1000");
+    });
+
+    it("keeps horizontal sizing for virtualized non-wrapping diff lines", () => {
+        const markup = renderToStaticMarkup(
+            <GitDiffsView
+                files={[
+                    createLargeLineDiffFile({
+                        hunks: [
+                            {
+                                header: `@@ -1,0 +1,${GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD} @@`,
+                                id: "wide-line-hunk",
+                                lines: Array.from(
+                                    {
+                                        length: GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD,
+                                    },
+                                    (_, index) => ({
+                                        id: `wide-line-${index + 1}`,
+                                        kind: "add",
+                                        newLineNumber: index + 1,
+                                        oldLineNumber: null,
+                                        text:
+                                            index ===
+                                            GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD -
+                                                1
+                                                ? "x".repeat(220)
+                                                : `short-line-${index + 1}`,
+                                    }),
+                                ),
+                                newCount: GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD,
+                                newStart: 1,
+                                oldCount: 0,
+                                oldStart: 1,
+                            },
+                        ],
+                    }),
+                ]}
+                lineWrapping={false}
+                showFileSelector={false}
+            />,
+        );
+
+        expect(markup).toContain("min-width:max(100%, 238ch)");
+        expect(markup).not.toContain("x".repeat(220));
     });
 
     it("keeps diff code selectable inside non-selectable commit UI", () => {
@@ -354,6 +418,7 @@ describe("GitDiffsView", () => {
 
         expect(markup).toContain("giant-diff.ts");
         expect(markup).not.toContain("giant-diff-line-1");
+        expect(markup).not.toContain('data-virtualized-diff-lines="true"');
         expect(markup).toContain("large-file-1-line");
     });
 

--- a/src/renderer/src/components/git/GitDiffsView.test.tsx
+++ b/src/renderer/src/components/git/GitDiffsView.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
@@ -192,6 +193,34 @@ describe("GitDiffsView", () => {
 
         expect(markup).toContain("select-text");
         expect(markup).toContain("user-select:text");
+    });
+
+    it("owns vertical scroll when no external scroll container is provided", () => {
+        const markup = renderToStaticMarkup(
+            <GitDiffsView
+                files={[createDiffFile()]}
+                showFileSelector={false}
+            />,
+        );
+
+        expect(markup).toContain(
+            'class="shell-scrollbar min-h-0 flex-1 overflow-y-auto px-2 py-2"',
+        );
+    });
+
+    it("uses the parent scroll container when an external ref is provided", () => {
+        const markup = renderToStaticMarkup(
+            <GitDiffsView
+                files={[createDiffFile()]}
+                scrollContainerRef={createRef<HTMLElement>()}
+                showFileSelector={false}
+            />,
+        );
+
+        expect(markup).toContain('class="min-h-0 flex-1 px-2 py-2"');
+        expect(markup).not.toContain(
+            'class="shell-scrollbar min-h-0 flex-1 overflow-y-auto px-2 py-2"',
+        );
     });
 
     it("keeps the message for binary files", () => {

--- a/src/renderer/src/components/git/GitDiffsView.test.tsx
+++ b/src/renderer/src/components/git/GitDiffsView.test.tsx
@@ -1,7 +1,11 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { GitDiffsView } from "./GitDiffsView";
+import {
+    GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD,
+    GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD,
+    GitDiffsView,
+} from "./GitDiffsView";
 import type { GitDiffFile } from "./types";
 
 function createDiffFile(overrides: Partial<GitDiffFile> = {}): GitDiffFile {
@@ -51,6 +55,61 @@ function createDiffFile(overrides: Partial<GitDiffFile> = {}): GitDiffFile {
         summary: "+1 -1",
         ...overrides,
     };
+}
+
+function createLargeDiffFile(index: number): GitDiffFile {
+    return createDiffFile({
+        hunks: [
+            {
+                header: "@@ -1,1 +1,1 @@",
+                id: `hunk-${index}`,
+                lines: [
+                    {
+                        id: `line-${index}`,
+                        kind: "add",
+                        newLineNumber: 1,
+                        oldLineNumber: null,
+                        text: `large-file-${index}-line`,
+                    },
+                ],
+                newCount: 1,
+                newStart: 1,
+                oldCount: 0,
+                oldStart: 1,
+            },
+        ],
+        id: `src/large-file-${index}.ts`,
+        path: `src/large-file-${index}.ts`,
+        summary: "+1 -0",
+    });
+}
+
+function createLargeLineDiffFile(): GitDiffFile {
+    return createDiffFile({
+        hunks: [
+            {
+                header: `@@ -1,0 +1,${GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD} @@`,
+                id: "large-line-hunk",
+                lines: Array.from(
+                    { length: GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD },
+                    (_, index) => ({
+                        id: `large-line-${index + 1}`,
+                        kind: "add",
+                        newLineNumber: index + 1,
+                        oldLineNumber: null,
+                        text: `giant-diff-line-${index + 1}`,
+                    }),
+                ),
+                newCount: GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD,
+                newStart: 1,
+                oldCount: 0,
+                oldStart: 1,
+            },
+        ],
+        id: "src/giant-diff.ts",
+        path: "src/giant-diff.ts",
+        summary: `+${GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD} -0`,
+    });
 }
 
 describe("GitDiffsView", () => {
@@ -151,5 +210,50 @@ describe("GitDiffsView", () => {
         );
 
         expect(markup).toContain("This file is binary");
+    });
+
+    it("renders the large stacked diff baseline without dropping files or lines", () => {
+        const files = [
+            ...Array.from(
+                { length: GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD },
+                (_, index) => createLargeDiffFile(index + 1),
+            ),
+            createLargeLineDiffFile(),
+        ];
+
+        const markup = renderToStaticMarkup(
+            <GitDiffsView
+                displayMode="stack"
+                files={files}
+                showFileSelector={false}
+            />,
+        );
+
+        expect(markup).toContain("large-file-1.ts");
+        expect(markup).toContain(
+            `large-file-${GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD}.ts`,
+        );
+        expect(markup).toContain("giant-diff-line-1");
+        expect(markup).toContain(
+            `giant-diff-line-${GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD}`,
+        );
+    });
+
+    it("keeps collapse state authoritative in the large stacked diff baseline", () => {
+        const collapsedFile = createLargeLineDiffFile();
+        const files = [createLargeDiffFile(1), collapsedFile];
+
+        const markup = renderToStaticMarkup(
+            <GitDiffsView
+                collapsedFileIds={[collapsedFile.id]}
+                displayMode="stack"
+                files={files}
+                showFileSelector={false}
+            />,
+        );
+
+        expect(markup).toContain("giant-diff.ts");
+        expect(markup).not.toContain("giant-diff-line-1");
+        expect(markup).toContain("large-file-1-line");
     });
 });

--- a/src/renderer/src/components/git/GitDiffsView.test.tsx
+++ b/src/renderer/src/components/git/GitDiffsView.test.tsx
@@ -1,11 +1,63 @@
-import { createRef } from "react";
+import { createRef, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const mockScrollToIndex = vi.hoisted(() => vi.fn());
+
+vi.mock("@renderer/components/virtual/MeasuredVirtualList", () => ({
+    MeasuredVirtualList: <T,>({
+        enabled = true,
+        estimateSize,
+        getItemKey,
+        items,
+        onReady,
+        renderItem,
+        scrollMarginTop = 0,
+    }: {
+        readonly enabled?: boolean;
+        readonly estimateSize: (item: T, index: number) => number;
+        readonly getItemKey: (item: T, index: number) => string;
+        readonly items: readonly T[];
+        readonly onReady?: (
+            handle: { readonly scrollToIndex: typeof mockScrollToIndex } | null,
+        ) => void;
+        readonly renderItem: (params: {
+            readonly index: number;
+            readonly isVisible: boolean;
+            readonly item: T;
+        }) => ReactNode;
+        readonly scrollMarginTop?: number;
+    }) => {
+        onReady?.({ scrollToIndex: mockScrollToIndex });
+        const renderedItems = enabled ? items.slice(0, 6) : items;
+
+        return (
+            <div
+                data-measured-virtual-list="true"
+                data-scroll-margin-top={scrollMarginTop}
+            >
+                {renderedItems.map((item, index) => (
+                    <div
+                        data-estimated-size={estimateSize(item, index)}
+                        key={getItemKey(item, index)}
+                    >
+                        {renderItem({
+                            index,
+                            isVisible: true,
+                            item,
+                        })}
+                    </div>
+                ))}
+            </div>
+        );
+    },
+}));
 
 import {
     GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD,
     GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD,
     GitDiffsView,
+    estimateDiffFileSurfaceHeight,
 } from "./GitDiffsView";
 import type { GitDiffFile } from "./types";
 
@@ -241,10 +293,31 @@ describe("GitDiffsView", () => {
         expect(markup).toContain("This file is binary");
     });
 
-    it("renders the large stacked diff baseline without dropping files or lines", () => {
+    it("renders every stacked diff file below the virtualization threshold", () => {
+        const files = Array.from(
+            { length: GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD - 1 },
+            (_, index) => createLargeDiffFile(index + 1),
+        );
+
+        const markup = renderToStaticMarkup(
+            <GitDiffsView
+                displayMode="stack"
+                files={files}
+                showFileSelector={false}
+            />,
+        );
+
+        expect(markup).not.toContain('data-measured-virtual-list="true"');
+        expect(markup).toContain("large-file-1.ts");
+        expect(markup).toContain(
+            `large-file-${GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD - 1}.ts`,
+        );
+    });
+
+    it("virtualizes large stacked diffs by mounting a measured subset", () => {
         const files = [
             ...Array.from(
-                { length: GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD },
+                { length: GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD + 1 },
                 (_, index) => createLargeDiffFile(index + 1),
             ),
             createLargeLineDiffFile(),
@@ -258,14 +331,12 @@ describe("GitDiffsView", () => {
             />,
         );
 
+        expect(markup).toContain('data-measured-virtual-list="true"');
         expect(markup).toContain("large-file-1.ts");
-        expect(markup).toContain(
-            `large-file-${GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD}.ts`,
+        expect(markup).not.toContain(
+            `large-file-${GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD + 1}.ts`,
         );
-        expect(markup).toContain("giant-diff-line-1");
-        expect(markup).toContain(
-            `giant-diff-line-${GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD}`,
-        );
+        expect(markup).not.toContain("giant-diff-line-1");
     });
 
     it("keeps collapse state authoritative in the large stacked diff baseline", () => {
@@ -284,5 +355,19 @@ describe("GitDiffsView", () => {
         expect(markup).toContain("giant-diff.ts");
         expect(markup).not.toContain("giant-diff-line-1");
         expect(markup).toContain("large-file-1-line");
+    });
+
+    it("estimates collapsed diff files smaller than expanded text files", () => {
+        const file = createLargeLineDiffFile();
+
+        expect(estimateDiffFileSurfaceHeight(file, true, 20)).toBeLessThan(
+            estimateDiffFileSurfaceHeight(file, false, 20),
+        );
+    });
+
+    it("caps extremely large initial diff file estimates", () => {
+        expect(
+            estimateDiffFileSurfaceHeight(createLargeLineDiffFile(), false, 20),
+        ).toBe(1600);
     });
 });

--- a/src/renderer/src/components/git/GitDiffsView.tsx
+++ b/src/renderer/src/components/git/GitDiffsView.tsx
@@ -16,6 +16,10 @@ import type {
     GitDiffsViewProps,
 } from "./types";
 
+// Baseline thresholds for the upcoming diff virtualization pass.
+export const GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD = 60;
+export const GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD = 2_000;
+
 export function GitDiffsView({
     activeFileId = null,
     className,

--- a/src/renderer/src/components/git/GitDiffsView.tsx
+++ b/src/renderer/src/components/git/GitDiffsView.tsx
@@ -24,9 +24,10 @@ import type {
 } from "./types";
 
 export const GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD = 25;
-export const GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD = 2_000;
+export const GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD = 1_000;
 
 const DIFF_FILE_STACK_OVERSCAN = 4;
+const DIFF_LINE_LIST_OVERSCAN = 32;
 const DIFF_FILE_STACK_GAP_PX = 12;
 const DIFF_FILE_HEADER_HEIGHT_PX = 52;
 const DIFF_FILE_EMPTY_STATE_HEIGHT_PX = 76;
@@ -35,6 +36,20 @@ const DIFF_HUNK_VERTICAL_PADDING_PX = 24;
 const DIFF_HUNK_GAP_PX = 12;
 const DEFAULT_DIFF_LINE_HEIGHT_PX = 20;
 const MAX_ESTIMATED_DIFF_FILE_HEIGHT_PX = 1_600;
+
+type DiffVisualBlock =
+    | {
+          readonly kind: "hunkHeader";
+          readonly hasLeadingGap: boolean;
+          readonly hunk: GitDiffHunk;
+          readonly key: string;
+      }
+    | {
+          readonly kind: "line";
+          readonly filePath: string;
+          readonly key: string;
+          readonly line: GitDiffLine;
+      };
 
 function resolveDiffLineHeightPx(codeLineHeight: number | null): number {
     if (typeof codeLineHeight !== "number" || !Number.isFinite(codeLineHeight)) {
@@ -75,6 +90,69 @@ export function estimateDiffFileSurfaceHeight(
         hunksHeight;
 
     return Math.min(estimatedHeight, MAX_ESTIMATED_DIFF_FILE_HEIGHT_PX);
+}
+
+function countDiffLines(file: GitDiffFile): number {
+    return file.hunks.reduce((total, hunk) => total + hunk.lines.length, 0);
+}
+
+function shouldVirtualizeDiffLines({
+    allowLineVirtualization,
+    file,
+    lineWrapping,
+}: {
+    readonly allowLineVirtualization: boolean;
+    readonly file: GitDiffFile;
+    readonly lineWrapping: boolean;
+}): boolean {
+    return (
+        allowLineVirtualization &&
+        !lineWrapping &&
+        file.isText &&
+        countDiffLines(file) >= GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD
+    );
+}
+
+function buildDiffVisualBlocks(file: GitDiffFile): readonly DiffVisualBlock[] {
+    const blocks: DiffVisualBlock[] = [];
+
+    file.hunks.forEach((hunk, hunkIndex) => {
+        blocks.push({
+            hasLeadingGap: hunkIndex > 0,
+            hunk,
+            key: `${hunk.id}:header`,
+            kind: "hunkHeader",
+        });
+
+        hunk.lines.forEach((line) => {
+            blocks.push({
+                filePath: file.path,
+                key: `${hunk.id}:line:${line.id}`,
+                kind: "line",
+                line,
+            });
+        });
+    });
+
+    return blocks;
+}
+
+function estimateDiffVisualBlockHeight(
+    block: DiffVisualBlock,
+    codeLineHeight: number | null,
+): number {
+    if (block.kind === "hunkHeader") {
+        return (
+            DIFF_HUNK_HEADER_HEIGHT_PX +
+            (block.hasLeadingGap ? DIFF_HUNK_GAP_PX : 0)
+        );
+    }
+
+    return resolveDiffLineHeightPx(codeLineHeight);
+}
+
+function getDiffVisualBlockKey(block: DiffVisualBlock): string {
+    return block.key;
 }
 
 export function GitDiffsView({
@@ -194,11 +272,13 @@ export function GitDiffsView({
                 />
             ) : (
                 <DiffFileSurface
+                    allowLineVirtualization
                     codeFontFamily={codeFontFamily}
                     codeFontSize={codeFontSize}
                     codeLineHeight={codeLineHeight}
                     file={activeFile}
                     lineWrapping={lineWrapping}
+                    scrollContainerRef={resolvedScrollContainerRef}
                     surfaceVariant={surfaceVariant}
                 />
             )}
@@ -343,6 +423,7 @@ function VirtualizedGitDiffStack({
     const renderDiffFile = useCallback(
         (file: GitDiffFile) => (
             <DiffFileSurface
+                allowLineVirtualization
                 codeFontFamily={codeFontFamily}
                 codeFontSize={codeFontSize}
                 codeLineHeight={codeLineHeight}
@@ -351,6 +432,7 @@ function VirtualizedGitDiffStack({
                 fileId={file.id}
                 lineWrapping={lineWrapping}
                 onToggleCollapse={onToggleFileCollapse}
+                scrollContainerRef={scrollContainerRef}
                 surfaceVariant={surfaceVariant}
             />
         ),
@@ -361,6 +443,7 @@ function VirtualizedGitDiffStack({
             collapsedFileIdSet,
             lineWrapping,
             onToggleFileCollapse,
+            scrollContainerRef,
             surfaceVariant,
         ],
     );
@@ -418,6 +501,7 @@ function VirtualizedGitDiffStack({
 }
 
 const DiffFileSurface = memo(function DiffFileSurface({
+    allowLineVirtualization = false,
     codeFontFamily = null,
     codeFontSize = null,
     codeLineHeight = null,
@@ -426,8 +510,10 @@ const DiffFileSurface = memo(function DiffFileSurface({
     fileId,
     lineWrapping = true,
     onToggleCollapse,
+    scrollContainerRef,
     surfaceVariant,
 }: {
+    readonly allowLineVirtualization?: boolean;
     readonly codeFontFamily?: string | null;
     readonly codeFontSize?: number | null;
     readonly codeLineHeight?: number | null;
@@ -436,6 +522,7 @@ const DiffFileSurface = memo(function DiffFileSurface({
     readonly fileId?: string;
     readonly lineWrapping?: boolean;
     readonly onToggleCollapse?: ((fileId: string) => void) | undefined;
+    readonly scrollContainerRef?: RefObject<HTMLElement | null>;
     readonly surfaceVariant: "flat" | "panel";
 }) {
     const isCollapsible = typeof onToggleCollapse === "function";
@@ -495,6 +582,13 @@ const DiffFileSurface = memo(function DiffFileSurface({
                 ))}
             </div>
         ) : null;
+    const virtualizeLines =
+        scrollContainerRef !== undefined &&
+        shouldVirtualizeDiffLines({
+            allowLineVirtualization,
+            file,
+            lineWrapping,
+        });
 
     return (
         <section
@@ -546,6 +640,16 @@ const DiffFileSurface = memo(function DiffFileSurface({
                     </GitEmptyState>
                 </div>
             ) : file.hunks.length > 0 ? (
+                virtualizeLines ? (
+                    <VirtualizedDiffHunks
+                        codeFontFamily={codeFontFamily}
+                        codeFontSize={codeFontSize}
+                        codeLineHeight={codeLineHeight}
+                        file={file}
+                        lineWrapping={lineWrapping}
+                        scrollContainerRef={scrollContainerRef}
+                    />
+                ) : (
                 <div className="space-y-3 p-3">
                     {file.hunks.map((hunk) => (
                         <section
@@ -579,6 +683,7 @@ const DiffFileSurface = memo(function DiffFileSurface({
                         </section>
                     ))}
                 </div>
+                )
             ) : (
                 <div className="p-3">
                     <GitEmptyState>
@@ -590,6 +695,156 @@ const DiffFileSurface = memo(function DiffFileSurface({
         </section>
     );
 });
+
+function VirtualizedDiffHunks({
+    codeFontFamily,
+    codeFontSize,
+    codeLineHeight,
+    file,
+    lineWrapping,
+    scrollContainerRef,
+}: {
+    readonly codeFontFamily: string | null;
+    readonly codeFontSize: number | null;
+    readonly codeLineHeight: number | null;
+    readonly file: GitDiffFile;
+    readonly lineWrapping: boolean;
+    readonly scrollContainerRef: RefObject<HTMLElement | null>;
+}) {
+    const listRef = useRef<HTMLDivElement | null>(null);
+    const [scrollMarginTop, setScrollMarginTop] = useState(0);
+    const blocks = useMemo(() => buildDiffVisualBlocks(file), [file]);
+    const maxLineWidthCh = useMemo(() => {
+        const maxTextLength = file.hunks.reduce((maxLength, hunk) => {
+            const hunkMaxLength = hunk.lines.reduce(
+                (lineMaxLength, line) =>
+                    Math.max(lineMaxLength, line.text.length),
+                0,
+            );
+            return Math.max(maxLength, hunkMaxLength);
+        }, 0);
+
+        return Math.max(80, maxTextLength + 18);
+    }, [file]);
+    const contentStyle = lineWrapping
+        ? undefined
+        : { minWidth: `max(100%, ${maxLineWidthCh}ch)` };
+
+    useEffect(() => {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        const syncScrollMarginTop = () => {
+            setScrollMarginTop(
+                calculateScrollMarginTop(
+                    listRef.current,
+                    scrollContainerRef.current,
+                ),
+            );
+        };
+
+        syncScrollMarginTop();
+
+        const scrollContainer = scrollContainerRef.current;
+        let observer: ResizeObserver | null = null;
+
+        if (typeof ResizeObserver !== "undefined") {
+            observer = new ResizeObserver(syncScrollMarginTop);
+            if (listRef.current) {
+                observer.observe(listRef.current);
+            }
+            if (scrollContainer) {
+                observer.observe(scrollContainer);
+            }
+        }
+
+        window.addEventListener("resize", syncScrollMarginTop);
+
+        return () => {
+            observer?.disconnect();
+            window.removeEventListener("resize", syncScrollMarginTop);
+        };
+    }, [scrollContainerRef]);
+
+    const estimateBlockSize = useCallback(
+        (block: DiffVisualBlock) =>
+            estimateDiffVisualBlockHeight(block, codeLineHeight),
+        [codeLineHeight],
+    );
+
+    const renderBlock = useCallback(
+        ({ item }: { readonly item: DiffVisualBlock }) => {
+            if (item.kind === "hunkHeader") {
+                return <VirtualizedDiffHunkHeader block={item} />;
+            }
+
+            return (
+                <DiffLineRow
+                    codeFontFamily={codeFontFamily}
+                    codeFontSize={codeFontSize}
+                    codeLineHeight={codeLineHeight}
+                    filePath={item.filePath}
+                    line={item.line}
+                    lineWrapping={lineWrapping}
+                />
+            );
+        },
+        [codeFontFamily, codeFontSize, codeLineHeight, lineWrapping],
+    );
+
+    return (
+        <div className="p-3">
+            <div
+                className="select-text overflow-x-auto"
+                data-virtualized-diff-lines="true"
+            >
+                <div
+                    className={lineWrapping ? "min-w-160" : "min-w-full w-max"}
+                    style={contentStyle}
+                >
+                    <div
+                        className="min-w-full overflow-hidden rounded-lg border border-border bg-bg-primary"
+                        ref={listRef}
+                    >
+                        <MeasuredVirtualList
+                            enabled
+                            estimateSize={estimateBlockSize}
+                            getItemKey={getDiffVisualBlockKey}
+                            items={blocks}
+                            overscan={DIFF_LINE_LIST_OVERSCAN}
+                            renderItem={renderBlock}
+                            scrollContainerRef={scrollContainerRef}
+                            scrollMarginTop={scrollMarginTop}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function VirtualizedDiffHunkHeader({
+    block,
+}: {
+    readonly block: Extract<DiffVisualBlock, { readonly kind: "hunkHeader" }>;
+}) {
+    return (
+        <div
+            className={block.hasLeadingGap ? "pt-3" : undefined}
+            data-diff-hunk-header="true"
+        >
+            <div
+                className={[
+                    "border-b border-border px-3 py-1.5 font-mono text-[10px] text-text-secondary/50",
+                    block.hasLeadingGap ? "border-t" : "",
+                ].join(" ")}
+            >
+                {formatHunkHeader(block.hunk)}
+            </div>
+        </div>
+    );
+}
 
 function DiffFileActionButton({
     action,

--- a/src/renderer/src/components/git/GitDiffsView.tsx
+++ b/src/renderer/src/components/git/GitDiffsView.tsx
@@ -34,9 +34,11 @@ export function GitDiffsView({
     onScroll,
     onSelectFile,
     onToggleFileCollapse,
+    scrollContainerRef,
     showFileSelector = true,
     surfaceVariant = "panel",
 }: GitDiffsViewProps) {
+    const ownsScrollContainer = scrollContainerRef === undefined;
     const isControlled = controlledCollapsedFileIds !== undefined;
     const [localCollapsedFileIds, setLocalCollapsedFileIds] = useState<
         readonly string[]
@@ -91,12 +93,14 @@ export function GitDiffsView({
     return (
         <div
             className={[
-                "shell-scrollbar min-h-0 flex-1 overflow-y-auto px-2 py-2",
+                ownsScrollContainer
+                    ? "shell-scrollbar min-h-0 flex-1 overflow-y-auto px-2 py-2"
+                    : "min-h-0 flex-1 px-2 py-2",
                 className,
             ]
                 .filter(Boolean)
                 .join(" ")}
-            onScroll={onScroll}
+            onScroll={ownsScrollContainer ? onScroll : undefined}
         >
             {showFileSelector ? (
                 <div className="mb-3 flex flex-wrap items-center gap-2">

--- a/src/renderer/src/components/git/GitDiffsView.tsx
+++ b/src/renderer/src/components/git/GitDiffsView.tsx
@@ -1,11 +1,18 @@
 import {
     memo,
     useCallback,
+    useEffect,
     useMemo,
+    useRef,
     useState,
     type MouseEvent as ReactMouseEvent,
+    type RefObject,
 } from "react";
 
+import {
+    MeasuredVirtualList,
+    type MeasuredVirtualListHandle,
+} from "@renderer/components/virtual/MeasuredVirtualList";
 import { DiffLineView } from "@renderer/components/workspace/review/DiffLineView";
 
 import { GitBadge, GitEmptyState } from "./GitUi";
@@ -16,9 +23,59 @@ import type {
     GitDiffsViewProps,
 } from "./types";
 
-// Baseline thresholds for the upcoming diff virtualization pass.
-export const GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD = 60;
+export const GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD = 25;
 export const GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD = 2_000;
+
+const DIFF_FILE_STACK_OVERSCAN = 4;
+const DIFF_FILE_STACK_GAP_PX = 12;
+const DIFF_FILE_HEADER_HEIGHT_PX = 52;
+const DIFF_FILE_EMPTY_STATE_HEIGHT_PX = 76;
+const DIFF_HUNK_HEADER_HEIGHT_PX = 26;
+const DIFF_HUNK_VERTICAL_PADDING_PX = 24;
+const DIFF_HUNK_GAP_PX = 12;
+const DEFAULT_DIFF_LINE_HEIGHT_PX = 20;
+const MAX_ESTIMATED_DIFF_FILE_HEIGHT_PX = 1_600;
+
+function resolveDiffLineHeightPx(codeLineHeight: number | null): number {
+    if (typeof codeLineHeight !== "number" || !Number.isFinite(codeLineHeight)) {
+        return DEFAULT_DIFF_LINE_HEIGHT_PX;
+    }
+
+    return codeLineHeight > 4
+        ? Math.max(1, codeLineHeight)
+        : Math.max(1, Math.round(DEFAULT_DIFF_LINE_HEIGHT_PX * codeLineHeight));
+}
+
+export function estimateDiffFileSurfaceHeight(
+    file: GitDiffFile,
+    collapsed: boolean,
+    codeLineHeight: number | null,
+): number {
+    if (collapsed) {
+        return DIFF_FILE_HEADER_HEIGHT_PX;
+    }
+
+    if (!file.isText || file.hunks.length === 0) {
+        return DIFF_FILE_HEADER_HEIGHT_PX + DIFF_FILE_EMPTY_STATE_HEIGHT_PX;
+    }
+
+    const lineHeight = resolveDiffLineHeightPx(codeLineHeight);
+    const hunksHeight = file.hunks.reduce((total, hunk, index) => {
+        const gap = index === 0 ? 0 : DIFF_HUNK_GAP_PX;
+        return (
+            total +
+            gap +
+            DIFF_HUNK_HEADER_HEIGHT_PX +
+            hunk.lines.length * lineHeight
+        );
+    }, 0);
+    const estimatedHeight =
+        DIFF_FILE_HEADER_HEIGHT_PX +
+        DIFF_HUNK_VERTICAL_PADDING_PX +
+        hunksHeight;
+
+    return Math.min(estimatedHeight, MAX_ESTIMATED_DIFF_FILE_HEIGHT_PX);
+}
 
 export function GitDiffsView({
     activeFileId = null,
@@ -39,6 +96,12 @@ export function GitDiffsView({
     surfaceVariant = "panel",
 }: GitDiffsViewProps) {
     const ownsScrollContainer = scrollContainerRef === undefined;
+    const ownScrollContainerRef = useRef<HTMLElement | null>(null);
+    const setOwnScrollContainer = useCallback((node: HTMLDivElement | null) => {
+        ownScrollContainerRef.current = node;
+    }, []);
+    const resolvedScrollContainerRef =
+        scrollContainerRef ?? ownScrollContainerRef;
     const isControlled = controlledCollapsedFileIds !== undefined;
     const [localCollapsedFileIds, setLocalCollapsedFileIds] = useState<
         readonly string[]
@@ -101,6 +164,7 @@ export function GitDiffsView({
                 .filter(Boolean)
                 .join(" ")}
             onScroll={ownsScrollContainer ? onScroll : undefined}
+            ref={ownsScrollContainer ? setOwnScrollContainer : undefined}
         >
             {showFileSelector ? (
                 <div className="mb-3 flex flex-wrap items-center gap-2">
@@ -116,22 +180,18 @@ export function GitDiffsView({
             ) : null}
 
             {displayMode === "stack" ? (
-                <div className="space-y-3">
-                    {files.map((file) => (
-                        <DiffFileSurface
-                            codeFontFamily={codeFontFamily}
-                            codeFontSize={codeFontSize}
-                            codeLineHeight={codeLineHeight}
-                            collapsed={collapsedFileIdSet.has(file.id)}
-                            file={file}
-                            fileId={file.id}
-                            key={file.id}
-                            lineWrapping={lineWrapping}
-                            onToggleCollapse={toggleFileCollapse}
-                            surfaceVariant={surfaceVariant}
-                        />
-                    ))}
-                </div>
+                <VirtualizedGitDiffStack
+                    activeFileId={activeFileId}
+                    codeFontFamily={codeFontFamily}
+                    codeFontSize={codeFontSize}
+                    codeLineHeight={codeLineHeight}
+                    collapsedFileIdSet={collapsedFileIdSet}
+                    files={files}
+                    lineWrapping={lineWrapping}
+                    onToggleFileCollapse={toggleFileCollapse}
+                    scrollContainerRef={resolvedScrollContainerRef}
+                    surfaceVariant={surfaceVariant}
+                />
             ) : (
                 <DiffFileSurface
                     codeFontFamily={codeFontFamily}
@@ -180,6 +240,182 @@ const FileSelectorButton = memo(function FileSelectorButton({
         </button>
     );
 });
+
+function calculateScrollMarginTop(
+    element: HTMLElement | null,
+    scrollContainer: HTMLElement | null,
+): number {
+    if (!element || !scrollContainer || element === scrollContainer) {
+        return 0;
+    }
+
+    const elementRect = element.getBoundingClientRect();
+    const containerRect = scrollContainer.getBoundingClientRect();
+    return Math.max(
+        0,
+        elementRect.top - containerRect.top + scrollContainer.scrollTop,
+    );
+}
+
+function VirtualizedGitDiffStack({
+    activeFileId,
+    codeFontFamily,
+    codeFontSize,
+    codeLineHeight,
+    collapsedFileIdSet,
+    files,
+    lineWrapping,
+    onToggleFileCollapse,
+    scrollContainerRef,
+    surfaceVariant,
+}: {
+    readonly activeFileId: string | null | undefined;
+    readonly codeFontFamily: string | null;
+    readonly codeFontSize: number | null;
+    readonly codeLineHeight: number | null;
+    readonly collapsedFileIdSet: ReadonlySet<string>;
+    readonly files: readonly GitDiffFile[];
+    readonly lineWrapping: boolean;
+    readonly onToggleFileCollapse: (fileId: string) => void;
+    readonly scrollContainerRef: RefObject<HTMLElement | null>;
+    readonly surfaceVariant: "flat" | "panel";
+}) {
+    const stackRef = useRef<HTMLDivElement | null>(null);
+    const virtualListHandleRef = useRef<MeasuredVirtualListHandle | null>(null);
+    const [scrollMarginTop, setScrollMarginTop] = useState(0);
+    const shouldVirtualize = files.length >= GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD;
+    const activeFileIndex = useMemo(
+        () =>
+            activeFileId
+                ? files.findIndex((file) => file.id === activeFileId)
+                : -1,
+        [activeFileId, files],
+    );
+
+    useEffect(() => {
+        if (!shouldVirtualize || typeof window === "undefined") {
+            return;
+        }
+
+        const syncScrollMarginTop = () => {
+            setScrollMarginTop(
+                calculateScrollMarginTop(
+                    stackRef.current,
+                    scrollContainerRef.current,
+                ),
+            );
+        };
+
+        syncScrollMarginTop();
+
+        const scrollContainer = scrollContainerRef.current;
+        let observer: ResizeObserver | null = null;
+
+        if (typeof ResizeObserver !== "undefined") {
+            observer = new ResizeObserver(syncScrollMarginTop);
+            if (stackRef.current) {
+                observer.observe(stackRef.current);
+            }
+            if (scrollContainer) {
+                observer.observe(scrollContainer);
+            }
+        }
+
+        window.addEventListener("resize", syncScrollMarginTop);
+
+        return () => {
+            observer?.disconnect();
+            window.removeEventListener("resize", syncScrollMarginTop);
+        };
+    }, [scrollContainerRef, shouldVirtualize]);
+
+    useEffect(() => {
+        if (!shouldVirtualize || activeFileIndex < 0) {
+            return;
+        }
+
+        virtualListHandleRef.current?.scrollToIndex(activeFileIndex, {
+            align: "start",
+            offset: -8,
+        });
+    }, [activeFileIndex, shouldVirtualize]);
+
+    const renderDiffFile = useCallback(
+        (file: GitDiffFile) => (
+            <DiffFileSurface
+                codeFontFamily={codeFontFamily}
+                codeFontSize={codeFontSize}
+                codeLineHeight={codeLineHeight}
+                collapsed={collapsedFileIdSet.has(file.id)}
+                file={file}
+                fileId={file.id}
+                lineWrapping={lineWrapping}
+                onToggleCollapse={onToggleFileCollapse}
+                surfaceVariant={surfaceVariant}
+            />
+        ),
+        [
+            codeFontFamily,
+            codeFontSize,
+            codeLineHeight,
+            collapsedFileIdSet,
+            lineWrapping,
+            onToggleFileCollapse,
+            surfaceVariant,
+        ],
+    );
+
+    const estimateFileSize = useCallback(
+        (file: GitDiffFile, index: number) =>
+            estimateDiffFileSurfaceHeight(
+                file,
+                collapsedFileIdSet.has(file.id),
+                codeLineHeight,
+            ) + (index === files.length - 1 ? 0 : DIFF_FILE_STACK_GAP_PX),
+        [codeLineHeight, collapsedFileIdSet, files.length],
+    );
+
+    const handleVirtualListReady = useCallback(
+        (handle: MeasuredVirtualListHandle | null) => {
+            virtualListHandleRef.current = handle;
+        },
+        [],
+    );
+
+    if (!shouldVirtualize) {
+        return (
+            <div className="space-y-3" ref={stackRef}>
+                {files.map((file) => (
+                    <div key={file.id}>{renderDiffFile(file)}</div>
+                ))}
+            </div>
+        );
+    }
+
+    return (
+        <div ref={stackRef}>
+            <MeasuredVirtualList
+                enabled
+                estimateSize={estimateFileSize}
+                getItemKey={(file) => file.id}
+                items={files}
+                onReady={handleVirtualListReady}
+                overscan={DIFF_FILE_STACK_OVERSCAN}
+                renderItem={({ index, item }) => (
+                    <div
+                        className={
+                            index === files.length - 1 ? undefined : "pb-3"
+                        }
+                    >
+                        {renderDiffFile(item)}
+                    </div>
+                )}
+                scrollContainerRef={scrollContainerRef}
+                scrollMarginTop={scrollMarginTop}
+            />
+        </div>
+    );
+}
 
 const DiffFileSurface = memo(function DiffFileSurface({
     codeFontFamily = null,

--- a/src/renderer/src/components/git/types.ts
+++ b/src/renderer/src/components/git/types.ts
@@ -1,6 +1,8 @@
 import type {
     KeyboardEvent as ReactKeyboardEvent,
     MouseEvent as ReactMouseEvent,
+    RefObject,
+    UIEventHandler,
     ReactNode,
 } from "react";
 
@@ -223,9 +225,10 @@ export interface GitDiffsViewProps {
     readonly emptyState?: ReactNode;
     readonly files: readonly GitDiffFile[];
     readonly lineWrapping?: boolean;
-    readonly onScroll?: (event: React.UIEvent<HTMLDivElement>) => void;
+    readonly onScroll?: UIEventHandler<HTMLDivElement>;
     readonly onSelectFile?: (file: GitDiffFile) => void;
     readonly onToggleFileCollapse?: (fileId: string) => void;
+    readonly scrollContainerRef?: RefObject<HTMLElement | null>;
     readonly showFileSelector?: boolean;
     readonly surfaceVariant?: "flat" | "panel";
 }

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx
@@ -1,0 +1,162 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+    calculateMeasuredVirtualRange,
+    calculateMeasuredVirtualScrollTop,
+    MeasuredVirtualList,
+} from "./MeasuredVirtualList";
+
+const ITEM_HEIGHT = 20;
+const VIEWPORT_HEIGHT = 100;
+
+function createItems(count: number): string[] {
+    return Array.from({ length: count }, (_, index) => `Item ${index}`);
+}
+
+function createOffsets(count: number): number[] {
+    return Array.from({ length: count }, (_, index) => index * ITEM_HEIGHT);
+}
+
+function createSizes(count: number): number[] {
+    return Array.from({ length: count }, () => ITEM_HEIGHT);
+}
+
+describe("MeasuredVirtualList", () => {
+    it("keeps the existing visible range behavior without a scroll margin", () => {
+        expect(
+            calculateMeasuredVirtualRange({
+                itemCount: 100,
+                offsets: createOffsets(100),
+                overscan: 0,
+                scrollMarginTop: 0,
+                scrollTop: 0,
+                sizes: createSizes(100),
+                viewportHeight: VIEWPORT_HEIGHT,
+                virtualizationEnabled: true,
+            }),
+        ).toEqual({
+            endIndex: 4,
+            startIndex: 0,
+            visibleEndIndex: 4,
+            visibleStartIndex: 0,
+        });
+
+        expect(
+            calculateMeasuredVirtualRange({
+                itemCount: 100,
+                offsets: createOffsets(100),
+                overscan: 0,
+                scrollMarginTop: 0,
+                scrollTop: 60,
+                sizes: createSizes(100),
+                viewportHeight: VIEWPORT_HEIGHT,
+                virtualizationEnabled: true,
+            }),
+        ).toEqual({
+            endIndex: 7,
+            startIndex: 3,
+            visibleEndIndex: 7,
+            visibleStartIndex: 3,
+        });
+    });
+
+    it("subtracts scrollMarginTop when calculating the visible range", () => {
+        expect(
+            calculateMeasuredVirtualRange({
+                itemCount: 100,
+                offsets: createOffsets(100),
+                overscan: 0,
+                scrollMarginTop: 40,
+                scrollTop: 60,
+                sizes: createSizes(100),
+                viewportHeight: VIEWPORT_HEIGHT,
+                virtualizationEnabled: true,
+            }),
+        ).toEqual({
+            endIndex: 5,
+            startIndex: 1,
+            visibleEndIndex: 5,
+            visibleStartIndex: 1,
+        });
+    });
+
+    it("positions scrollToIndex targets below the scroll margin", () => {
+        expect(
+            calculateMeasuredVirtualScrollTop({
+                align: "start",
+                itemSize: ITEM_HEIGHT,
+                itemStart: 10 * ITEM_HEIGHT,
+                offset: 0,
+                scrollMarginTop: 40,
+                totalSize: 100 * ITEM_HEIGHT,
+                viewportHeight: VIEWPORT_HEIGHT,
+            }),
+        ).toBe(240);
+    });
+
+    it("clamps centered and end-aligned scroll targets to the virtual size", () => {
+        expect(
+            calculateMeasuredVirtualScrollTop({
+                align: "center",
+                itemSize: ITEM_HEIGHT,
+                itemStart: 0,
+                offset: 0,
+                scrollMarginTop: 40,
+                totalSize: 100 * ITEM_HEIGHT,
+                viewportHeight: VIEWPORT_HEIGHT,
+            }),
+        ).toBe(0);
+
+        expect(
+            calculateMeasuredVirtualScrollTop({
+                align: "end",
+                itemSize: ITEM_HEIGHT,
+                itemStart: 99 * ITEM_HEIGHT,
+                offset: 0,
+                scrollMarginTop: 40,
+                totalSize: 100 * ITEM_HEIGHT,
+                viewportHeight: VIEWPORT_HEIGHT,
+            }),
+        ).toBe(1940);
+    });
+
+    it("reports the full range when virtualization is disabled", () => {
+        expect(
+            calculateMeasuredVirtualRange({
+                itemCount: 10,
+                offsets: createOffsets(10),
+                overscan: 0,
+                scrollMarginTop: 40,
+                scrollTop: 60,
+                sizes: createSizes(10),
+                viewportHeight: VIEWPORT_HEIGHT,
+                virtualizationEnabled: false,
+            }),
+        ).toEqual({
+            endIndex: 9,
+            startIndex: 0,
+            visibleEndIndex: 9,
+            visibleStartIndex: 0,
+        });
+    });
+
+    it("renders every item during server rendering", () => {
+        const markup = renderToStaticMarkup(
+            <MeasuredVirtualList
+                defaultViewportHeight={VIEWPORT_HEIGHT}
+                estimateSize={() => ITEM_HEIGHT}
+                getItemKey={(item) => item}
+                items={createItems(5)}
+                renderItem={({ index, item }) => (
+                    <div data-row-index={index}>{item}</div>
+                )}
+                scrollContainerRef={{ current: null }}
+            />,
+        );
+
+        expect(markup).toContain("Item 0");
+        expect(markup).toContain("Item 4");
+        expect(markup.match(/data-row-index=/g)).toHaveLength(5);
+    });
+});

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -11,6 +11,13 @@ import {
 const DEFAULT_OVERSCAN = 4;
 const DEFAULT_VIEWPORT_HEIGHT = 720;
 
+export interface MeasuredVirtualRange {
+    readonly startIndex: number;
+    readonly endIndex: number;
+    readonly visibleStartIndex: number;
+    readonly visibleEndIndex: number;
+}
+
 export interface MeasuredVirtualListHandle {
     readonly scrollToIndex: (
         index: number,
@@ -26,9 +33,11 @@ export interface MeasuredVirtualListProps<T> {
     readonly enabled?: boolean;
     readonly overscan?: number;
     readonly defaultViewportHeight?: number;
+    readonly scrollMarginTop?: number;
     readonly scrollContainerRef: RefObject<HTMLElement | null>;
     readonly estimateSize: (item: T, index: number) => number;
     readonly getItemKey: (item: T, index: number) => string;
+    readonly onRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onReady?: (handle: MeasuredVirtualListHandle | null) => void;
     readonly renderItem: (params: {
         readonly index: number;
@@ -47,12 +56,47 @@ interface MeasuredVirtualItem<T> {
 }
 
 interface LayoutSnapshot<T> {
+    readonly range: MeasuredVirtualRange;
     readonly totalSize: number;
     readonly virtualItems: readonly MeasuredVirtualItem<T>[];
 }
 
+interface CalculateMeasuredVirtualRangeOptions {
+    readonly itemCount: number;
+    readonly offsets: readonly number[];
+    readonly overscan: number;
+    readonly scrollMarginTop: number;
+    readonly scrollTop: number;
+    readonly sizes: readonly number[];
+    readonly viewportHeight: number;
+    readonly virtualizationEnabled: boolean;
+}
+
+interface CalculateMeasuredVirtualScrollTopOptions {
+    readonly align: "center" | "end" | "start";
+    readonly itemSize: number;
+    readonly itemStart: number;
+    readonly offset: number;
+    readonly scrollMarginTop: number;
+    readonly totalSize: number;
+    readonly viewportHeight: number;
+}
+
 function clamp(value: number, min: number, max: number): number {
     return Math.min(Math.max(value, min), max);
+}
+
+function areRangesEqual(
+    left: MeasuredVirtualRange | null,
+    right: MeasuredVirtualRange,
+): boolean {
+    return (
+        left !== null &&
+        left.startIndex === right.startIndex &&
+        left.endIndex === right.endIndex &&
+        left.visibleStartIndex === right.visibleStartIndex &&
+        left.visibleEndIndex === right.visibleEndIndex
+    );
 }
 
 function findFirstVisibleIndex(
@@ -100,18 +144,113 @@ function findLastVisibleIndex(
     return result;
 }
 
+export function calculateMeasuredVirtualRange({
+    itemCount,
+    offsets,
+    overscan,
+    scrollMarginTop,
+    scrollTop,
+    sizes,
+    viewportHeight,
+    virtualizationEnabled,
+}: CalculateMeasuredVirtualRangeOptions): MeasuredVirtualRange {
+    if (itemCount === 0) {
+        return {
+            endIndex: -1,
+            startIndex: 0,
+            visibleEndIndex: -1,
+            visibleStartIndex: 0,
+        };
+    }
+
+    if (!virtualizationEnabled) {
+        const endIndex = itemCount - 1;
+
+        return {
+            endIndex,
+            startIndex: 0,
+            visibleEndIndex: endIndex,
+            visibleStartIndex: 0,
+        };
+    }
+
+    const effectiveScrollTop = Math.max(0, scrollTop - scrollMarginTop);
+    const scrollBottom = effectiveScrollTop + Math.max(1, viewportHeight);
+    const firstVisibleIndex = findFirstVisibleIndex(
+        offsets,
+        sizes,
+        effectiveScrollTop,
+    );
+    const lastVisibleIndex = findLastVisibleIndex(offsets, scrollBottom);
+    const visibleStartIndex =
+        firstVisibleIndex >= itemCount ? itemCount - 1 : firstVisibleIndex;
+    const visibleEndIndex = clamp(
+        lastVisibleIndex,
+        visibleStartIndex,
+        itemCount - 1,
+    );
+    const startIndex = Math.max(0, visibleStartIndex - overscan);
+    const endIndex = Math.min(itemCount - 1, visibleEndIndex + overscan);
+
+    return {
+        endIndex,
+        startIndex,
+        visibleEndIndex,
+        visibleStartIndex,
+    };
+}
+
+export function calculateMeasuredVirtualScrollTop({
+    align,
+    itemSize,
+    itemStart,
+    offset,
+    scrollMarginTop,
+    totalSize,
+    viewportHeight,
+}: CalculateMeasuredVirtualScrollTopOptions): number {
+    const normalizedViewportHeight = Math.max(1, viewportHeight);
+    const maxScrollTop = Math.max(
+        0,
+        totalSize + scrollMarginTop - normalizedViewportHeight,
+    );
+
+    let nextScrollTop = itemStart + scrollMarginTop + offset;
+
+    if (align === "center") {
+        nextScrollTop =
+            itemStart -
+            normalizedViewportHeight / 2 +
+            itemSize / 2 +
+            scrollMarginTop +
+            offset;
+    } else if (align === "end") {
+        nextScrollTop =
+            itemStart -
+            normalizedViewportHeight +
+            itemSize +
+            scrollMarginTop +
+            offset;
+    }
+
+    return clamp(nextScrollTop, 0, maxScrollTop);
+}
+
 export function MeasuredVirtualList<T>({
     items,
     enabled = true,
     overscan = DEFAULT_OVERSCAN,
     defaultViewportHeight = DEFAULT_VIEWPORT_HEIGHT,
+    scrollMarginTop = 0,
     scrollContainerRef,
     estimateSize,
     getItemKey,
+    onRangeChange,
     onReady,
     renderItem,
 }: MeasuredVirtualListProps<T>) {
     const isBrowser = typeof window !== "undefined";
+    const normalizedScrollMarginTop = Math.max(0, scrollMarginTop);
     const [measuredSizes, setMeasuredSizes] = useState<Map<string, number>>(
         () => new Map(),
     );
@@ -124,6 +263,7 @@ export function MeasuredVirtualList<T>({
     const elementByKeyRef = useRef(new Map<string, HTMLDivElement>());
     const keyByElementRef = useRef(new WeakMap<Element, string>());
     const resizeObserverRef = useRef<ResizeObserver | null>(null);
+    const previousRangeRef = useRef<MeasuredVirtualRange | null>(null);
     const itemKeys = useMemo(
         () => items.map((item, index) => getItemKey(item, index)),
         [getItemKey, items],
@@ -249,8 +389,28 @@ export function MeasuredVirtualList<T>({
             totalSize += sizes[index];
         }
 
-        if (!virtualizationEnabled || items.length === 0) {
+        const range = calculateMeasuredVirtualRange({
+            itemCount: items.length,
+            offsets,
+            overscan,
+            scrollMarginTop: normalizedScrollMarginTop,
+            scrollTop: scrollState.scrollTop,
+            sizes,
+            viewportHeight: scrollState.viewportHeight,
+            virtualizationEnabled,
+        });
+
+        if (items.length === 0) {
             return {
+                range,
+                totalSize,
+                virtualItems: [],
+            };
+        }
+
+        if (!virtualizationEnabled) {
+            return {
+                range,
                 totalSize,
                 virtualItems: items.map((item, index) => ({
                     index,
@@ -263,32 +423,18 @@ export function MeasuredVirtualList<T>({
             };
         }
 
-        const scrollBottom =
-            scrollState.scrollTop + Math.max(1, scrollState.viewportHeight);
-        const firstVisibleIndex = findFirstVisibleIndex(
-            offsets,
-            sizes,
-            scrollState.scrollTop,
-        );
-        const lastVisibleIndex = findLastVisibleIndex(offsets, scrollBottom);
-        const visibleStartIndex =
-            firstVisibleIndex >= items.length
-                ? items.length - 1
-                : firstVisibleIndex;
-        const visibleEndIndex = clamp(
-            lastVisibleIndex,
-            visibleStartIndex,
-            items.length - 1,
-        );
-        const startIndex = Math.max(0, visibleStartIndex - overscan);
-        const endIndex = Math.min(items.length - 1, visibleEndIndex + overscan);
         const virtualItems: MeasuredVirtualItem<T>[] = [];
 
-        for (let index = startIndex; index <= endIndex; index += 1) {
+        for (
+            let index = range.startIndex;
+            index <= range.endIndex;
+            index += 1
+        ) {
             virtualItems.push({
                 index,
                 isVisible:
-                    index >= visibleStartIndex && index <= visibleEndIndex,
+                    index >= range.visibleStartIndex &&
+                    index <= range.visibleEndIndex,
                 item: items[index],
                 key: itemKeys[index],
                 size: sizes[index],
@@ -297,6 +443,7 @@ export function MeasuredVirtualList<T>({
         }
 
         return {
+            range,
             totalSize,
             virtualItems,
         };
@@ -305,11 +452,24 @@ export function MeasuredVirtualList<T>({
         itemKeys,
         items,
         measuredSizes,
+        normalizedScrollMarginTop,
         overscan,
         scrollState.scrollTop,
         scrollState.viewportHeight,
         virtualizationEnabled,
     ]);
+
+    useEffect(() => {
+        if (
+            !onRangeChange ||
+            areRangesEqual(previousRangeRef.current, layout.range)
+        ) {
+            return;
+        }
+
+        previousRangeRef.current = layout.range;
+        onRangeChange(layout.range);
+    }, [layout.range, onRangeChange]);
 
     const setMeasuredElement = useCallback(
         (key: string, node: HTMLDivElement | null) => {
@@ -370,25 +530,15 @@ export function MeasuredVirtualList<T>({
                 targetItem?.size ??
                 measuredSizes.get(itemKeys[index]) ??
                 estimateSize(items[index], index);
-            const maxScrollTop = Math.max(
-                0,
-                layout.totalSize - container.clientHeight,
-            );
-
-            let nextScrollTop = itemStart + offset;
-
-            if (align === "center") {
-                nextScrollTop =
-                    itemStart -
-                    container.clientHeight / 2 +
-                    itemSize / 2 +
-                    offset;
-            } else if (align === "end") {
-                nextScrollTop =
-                    itemStart - container.clientHeight + itemSize + offset;
-            }
-
-            container.scrollTop = clamp(nextScrollTop, 0, maxScrollTop);
+            container.scrollTop = calculateMeasuredVirtualScrollTop({
+                align,
+                itemSize,
+                itemStart,
+                offset,
+                scrollMarginTop: normalizedScrollMarginTop,
+                totalSize: layout.totalSize,
+                viewportHeight: container.clientHeight,
+            });
         },
         [
             estimateSize,
@@ -396,6 +546,7 @@ export function MeasuredVirtualList<T>({
             items,
             layout,
             measuredSizes,
+            normalizedScrollMarginTop,
             scrollContainerRef,
         ],
     );

--- a/src/renderer/src/components/workspace/GitCommitTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitCommitTabView.test.tsx
@@ -6,6 +6,11 @@ import type { GitCommitDetail } from "@shared/ipc";
 import type { RuntimeWorkspaceGitCommitTab } from "@renderer/app/workspace/tree";
 
 import {
+    GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD,
+    GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD,
+} from "@renderer/components/git/GitDiffsView";
+
+import {
     getGitCommitDiffCollapseStorageKey,
     persistGitCommitDiffCollapseState,
 } from "./gitCommitDiffCollapsePersistence";
@@ -92,7 +97,9 @@ const TAB: RuntimeWorkspaceGitCommitTab = {
 
 const CONTEXT_KEY = `${TAB.projectId}::primary`;
 
-function createCommitDetail(): GitCommitDetail {
+function createCommitDetail(
+    overrides: Partial<GitCommitDetail> = {},
+): GitCommitDetail {
     return {
         authorEmail: "jose@example.com",
         authorName: "Jose",
@@ -167,6 +174,72 @@ function createCommitDetail(): GitCommitDetail {
         sha: TAB.commitSha,
         shortSha: "d094662",
         subject: "Open Claude Code from agents sidebar",
+        ...overrides,
+    };
+}
+
+function createCommitDiffFile(
+    index: number,
+): GitCommitDetail["files"][number] {
+    return {
+        additions: 1,
+        deletions: 0,
+        hunks: [
+            {
+                id: `large-hunk-${index}`,
+                lines: [
+                    {
+                        id: `large-line-${index}`,
+                        text: `large-commit-file-${index}-line`,
+                        type: "add",
+                    },
+                ],
+                newCount: 1,
+                newStart: 1,
+                oldCount: 0,
+                oldStart: 1,
+            },
+        ],
+        isText: true,
+        kind: "update",
+        newText: null,
+        oldText: null,
+        path: `src/commit-file-${index}.ts`,
+        previousPath: null,
+        reversible: true,
+        statusLabel: "modified",
+    };
+}
+
+function createLargeCommitDiffFile(): GitCommitDetail["files"][number] {
+    return {
+        additions: GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD,
+        deletions: 0,
+        hunks: [
+            {
+                id: "giant-commit-hunk",
+                lines: Array.from(
+                    { length: GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD },
+                    (_, index) => ({
+                        id: `giant-commit-line-${index + 1}`,
+                        text: `giant-commit-diff-line-${index + 1}`,
+                        type: "add",
+                    }),
+                ),
+                newCount: GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD,
+                newStart: 1,
+                oldCount: 0,
+                oldStart: 1,
+            },
+        ],
+        isText: true,
+        kind: "update",
+        newText: null,
+        oldText: null,
+        path: "src/giant-commit-diff.ts",
+        previousPath: null,
+        reversible: true,
+        statusLabel: "modified",
     };
 }
 
@@ -243,5 +316,47 @@ describe("GitCommitTabView", () => {
         expect(markup).not.toContain("expanded-line-a");
         expect(markup).not.toContain("expanded-line-b");
         expect(markup).toContain("expand all");
+    });
+
+    it("renders the large commit diff baseline and preserves collapse state", () => {
+        const collapsedFile = createLargeCommitDiffFile();
+        mockGitStoreState.current.commitDetailsByContext = {
+            [CONTEXT_KEY]: {
+                [TAB.commitSha]: createCommitDetail({
+                    changedFileCount:
+                        GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD + 1,
+                    files: [
+                        ...Array.from(
+                            {
+                                length: GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD,
+                            },
+                            (_, index) => createCommitDiffFile(index + 1),
+                        ),
+                        collapsedFile,
+                    ],
+                    insertions:
+                        GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD +
+                        GIT_DIFF_LINE_VIRTUALIZATION_THRESHOLD,
+                }),
+            },
+        };
+
+        const storageKey = getGitCommitDiffCollapseStorageKey({
+            commitSha: TAB.commitSha,
+            projectId: TAB.projectId,
+            surface: TAB.kind,
+            worktreeId: TAB.worktreeId,
+        });
+        persistGitCommitDiffCollapseState(storageKey, [collapsedFile.path]);
+
+        const markup = renderCommitMarkup();
+
+        expect(markup).toContain("commit-file-1.ts");
+        expect(markup).toContain(
+            `commit-file-${GIT_DIFF_FILE_VIRTUALIZATION_THRESHOLD}.ts`,
+        );
+        expect(markup).toContain("giant-commit-diff.ts");
+        expect(markup).not.toContain("giant-commit-diff-line-1");
+        expect(markup).toContain("collapse all");
     });
 });

--- a/src/renderer/src/components/workspace/GitCommitTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitCommitTabView.test.tsx
@@ -281,6 +281,16 @@ describe("GitCommitTabView", () => {
         expect(markup).toContain("collapse all");
     });
 
+    it("keeps the persisted commit scroll container as the diff scroll owner", () => {
+        const markup = renderCommitMarkup();
+
+        expect(markup).toContain(
+            'class="shell-scrollbar flex min-h-0 flex-1 overflow-y-auto px-3 py-3"',
+        );
+        expect(markup).toContain('class="min-h-0 flex-1 px-2 py-2"');
+        expect(markup).not.toContain("!overflow-visible");
+    });
+
     it("restores persisted collapsed files when the commit tab remounts", () => {
         const storageKey = getGitCommitDiffCollapseStorageKey({
             commitSha: TAB.commitSha,

--- a/src/renderer/src/components/workspace/GitCommitTabView.tsx
+++ b/src/renderer/src/components/workspace/GitCommitTabView.tsx
@@ -50,6 +50,7 @@ export function GitCommitTabView({
             surface: tab.kind,
             worktreeId,
         });
+    const commitScrollContainerRef = useRef<HTMLDivElement | null>(null);
 
     const detail = useGitStore((state) =>
         contextKey && projectId
@@ -198,6 +199,13 @@ export function GitCommitTabView({
             }
         },
         [detail?.body, handleDiffScroll, persistCommitScroll],
+    );
+    const setCommitScrollContainer = useCallback(
+        (node: HTMLDivElement | null) => {
+            commitScrollContainerRef.current = node;
+            commitScrollRef(node);
+        },
+        [commitScrollRef],
     );
 
     useEffect(() => {
@@ -406,10 +414,9 @@ export function GitCommitTabView({
             <section
                 className="shell-scrollbar flex min-h-0 flex-1 overflow-y-auto px-3 py-3"
                 onScroll={handleCommitScroll}
-                ref={commitScrollRef}
+                ref={setCommitScrollContainer}
             >
                 <GitDiffsView
-                    className="!overflow-visible"
                     codeFontFamily={codeFontFamily}
                     codeFontSize={codeFontSize}
                     codeLineHeight={codeLineHeight}
@@ -418,6 +425,7 @@ export function GitCommitTabView({
                     files={diffFiles}
                     lineWrapping={false}
                     onToggleFileCollapse={handleToggleFileCollapse}
+                    scrollContainerRef={commitScrollContainerRef}
                     showFileSelector={false}
                     surfaceVariant="flat"
                 />

--- a/src/renderer/src/components/workspace/GitHubIssuesTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitHubIssuesTabView.test.tsx
@@ -1,4 +1,5 @@
 import { createElement } from "react";
+import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -37,6 +38,8 @@ const mockWorkspaceStoreState = vi.hoisted(() => ({
     },
 }));
 
+const measuredVirtualListMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@renderer/app/store/github-store", () => ({
     EMPTY_GITHUB_LIST: Object.freeze([]),
     getGitHubRepoKey: (ref: GitHubRepositoryRef) =>
@@ -52,8 +55,48 @@ vi.mock("@renderer/app/store/workspace-store", () => ({
     ) => selector(mockWorkspaceStoreState.current),
 }));
 
+vi.mock("../virtual/MeasuredVirtualList", async () => {
+    const { createElement } =
+        await vi.importActual<typeof import("react")>("react");
+
+    return {
+        MeasuredVirtualList: <T,>({
+            getItemKey,
+            items,
+            renderItem,
+        }: {
+            readonly getItemKey: (item: T, index: number) => string;
+            readonly items: readonly T[];
+            readonly renderItem: (params: {
+                readonly index: number;
+                readonly isVisible: boolean;
+                readonly item: T;
+            }) => ReactNode;
+        }) => {
+            measuredVirtualListMock({ itemCount: items.length });
+
+            return createElement(
+                "div",
+                { "data-testid": "mock-measured-virtual-list" },
+                items.slice(0, 5).map((item, index) =>
+                    createElement(
+                        "div",
+                        { key: getItemKey(item, index) },
+                        renderItem({
+                            index,
+                            isVisible: true,
+                            item,
+                        }),
+                    ),
+                ),
+            );
+        },
+    };
+});
+
 import {
     GITHUB_ISSUES_ROW_VIRTUALIZATION_THRESHOLD,
+    GITHUB_ISSUES_VIRTUALIZATION_THRESHOLD,
     GitHubIssuesTabView,
 } from "./GitHubIssuesTabView";
 
@@ -180,6 +223,7 @@ function resetStoreState() {
     mockGitHubStoreState.current.refreshAuthStatus.mockClear();
     mockGitHubStoreState.current.refreshIssues.mockClear();
     mockWorkspaceStoreState.current.openGitHubIssueTab.mockClear();
+    measuredVirtualListMock.mockClear();
 }
 
 describe("GitHubIssuesTabView", () => {
@@ -192,7 +236,7 @@ describe("GitHubIssuesTabView", () => {
         resetStoreState();
     });
 
-    it("renders the large issues table baseline with table affordances intact", () => {
+    it("virtualizes the large issues table with table affordances intact", () => {
         const markup = renderToStaticMarkup(
             createElement(GitHubIssuesTabView, { tab: TAB }),
         );
@@ -201,12 +245,39 @@ describe("GitHubIssuesTabView", () => {
             `${GITHUB_ISSUES_ROW_VIRTUALIZATION_THRESHOLD} items`,
         );
         expect(markup).toContain("Baseline issue 1");
-        expect(markup).toContain(
+        expect(markup).not.toContain(
             `Baseline issue ${GITHUB_ISSUES_ROW_VIRTUALIZATION_THRESHOLD}`,
         );
+        expect(measuredVirtualListMock).toHaveBeenCalledWith({
+            itemCount: GITHUB_ISSUES_ROW_VIRTUALIZATION_THRESHOLD,
+        });
         expect(markup).toContain('aria-label="Resize # column"');
         expect(markup).toContain('aria-label="Resize Description column"');
         expect(markup).toContain("Drag to reorder. Drag the edge to resize.");
         expect(markup).toContain("Open in GitHub");
+    });
+
+    it("renders every issue below the virtualization threshold", () => {
+        mockGitHubStoreState.current.issuesByRepoAndState = {
+            [REPO_KEY]: {
+                open: Array.from(
+                    { length: GITHUB_ISSUES_VIRTUALIZATION_THRESHOLD - 1 },
+                    (_, index) => createIssueSummary(index + 1),
+                ),
+            },
+        };
+
+        const markup = renderToStaticMarkup(
+            createElement(GitHubIssuesTabView, { tab: TAB }),
+        );
+
+        expect(markup).toContain(
+            `${GITHUB_ISSUES_VIRTUALIZATION_THRESHOLD - 1} items`,
+        );
+        expect(markup).toContain("Baseline issue 1");
+        expect(markup).toContain(
+            `Baseline issue ${GITHUB_ISSUES_VIRTUALIZATION_THRESHOLD - 1}`,
+        );
+        expect(measuredVirtualListMock).not.toHaveBeenCalled();
     });
 });

--- a/src/renderer/src/components/workspace/GitHubIssuesTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitHubIssuesTabView.test.tsx
@@ -1,0 +1,212 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+    GitHubAuthStatus,
+    GitHubIssueSummary,
+    GitHubRepositoryRef,
+} from "@shared/ipc";
+import type { RuntimeWorkspaceGitHubIssuesTab } from "@renderer/app/workspace/tree";
+
+const REPO: GitHubRepositoryRef = {
+    host: "github.com",
+    owner: "octocat",
+    repo: "hello-world",
+};
+const REPO_KEY = "github.com/octocat/hello-world";
+
+const mockGitHubStoreState = vi.hoisted(() => ({
+    current: {
+        authStatusByHost: {},
+        createIssue: vi.fn(),
+        errors: {},
+        issueListStateByRepo: {},
+        issuesByRepo: {},
+        issuesByRepoAndState: {},
+        loadingKeys: {},
+        mutatingKeys: {},
+        refreshAuthStatus: vi.fn(),
+        refreshIssues: vi.fn(),
+    },
+}));
+
+const mockWorkspaceStoreState = vi.hoisted(() => ({
+    current: {
+        openGitHubIssueTab: vi.fn(async () => {}),
+    },
+}));
+
+vi.mock("@renderer/app/store/github-store", () => ({
+    EMPTY_GITHUB_LIST: Object.freeze([]),
+    getGitHubRepoKey: (ref: GitHubRepositoryRef) =>
+        `${ref.host.toLowerCase()}/${ref.owner}/${ref.repo}`,
+    useGitHubStore: (
+        selector: (state: typeof mockGitHubStoreState.current) => unknown,
+    ) => selector(mockGitHubStoreState.current),
+}));
+
+vi.mock("@renderer/app/store/workspace-store", () => ({
+    useWorkspaceStore: (
+        selector: (state: typeof mockWorkspaceStoreState.current) => unknown,
+    ) => selector(mockWorkspaceStoreState.current),
+}));
+
+import {
+    GITHUB_ISSUES_ROW_VIRTUALIZATION_THRESHOLD,
+    GitHubIssuesTabView,
+} from "./GitHubIssuesTabView";
+
+class MemoryStorage implements Storage {
+    private readonly values = new Map<string, string>();
+
+    get length() {
+        return this.values.size;
+    }
+
+    clear() {
+        this.values.clear();
+    }
+
+    getItem(key: string) {
+        return this.values.get(key) ?? null;
+    }
+
+    key(index: number) {
+        return [...this.values.keys()][index] ?? null;
+    }
+
+    removeItem(key: string) {
+        this.values.delete(key);
+    }
+
+    setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+}
+
+const TAB: RuntimeWorkspaceGitHubIssuesTab = {
+    createdAt: "2026-05-28T00:00:00.000Z",
+    id: "github-issues-tab-1",
+    kind: "github_issues",
+    projectId: "project-1",
+    ref: REPO,
+    title: "Issues",
+    worktreeId: null,
+};
+
+function createAuthStatus(): GitHubAuthStatus {
+    return {
+        canReadActions: true,
+        canWriteActions: true,
+        canWriteIssues: true,
+        canWritePullRequests: true,
+        checkedAt: "2026-05-28T00:00:00.000Z",
+        errorCode: null,
+        host: REPO.host,
+        readOnly: false,
+        state: "authenticated",
+        tokenSource: "gh_cli",
+        user: {
+            avatarUrl: null,
+            id: 1,
+            login: "octocat",
+            url: "https://github.com/octocat",
+        },
+    };
+}
+
+function createIssueSummary(index: number): GitHubIssueSummary {
+    return {
+        assignees:
+            index % 10 === 0
+                ? [
+                      {
+                          avatarUrl: null,
+                          id: 1,
+                          login: "octocat",
+                          url: "https://github.com/octocat",
+                      },
+                  ]
+                : [],
+        author: null,
+        closedAt: null,
+        commentCount: index % 5,
+        createdAt: `2026-05-${String(1 + (index % 28)).padStart(2, "0")}T00:00:00.000Z`,
+        id: index,
+        isLocked: false,
+        labels:
+            index % 3 === 0
+                ? [
+                      {
+                          color: "d73a4a",
+                          description: "Baseline label",
+                          id: index,
+                          name: `area-${index}`,
+                      },
+                  ]
+                : [],
+        milestone: null,
+        nodeId: `ISSUE_${index}`,
+        number: index,
+        state: "open",
+        stateReason: null,
+        title: `Baseline issue ${index}`,
+        updatedAt: `2026-05-${String(1 + (index % 28)).padStart(2, "0")}T12:00:00.000Z`,
+        url: `https://github.com/octocat/hello-world/issues/${index}`,
+    };
+}
+
+function resetStoreState() {
+    mockGitHubStoreState.current.authStatusByHost = {
+        [REPO.host]: createAuthStatus(),
+    };
+    mockGitHubStoreState.current.createIssue.mockClear();
+    mockGitHubStoreState.current.errors = {};
+    mockGitHubStoreState.current.issueListStateByRepo = {
+        [REPO_KEY]: "open",
+    };
+    mockGitHubStoreState.current.issuesByRepo = {};
+    mockGitHubStoreState.current.issuesByRepoAndState = {
+        [REPO_KEY]: {
+            open: Array.from(
+                { length: GITHUB_ISSUES_ROW_VIRTUALIZATION_THRESHOLD },
+                (_, index) => createIssueSummary(index + 1),
+            ),
+        },
+    };
+    mockGitHubStoreState.current.loadingKeys = {};
+    mockGitHubStoreState.current.mutatingKeys = {};
+    mockGitHubStoreState.current.refreshAuthStatus.mockClear();
+    mockGitHubStoreState.current.refreshIssues.mockClear();
+    mockWorkspaceStoreState.current.openGitHubIssueTab.mockClear();
+}
+
+describe("GitHubIssuesTabView", () => {
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "localStorage", {
+            configurable: true,
+            value: new MemoryStorage(),
+            writable: true,
+        });
+        resetStoreState();
+    });
+
+    it("renders the large issues table baseline with table affordances intact", () => {
+        const markup = renderToStaticMarkup(
+            createElement(GitHubIssuesTabView, { tab: TAB }),
+        );
+
+        expect(markup).toContain(
+            `${GITHUB_ISSUES_ROW_VIRTUALIZATION_THRESHOLD} items`,
+        );
+        expect(markup).toContain("Baseline issue 1");
+        expect(markup).toContain(
+            `Baseline issue ${GITHUB_ISSUES_ROW_VIRTUALIZATION_THRESHOLD}`,
+        );
+        expect(markup).toContain('aria-label="Resize # column"');
+        expect(markup).toContain('aria-label="Resize Description column"');
+        expect(markup).toContain("Drag to reorder. Drag the edge to resize.");
+        expect(markup).toContain("Open in GitHub");
+    });
+});

--- a/src/renderer/src/components/workspace/GitHubIssuesTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubIssuesTabView.tsx
@@ -55,6 +55,8 @@ const ISSUE_TABLE_COLUMN_IDS = [
 ] as const;
 const ISSUE_TABLE_LAYOUT_STORAGE_KEY = "comando.github.issues.table.layout";
 const ISSUE_TABLE_LAYOUT_VERSION = 1;
+// Baseline threshold for enabling GitHub issues table virtualization.
+export const GITHUB_ISSUES_ROW_VIRTUALIZATION_THRESHOLD = 150;
 const DEFAULT_ISSUE_TABLE_COLUMN_ORDER: readonly IssueColumnId[] =
     ISSUE_TABLE_COLUMN_IDS;
 const DEFAULT_ISSUE_TABLE_COLUMN_WIDTHS: IssueColumnWidths = {

--- a/src/renderer/src/components/workspace/GitHubIssuesTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubIssuesTabView.tsx
@@ -35,6 +35,7 @@ import {
     hasGitHubWritePermission,
     openGitHubWebUrl,
 } from "./GitHubWorkspacePrimitives";
+import { GitHubVirtualizedTableBody } from "./GitHubVirtualizedTableBody";
 import { IdeActionButton } from "./ide-bar";
 
 type IssueFilter = GitHubIssueState | "all" | "assigned";
@@ -56,7 +57,9 @@ const ISSUE_TABLE_COLUMN_IDS = [
 const ISSUE_TABLE_LAYOUT_STORAGE_KEY = "comando.github.issues.table.layout";
 const ISSUE_TABLE_LAYOUT_VERSION = 1;
 // Baseline threshold for enabling GitHub issues table virtualization.
-export const GITHUB_ISSUES_ROW_VIRTUALIZATION_THRESHOLD = 150;
+export const GITHUB_ISSUES_VIRTUALIZATION_THRESHOLD = 100;
+export const GITHUB_ISSUES_ROW_VIRTUALIZATION_THRESHOLD =
+    GITHUB_ISSUES_VIRTUALIZATION_THRESHOLD;
 const DEFAULT_ISSUE_TABLE_COLUMN_ORDER: readonly IssueColumnId[] =
     ISSUE_TABLE_COLUMN_IDS;
 const DEFAULT_ISSUE_TABLE_COLUMN_WIDTHS: IssueColumnWidths = {
@@ -358,6 +361,26 @@ export function GitHubIssuesTabView({
             worktreeId: tab.worktreeId ?? null,
         });
     };
+    const handleOpenIssue = useCallback(
+        (issueNumber: number) =>
+            void openGitHubIssueTab({
+                issueNumber,
+                projectId: tab.projectId,
+                ref: tab.ref,
+                worktreeId: tab.worktreeId ?? null,
+            }),
+        [openGitHubIssueTab, tab.projectId, tab.ref, tab.worktreeId],
+    );
+    const renderIssueRow = useCallback(
+        (issue: GitHubIssueSummary) => (
+            <IssueTableRow
+                issue={issue}
+                onOpenIssue={handleOpenIssue}
+                tableLayout={tableLayout}
+            />
+        ),
+        [handleOpenIssue, tableLayout],
+    );
 
     return (
         <GitHubTabShell
@@ -396,182 +419,217 @@ export function GitHubIssuesTabView({
                 worktreeId: tab.worktreeId ?? null,
             }}
         >
-            <div className="space-y-3 p-4">
-                <GitHubAuthNotice authStatus={authStatus} />
-                {error ? <GitHubErrorState>{error}</GitHubErrorState> : null}
-                <div className="flex flex-wrap items-center gap-2">
-                    <GitHubSearchBox
-                        onChange={setQuery}
-                        placeholder="Search issues..."
-                        value={query}
-                    />
-                    <GitHubFilterButton
-                        active={filter === "open"}
-                        onClick={() => setFilter("open")}
-                    >
-                        Open
-                    </GitHubFilterButton>
-                    <GitHubFilterButton
-                        active={filter === "closed"}
-                        onClick={() => setFilter("closed")}
-                    >
-                        Closed
-                    </GitHubFilterButton>
-                    <GitHubFilterButton
-                        active={filter === "assigned"}
-                        onClick={() => setFilter("assigned")}
-                    >
-                        Assigned to me
-                    </GitHubFilterButton>
-                    <GitHubFilterButton
-                        active={filter === "all"}
-                        onClick={() => setFilter("all")}
-                    >
-                        All
-                    </GitHubFilterButton>
-                </div>
-                {isCreating ? (
-                    <div className="rounded-lg border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-secondary p-3">
-                        <input
-                            className="h-[22px] w-full rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-2 font-mono text-[12px] text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
-                            onChange={(event) =>
-                                setNewTitle(event.currentTarget.value)
-                            }
-                            placeholder="Issue title"
-                            value={newTitle}
-                        />
-                        <textarea
-                            className="mt-2 min-h-28 w-full resize-y rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-3 py-2 text-[13px] leading-5 text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
-                            onChange={(event) =>
-                                setNewBody(event.currentTarget.value)
-                            }
-                            placeholder="Describe the issue..."
-                            value={newBody}
-                        />
-                        <input
-                            className="mt-2 h-[22px] w-full rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-2 font-mono text-[12px] text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
-                            onChange={(event) =>
-                                setNewLabels(event.currentTarget.value)
-                            }
-                            placeholder="Labels, comma separated"
-                            value={newLabels}
-                        />
-                        <div className="mt-3">
-                            <GitHubDraftPreview
-                                body={newBody}
-                                collapsible
-                                defaultExpanded={false}
-                                meta={
-                                    parseCsv(newLabels)?.length
-                                        ? `Labels: ${parseCsv(newLabels)?.join(", ")}`
-                                        : "No labels"
-                                }
-                                title={newTitle}
+            {({ scrollContainerRef }) => (
+                <>
+                    <div className="space-y-3 p-4">
+                        <GitHubAuthNotice authStatus={authStatus} />
+                        {error ? (
+                            <GitHubErrorState>{error}</GitHubErrorState>
+                        ) : null}
+                        <div className="flex flex-wrap items-center gap-2">
+                            <GitHubSearchBox
+                                onChange={setQuery}
+                                placeholder="Search issues..."
+                                value={query}
                             />
-                        </div>
-                        <div className="mt-3 flex justify-end gap-2">
-                            <IdeActionButton
-                                disabled={isCreatingIssue}
-                                onClick={() => setIsCreating(false)}
+                            <GitHubFilterButton
+                                active={filter === "open"}
+                                onClick={() => setFilter("open")}
                             >
-                                Cancel
-                            </IdeActionButton>
-                            <IdeActionButton
-                                disabled={
-                                    isCreatingIssue ||
-                                    !canWriteIssues ||
-                                    newTitle.trim().length === 0
-                                }
-                                onClick={() => void handleCreateIssue()}
+                                Open
+                            </GitHubFilterButton>
+                            <GitHubFilterButton
+                                active={filter === "closed"}
+                                onClick={() => setFilter("closed")}
                             >
-                                {isCreatingIssue
-                                    ? "Creating..."
-                                    : "Create Issue"}
-                            </IdeActionButton>
+                                Closed
+                            </GitHubFilterButton>
+                            <GitHubFilterButton
+                                active={filter === "assigned"}
+                                onClick={() => setFilter("assigned")}
+                            >
+                                Assigned to me
+                            </GitHubFilterButton>
+                            <GitHubFilterButton
+                                active={filter === "all"}
+                                onClick={() => setFilter("all")}
+                            >
+                                All
+                            </GitHubFilterButton>
                         </div>
+                        {isCreating ? (
+                            <div className="rounded-lg border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-secondary p-3">
+                                <input
+                                    className="h-[22px] w-full rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-2 font-mono text-[12px] text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
+                                    onChange={(event) =>
+                                        setNewTitle(
+                                            event.currentTarget.value,
+                                        )
+                                    }
+                                    placeholder="Issue title"
+                                    value={newTitle}
+                                />
+                                <textarea
+                                    className="mt-2 min-h-28 w-full resize-y rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-3 py-2 text-[13px] leading-5 text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
+                                    onChange={(event) =>
+                                        setNewBody(event.currentTarget.value)
+                                    }
+                                    placeholder="Describe the issue..."
+                                    value={newBody}
+                                />
+                                <input
+                                    className="mt-2 h-[22px] w-full rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-2 font-mono text-[12px] text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
+                                    onChange={(event) =>
+                                        setNewLabels(
+                                            event.currentTarget.value,
+                                        )
+                                    }
+                                    placeholder="Labels, comma separated"
+                                    value={newLabels}
+                                />
+                                <div className="mt-3">
+                                    <GitHubDraftPreview
+                                        body={newBody}
+                                        collapsible
+                                        defaultExpanded={false}
+                                        meta={
+                                            parseCsv(newLabels)?.length
+                                                ? `Labels: ${parseCsv(newLabels)?.join(", ")}`
+                                                : "No labels"
+                                        }
+                                        title={newTitle}
+                                    />
+                                </div>
+                                <div className="mt-3 flex justify-end gap-2">
+                                    <IdeActionButton
+                                        disabled={isCreatingIssue}
+                                        onClick={() => setIsCreating(false)}
+                                    >
+                                        Cancel
+                                    </IdeActionButton>
+                                    <IdeActionButton
+                                        disabled={
+                                            isCreatingIssue ||
+                                            !canWriteIssues ||
+                                            newTitle.trim().length === 0
+                                        }
+                                        onClick={() => void handleCreateIssue()}
+                                    >
+                                        {isCreatingIssue
+                                            ? "Creating..."
+                                            : "Create Issue"}
+                                    </IdeActionButton>
+                                </div>
+                            </div>
+                        ) : null}
+                        {isLoading || isCheckingAuth ? (
+                            <div className="text-[12px] text-text-secondary">
+                                Loading issues...
+                            </div>
+                        ) : null}
+                        {!isLoading && visibleIssues.length === 0 ? (
+                            <GitHubEmptyState>
+                                No issues match this view.
+                            </GitHubEmptyState>
+                        ) : null}
                     </div>
-                ) : null}
-                {isLoading || isCheckingAuth ? (
-                    <div className="text-[12px] text-text-secondary">
-                        Loading issues...
-                    </div>
-                ) : null}
-                {!isLoading && visibleIssues.length === 0 ? (
-                    <GitHubEmptyState>No issues match this view.</GitHubEmptyState>
-                ) : null}
-            </div>
-            {!isLoading && visibleIssues.length > 0 ? (
-                <div className="shell-scrollbar overflow-x-auto">
-                    <div
-                        className="sticky top-0 z-10 grid items-center px-3 py-1.5 text-[10px] font-semibold uppercase text-text-secondary"
-                        style={{
-                            backgroundColor: "var(--color-bg-secondary)",
-                            borderBottom:
-                                "1px solid color-mix(in srgb, var(--color-border) 60%, transparent)",
-                            fontFamily: "var(--font-mono)",
-                            gridTemplateColumns: tableGridTemplate,
-                            letterSpacing: "0.06em",
-                            minWidth: tableMinWidth,
-                        }}
-                    >
-                        {tableLayout.order.map((columnId) => (
-                            <IssueHeaderCell
-                                columnId={columnId}
-                                dragged={draggedColumnId === columnId}
-                                key={columnId}
-                                label={ISSUE_TABLE_COLUMN_LABELS[columnId]}
-                                onDragEnd={() => setDraggedColumnId(null)}
-                                onDragOver={(event) => {
-                                    event.preventDefault();
-                                    event.dataTransfer.dropEffect = "move";
-                                }}
-                                onDragStart={(event) =>
-                                    handleColumnDragStart(columnId, event)
-                                }
-                                onDrop={(event) =>
-                                    handleColumnDrop(columnId, event)
-                                }
-                                onResizePointerDown={(event) =>
-                                    handleColumnResizePointerDown(
-                                        columnId,
-                                        event,
-                                    )
-                                }
-                            />
-                        ))}
-                    </div>
-                    {visibleIssues.map((issue) => {
-                        const handleOpenIssue = () =>
-                            void openGitHubIssueTab({
-                                issueNumber: issue.number,
-                                projectId: tab.projectId,
-                                ref: tab.ref,
-                                worktreeId: tab.worktreeId ?? null,
-                            });
-
-                        return (
+                    {!isLoading && visibleIssues.length > 0 ? (
+                        <div className="shell-scrollbar overflow-x-auto">
                             <div
-                                className="group/row grid items-stretch border-l-[3px] border-l-transparent pl-2.5 pr-3 text-left text-[11px] text-text-secondary transition-[color,background-color,border-color] duration-120 hover:border-l-[color-mix(in_srgb,var(--color-accent)_60%,transparent)] hover:bg-bg-secondary hover:text-text-primary"
-                                key={issue.id}
+                                className="sticky top-0 z-10 grid items-center px-3 py-1.5 text-[10px] font-semibold uppercase text-text-secondary"
                                 style={{
+                                    backgroundColor:
+                                        "var(--color-bg-secondary)",
+                                    borderBottom:
+                                        "1px solid color-mix(in srgb, var(--color-border) 60%, transparent)",
+                                    fontFamily: "var(--font-mono)",
                                     gridTemplateColumns: tableGridTemplate,
+                                    letterSpacing: "0.06em",
                                     minWidth: tableMinWidth,
                                 }}
                             >
                                 {tableLayout.order.map((columnId) => (
-                                    <IssueTableCell
+                                    <IssueHeaderCell
                                         columnId={columnId}
-                                        issue={issue}
+                                        dragged={
+                                            draggedColumnId === columnId
+                                        }
                                         key={columnId}
-                                        onOpen={handleOpenIssue}
+                                        label={
+                                            ISSUE_TABLE_COLUMN_LABELS[columnId]
+                                        }
+                                        onDragEnd={() =>
+                                            setDraggedColumnId(null)
+                                        }
+                                        onDragOver={(event) => {
+                                            event.preventDefault();
+                                            event.dataTransfer.dropEffect =
+                                                "move";
+                                        }}
+                                        onDragStart={(event) =>
+                                            handleColumnDragStart(
+                                                columnId,
+                                                event,
+                                            )
+                                        }
+                                        onDrop={(event) =>
+                                            handleColumnDrop(columnId, event)
+                                        }
+                                        onResizePointerDown={(event) =>
+                                            handleColumnResizePointerDown(
+                                                columnId,
+                                                event,
+                                            )
+                                        }
                                     />
                                 ))}
                             </div>
-                        );
-                    })}
-                </div>
-            ) : null}
+                            <GitHubVirtualizedTableBody
+                                estimateRowHeight={
+                                    estimateIssueTableRowHeight
+                                }
+                                getRowKey={(issue) => String(issue.id)}
+                                gridTemplateColumns={tableGridTemplate}
+                                items={visibleIssues}
+                                minWidth={tableMinWidth}
+                                renderRow={renderIssueRow}
+                                scrollContainerRef={scrollContainerRef}
+                                threshold={
+                                    GITHUB_ISSUES_VIRTUALIZATION_THRESHOLD
+                                }
+                            />
+                        </div>
+                    ) : null}
+                </>
+            )}
         </GitHubTabShell>
+    );
+}
+
+function IssueTableRow({
+    issue,
+    onOpenIssue,
+    tableLayout,
+}: {
+    readonly issue: GitHubIssueSummary;
+    readonly onOpenIssue: (issueNumber: number) => void;
+    readonly tableLayout: IssueTableLayout;
+}) {
+    const handleOpenIssue = () => {
+        onOpenIssue(issue.number);
+    };
+
+    return (
+        <div className="group/row items-stretch border-l-[3px] border-l-transparent pl-2.5 pr-3 text-left text-[11px] text-text-secondary transition-[color,background-color,border-color] duration-120 hover:border-l-[color-mix(in_srgb,var(--color-accent)_60%,transparent)] hover:bg-bg-secondary hover:text-text-primary">
+            {tableLayout.order.map((columnId) => (
+                <IssueTableCell
+                    columnId={columnId}
+                    issue={issue}
+                    key={columnId}
+                    onOpen={handleOpenIssue}
+                />
+            ))}
+        </div>
     );
 }
 
@@ -836,6 +894,10 @@ function moveIssueColumn(
 
     nextOrder.splice(targetIndex, 0, sourceColumnId);
     return nextOrder;
+}
+
+function estimateIssueTableRowHeight(issue: GitHubIssueSummary): number {
+    return issue.labels.length > 0 ? 68 : 56;
 }
 
 function getStorage(): Storage | null {

--- a/src/renderer/src/components/workspace/GitHubPullRequestsTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestsTabView.test.tsx
@@ -1,0 +1,238 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+    GitHubAuthStatus,
+    GitHubPullRequestSummary,
+    GitHubRepositoryRef,
+} from "@shared/ipc";
+import type { RuntimeWorkspaceGitHubPullRequestsTab } from "@renderer/app/workspace/tree";
+
+const REPO: GitHubRepositoryRef = {
+    host: "github.com",
+    owner: "octocat",
+    repo: "hello-world",
+};
+const REPO_KEY = "github.com/octocat/hello-world";
+
+const mockGitStoreState = vi.hoisted(() => ({
+    current: {
+        snapshots: {},
+    },
+}));
+
+const mockGitHubStoreState = vi.hoisted(() => ({
+    current: {
+        authStatusByHost: {},
+        createPullRequest: vi.fn(),
+        errors: {},
+        loadingKeys: {},
+        mutatingKeys: {},
+        pullRequestChecksByRepo: {},
+        pullRequestListStateByRepo: {},
+        pullRequestsByRepo: {},
+        pullRequestsByRepoAndState: {},
+        refreshAuthStatus: vi.fn(),
+        refreshPullRequestChecks: vi.fn(),
+        refreshPullRequests: vi.fn(),
+    },
+}));
+
+const mockWorkspaceStoreState = vi.hoisted(() => ({
+    current: {
+        openGitHubPullRequestTab: vi.fn(async () => {}),
+    },
+}));
+
+vi.mock("@renderer/app/store/git-store", () => ({
+    useGitStore: (
+        selector: (state: typeof mockGitStoreState.current) => unknown,
+    ) => selector(mockGitStoreState.current),
+}));
+
+vi.mock("@renderer/app/store/github-store", () => ({
+    EMPTY_GITHUB_LIST: Object.freeze([]),
+    EMPTY_GITHUB_RECORD: Object.freeze({}),
+    getGitHubPullRequestChecksKey: (
+        ref: GitHubRepositoryRef,
+        headSha: string,
+    ) => `${ref.host.toLowerCase()}/${ref.owner}/${ref.repo}:pr-checks:${headSha}`,
+    getGitHubRepoKey: (ref: GitHubRepositoryRef) =>
+        `${ref.host.toLowerCase()}/${ref.owner}/${ref.repo}`,
+    useGitHubStore: (
+        selector: (state: typeof mockGitHubStoreState.current) => unknown,
+    ) => selector(mockGitHubStoreState.current),
+}));
+
+vi.mock("@renderer/app/store/workspace-store", () => ({
+    useWorkspaceStore: (
+        selector: (state: typeof mockWorkspaceStoreState.current) => unknown,
+    ) => selector(mockWorkspaceStoreState.current),
+}));
+
+import {
+    GITHUB_PULL_REQUESTS_ROW_VIRTUALIZATION_THRESHOLD,
+    GitHubPullRequestsTabView,
+} from "./GitHubPullRequestsTabView";
+
+class MemoryStorage implements Storage {
+    private readonly values = new Map<string, string>();
+
+    get length() {
+        return this.values.size;
+    }
+
+    clear() {
+        this.values.clear();
+    }
+
+    getItem(key: string) {
+        return this.values.get(key) ?? null;
+    }
+
+    key(index: number) {
+        return [...this.values.keys()][index] ?? null;
+    }
+
+    removeItem(key: string) {
+        this.values.delete(key);
+    }
+
+    setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+}
+
+const TAB: RuntimeWorkspaceGitHubPullRequestsTab = {
+    createdAt: "2026-05-28T00:00:00.000Z",
+    id: "github-pull-requests-tab-1",
+    kind: "github_pull_requests",
+    projectId: "project-1",
+    ref: REPO,
+    title: "Pull Requests",
+    worktreeId: null,
+};
+
+function createAuthStatus(): GitHubAuthStatus {
+    return {
+        canReadActions: true,
+        canWriteActions: true,
+        canWriteIssues: true,
+        canWritePullRequests: true,
+        checkedAt: "2026-05-28T00:00:00.000Z",
+        errorCode: null,
+        host: REPO.host,
+        readOnly: false,
+        state: "authenticated",
+        tokenSource: "gh_cli",
+        user: {
+            avatarUrl: null,
+            id: 1,
+            login: "octocat",
+            url: "https://github.com/octocat",
+        },
+    };
+}
+
+function createPullRequestSummary(index: number): GitHubPullRequestSummary {
+    return {
+        additions: index,
+        author: null,
+        base: {
+            label: "octocat:main",
+            ref: "main",
+            repository: REPO,
+            sha: `base-${index}`,
+        },
+        changedFileCount: index % 7,
+        closedAt: null,
+        commentCount: index % 4,
+        commitCount: index % 6,
+        createdAt: `2026-05-${String(1 + (index % 28)).padStart(2, "0")}T00:00:00.000Z`,
+        deletions: index % 3,
+        draft: index % 11 === 0,
+        head: {
+            label: `octocat:feature-${index}`,
+            ref: `feature-${index}`,
+            repository: REPO,
+            sha: `head-${index}`,
+        },
+        id: index,
+        labels:
+            index % 5 === 0
+                ? [
+                      {
+                          color: "0e8a16",
+                          description: "Baseline label",
+                          id: index,
+                          name: `stack-${index}`,
+                      },
+                  ]
+                : [],
+        mergedAt: null,
+        nodeId: `PR_${index}`,
+        number: index,
+        state: "open",
+        title: `Baseline pull request ${index}`,
+        updatedAt: `2026-05-${String(1 + (index % 28)).padStart(2, "0")}T12:00:00.000Z`,
+        url: `https://github.com/octocat/hello-world/pull/${index}`,
+    };
+}
+
+function resetStoreState() {
+    mockGitStoreState.current.snapshots = {};
+    mockGitHubStoreState.current.authStatusByHost = {
+        [REPO.host]: createAuthStatus(),
+    };
+    mockGitHubStoreState.current.createPullRequest.mockClear();
+    mockGitHubStoreState.current.errors = {};
+    mockGitHubStoreState.current.loadingKeys = {};
+    mockGitHubStoreState.current.mutatingKeys = {};
+    mockGitHubStoreState.current.pullRequestChecksByRepo = {};
+    mockGitHubStoreState.current.pullRequestListStateByRepo = {
+        [REPO_KEY]: "open",
+    };
+    mockGitHubStoreState.current.pullRequestsByRepo = {};
+    mockGitHubStoreState.current.pullRequestsByRepoAndState = {
+        [REPO_KEY]: {
+            open: Array.from(
+                { length: GITHUB_PULL_REQUESTS_ROW_VIRTUALIZATION_THRESHOLD },
+                (_, index) => createPullRequestSummary(index + 1),
+            ),
+        },
+    };
+    mockGitHubStoreState.current.refreshAuthStatus.mockClear();
+    mockGitHubStoreState.current.refreshPullRequestChecks.mockClear();
+    mockGitHubStoreState.current.refreshPullRequests.mockClear();
+    mockWorkspaceStoreState.current.openGitHubPullRequestTab.mockClear();
+}
+
+describe("GitHubPullRequestsTabView", () => {
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "localStorage", {
+            configurable: true,
+            value: new MemoryStorage(),
+            writable: true,
+        });
+        resetStoreState();
+    });
+
+    it("renders the large pull requests table baseline with table affordances intact", () => {
+        const markup = renderToStaticMarkup(
+            createElement(GitHubPullRequestsTabView, { tab: TAB }),
+        );
+
+        expect(markup).toContain(
+            `${GITHUB_PULL_REQUESTS_ROW_VIRTUALIZATION_THRESHOLD} items`,
+        );
+        expect(markup).toContain("Baseline pull request 1");
+        expect(markup).toContain(
+            `Baseline pull request ${GITHUB_PULL_REQUESTS_ROW_VIRTUALIZATION_THRESHOLD}`,
+        );
+        expect(markup).toContain('aria-label="Resize # column"');
+        expect(markup).toContain('aria-label="Resize Branch column"');
+        expect(markup).toContain("Drag to reorder. Drag the edge to resize.");
+        expect(markup).toContain("Open");
+    });
+});

--- a/src/renderer/src/components/workspace/GitHubPullRequestsTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestsTabView.test.tsx
@@ -1,9 +1,11 @@
 import { createElement } from "react";
+import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
     GitHubAuthStatus,
+    GitHubPullRequestChecksResult,
     GitHubPullRequestSummary,
     GitHubRepositoryRef,
 } from "@shared/ipc";
@@ -45,6 +47,8 @@ const mockWorkspaceStoreState = vi.hoisted(() => ({
     },
 }));
 
+const measuredVirtualListMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@renderer/app/store/git-store", () => ({
     useGitStore: (
         selector: (state: typeof mockGitStoreState.current) => unknown,
@@ -71,9 +75,55 @@ vi.mock("@renderer/app/store/workspace-store", () => ({
     ) => selector(mockWorkspaceStoreState.current),
 }));
 
+vi.mock("../virtual/MeasuredVirtualList", async () => {
+    const { createElement } =
+        await vi.importActual<typeof import("react")>("react");
+
+    return {
+        MeasuredVirtualList: <T,>({
+            getItemKey,
+            items,
+            onRangeChange,
+            renderItem,
+        }: {
+            readonly getItemKey: (item: T, index: number) => string;
+            readonly items: readonly T[];
+            readonly onRangeChange?: () => void;
+            readonly renderItem: (params: {
+                readonly index: number;
+                readonly isVisible: boolean;
+                readonly item: T;
+            }) => ReactNode;
+        }) => {
+            measuredVirtualListMock({
+                hasRangeChange: typeof onRangeChange === "function",
+                itemCount: items.length,
+            });
+
+            return createElement(
+                "div",
+                { "data-testid": "mock-measured-virtual-list" },
+                items.slice(0, 5).map((item, index) =>
+                    createElement(
+                        "div",
+                        { key: getItemKey(item, index) },
+                        renderItem({
+                            index,
+                            isVisible: true,
+                            item,
+                        }),
+                    ),
+                ),
+            );
+        },
+    };
+});
+
 import {
     GITHUB_PULL_REQUESTS_ROW_VIRTUALIZATION_THRESHOLD,
+    GITHUB_PULL_REQUESTS_VIRTUALIZATION_THRESHOLD,
     GitHubPullRequestsTabView,
+    getVisiblePullRequestCheckTargets,
 } from "./GitHubPullRequestsTabView";
 
 class MemoryStorage implements Storage {
@@ -180,6 +230,20 @@ function createPullRequestSummary(index: number): GitHubPullRequestSummary {
     };
 }
 
+function createPullRequestChecks(
+    overrides: Partial<GitHubPullRequestChecksResult> = {},
+): GitHubPullRequestChecksResult {
+    return {
+        checkedAt: "2026-05-28T00:00:00.000Z",
+        checks: [],
+        headSha: "head-1",
+        pullRequestNumber: 1,
+        state: "success",
+        url: "https://github.com/octocat/hello-world/pull/1/checks",
+        ...overrides,
+    };
+}
+
 function resetStoreState() {
     mockGitStoreState.current.snapshots = {};
     mockGitHubStoreState.current.authStatusByHost = {
@@ -206,6 +270,7 @@ function resetStoreState() {
     mockGitHubStoreState.current.refreshPullRequestChecks.mockClear();
     mockGitHubStoreState.current.refreshPullRequests.mockClear();
     mockWorkspaceStoreState.current.openGitHubPullRequestTab.mockClear();
+    measuredVirtualListMock.mockClear();
 }
 
 describe("GitHubPullRequestsTabView", () => {
@@ -218,7 +283,7 @@ describe("GitHubPullRequestsTabView", () => {
         resetStoreState();
     });
 
-    it("renders the large pull requests table baseline with table affordances intact", () => {
+    it("virtualizes the large pull requests table with table affordances intact", () => {
         const markup = renderToStaticMarkup(
             createElement(GitHubPullRequestsTabView, { tab: TAB }),
         );
@@ -226,13 +291,186 @@ describe("GitHubPullRequestsTabView", () => {
         expect(markup).toContain(
             `${GITHUB_PULL_REQUESTS_ROW_VIRTUALIZATION_THRESHOLD} items`,
         );
-        expect(markup).toContain("Baseline pull request 1");
-        expect(markup).toContain(
+        expect(markup).toContain("Baseline pull request");
+        expect(markup).not.toContain(
             `Baseline pull request ${GITHUB_PULL_REQUESTS_ROW_VIRTUALIZATION_THRESHOLD}`,
         );
+        expect(measuredVirtualListMock).toHaveBeenCalledWith({
+            hasRangeChange: true,
+            itemCount: GITHUB_PULL_REQUESTS_ROW_VIRTUALIZATION_THRESHOLD,
+        });
         expect(markup).toContain('aria-label="Resize # column"');
         expect(markup).toContain('aria-label="Resize Branch column"');
         expect(markup).toContain("Drag to reorder. Drag the edge to resize.");
         expect(markup).toContain("Open");
+    });
+
+    it("renders every pull request below the virtualization threshold", () => {
+        mockGitHubStoreState.current.pullRequestsByRepoAndState = {
+            [REPO_KEY]: {
+                open: Array.from(
+                    {
+                        length:
+                            GITHUB_PULL_REQUESTS_VIRTUALIZATION_THRESHOLD - 1,
+                    },
+                    (_, index) => createPullRequestSummary(index + 1),
+                ),
+            },
+        };
+
+        const markup = renderToStaticMarkup(
+            createElement(GitHubPullRequestsTabView, { tab: TAB }),
+        );
+
+        expect(markup).toContain(
+            `${GITHUB_PULL_REQUESTS_VIRTUALIZATION_THRESHOLD - 1} items`,
+        );
+        expect(markup).toContain("Baseline pull request 1");
+        expect(markup).toContain(
+            `Baseline pull request ${
+                GITHUB_PULL_REQUESTS_VIRTUALIZATION_THRESHOLD - 1
+            }`,
+        );
+        expect(measuredVirtualListMock).not.toHaveBeenCalled();
+    });
+
+    it("keeps the current branch highlight inside virtualized rows", () => {
+        mockGitStoreState.current.snapshots = {
+            "project-1::primary": {
+                branch: {
+                    ahead: 0,
+                    behind: 0,
+                    isDetached: false,
+                    name: "feature-2",
+                    upstreamName: "origin/feature-2",
+                },
+                projectId: "project-1",
+                worktrees: [],
+            },
+        };
+
+        const markup = renderToStaticMarkup(
+            createElement(GitHubPullRequestsTabView, { tab: TAB }),
+        );
+
+        expect(markup).toContain("Current branch");
+    });
+
+    it("renders pull request check states", () => {
+        mockGitHubStoreState.current.pullRequestsByRepoAndState = {
+            [REPO_KEY]: {
+                open: Array.from({ length: 5 }, (_, index) =>
+                    createPullRequestSummary(index + 1),
+                ),
+            },
+        };
+        mockGitHubStoreState.current.pullRequestChecksByRepo = {
+            [REPO_KEY]: {
+                "head-1": createPullRequestChecks({
+                    headSha: "head-1",
+                    pullRequestNumber: 1,
+                    state: "success",
+                }),
+                "head-2": createPullRequestChecks({
+                    headSha: "head-2",
+                    pullRequestNumber: 2,
+                    state: "failure",
+                }),
+                "head-3": createPullRequestChecks({
+                    headSha: "head-3",
+                    pullRequestNumber: 3,
+                    state: "pending",
+                }),
+            },
+        };
+        mockGitHubStoreState.current.loadingKeys = {
+            [`${REPO_KEY}:pr-checks:head-4`]: true,
+        };
+
+        const markup = renderToStaticMarkup(
+            createElement(GitHubPullRequestsTabView, { tab: TAB }),
+        );
+
+        expect(markup).toContain("checks passing");
+        expect(markup).toContain("checks failed");
+        expect(markup).toContain("checks pending");
+        expect(markup).toContain("checks...");
+        expect(markup).toContain("checks unknown");
+    });
+
+    it("derives check targets from the virtual visible range", () => {
+        const pullRequests = Array.from({ length: 60 }, (_, index) =>
+            createPullRequestSummary(index + 1),
+        );
+        const initialTargets = getVisiblePullRequestCheckTargets({
+            pullRequests,
+            range: null,
+        });
+        const rangedTargets = getVisiblePullRequestCheckTargets({
+            pullRequests,
+            range: {
+                endIndex: 40,
+                startIndex: 24,
+                visibleEndIndex: 34,
+                visibleStartIndex: 30,
+            },
+        });
+
+        expect(initialTargets).toHaveLength(20);
+        expect(initialTargets[0]).toEqual({ headSha: "head-1", number: 1 });
+        expect(initialTargets.at(-1)).toEqual({
+            headSha: "head-20",
+            number: 20,
+        });
+        expect(rangedTargets[0]).toEqual({
+            headSha: "head-21",
+            number: 21,
+        });
+        expect(rangedTargets.at(-1)).toEqual({
+            headSha: "head-45",
+            number: 45,
+        });
+    });
+
+    it("deduplicates check targets by head sha", () => {
+        const firstPullRequest = createPullRequestSummary(1);
+        const secondPullRequest = createPullRequestSummary(2);
+        const targets = getVisiblePullRequestCheckTargets({
+            pullRequests: [
+                firstPullRequest,
+                {
+                    ...secondPullRequest,
+                    head: {
+                        ...secondPullRequest.head,
+                        sha: firstPullRequest.head.sha,
+                    },
+                },
+            ],
+            range: null,
+        });
+
+        expect(targets).toEqual([{ headSha: "head-1", number: 1 }]);
+    });
+
+    it("falls back to initial check targets when a virtual range is stale", () => {
+        const pullRequests = Array.from({ length: 12 }, (_, index) =>
+            createPullRequestSummary(index + 1),
+        );
+        const targets = getVisiblePullRequestCheckTargets({
+            pullRequests,
+            range: {
+                endIndex: 220,
+                startIndex: 200,
+                visibleEndIndex: 210,
+                visibleStartIndex: 200,
+            },
+        });
+
+        expect(targets).toHaveLength(12);
+        expect(targets[0]).toEqual({ headSha: "head-1", number: 1 });
+        expect(targets.at(-1)).toEqual({
+            headSha: "head-12",
+            number: 12,
+        });
     });
 });

--- a/src/renderer/src/components/workspace/GitHubPullRequestsTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestsTabView.tsx
@@ -68,6 +68,8 @@ const PR_TABLE_COLUMN_IDS = [
 ] as const;
 const PR_TABLE_LAYOUT_STORAGE_KEY = "comando.github.pull-requests.table.layout";
 const PR_TABLE_LAYOUT_VERSION = 1;
+// Baseline threshold for enabling GitHub pull requests table virtualization.
+export const GITHUB_PULL_REQUESTS_ROW_VIRTUALIZATION_THRESHOLD = 150;
 const DEFAULT_PR_TABLE_COLUMN_ORDER: readonly PullRequestColumnId[] =
     PR_TABLE_COLUMN_IDS;
 const DEFAULT_PR_TABLE_COLUMN_WIDTHS: PullRequestColumnWidths = {

--- a/src/renderer/src/components/workspace/GitHubPullRequestsTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestsTabView.tsx
@@ -30,6 +30,7 @@ import {
 } from "@renderer/app/store/github-store";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
 import type { RuntimeWorkspaceGitHubPullRequestsTab } from "@renderer/app/workspace/tree";
+import type { MeasuredVirtualRange } from "../virtual/MeasuredVirtualList";
 
 import {
     formatGitHubRelativeTime,
@@ -48,6 +49,7 @@ import {
     hasGitHubWritePermission,
     openGitHubWebUrl,
 } from "./GitHubWorkspacePrimitives";
+import { GitHubVirtualizedTableBody } from "./GitHubVirtualizedTableBody";
 import { IdeActionButton } from "./ide-bar";
 
 type PullRequestFilter = "all" | "branch" | "closed" | "draft" | "open";
@@ -69,7 +71,11 @@ const PR_TABLE_COLUMN_IDS = [
 const PR_TABLE_LAYOUT_STORAGE_KEY = "comando.github.pull-requests.table.layout";
 const PR_TABLE_LAYOUT_VERSION = 1;
 // Baseline threshold for enabling GitHub pull requests table virtualization.
-export const GITHUB_PULL_REQUESTS_ROW_VIRTUALIZATION_THRESHOLD = 150;
+export const GITHUB_PULL_REQUESTS_VIRTUALIZATION_THRESHOLD = 100;
+export const GITHUB_PULL_REQUESTS_ROW_VIRTUALIZATION_THRESHOLD =
+    GITHUB_PULL_REQUESTS_VIRTUALIZATION_THRESHOLD;
+const PULL_REQUEST_CHECK_DATA_OVERSCAN = 10;
+const PULL_REQUEST_INITIAL_CHECK_TARGET_COUNT = 20;
 const DEFAULT_PR_TABLE_COLUMN_ORDER: readonly PullRequestColumnId[] =
     PR_TABLE_COLUMN_IDS;
 const DEFAULT_PR_TABLE_COLUMN_WIDTHS: PullRequestColumnWidths = {
@@ -121,6 +127,8 @@ export function GitHubPullRequestsTabView({
     const [newBase, setNewBase] = useState("main");
     const [newHead, setNewHead] = useState(currentBranch ?? "");
     const [newDraft, setNewDraft] = useState(true);
+    const [virtualPullRequestRange, setVirtualPullRequestRange] =
+        useState<MeasuredVirtualRange | null>(null);
     const requiredPullRequestListState = getPullRequestListState(filter);
     const pullRequests = useGitHubStore((state) =>
         state.pullRequestsByRepoAndState[repoKey]?.[
@@ -402,14 +410,15 @@ export function GitHubPullRequestsTabView({
     );
     const visiblePullRequestCheckTargets = useMemo(
         () =>
-            visiblePullRequests
-                .slice(0, 20)
-                .map((pullRequest) => ({
-                    headSha: pullRequest.head.sha,
-                    number: pullRequest.number,
-                }))
-                .filter((target) => target.headSha.trim().length > 0),
-        [visiblePullRequests],
+            getVisiblePullRequestCheckTargets({
+                pullRequests: visiblePullRequests,
+                range:
+                    visiblePullRequests.length >=
+                    GITHUB_PULL_REQUESTS_VIRTUALIZATION_THRESHOLD
+                        ? virtualPullRequestRange
+                        : null,
+            }),
+        [visiblePullRequests, virtualPullRequestRange],
     );
 
     useEffect(() => {
@@ -489,6 +498,66 @@ export function GitHubPullRequestsTabView({
             worktreeId: tab.worktreeId ?? null,
         });
     };
+    const handleOpenPullRequest = useCallback(
+        (pullRequestNumber: number) =>
+            void openGitHubPullRequestTab({
+                projectId: tab.projectId,
+                pullRequestNumber,
+                ref: tab.ref,
+                worktreeId: tab.worktreeId ?? null,
+            }),
+        [
+            openGitHubPullRequestTab,
+            tab.projectId,
+            tab.ref,
+            tab.worktreeId,
+        ],
+    );
+    const handlePullRequestRangeChange = useCallback(
+        (range: MeasuredVirtualRange) => {
+            setVirtualPullRequestRange((current) =>
+                areMeasuredVirtualRangesEqual(current, range)
+                    ? current
+                    : range,
+            );
+        },
+        [],
+    );
+    const renderPullRequestRow = useCallback(
+        (pullRequest: GitHubPullRequestSummary) => {
+            const checksKey = getGitHubPullRequestChecksKey(
+                tab.ref,
+                pullRequest.head.sha,
+            );
+            const checks =
+                pullRequestChecksByHeadSha[pullRequest.head.sha] ?? null;
+            const checksState = loadingKeys[checksKey]
+                ? "loading"
+                : (checks?.state ?? "unknown");
+
+            return (
+                <PullRequestTableRow
+                    checksState={checksState}
+                    isCurrentBranchPullRequest={isPullRequestForCurrentBranch(
+                        pullRequest,
+                        currentBranch,
+                        tab.ref,
+                    )}
+                    onOpenPullRequest={handleOpenPullRequest}
+                    pullRequest={pullRequest}
+                    tableLayout={tableLayout}
+                />
+            );
+        },
+        [
+            currentBranch,
+            handleOpenPullRequest,
+            loadingKeys,
+            pullRequestChecksByHeadSha,
+            tab.ref,
+            tableLayout,
+        ],
+    );
 
     return (
         <GitHubTabShell
@@ -527,244 +596,276 @@ export function GitHubPullRequestsTabView({
                 worktreeId: tab.worktreeId ?? null,
             }}
         >
-            <div className="space-y-3 p-4">
-                <GitHubAuthNotice authStatus={authStatus} />
-                {error ? <GitHubErrorState>{error}</GitHubErrorState> : null}
-                <div className="flex flex-wrap items-center gap-2">
-                    <GitHubSearchBox
-                        onChange={setQuery}
-                        placeholder="Search pull requests..."
-                        value={query}
-                    />
-                    <GitHubFilterButton
-                        active={filter === "open"}
-                        onClick={() => setFilter("open")}
-                    >
-                        Open
-                    </GitHubFilterButton>
-                    <GitHubFilterButton
-                        active={filter === "closed"}
-                        onClick={() => setFilter("closed")}
-                    >
-                        Closed
-                    </GitHubFilterButton>
-                    <GitHubFilterButton
-                        active={filter === "draft"}
-                        onClick={() => setFilter("draft")}
-                    >
-                        Draft
-                    </GitHubFilterButton>
-                    <GitHubFilterButton
-                        active={filter === "branch"}
-                        onClick={() => setFilter("branch")}
-                    >
-                        {currentBranchPullRequestCount > 0
-                            ? `Current branch (${currentBranchPullRequestCount})`
-                            : "Current branch"}
-                    </GitHubFilterButton>
-                    <GitHubFilterButton
-                        active={filter === "all"}
-                        onClick={() => setFilter("all")}
-                    >
-                        All
-                    </GitHubFilterButton>
-                </div>
-                {isCreating ? (
-                    <div className="rounded-lg border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-secondary p-3">
-                        {branchNeedsPush ? (
-                            <div className="mb-3 rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-3 py-2 text-[11px] leading-5 text-text-secondary">
-                                Current branch has no upstream. Push it before
-                                creating a pull request if GitHub cannot find
-                                the head ref.
+            {({ scrollContainerRef }) => (
+                <>
+                    <div className="space-y-3 p-4">
+                        <GitHubAuthNotice authStatus={authStatus} />
+                        {error ? (
+                            <GitHubErrorState>{error}</GitHubErrorState>
+                        ) : null}
+                        <div className="flex flex-wrap items-center gap-2">
+                            <GitHubSearchBox
+                                onChange={setQuery}
+                                placeholder="Search pull requests..."
+                                value={query}
+                            />
+                            <GitHubFilterButton
+                                active={filter === "open"}
+                                onClick={() => setFilter("open")}
+                            >
+                                Open
+                            </GitHubFilterButton>
+                            <GitHubFilterButton
+                                active={filter === "closed"}
+                                onClick={() => setFilter("closed")}
+                            >
+                                Closed
+                            </GitHubFilterButton>
+                            <GitHubFilterButton
+                                active={filter === "draft"}
+                                onClick={() => setFilter("draft")}
+                            >
+                                Draft
+                            </GitHubFilterButton>
+                            <GitHubFilterButton
+                                active={filter === "branch"}
+                                onClick={() => setFilter("branch")}
+                            >
+                                {currentBranchPullRequestCount > 0
+                                    ? `Current branch (${currentBranchPullRequestCount})`
+                                    : "Current branch"}
+                            </GitHubFilterButton>
+                            <GitHubFilterButton
+                                active={filter === "all"}
+                                onClick={() => setFilter("all")}
+                            >
+                                All
+                            </GitHubFilterButton>
+                        </div>
+                        {isCreating ? (
+                            <div className="rounded-lg border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-secondary p-3">
+                                {branchNeedsPush ? (
+                                    <div className="mb-3 rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-3 py-2 text-[11px] leading-5 text-text-secondary">
+                                        Current branch has no upstream. Push it
+                                        before creating a pull request if GitHub
+                                        cannot find the head ref.
+                                    </div>
+                                ) : null}
+                                <input
+                                    className="h-[22px] w-full rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-2 font-mono text-[12px] text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
+                                    onChange={(event) =>
+                                        setNewTitle(
+                                            event.currentTarget.value,
+                                        )
+                                    }
+                                    placeholder="Pull request title"
+                                    value={newTitle}
+                                />
+                                <div className="mt-2 grid grid-cols-2 gap-2">
+                                    <input
+                                        className="h-[22px] rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-2 font-mono text-[12px] text-text-primary outline-none focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
+                                        onChange={(event) =>
+                                            setNewBase(
+                                                event.currentTarget.value,
+                                            )
+                                        }
+                                        placeholder="base"
+                                        value={newBase}
+                                    />
+                                    <input
+                                        className="h-[22px] rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-2 font-mono text-[12px] text-text-primary outline-none focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
+                                        onChange={(event) =>
+                                            setNewHead(
+                                                event.currentTarget.value,
+                                            )
+                                        }
+                                        placeholder="head"
+                                        value={newHead}
+                                    />
+                                </div>
+                                <textarea
+                                    className="mt-2 min-h-28 w-full resize-y rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-3 py-2 text-[13px] leading-5 text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
+                                    onChange={(event) =>
+                                        setNewBody(
+                                            event.currentTarget.value,
+                                        )
+                                    }
+                                    placeholder="Describe the pull request..."
+                                    value={newBody}
+                                />
+                                <label className="mt-2 flex items-center gap-2 text-[11px] text-text-secondary">
+                                    <input
+                                        checked={newDraft}
+                                        onChange={(event) =>
+                                            setNewDraft(
+                                                event.currentTarget.checked,
+                                            )
+                                        }
+                                        type="checkbox"
+                                    />
+                                    Create as draft
+                                </label>
+                                <div className="mt-3">
+                                    <GitHubDraftPreview
+                                        body={newBody}
+                                        meta={`${
+                                            newHead.trim() || "head"
+                                        } into ${
+                                            newBase.trim() || "base"
+                                        }${newDraft ? " · draft" : ""}`}
+                                        title={newTitle}
+                                    />
+                                </div>
+                                <div className="mt-3 flex justify-end gap-2">
+                                    <IdeActionButton
+                                        disabled={isCreatingPullRequest}
+                                        onClick={() => setIsCreating(false)}
+                                    >
+                                        Cancel
+                                    </IdeActionButton>
+                                    <IdeActionButton
+                                        disabled={
+                                            isCreatingPullRequest ||
+                                            !canWritePullRequests ||
+                                            newTitle.trim().length === 0 ||
+                                            newBase.trim().length === 0 ||
+                                            newHead.trim().length === 0
+                                        }
+                                        onClick={() =>
+                                            void handleCreatePullRequest()
+                                        }
+                                    >
+                                        {isCreatingPullRequest
+                                            ? "Creating..."
+                                            : "Create Pull Request"}
+                                    </IdeActionButton>
+                                </div>
                             </div>
                         ) : null}
-                        <input
-                            className="h-[22px] w-full rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-2 font-mono text-[12px] text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
-                            onChange={(event) =>
-                                setNewTitle(event.currentTarget.value)
-                            }
-                            placeholder="Pull request title"
-                            value={newTitle}
-                        />
-                        <div className="mt-2 grid grid-cols-2 gap-2">
-                            <input
-                                className="h-[22px] rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-2 font-mono text-[12px] text-text-primary outline-none focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
-                                onChange={(event) =>
-                                    setNewBase(event.currentTarget.value)
-                                }
-                                placeholder="base"
-                                value={newBase}
-                            />
-                            <input
-                                className="h-[22px] rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-2 font-mono text-[12px] text-text-primary outline-none focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
-                                onChange={(event) =>
-                                    setNewHead(event.currentTarget.value)
-                                }
-                                placeholder="head"
-                                value={newHead}
-                            />
-                        </div>
-                        <textarea
-                            className="mt-2 min-h-28 w-full resize-y rounded-md border border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-primary px-3 py-2 text-[13px] leading-5 text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
-                            onChange={(event) =>
-                                setNewBody(event.currentTarget.value)
-                            }
-                            placeholder="Describe the pull request..."
-                            value={newBody}
-                        />
-                        <label className="mt-2 flex items-center gap-2 text-[11px] text-text-secondary">
-                            <input
-                                checked={newDraft}
-                                onChange={(event) =>
-                                    setNewDraft(event.currentTarget.checked)
-                                }
-                                type="checkbox"
-                            />
-                            Create as draft
-                        </label>
-                        <div className="mt-3">
-                            <GitHubDraftPreview
-                                body={newBody}
-                                meta={`${newHead.trim() || "head"} into ${
-                                    newBase.trim() || "base"
-                                }${newDraft ? " · draft" : ""}`}
-                                title={newTitle}
-                            />
-                        </div>
-                        <div className="mt-3 flex justify-end gap-2">
-                            <IdeActionButton
-                                disabled={isCreatingPullRequest}
-                                onClick={() => setIsCreating(false)}
-                            >
-                                Cancel
-                            </IdeActionButton>
-                            <IdeActionButton
-                                disabled={
-                                    isCreatingPullRequest ||
-                                    !canWritePullRequests ||
-                                    newTitle.trim().length === 0 ||
-                                    newBase.trim().length === 0 ||
-                                    newHead.trim().length === 0
-                                }
-                                onClick={() =>
-                                    void handleCreatePullRequest()
-                                }
-                            >
-                                {isCreatingPullRequest
-                                    ? "Creating..."
-                                    : "Create Pull Request"}
-                            </IdeActionButton>
-                        </div>
+                        {isLoading || isCheckingAuth ? (
+                            <div className="text-[12px] text-text-secondary">
+                                Loading pull requests...
+                            </div>
+                        ) : null}
+                        {!isLoading && visiblePullRequests.length === 0 ? (
+                            <GitHubEmptyState>
+                                No pull requests match this view.
+                            </GitHubEmptyState>
+                        ) : null}
                     </div>
-                ) : null}
-                {isLoading || isCheckingAuth ? (
-                    <div className="text-[12px] text-text-secondary">
-                        Loading pull requests...
-                    </div>
-                ) : null}
-                {!isLoading && visiblePullRequests.length === 0 ? (
-                    <GitHubEmptyState>
-                        No pull requests match this view.
-                    </GitHubEmptyState>
-                ) : null}
-            </div>
-            {!isLoading && visiblePullRequests.length > 0 ? (
-                <div className="shell-scrollbar overflow-x-auto">
-                    <div
-                        className="sticky top-0 z-10 grid items-center px-3 py-1.5 text-[10px] font-semibold uppercase text-text-secondary"
-                        style={{
-                            backgroundColor: "var(--color-bg-secondary)",
-                            borderBottom:
-                                "1px solid color-mix(in srgb, var(--color-border) 60%, transparent)",
-                            fontFamily: "var(--font-mono)",
-                            gridTemplateColumns: tableGridTemplate,
-                            letterSpacing: "0.06em",
-                            minWidth: tableMinWidth,
-                        }}
-                    >
-                        {tableLayout.order.map((columnId) => (
-                            <PullRequestHeaderCell
-                                columnId={columnId}
-                                dragged={draggedColumnId === columnId}
-                                key={columnId}
-                                label={PR_TABLE_COLUMN_LABELS[columnId]}
-                                onDragEnd={() => setDraggedColumnId(null)}
-                                onDragOver={(event) => {
-                                    event.preventDefault();
-                                    event.dataTransfer.dropEffect = "move";
-                                }}
-                                onDragStart={(event) =>
-                                    handleColumnDragStart(columnId, event)
-                                }
-                                onDrop={(event) =>
-                                    handleColumnDrop(columnId, event)
-                                }
-                                onResizePointerDown={(event) =>
-                                    handleColumnResizePointerDown(
-                                        columnId,
-                                        event,
-                                    )
-                                }
-                            />
-                        ))}
-                    </div>
-                    {visiblePullRequests.map((pullRequest) => {
-                        const isCurrentBranchPullRequest =
-                            isPullRequestForCurrentBranch(
-                                pullRequest,
-                                currentBranch,
-                                tab.ref,
-                            );
-                        const checksKey = getGitHubPullRequestChecksKey(
-                            tab.ref,
-                            pullRequest.head.sha,
-                        );
-                        const checks =
-                            pullRequestChecksByHeadSha[pullRequest.head.sha] ??
-                            null;
-                        const checksState = loadingKeys[checksKey]
-                            ? "loading"
-                            : (checks?.state ?? "unknown");
-                        const handleOpenPullRequest = () =>
-                            void openGitHubPullRequestTab({
-                                projectId: tab.projectId,
-                                pullRequestNumber: pullRequest.number,
-                                ref: tab.ref,
-                                worktreeId: tab.worktreeId ?? null,
-                            });
-
-                        return (
+                    {!isLoading && visiblePullRequests.length > 0 ? (
+                        <div className="shell-scrollbar overflow-x-auto">
                             <div
-                                className={[
-                                    "group/row grid items-stretch border-l-[3px] pl-2.5 pr-3 text-left text-[11px] transition-[color,background-color,border-color] duration-120",
-                                    isCurrentBranchPullRequest
-                                        ? "border-l-[color-mix(in_srgb,var(--color-accent)_70%,transparent)] bg-[color-mix(in_srgb,var(--color-accent)_9%,var(--color-bg-primary))] text-text-primary"
-                                        : "border-l-transparent text-text-secondary hover:border-l-[color-mix(in_srgb,var(--color-accent)_60%,transparent)] hover:bg-bg-secondary hover:text-text-primary",
-                                ].join(" ")}
-                                key={pullRequest.id}
+                                className="sticky top-0 z-10 grid items-center px-3 py-1.5 text-[10px] font-semibold uppercase text-text-secondary"
                                 style={{
+                                    backgroundColor:
+                                        "var(--color-bg-secondary)",
+                                    borderBottom:
+                                        "1px solid color-mix(in srgb, var(--color-border) 60%, transparent)",
+                                    fontFamily: "var(--font-mono)",
                                     gridTemplateColumns: tableGridTemplate,
+                                    letterSpacing: "0.06em",
                                     minWidth: tableMinWidth,
                                 }}
                             >
                                 {tableLayout.order.map((columnId) => (
-                                    <PullRequestTableCell
-                                        checksState={checksState}
+                                    <PullRequestHeaderCell
                                         columnId={columnId}
-                                        isCurrentBranchPullRequest={
-                                            isCurrentBranchPullRequest
+                                        dragged={
+                                            draggedColumnId === columnId
                                         }
                                         key={columnId}
-                                        onOpen={handleOpenPullRequest}
-                                        pullRequest={pullRequest}
+                                        label={
+                                            PR_TABLE_COLUMN_LABELS[columnId]
+                                        }
+                                        onDragEnd={() =>
+                                            setDraggedColumnId(null)
+                                        }
+                                        onDragOver={(event) => {
+                                            event.preventDefault();
+                                            event.dataTransfer.dropEffect =
+                                                "move";
+                                        }}
+                                        onDragStart={(event) =>
+                                            handleColumnDragStart(
+                                                columnId,
+                                                event,
+                                            )
+                                        }
+                                        onDrop={(event) =>
+                                            handleColumnDrop(columnId, event)
+                                        }
+                                        onResizePointerDown={(event) =>
+                                            handleColumnResizePointerDown(
+                                                columnId,
+                                                event,
+                                            )
+                                        }
                                     />
                                 ))}
                             </div>
-                        );
-                    })}
-                </div>
-            ) : null}
+                            <GitHubVirtualizedTableBody
+                                estimateRowHeight={
+                                    estimatePullRequestTableRowHeight
+                                }
+                                getRowKey={(pullRequest) =>
+                                    String(pullRequest.id)
+                                }
+                                gridTemplateColumns={tableGridTemplate}
+                                items={visiblePullRequests}
+                                minWidth={tableMinWidth}
+                                onRangeChange={handlePullRequestRangeChange}
+                                renderRow={renderPullRequestRow}
+                                scrollContainerRef={scrollContainerRef}
+                                threshold={
+                                    GITHUB_PULL_REQUESTS_VIRTUALIZATION_THRESHOLD
+                                }
+                            />
+                        </div>
+                    ) : null}
+                </>
+            )}
         </GitHubTabShell>
+    );
+}
+
+function PullRequestTableRow({
+    checksState,
+    isCurrentBranchPullRequest,
+    onOpenPullRequest,
+    pullRequest,
+    tableLayout,
+}: {
+    readonly checksState: GitHubPullRequestChecksState | "loading";
+    readonly isCurrentBranchPullRequest: boolean;
+    readonly onOpenPullRequest: (pullRequestNumber: number) => void;
+    readonly pullRequest: GitHubPullRequestSummary;
+    readonly tableLayout: PullRequestTableLayout;
+}) {
+    const handleOpenPullRequest = () => {
+        onOpenPullRequest(pullRequest.number);
+    };
+
+    return (
+        <div
+            className={[
+                "group/row items-stretch border-l-[3px] pl-2.5 pr-3 text-left text-[11px] transition-[color,background-color,border-color] duration-120",
+                isCurrentBranchPullRequest
+                    ? "border-l-[color-mix(in_srgb,var(--color-accent)_70%,transparent)] bg-[color-mix(in_srgb,var(--color-accent)_9%,var(--color-bg-primary))] text-text-primary"
+                    : "border-l-transparent text-text-secondary hover:border-l-[color-mix(in_srgb,var(--color-accent)_60%,transparent)] hover:bg-bg-secondary hover:text-text-primary",
+            ].join(" ")}
+        >
+            {tableLayout.order.map((columnId) => (
+                <PullRequestTableCell
+                    checksState={checksState}
+                    columnId={columnId}
+                    isCurrentBranchPullRequest={isCurrentBranchPullRequest}
+                    key={columnId}
+                    onOpen={handleOpenPullRequest}
+                    pullRequest={pullRequest}
+                />
+            ))}
+        </div>
     );
 }
 
@@ -943,6 +1044,77 @@ function renderPullRequestColumnContent({
             ) : null}
         </div>
     );
+}
+
+interface PullRequestCheckTarget {
+    readonly headSha: string;
+    readonly number: number;
+}
+
+export function getVisiblePullRequestCheckTargets({
+    pullRequests,
+    range,
+}: {
+    readonly pullRequests: readonly GitHubPullRequestSummary[];
+    readonly range: MeasuredVirtualRange | null;
+}): readonly PullRequestCheckTarget[] {
+    const hasVisibleRange =
+        range !== null &&
+        range.visibleEndIndex >= range.visibleStartIndex &&
+        range.visibleStartIndex < pullRequests.length;
+    const startIndex =
+        hasVisibleRange
+            ? Math.max(
+                  0,
+                  range.visibleStartIndex - PULL_REQUEST_CHECK_DATA_OVERSCAN,
+              )
+            : 0;
+    const endIndex =
+        hasVisibleRange
+            ? Math.min(
+                  pullRequests.length,
+                  range.visibleEndIndex + PULL_REQUEST_CHECK_DATA_OVERSCAN + 1,
+              )
+            : Math.min(
+                  pullRequests.length,
+                  PULL_REQUEST_INITIAL_CHECK_TARGET_COUNT,
+              );
+    const seenHeadShas = new Set<string>();
+    const targets: PullRequestCheckTarget[] = [];
+
+    for (const pullRequest of pullRequests.slice(startIndex, endIndex)) {
+        const headSha = pullRequest.head.sha.trim();
+        if (!headSha || seenHeadShas.has(headSha)) {
+            continue;
+        }
+
+        seenHeadShas.add(headSha);
+        targets.push({
+            headSha,
+            number: pullRequest.number,
+        });
+    }
+
+    return targets;
+}
+
+function areMeasuredVirtualRangesEqual(
+    left: MeasuredVirtualRange | null,
+    right: MeasuredVirtualRange,
+): boolean {
+    return (
+        left !== null &&
+        left.startIndex === right.startIndex &&
+        left.endIndex === right.endIndex &&
+        left.visibleStartIndex === right.visibleStartIndex &&
+        left.visibleEndIndex === right.visibleEndIndex
+    );
+}
+
+function estimatePullRequestTableRowHeight(
+    pullRequest: GitHubPullRequestSummary,
+): number {
+    return pullRequest.labels.length > 0 ? 72 : 58;
 }
 
 function clampWidth(value: number, min: number, max: number): number {

--- a/src/renderer/src/components/workspace/GitHubVirtualizedTableBody.test.tsx
+++ b/src/renderer/src/components/workspace/GitHubVirtualizedTableBody.test.tsx
@@ -34,11 +34,25 @@ vi.mock("../virtual/MeasuredVirtualList", () => ({
 
 import {
     applyGitHubVirtualizedTableRowLayout,
+    calculateGitHubVirtualizedTableScrollMarginTop,
     GitHubVirtualizedTableBody,
 } from "./GitHubVirtualizedTableBody";
 
 function createItems(count: number): string[] {
     return Array.from({ length: count }, (_, index) => `row-${index}`);
+}
+
+function createMeasuredElement({
+    scrollTop = 0,
+    top,
+}: {
+    readonly scrollTop?: number;
+    readonly top: number;
+}): HTMLElement {
+    return {
+        getBoundingClientRect: () => ({ top }) as DOMRect,
+        scrollTop,
+    } as HTMLElement;
 }
 
 function renderBody({
@@ -155,5 +169,29 @@ describe("GitHubVirtualizedTableBody", () => {
 
         row.props.onClick();
         expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("calculates the scroll margin from the current table position", () => {
+        expect(
+            calculateGitHubVirtualizedTableScrollMarginTop({
+                bodyElement: createMeasuredElement({ top: 220 }),
+                scrollContainer: createMeasuredElement({
+                    scrollTop: 360,
+                    top: 80,
+                }),
+            }),
+        ).toBe(500);
+    });
+
+    it("clamps negative scroll margins to zero", () => {
+        expect(
+            calculateGitHubVirtualizedTableScrollMarginTop({
+                bodyElement: createMeasuredElement({ top: 40 }),
+                scrollContainer: createMeasuredElement({
+                    scrollTop: 0,
+                    top: 80,
+                }),
+            }),
+        ).toBe(0);
     });
 });

--- a/src/renderer/src/components/workspace/GitHubVirtualizedTableBody.test.tsx
+++ b/src/renderer/src/components/workspace/GitHubVirtualizedTableBody.test.tsx
@@ -1,0 +1,159 @@
+import { isValidElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const measuredVirtualListMock = vi.hoisted(() =>
+    vi.fn(
+        ({
+            items,
+            renderItem,
+        }: {
+            readonly items: readonly string[];
+            readonly renderItem: (params: {
+                readonly index: number;
+                readonly isVisible: boolean;
+                readonly item: string;
+            }) => ReactNode;
+        }) => (
+            <div data-testid="measured-virtual-list">
+                {items.slice(0, 2).map((item, index) =>
+                    renderItem({
+                        index,
+                        isVisible: true,
+                        item,
+                    }),
+                )}
+            </div>
+        ),
+    ),
+);
+
+vi.mock("../virtual/MeasuredVirtualList", () => ({
+    MeasuredVirtualList: measuredVirtualListMock,
+}));
+
+import {
+    applyGitHubVirtualizedTableRowLayout,
+    GitHubVirtualizedTableBody,
+} from "./GitHubVirtualizedTableBody";
+
+function createItems(count: number): string[] {
+    return Array.from({ length: count }, (_, index) => `row-${index}`);
+}
+
+function renderBody({
+    gridTemplateColumns = "40px 1fr",
+    items,
+    minWidth = 240,
+    threshold = 5,
+}: {
+    readonly gridTemplateColumns?: string;
+    readonly items: readonly string[];
+    readonly minWidth?: number;
+    readonly threshold?: number;
+}) {
+    return renderToStaticMarkup(
+        <GitHubVirtualizedTableBody
+            estimateRowHeight={() => 48}
+            getRowKey={(item) => item}
+            gridTemplateColumns={gridTemplateColumns}
+            items={items}
+            minWidth={minWidth}
+            renderRow={(item) => (
+                <div className="group/row items-stretch">
+                    <button type="button">{item}</button>
+                </div>
+            )}
+            scrollContainerRef={{ current: null }}
+            threshold={threshold}
+        />,
+    );
+}
+
+describe("GitHubVirtualizedTableBody", () => {
+    beforeEach(() => {
+        measuredVirtualListMock.mockClear();
+    });
+
+    it("renders every row below the virtualization threshold", () => {
+        const markup = renderBody({
+            items: createItems(4),
+            threshold: 5,
+        });
+
+        expect(markup).toContain("row-0");
+        expect(markup).toContain("row-3");
+        expect(markup.match(/group\/row/g)).toHaveLength(4);
+        expect(measuredVirtualListMock).not.toHaveBeenCalled();
+    });
+
+    it("uses MeasuredVirtualList above the virtualization threshold", () => {
+        const markup = renderBody({
+            items: createItems(8),
+            threshold: 5,
+        });
+
+        expect(markup).toContain("row-0");
+        expect(markup).toContain("row-1");
+        expect(markup).not.toContain("row-7");
+        expect(measuredVirtualListMock).toHaveBeenCalledTimes(1);
+        expect(measuredVirtualListMock.mock.calls[0]?.[0]).toMatchObject({
+            enabled: true,
+            overscan: 6,
+            scrollMarginTop: 0,
+        });
+    });
+
+    it("applies the table grid layout to rendered rows", () => {
+        const markup = renderBody({
+            gridTemplateColumns: "56px 420px 128px",
+            items: createItems(2),
+            minWidth: 604,
+            threshold: 5,
+        });
+
+        expect(markup).toContain("grid group/row items-stretch");
+        expect(markup).toContain("grid-template-columns:56px 420px 128px");
+        expect(markup).toContain("min-width:604px");
+    });
+
+    it("passes updated layout values to virtualized rows", () => {
+        renderBody({
+            gridTemplateColumns: "40px 1fr",
+            items: createItems(8),
+            minWidth: 240,
+            threshold: 5,
+        });
+
+        const markup = renderBody({
+            gridTemplateColumns: "72px 2fr",
+            items: createItems(8),
+            minWidth: 360,
+            threshold: 5,
+        });
+
+        expect(markup).toContain("grid-template-columns:72px 2fr");
+        expect(markup).toContain("min-width:360px");
+    });
+
+    it("preserves row click handlers when injecting layout props", () => {
+        const handleClick = vi.fn();
+        const row = applyGitHubVirtualizedTableRowLayout({
+            gridTemplateColumns: "1fr",
+            minWidth: 120,
+            row: (
+                <button onClick={handleClick} type="button">
+                    Open
+                </button>
+            ),
+        });
+
+        expect(isValidElement(row)).toBe(true);
+        if (!isValidElement<{ readonly onClick: () => void }>(row)) {
+            throw new Error("Expected a valid row element");
+        }
+
+        row.props.onClick();
+        expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/renderer/src/components/workspace/GitHubVirtualizedTableBody.tsx
+++ b/src/renderer/src/components/workspace/GitHubVirtualizedTableBody.tsx
@@ -10,7 +10,10 @@ import {
     type RefObject,
 } from "react";
 
-import { MeasuredVirtualList } from "../virtual/MeasuredVirtualList";
+import {
+    MeasuredVirtualList,
+    type MeasuredVirtualRange,
+} from "../virtual/MeasuredVirtualList";
 
 const DEFAULT_TABLE_ROW_OVERSCAN = 6;
 const DEFAULT_TABLE_VIEWPORT_HEIGHT = 720;
@@ -27,6 +30,7 @@ export interface GitHubVirtualizedTableBodyProps<T> {
     readonly gridTemplateColumns: string;
     readonly items: readonly T[];
     readonly minWidth: number;
+    readonly onRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly overscan?: number;
     readonly renderRow: (item: T, index: number) => ReactNode;
     readonly scrollContainerRef: RefObject<HTMLElement | null>;
@@ -40,6 +44,7 @@ export function GitHubVirtualizedTableBody<T>({
     gridTemplateColumns,
     items,
     minWidth,
+    onRangeChange,
     overscan = DEFAULT_TABLE_ROW_OVERSCAN,
     renderRow,
     scrollContainerRef,
@@ -127,6 +132,7 @@ export function GitHubVirtualizedTableBody<T>({
                 estimateSize={estimateRowHeight}
                 getItemKey={getRowKey}
                 items={items}
+                onRangeChange={onRangeChange}
                 overscan={overscan}
                 renderItem={({ index, item }) => renderLaidOutRow(item, index)}
                 scrollContainerRef={scrollContainerRef}

--- a/src/renderer/src/components/workspace/GitHubVirtualizedTableBody.tsx
+++ b/src/renderer/src/components/workspace/GitHubVirtualizedTableBody.tsx
@@ -3,6 +3,7 @@ import {
     isValidElement,
     useCallback,
     useEffect,
+    useLayoutEffect,
     useRef,
     useState,
     type CSSProperties,
@@ -17,6 +18,8 @@ import {
 
 const DEFAULT_TABLE_ROW_OVERSCAN = 6;
 const DEFAULT_TABLE_VIEWPORT_HEIGHT = 720;
+const useBrowserLayoutEffect =
+    typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 interface TableRowLayoutProps {
     readonly className?: string;
@@ -54,6 +57,22 @@ export function GitHubVirtualizedTableBody<T>({
     const [scrollMarginTop, setScrollMarginTop] = useState(0);
     const shouldVirtualize = items.length >= threshold;
 
+    const syncScrollMarginTop = useCallback(() => {
+        if (!shouldVirtualize) {
+            return;
+        }
+
+        const nextScrollMarginTop =
+            calculateGitHubVirtualizedTableScrollMarginTop({
+                bodyElement: bodyRef.current,
+                scrollContainer: scrollContainerRef.current,
+            });
+
+        setScrollMarginTop((current) =>
+            current === nextScrollMarginTop ? current : nextScrollMarginTop,
+        );
+    }, [scrollContainerRef, shouldVirtualize]);
+
     const renderLaidOutRow = useCallback(
         (item: T, index: number) =>
             applyGitHubVirtualizedTableRowLayout({
@@ -63,6 +82,10 @@ export function GitHubVirtualizedTableBody<T>({
             }),
         [gridTemplateColumns, minWidth, renderRow],
     );
+
+    useBrowserLayoutEffect(() => {
+        syncScrollMarginTop();
+    });
 
     useEffect(() => {
         if (!shouldVirtualize) {
@@ -74,23 +97,6 @@ export function GitHubVirtualizedTableBody<T>({
         if (!bodyElement || !scrollContainer) {
             return;
         }
-
-        const syncScrollMarginTop = () => {
-            const bodyRect = bodyElement.getBoundingClientRect();
-            const containerRect = scrollContainer.getBoundingClientRect();
-            const nextScrollMarginTop = Math.max(
-                0,
-                Math.round(
-                    bodyRect.top - containerRect.top + scrollContainer.scrollTop,
-                ),
-            );
-
-            setScrollMarginTop((current) =>
-                current === nextScrollMarginTop
-                    ? current
-                    : nextScrollMarginTop,
-            );
-        };
 
         syncScrollMarginTop();
         window.addEventListener("resize", syncScrollMarginTop);
@@ -106,7 +112,7 @@ export function GitHubVirtualizedTableBody<T>({
             window.removeEventListener("resize", syncScrollMarginTop);
             resizeObserver?.disconnect();
         };
-    }, [scrollContainerRef, shouldVirtualize]);
+    }, [scrollContainerRef, shouldVirtualize, syncScrollMarginTop]);
 
     if (items.length === 0) {
         return null;
@@ -139,6 +145,26 @@ export function GitHubVirtualizedTableBody<T>({
                 scrollMarginTop={scrollMarginTop}
             />
         </div>
+    );
+}
+
+export function calculateGitHubVirtualizedTableScrollMarginTop({
+    bodyElement,
+    scrollContainer,
+}: {
+    readonly bodyElement: HTMLElement | null;
+    readonly scrollContainer: HTMLElement | null;
+}): number {
+    if (!bodyElement || !scrollContainer) {
+        return 0;
+    }
+
+    const bodyRect = bodyElement.getBoundingClientRect();
+    const containerRect = scrollContainer.getBoundingClientRect();
+
+    return Math.max(
+        0,
+        Math.round(bodyRect.top - containerRect.top + scrollContainer.scrollTop),
     );
 }
 

--- a/src/renderer/src/components/workspace/GitHubVirtualizedTableBody.tsx
+++ b/src/renderer/src/components/workspace/GitHubVirtualizedTableBody.tsx
@@ -1,0 +1,178 @@
+import {
+    cloneElement,
+    isValidElement,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    type CSSProperties,
+    type ReactNode,
+    type RefObject,
+} from "react";
+
+import { MeasuredVirtualList } from "../virtual/MeasuredVirtualList";
+
+const DEFAULT_TABLE_ROW_OVERSCAN = 6;
+const DEFAULT_TABLE_VIEWPORT_HEIGHT = 720;
+
+interface TableRowLayoutProps {
+    readonly className?: string;
+    readonly style?: CSSProperties;
+}
+
+export interface GitHubVirtualizedTableBodyProps<T> {
+    readonly defaultViewportHeight?: number;
+    readonly estimateRowHeight: (item: T, index: number) => number;
+    readonly getRowKey: (item: T, index: number) => string;
+    readonly gridTemplateColumns: string;
+    readonly items: readonly T[];
+    readonly minWidth: number;
+    readonly overscan?: number;
+    readonly renderRow: (item: T, index: number) => ReactNode;
+    readonly scrollContainerRef: RefObject<HTMLElement | null>;
+    readonly threshold: number;
+}
+
+export function GitHubVirtualizedTableBody<T>({
+    defaultViewportHeight = DEFAULT_TABLE_VIEWPORT_HEIGHT,
+    estimateRowHeight,
+    getRowKey,
+    gridTemplateColumns,
+    items,
+    minWidth,
+    overscan = DEFAULT_TABLE_ROW_OVERSCAN,
+    renderRow,
+    scrollContainerRef,
+    threshold,
+}: GitHubVirtualizedTableBodyProps<T>) {
+    const bodyRef = useRef<HTMLDivElement | null>(null);
+    const [scrollMarginTop, setScrollMarginTop] = useState(0);
+    const shouldVirtualize = items.length >= threshold;
+
+    const renderLaidOutRow = useCallback(
+        (item: T, index: number) =>
+            applyGitHubVirtualizedTableRowLayout({
+                gridTemplateColumns,
+                minWidth,
+                row: renderRow(item, index),
+            }),
+        [gridTemplateColumns, minWidth, renderRow],
+    );
+
+    useEffect(() => {
+        if (!shouldVirtualize) {
+            return;
+        }
+
+        const bodyElement = bodyRef.current;
+        const scrollContainer = scrollContainerRef.current;
+        if (!bodyElement || !scrollContainer) {
+            return;
+        }
+
+        const syncScrollMarginTop = () => {
+            const bodyRect = bodyElement.getBoundingClientRect();
+            const containerRect = scrollContainer.getBoundingClientRect();
+            const nextScrollMarginTop = Math.max(
+                0,
+                Math.round(
+                    bodyRect.top - containerRect.top + scrollContainer.scrollTop,
+                ),
+            );
+
+            setScrollMarginTop((current) =>
+                current === nextScrollMarginTop
+                    ? current
+                    : nextScrollMarginTop,
+            );
+        };
+
+        syncScrollMarginTop();
+        window.addEventListener("resize", syncScrollMarginTop);
+
+        let resizeObserver: ResizeObserver | null = null;
+        if (typeof ResizeObserver !== "undefined") {
+            resizeObserver = new ResizeObserver(syncScrollMarginTop);
+            resizeObserver.observe(bodyElement);
+            resizeObserver.observe(scrollContainer);
+        }
+
+        return () => {
+            window.removeEventListener("resize", syncScrollMarginTop);
+            resizeObserver?.disconnect();
+        };
+    }, [scrollContainerRef, shouldVirtualize]);
+
+    if (items.length === 0) {
+        return null;
+    }
+
+    if (!shouldVirtualize) {
+        return (
+            <div className="relative w-full" ref={bodyRef}>
+                {items.map((item, index) => (
+                    <div key={getRowKey(item, index)}>
+                        {renderLaidOutRow(item, index)}
+                    </div>
+                ))}
+            </div>
+        );
+    }
+
+    return (
+        <div className="relative w-full" ref={bodyRef}>
+            <MeasuredVirtualList
+                defaultViewportHeight={defaultViewportHeight}
+                enabled
+                estimateSize={estimateRowHeight}
+                getItemKey={getRowKey}
+                items={items}
+                overscan={overscan}
+                renderItem={({ index, item }) => renderLaidOutRow(item, index)}
+                scrollContainerRef={scrollContainerRef}
+                scrollMarginTop={scrollMarginTop}
+            />
+        </div>
+    );
+}
+
+export function applyGitHubVirtualizedTableRowLayout({
+    gridTemplateColumns,
+    minWidth,
+    row,
+}: {
+    readonly gridTemplateColumns: string;
+    readonly minWidth: number;
+    readonly row: ReactNode;
+}): ReactNode {
+    const layoutStyle: CSSProperties = {
+        gridTemplateColumns,
+        minWidth,
+    };
+
+    if (!isValidElement<TableRowLayoutProps>(row)) {
+        return (
+            <div className="grid" style={layoutStyle}>
+                {row}
+            </div>
+        );
+    }
+
+    return cloneElement(row, {
+        className: mergeGridClassName(row.props.className),
+        style: {
+            ...row.props.style,
+            ...layoutStyle,
+        },
+    });
+}
+
+function mergeGridClassName(className: string | undefined): string {
+    if (!className) {
+        return "grid";
+    }
+
+    return className.split(/\s+/).includes("grid")
+        ? className
+        : `grid ${className}`;
+}

--- a/src/renderer/src/components/workspace/GitHubWorkspacePrimitives.test.tsx
+++ b/src/renderer/src/components/workspace/GitHubWorkspacePrimitives.test.tsx
@@ -1,0 +1,94 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { WorkspaceScrollScope } from "./usePersistedWorkspaceScroll";
+
+const mockPersistedScroll = vi.hoisted(() => {
+    const handleScroll = vi.fn();
+    const scrollRef = vi.fn();
+    const usePersistedWorkspaceScroll = vi.fn(() => ({
+        handleScroll,
+        scrollRef,
+        storageKey: "test-scroll-key",
+    }));
+
+    return {
+        handleScroll,
+        scrollRef,
+        usePersistedWorkspaceScroll,
+    };
+});
+
+vi.mock("./usePersistedWorkspaceScroll", () => ({
+    usePersistedWorkspaceScroll:
+        mockPersistedScroll.usePersistedWorkspaceScroll,
+}));
+
+import {
+    GitHubTabShell,
+    type GitHubTabShellRenderContext,
+} from "./GitHubWorkspacePrimitives";
+
+const SCROLL_SCOPE: WorkspaceScrollScope = {
+    entityId: "github.com/octocat/hello-world",
+    projectId: "project-1",
+    surface: "github_issues",
+    worktreeId: null,
+};
+
+describe("GitHubTabShell", () => {
+    beforeEach(() => {
+        mockPersistedScroll.handleScroll.mockClear();
+        mockPersistedScroll.scrollRef.mockClear();
+        mockPersistedScroll.usePersistedWorkspaceScroll.mockClear();
+    });
+
+    it("keeps persisted workspace scroll in the shell while rendering normal children", () => {
+        const markup = renderToStaticMarkup(
+            <GitHubTabShell
+                header={<div>GitHub Header</div>}
+                scrollScope={SCROLL_SCOPE}
+            >
+                <div>Normal child content</div>
+            </GitHubTabShell>,
+        );
+
+        expect(
+            mockPersistedScroll.usePersistedWorkspaceScroll,
+        ).toHaveBeenCalledWith(SCROLL_SCOPE);
+        expect(markup).toContain("GitHub Header");
+        expect(markup).toContain("Normal child content");
+    });
+
+    it("passes the shared scroll ref to render prop children", () => {
+        const renderChild = vi.fn(
+            ({ scrollRef }: GitHubTabShellRenderContext) =>
+                createElement(
+                    "div",
+                    {
+                        "data-scroll-ref":
+                            scrollRef === mockPersistedScroll.scrollRef
+                                ? "shared"
+                                : "changed",
+                    },
+                    "Render prop content",
+                ),
+        );
+        const markup = renderToStaticMarkup(
+            <GitHubTabShell
+                header={<div>GitHub Header</div>}
+                scrollScope={SCROLL_SCOPE}
+            >
+                {renderChild}
+            </GitHubTabShell>,
+        );
+
+        expect(renderChild).toHaveBeenCalledTimes(1);
+        expect(renderChild.mock.calls[0]?.[0].scrollRef).toBe(
+            mockPersistedScroll.scrollRef,
+        );
+        expect(markup).toContain('data-scroll-ref="shared"');
+        expect(markup).toContain("Render prop content");
+    });
+});

--- a/src/renderer/src/components/workspace/GitHubWorkspacePrimitives.test.tsx
+++ b/src/renderer/src/components/workspace/GitHubWorkspacePrimitives.test.tsx
@@ -61,19 +61,22 @@ describe("GitHubTabShell", () => {
         expect(markup).toContain("Normal child content");
     });
 
-    it("passes the shared scroll ref to render prop children", () => {
+    it("passes the shared scroll container ref to render prop children", () => {
         const renderChild = vi.fn(
-            ({ scrollRef }: GitHubTabShellRenderContext) =>
-                createElement(
-                    "div",
-                    {
-                        "data-scroll-ref":
-                            scrollRef === mockPersistedScroll.scrollRef
-                                ? "shared"
-                                : "changed",
-                    },
-                    "Render prop content",
-                ),
+            (context: GitHubTabShellRenderContext) => {
+                return (
+                    createElement(
+                        "div",
+                        {
+                            "data-scroll-ref":
+                                context.scrollContainerRef.current === null
+                                    ? "shared"
+                                    : "changed",
+                        },
+                        "Render prop content",
+                    )
+                );
+            },
         );
         const markup = renderToStaticMarkup(
             <GitHubTabShell
@@ -85,9 +88,11 @@ describe("GitHubTabShell", () => {
         );
 
         expect(renderChild).toHaveBeenCalledTimes(1);
-        expect(renderChild.mock.calls[0]?.[0].scrollRef).toBe(
-            mockPersistedScroll.scrollRef,
-        );
+        const receivedContext = renderChild.mock.calls[0]?.[0];
+        expect(receivedContext).toBeDefined();
+        expect(receivedContext?.scrollContainerRef.current).toBeNull();
+        receivedContext?.scrollRef(null);
+        expect(mockPersistedScroll.scrollRef).toHaveBeenCalledTimes(1);
         expect(markup).toContain('data-scroll-ref="shared"');
         expect(markup).toContain("Render prop content");
     });

--- a/src/renderer/src/components/workspace/GitHubWorkspacePrimitives.tsx
+++ b/src/renderer/src/components/workspace/GitHubWorkspacePrimitives.tsx
@@ -1,11 +1,13 @@
 import {
+    useCallback,
     useEffect,
     useMemo,
     useRef,
     useState,
-    type RefCallback,
     type KeyboardEvent,
     type ReactNode,
+    type RefCallback,
+    type RefObject,
 } from "react";
 
 import type {
@@ -36,6 +38,7 @@ export type GitHubAuthCapability = "issues" | "pull_requests";
 export type GitHubMergeableState = "computing" | "conflicts" | "mergeable";
 
 export interface GitHubTabShellRenderContext {
+    readonly scrollContainerRef: RefObject<HTMLDivElement | null>;
     readonly scrollRef: RefCallback<HTMLDivElement>;
 }
 
@@ -54,9 +57,20 @@ export function GitHubTabShell({
 }) {
     const { handleScroll, scrollRef: setScrollContainerElement } =
         usePersistedWorkspaceScroll<HTMLDivElement>(scrollScope);
-    const renderContext = useMemo<GitHubTabShellRenderContext>(
-        () => ({ scrollRef: setScrollContainerElement }),
+    const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+    const setSharedScrollContainerElement = useCallback(
+        (node: HTMLDivElement | null) => {
+            scrollContainerRef.current = node;
+            setScrollContainerElement(node);
+        },
         [setScrollContainerElement],
+    );
+    const renderContext = useMemo<GitHubTabShellRenderContext>(
+        () => ({
+            scrollContainerRef,
+            scrollRef: setSharedScrollContainerElement,
+        }),
+        [setSharedScrollContainerElement],
     );
     const content =
         typeof children === "function"
@@ -71,7 +85,7 @@ export function GitHubTabShell({
             <div
                 className="shell-scrollbar min-h-0 flex-1 overflow-y-auto"
                 onScroll={handleScroll}
-                ref={setScrollContainerElement}
+                ref={setSharedScrollContainerElement}
             >
                 {content}
             </div>

--- a/src/renderer/src/components/workspace/GitHubWorkspacePrimitives.tsx
+++ b/src/renderer/src/components/workspace/GitHubWorkspacePrimitives.tsx
@@ -1,7 +1,9 @@
 import {
     useEffect,
+    useMemo,
     useRef,
     useState,
+    type RefCallback,
     type KeyboardEvent,
     type ReactNode,
 } from "react";
@@ -33,17 +35,35 @@ export type GitHubAuthCapability = "issues" | "pull_requests";
 
 export type GitHubMergeableState = "computing" | "conflicts" | "mergeable";
 
+export interface GitHubTabShellRenderContext {
+    readonly scrollRef: RefCallback<HTMLDivElement>;
+}
+
+type GitHubTabShellChildren =
+    | ReactNode
+    | ((context: GitHubTabShellRenderContext) => ReactNode);
+
 export function GitHubTabShell({
     children,
     header,
     scrollScope,
 }: {
-    readonly children: ReactNode;
+    readonly children: GitHubTabShellChildren;
     readonly header: ReactNode;
     readonly scrollScope: WorkspaceScrollScope;
 }) {
-    const { handleScroll, scrollRef } =
+    const { handleScroll, scrollRef: setScrollContainerElement } =
         usePersistedWorkspaceScroll<HTMLDivElement>(scrollScope);
+    const renderContext = useMemo<GitHubTabShellRenderContext>(
+        () => ({ scrollRef: setScrollContainerElement }),
+        [setScrollContainerElement],
+    );
+    const content =
+        typeof children === "function"
+            ? // Render prop consumers need the shell scroll target for row virtualization.
+              // eslint-disable-next-line react-hooks/refs
+              children(renderContext)
+            : children;
 
     return (
         <div className="flex h-full min-h-0 flex-col bg-editor text-text-primary">
@@ -51,9 +71,9 @@ export function GitHubTabShell({
             <div
                 className="shell-scrollbar min-h-0 flex-1 overflow-y-auto"
                 onScroll={handleScroll}
-                ref={scrollRef}
+                ref={setScrollContainerElement}
             >
-                {children}
+                {content}
             </div>
         </div>
     );

--- a/src/renderer/src/components/workspace/GitTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitTabView.test.tsx
@@ -45,7 +45,10 @@ vi.mock("@renderer/app/store/workspace-store", () => ({
     ) => selector(mockWorkspaceStoreState.current),
 }));
 
-import { GitTabView } from "./GitTabView";
+import {
+    GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD,
+    GitTabView,
+} from "./GitTabView";
 
 const TAB: RuntimeWorkspaceGitTab = {
     createdAt: "2026-04-15T00:00:00.000Z",
@@ -250,5 +253,55 @@ describe("GitTabView", () => {
         expect(markup).not.toContain(
             'aria-label="Open file src/renderer/src/components/git/RemovedFile.tsx"',
         );
+    });
+
+    it("renders the large commit history baseline and preserves active selection", () => {
+        resetStoreState();
+        const commits = Array.from(
+            { length: GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD },
+            (_, index) =>
+                createCommit({
+                    authoredAt: `2026-04-${String(1 + (index % 28)).padStart(2, "0")}T12:00:00.000Z`,
+                    sha: `commit-${String(index + 1).padStart(4, "0")}`,
+                    shortSha: `c${String(index + 1).padStart(6, "0")}`,
+                    subject: `Baseline commit ${index + 1}`,
+                }),
+        );
+        const selectedCommit = commits[299];
+        mockGitStoreState.current.historyByContext = {
+            [CONTEXT_KEY]: commits,
+        };
+        mockGitStoreState.current.historyMatchedCountsByContext = {
+            [CONTEXT_KEY]: commits.length,
+        };
+        mockGitStoreState.current.historyTotalsByContext = {
+            [CONTEXT_KEY]: commits.length,
+        };
+        mockGitStoreState.current.selectedCommitShas = {
+            [CONTEXT_KEY]: selectedCommit.sha,
+        };
+        mockGitStoreState.current.commitDetailsByContext = {
+            [CONTEXT_KEY]: {
+                [selectedCommit.sha]: createCommitDetail({
+                    ...selectedCommit,
+                    changedFileCount: 1,
+                    files: [],
+                }),
+            },
+        };
+
+        const markup = renderToStaticMarkup(
+            createElement(GitTabView, { tab: TAB }),
+        );
+
+        expect(markup).toContain(
+            `${GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD} commits`,
+        );
+        expect(markup).toContain("Baseline commit 1");
+        expect(markup).toContain(
+            `Baseline commit ${GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD}`,
+        );
+        expect(markup).toContain("Baseline commit 300");
+        expect(markup).toContain("Resize commit details sidebar");
     });
 });

--- a/src/renderer/src/components/workspace/GitTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitTabView.test.tsx
@@ -1,4 +1,4 @@
-import { createElement } from "react";
+import { createElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
@@ -32,6 +32,7 @@ const mockWorkspaceStoreState = vi.hoisted(() => ({
         openGitCommitTab: vi.fn(async () => {}),
     },
 }));
+const mockScrollToIndex = vi.hoisted(() => vi.fn());
 
 vi.mock("@renderer/app/store/git-store", () => ({
     useGitStore: (
@@ -43,6 +44,50 @@ vi.mock("@renderer/app/store/workspace-store", () => ({
     useWorkspaceStore: (
         selector: (state: typeof mockWorkspaceStoreState.current) => unknown,
     ) => selector(mockWorkspaceStoreState.current),
+}));
+
+vi.mock("@renderer/components/virtual/MeasuredVirtualList", () => ({
+    MeasuredVirtualList: <T,>({
+        enabled = true,
+        estimateSize,
+        getItemKey,
+        items,
+        onReady,
+        renderItem,
+    }: {
+        readonly enabled?: boolean;
+        readonly estimateSize: (item: T, index: number) => number;
+        readonly getItemKey: (item: T, index: number) => string;
+        readonly items: readonly T[];
+        readonly onReady?: (
+            handle: { readonly scrollToIndex: typeof mockScrollToIndex } | null,
+        ) => void;
+        readonly renderItem: (params: {
+            readonly index: number;
+            readonly isVisible: boolean;
+            readonly item: T;
+        }) => ReactNode;
+    }) => {
+        onReady?.({ scrollToIndex: mockScrollToIndex });
+        const renderedItems = enabled ? items.slice(0, 8) : items;
+
+        return (
+            <div data-measured-virtual-list={enabled ? "true" : "false"}>
+                {renderedItems.map((item, index) => (
+                    <div
+                        data-estimated-size={estimateSize(item, index)}
+                        key={getItemKey(item, index)}
+                    >
+                        {renderItem({
+                            index,
+                            isVisible: true,
+                            item,
+                        })}
+                    </div>
+                ))}
+            </div>
+        );
+    },
 }));
 
 import {
@@ -95,6 +140,7 @@ function resetStoreState() {
     mockGitStoreState.current.refreshHistory.mockClear();
     mockGitStoreState.current.refreshProject.mockClear();
     mockGitStoreState.current.selectCommit.mockClear();
+    mockScrollToIndex.mockClear();
     mockGitStoreState.current.selectedCommitShas = {};
     mockGitStoreState.current.snapshots = {
         [CONTEXT_KEY]: null,
@@ -255,10 +301,11 @@ describe("GitTabView", () => {
         );
     });
 
-    it("renders the large commit history baseline and preserves active selection", () => {
+    it("virtualizes large commit history rows and preserves active selection", () => {
         resetStoreState();
+        const commitCount = GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD + 120;
         const commits = Array.from(
-            { length: GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD },
+            { length: commitCount },
             (_, index) =>
                 createCommit({
                     authoredAt: `2026-04-${String(1 + (index % 28)).padStart(2, "0")}T12:00:00.000Z`,
@@ -294,14 +341,17 @@ describe("GitTabView", () => {
             createElement(GitTabView, { tab: TAB }),
         );
 
-        expect(markup).toContain(
-            `${GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD} commits`,
-        );
+        expect(markup).toContain(`${commitCount} commits`);
+        expect(markup).toContain('data-measured-virtual-list="true"');
         expect(markup).toContain("Baseline commit 1");
         expect(markup).toContain(
-            `Baseline commit ${GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD}`,
+            "Baseline commit 300",
         );
-        expect(markup).toContain("Baseline commit 300");
+        expect(markup).not.toContain(`Baseline commit ${commitCount}`);
         expect(markup).toContain("Resize commit details sidebar");
+
+        const circleCount = markup.match(/<circle/g)?.length ?? 0;
+        expect(circleCount).toBeGreaterThan(0);
+        expect(circleCount).toBeLessThan(commitCount);
     });
 });

--- a/src/renderer/src/components/workspace/GitTabView.tsx
+++ b/src/renderer/src/components/workspace/GitTabView.tsx
@@ -1,14 +1,14 @@
 import {
-    Fragment,
     useCallback,
     useEffect,
-    useLayoutEffect,
     useMemo,
     useRef,
     useState,
+    type CSSProperties,
     type KeyboardEvent as ReactKeyboardEvent,
     type PointerEvent as ReactPointerEvent,
     type ReactNode,
+    type UIEvent,
 } from "react";
 
 import type { GitCommitDetail, GitHistoryCommitSummary } from "@shared/ipc";
@@ -33,12 +33,18 @@ import {
     formatGitHistoryDate,
     getRefPillStyle,
     getTemporalGroupLabel,
+    type GitHistoryGraphRow,
 } from "@renderer/app/git/history-presentation";
 import { useGitStore } from "@renderer/app/store/git-store";
 import { openExternalUrl } from "@renderer/app/utils/external-url";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
 import type { RuntimeWorkspaceGitTab } from "@renderer/app/workspace/tree";
 import { GitAuthorAvatar, GitEmptyState } from "@renderer/components/git";
+import {
+    MeasuredVirtualList,
+    type MeasuredVirtualListHandle,
+    type MeasuredVirtualRange,
+} from "@renderer/components/virtual/MeasuredVirtualList";
 import { usePersistedWorkspaceScroll } from "@renderer/components/workspace/usePersistedWorkspaceScroll";
 
 import {
@@ -71,8 +77,10 @@ const DEFAULT_GIT_DETAIL_SIDEBAR_WIDTH = 280;
 const MIN_GIT_DETAIL_SIDEBAR_WIDTH = 280;
 const MIN_GIT_HISTORY_PANE_WIDTH = 420;
 
-// Baseline threshold for enabling commit history row virtualization.
-export const GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD = 600;
+export const GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD = 250;
+const GIT_HISTORY_GRAPH_RANGE_OVERSCAN_COMMITS = 20;
+const GIT_HISTORY_COMMIT_ROW_HEIGHT = 58;
+const GIT_HISTORY_SEPARATOR_ROW_HEIGHT = 28;
 
 type GitHistoryColumnKey =
     | "author"
@@ -82,6 +90,31 @@ type GitHistoryColumnKey =
     | "graph";
 
 type GitHistoryColumnWidths = Record<GitHistoryColumnKey, number>;
+
+type GitHistoryVirtualItem =
+    | {
+          readonly key: string;
+          readonly kind: "separator";
+          readonly label: string;
+      }
+    | {
+          readonly key: string;
+          readonly kind: "commit";
+          readonly row: GitHistoryGraphRow;
+          readonly rowIndex: number;
+      };
+
+interface GitHistoryVirtualLayout {
+    readonly rowPositions: Map<string, { top: number; height: number }>;
+    readonly totalHeight: number;
+}
+
+interface GitHistoryVisibleGraphRange {
+    readonly endIndex: number;
+    readonly height: number;
+    readonly startIndex: number;
+    readonly top: number;
+}
 
 function getContextKey(projectId: string, worktreeId: string | null): string {
     return getGitContextKey(projectId, worktreeId);
@@ -106,6 +139,7 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
             surface: tab.kind,
             worktreeId,
         });
+    const gitScrollContainerRef = useRef<HTMLDivElement | null>(null);
 
     const snapshot = useGitStore((state) =>
         contextKey ? (state.snapshots[contextKey] ?? null) : null,
@@ -239,6 +273,43 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
         () => getGitHistoryTableMinWidth(effectiveColumnWidths),
         [effectiveColumnWidths],
     );
+    const historyVirtualItems = useMemo(
+        () => buildGitHistoryVirtualItems(graphRows),
+        [graphRows],
+    );
+    const historyVirtualLayout = useMemo(
+        () => buildGitHistoryVirtualLayout(historyVirtualItems),
+        [historyVirtualItems],
+    );
+    const shouldVirtualizeHistory =
+        graphRows.length >= GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD;
+    const [historyVirtualRange, setHistoryVirtualRange] =
+        useState<MeasuredVirtualRange | null>(null);
+    const historyVirtualListHandleRef =
+        useRef<MeasuredVirtualListHandle | null>(null);
+    const effectiveHistoryVirtualRange = useMemo(
+        () =>
+            shouldVirtualizeHistory
+                ? (historyVirtualRange ??
+                  createInitialGitHistoryVirtualRange(historyVirtualItems))
+                : null,
+        [historyVirtualItems, historyVirtualRange, shouldVirtualizeHistory],
+    );
+    const visibleGraphRange = useMemo(
+        () =>
+            deriveVisibleGitHistoryGraphRange({
+                graphRows,
+                range: effectiveHistoryVirtualRange,
+                rowPositions: historyVirtualLayout.rowPositions,
+                virtualItems: historyVirtualItems,
+            }),
+        [
+            effectiveHistoryVirtualRange,
+            graphRows,
+            historyVirtualItems,
+            historyVirtualLayout.rowPositions,
+        ],
+    );
 
     const matchedCommitShas = useMemo(
         () => findHistoryMatches(history, searchQuery, isCaseSensitive),
@@ -252,40 +323,24 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
         typeof rawSelectedCommitSha === "string"
             ? matchedCommitShas.findIndex((sha) => sha === rawSelectedCommitSha)
             : -1;
+    const activeCommit =
+        typeof rawSelectedCommitSha === "string"
+            ? (history.find((commit) => commit.sha === rawSelectedCommitSha) ??
+              null)
+            : null;
+    const activeCommitSha = activeCommit?.sha ?? null;
 
-    const graphWrapperRef = useRef<HTMLDivElement>(null);
-    const rowRefsMap = useRef<Map<string, HTMLButtonElement>>(new Map());
-    const [rowPositions, setRowPositions] = useState<
-        Map<string, { top: number; height: number }>
-    >(new Map());
-
-    useLayoutEffect(() => {
-        if (!graphWrapperRef.current || graphRows.length === 0) return;
-        const next = new Map<string, { top: number; height: number }>();
-        for (const [sha, el] of rowRefsMap.current) {
-            next.set(sha, { top: el.offsetTop, height: el.offsetHeight });
-        }
-        // DOM measurement: positions feed the SVG graph lines. Bail out when
-        // unchanged so this doesn't cause cascading renders.
-        setRowPositions((prev) => {
-            if (prev.size === next.size) {
-                let same = true;
-                for (const [sha, pos] of next) {
-                    const existing = prev.get(sha);
-                    if (
-                        !existing ||
-                        existing.top !== pos.top ||
-                        existing.height !== pos.height
-                    ) {
-                        same = false;
-                        break;
-                    }
-                }
-                if (same) return prev;
-            }
-            return next;
-        });
-    }, [graphRows]);
+    const activeCommitVirtualIndex = useMemo(
+        () =>
+            activeCommitSha
+                ? historyVirtualItems.findIndex(
+                      (item) =>
+                          item.kind === "commit" &&
+                          item.row.commit.sha === activeCommitSha,
+                  )
+                : -1,
+        [activeCommitSha, historyVirtualItems],
+    );
 
     useEffect(() => {
         return () => {
@@ -381,12 +436,6 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
         worktreeId,
     ]);
 
-    const activeCommit =
-        typeof rawSelectedCommitSha === "string"
-            ? (history.find((commit) => commit.sha === rawSelectedCommitSha) ??
-              null)
-            : null;
-    const activeCommitSha = activeCommit?.sha ?? null;
     const activeCommitDetail = useGitStore((state) =>
         contextKey && activeCommitSha
             ? (state.commitDetailsByContext[contextKey]?.[activeCommitSha] ??
@@ -466,6 +515,35 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
         void loadMoreHistory(projectId, worktreeId);
     }, [loadMoreHistory, projectId, worktreeId]);
 
+    const setGitScrollContainer = useCallback(
+        (node: HTMLDivElement | null) => {
+            gitScrollContainerRef.current = node;
+            gitScrollRef(node);
+        },
+        [gitScrollRef],
+    );
+
+    const handleGitHistoryScroll = useCallback(
+        (event: UIEvent<HTMLDivElement>) => {
+            handleGitScroll(event);
+        },
+        [handleGitScroll],
+    );
+
+    const handleHistoryVirtualListReady = useCallback(
+        (handle: MeasuredVirtualListHandle | null) => {
+            historyVirtualListHandleRef.current = handle;
+        },
+        [],
+    );
+
+    const handleHistoryVirtualRangeChange = useCallback(
+        (range: MeasuredVirtualRange) => {
+            setHistoryVirtualRange(range);
+        },
+        [],
+    );
+
     const selectRelativeCommit = useCallback(
         (direction: "next" | "previous") => {
             if (history.length === 0) {
@@ -492,6 +570,35 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
         },
         [history, rawSelectedCommitSha, selectCommitSha],
     );
+
+    useEffect(() => {
+        if (
+            activeCommitVirtualIndex < 0 ||
+            !shouldVirtualizeHistory ||
+            !effectiveHistoryVirtualRange
+        ) {
+            return;
+        }
+
+        if (
+            activeCommitVirtualIndex >=
+                effectiveHistoryVirtualRange.visibleStartIndex &&
+            activeCommitVirtualIndex <= effectiveHistoryVirtualRange.visibleEndIndex
+        ) {
+            return;
+        }
+
+        historyVirtualListHandleRef.current?.scrollToIndex(
+            activeCommitVirtualIndex,
+            {
+                align: "center",
+            },
+        );
+    }, [
+        activeCommitVirtualIndex,
+        effectiveHistoryVirtualRange,
+        shouldVirtualizeHistory,
+    ]);
 
     const selectSearchMatch = useCallback(
         (direction: "next" | "previous") => {
@@ -789,8 +896,8 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
                 <section className="min-h-0 min-w-0 flex-1 overflow-hidden">
                     <div
                         className="shell-scrollbar h-full overflow-auto"
-                        onScroll={handleGitScroll}
-                        ref={gitScrollRef}
+                        onScroll={handleGitHistoryScroll}
+                        ref={setGitScrollContainer}
                     >
                         <div
                             className="sticky top-0 z-10 grid px-3 py-1.5"
@@ -856,151 +963,68 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
                             </div>
                         ) : (
                             <div
-                                ref={graphWrapperRef}
                                 style={{ position: "relative" }}
                             >
                                 <GitHistoryGraphSVG
                                     graphRows={graphRows}
                                     graphWidth={graphColumnWidth}
-                                    rowPositions={rowPositions}
+                                    rowPositions={
+                                        historyVirtualLayout.rowPositions
+                                    }
+                                    totalHeight={
+                                        historyVirtualLayout.totalHeight
+                                    }
+                                    visibleGraphRange={visibleGraphRange}
                                 />
-                                {graphRows.map((row, rowIndex) => {
-                                    const groupLabel = getTemporalGroupLabel(
-                                        row.commit.authoredAt,
-                                    );
-                                    const prevLabel =
-                                        rowIndex > 0
-                                            ? getTemporalGroupLabel(
-                                                  graphRows[rowIndex - 1].commit
-                                                      .authoredAt,
-                                              )
-                                            : null;
-                                    const showSeparator =
-                                        groupLabel !== prevLabel;
-
-                                    return (
-                                        <Fragment key={row.commit.sha}>
-                                            {showSeparator && (
-                                                <div className="flex items-center justify-center py-1.5 text-[10px] font-medium uppercase tracking-wider text-text-tertiary">
-                                                    <div className="h-px flex-1 bg-border-subtle" />
-                                                    <span className="shrink-0 px-3">
-                                                        {groupLabel}
-                                                    </span>
-                                                    <div className="h-px flex-1 bg-border-subtle" />
-                                                </div>
-                                            )}
-                                            <button
-                                                ref={(el) => {
-                                                    if (el)
-                                                        rowRefsMap.current.set(
-                                                            row.commit.sha,
-                                                            el,
-                                                        );
-                                                    else
-                                                        rowRefsMap.current.delete(
-                                                            row.commit.sha,
-                                                        );
-                                                }}
-                                                className={[
-                                                    "group/row grid w-full items-stretch border-l-[3px] border-l-transparent pl-2.25 pr-3 text-left text-[12px] transition-[color,background-color,border-color] duration-120",
-                                                    activeCommit?.sha ===
-                                                    row.commit.sha
-                                                        ? "border-l-[--row-branch-color]! bg-[color-mix(in_srgb,var(--color-accent)_9%,var(--color-bg-primary))] text-text-primary"
-                                                        : "text-text-secondary hover:border-l-[--row-branch-color] hover:bg-bg-secondary hover:text-text-primary",
-                                                ].join(" ")}
-                                                onClick={() => {
-                                                    selectCommitSha(
-                                                        row.commit.sha,
-                                                    );
-                                                }}
-                                                style={
-                                                    {
-                                                        gridTemplateColumns:
-                                                            gitHistoryGridTemplate,
-                                                        minWidth:
-                                                            gitHistoryTableMinWidth,
-                                                        "--row-branch-color":
-                                                            GRAPH_COLORS[
-                                                                row.colorId %
-                                                                    GRAPH_COLORS.length
-                                                            ],
-                                                    } as React.CSSProperties
+                                <MeasuredVirtualList
+                                    enabled={shouldVirtualizeHistory}
+                                    estimateSize={
+                                        estimateGitHistoryVirtualItemSize
+                                    }
+                                    getItemKey={getGitHistoryVirtualItemKey}
+                                    items={historyVirtualItems}
+                                    onRangeChange={
+                                        handleHistoryVirtualRangeChange
+                                    }
+                                    onReady={handleHistoryVirtualListReady}
+                                    overscan={6}
+                                    scrollContainerRef={gitScrollContainerRef}
+                                    renderItem={({ item }) =>
+                                        item.kind === "separator" ? (
+                                            <GitHistorySeparatorRow
+                                                label={item.label}
+                                                minWidth={
+                                                    gitHistoryTableMinWidth
                                                 }
-                                                type="button"
-                                            >
-                                                <div
-                                                    className="border-b border-border-subtle"
-                                                    style={{
-                                                        width: graphColumnWidth,
-                                                    }}
-                                                />
-
-                                                <div className="min-w-0 border-b border-border-subtle py-2.5 pr-4">
-                                                    <div className="mb-1 flex flex-wrap items-center gap-1.5">
-                                                        {row.commit.refs.map(
-                                                            (reference) => (
-                                                                <GitReferencePill
-                                                                    key={`${row.commit.sha}:${reference.label}`}
-                                                                    kind={
-                                                                        reference.kind
-                                                                    }
-                                                                    label={
-                                                                        reference.label
-                                                                    }
-                                                                />
-                                                            ),
-                                                        )}
-                                                    </div>
-                                                    <div className="truncate text-[12px] text-text-primary">
-                                                        {renderHighlightedText(
-                                                            row.commit.subject,
-                                                            searchQuery,
-                                                            isCaseSensitive,
-                                                            matchedCommitSet.has(
-                                                                row.commit.sha,
-                                                            ),
-                                                        )}
-                                                    </div>
-                                                </div>
-
-                                                <div className="min-w-0 border-b border-border-subtle py-2.5 pr-3 text-[11px]">
-                                                    {formatGitHistoryDate(
-                                                        row.commit.authoredAt,
-                                                    )}
-                                                </div>
-
-                                                <div className="flex min-w-0 items-center gap-1.5 border-b border-border-subtle py-2.5 pr-3 text-[11px]">
-                                                    <GitAuthorAvatar
-                                                        email={
-                                                            row.commit
-                                                                .authorEmail
-                                                        }
-                                                        name={
-                                                            row.commit
-                                                                .authorName
-                                                        }
-                                                        size={20}
-                                                    />
-                                                    <span className="truncate">
-                                                        {row.commit.authorName}
-                                                    </span>
-                                                </div>
-
-                                                <div className="min-w-0 truncate border-b border-border-subtle py-2.5 font-mono text-[11px]">
-                                                    <CopyableHash
-                                                        as="span"
-                                                        className="cursor-pointer rounded px-1 py-0.5 transition-colors hover:bg-bg-secondary hover:text-text-primary"
-                                                        display={
-                                                            row.commit.shortSha
-                                                        }
-                                                        sha={row.commit.sha}
-                                                        stopPropagation
-                                                    />
-                                                </div>
-                                            </button>
-                                        </Fragment>
-                                    );
-                                })}
+                                            />
+                                        ) : (
+                                            <GitHistoryCommitRow
+                                                graphColumnWidth={
+                                                    graphColumnWidth
+                                                }
+                                                gridTemplateColumns={
+                                                    gitHistoryGridTemplate
+                                                }
+                                                isActive={
+                                                    activeCommit?.sha ===
+                                                    item.row.commit.sha
+                                                }
+                                                isCaseSensitive={
+                                                    isCaseSensitive
+                                                }
+                                                isMatched={matchedCommitSet.has(
+                                                    item.row.commit.sha,
+                                                )}
+                                                minWidth={
+                                                    gitHistoryTableMinWidth
+                                                }
+                                                onSelect={selectCommitSha}
+                                                row={item.row}
+                                                searchQuery={searchQuery}
+                                            />
+                                        )
+                                    }
+                                />
                                 {canLoadMoreHistory ? (
                                     <div
                                         className="flex items-center justify-center border-b border-border-subtle px-3 py-3"
@@ -1063,6 +1087,122 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
                 ) : null}
             </div>
         </div>
+    );
+}
+
+function GitHistorySeparatorRow({
+    label,
+    minWidth,
+}: {
+    readonly label: string;
+    readonly minWidth: number;
+}) {
+    return (
+        <div
+            className="flex items-center justify-center text-[10px] font-medium uppercase tracking-wider text-text-tertiary"
+            style={{
+                height: GIT_HISTORY_SEPARATOR_ROW_HEIGHT,
+                minWidth,
+            }}
+        >
+            <div className="h-px flex-1 bg-border-subtle" />
+            <span className="shrink-0 px-3">{label}</span>
+            <div className="h-px flex-1 bg-border-subtle" />
+        </div>
+    );
+}
+
+function GitHistoryCommitRow({
+    graphColumnWidth,
+    gridTemplateColumns,
+    isActive,
+    isCaseSensitive,
+    isMatched,
+    minWidth,
+    onSelect,
+    row,
+    searchQuery,
+}: {
+    readonly graphColumnWidth: number;
+    readonly gridTemplateColumns: string;
+    readonly isActive: boolean;
+    readonly isCaseSensitive: boolean;
+    readonly isMatched: boolean;
+    readonly minWidth: number;
+    readonly onSelect: (sha: string) => void;
+    readonly row: GitHistoryGraphRow;
+    readonly searchQuery: string;
+}) {
+    return (
+        <button
+            className={[
+                "group/row grid w-full items-stretch border-l-[3px] border-l-transparent pl-2.25 pr-3 text-left text-[12px] transition-[color,background-color,border-color] duration-120",
+                isActive
+                    ? "border-l-[--row-branch-color]! bg-[color-mix(in_srgb,var(--color-accent)_9%,var(--color-bg-primary))] text-text-primary"
+                    : "text-text-secondary hover:border-l-[--row-branch-color] hover:bg-bg-secondary hover:text-text-primary",
+            ].join(" ")}
+            onClick={() => {
+                onSelect(row.commit.sha);
+            }}
+            style={
+                {
+                    "--row-branch-color":
+                        GRAPH_COLORS[row.colorId % GRAPH_COLORS.length],
+                    gridTemplateColumns,
+                    height: GIT_HISTORY_COMMIT_ROW_HEIGHT,
+                    minWidth,
+                } as CSSProperties
+            }
+            type="button"
+        >
+            <div
+                className="border-b border-border-subtle"
+                style={{ width: graphColumnWidth }}
+            />
+
+            <div className="min-w-0 overflow-hidden border-b border-border-subtle py-2.5 pr-4">
+                <div className="mb-1 flex min-w-0 items-center gap-1.5 overflow-hidden">
+                    {row.commit.refs.map((reference) => (
+                        <GitReferencePill
+                            key={`${row.commit.sha}:${reference.label}`}
+                            kind={reference.kind}
+                            label={reference.label}
+                        />
+                    ))}
+                </div>
+                <div className="truncate text-[12px] text-text-primary">
+                    {renderHighlightedText(
+                        row.commit.subject,
+                        searchQuery,
+                        isCaseSensitive,
+                        isMatched,
+                    )}
+                </div>
+            </div>
+
+            <div className="min-w-0 border-b border-border-subtle py-2.5 pr-3 text-[11px]">
+                {formatGitHistoryDate(row.commit.authoredAt)}
+            </div>
+
+            <div className="flex min-w-0 items-center gap-1.5 border-b border-border-subtle py-2.5 pr-3 text-[11px]">
+                <GitAuthorAvatar
+                    email={row.commit.authorEmail}
+                    name={row.commit.authorName}
+                    size={20}
+                />
+                <span className="truncate">{row.commit.authorName}</span>
+            </div>
+
+            <div className="min-w-0 truncate border-b border-border-subtle py-2.5 font-mono text-[11px]">
+                <CopyableHash
+                    as="span"
+                    className="cursor-pointer rounded px-1 py-0.5 transition-colors hover:bg-bg-secondary hover:text-text-primary"
+                    display={row.commit.shortSha}
+                    sha={row.commit.sha}
+                    stopPropagation
+                />
+            </div>
+        </button>
     );
 }
 
@@ -1355,6 +1495,151 @@ function GitCommitDetailSidebar({
     );
 }
 
+function buildGitHistoryVirtualItems(
+    graphRows: readonly GitHistoryGraphRow[],
+): readonly GitHistoryVirtualItem[] {
+    const items: GitHistoryVirtualItem[] = [];
+
+    graphRows.forEach((row, rowIndex) => {
+        const groupLabel = getTemporalGroupLabel(row.commit.authoredAt);
+        const prevLabel =
+            rowIndex > 0
+                ? getTemporalGroupLabel(graphRows[rowIndex - 1].commit.authoredAt)
+                : null;
+
+        if (groupLabel !== prevLabel) {
+            items.push({
+                key: `separator:${groupLabel}:${row.commit.sha}`,
+                kind: "separator",
+                label: groupLabel,
+            });
+        }
+
+        items.push({
+            key: `commit:${row.commit.sha}`,
+            kind: "commit",
+            row,
+            rowIndex,
+        });
+    });
+
+    return items;
+}
+
+function getGitHistoryVirtualItemKey(item: GitHistoryVirtualItem): string {
+    return item.key;
+}
+
+function estimateGitHistoryVirtualItemSize(item: GitHistoryVirtualItem): number {
+    return item.kind === "separator"
+        ? GIT_HISTORY_SEPARATOR_ROW_HEIGHT
+        : GIT_HISTORY_COMMIT_ROW_HEIGHT;
+}
+
+function buildGitHistoryVirtualLayout(
+    items: readonly GitHistoryVirtualItem[],
+): GitHistoryVirtualLayout {
+    const rowPositions = new Map<string, { top: number; height: number }>();
+    let totalHeight = 0;
+
+    for (const item of items) {
+        const height = estimateGitHistoryVirtualItemSize(item);
+
+        if (item.kind === "commit") {
+            rowPositions.set(item.row.commit.sha, {
+                height,
+                top: totalHeight,
+            });
+        }
+
+        totalHeight += height;
+    }
+
+    return {
+        rowPositions,
+        totalHeight,
+    };
+}
+
+function createInitialGitHistoryVirtualRange(
+    items: readonly GitHistoryVirtualItem[],
+): MeasuredVirtualRange | null {
+    if (items.length === 0) {
+        return null;
+    }
+
+    const endIndex = Math.min(items.length - 1, 28);
+
+    return {
+        endIndex,
+        startIndex: 0,
+        visibleEndIndex: endIndex,
+        visibleStartIndex: 0,
+    };
+}
+
+function deriveVisibleGitHistoryGraphRange({
+    graphRows,
+    range,
+    rowPositions,
+    virtualItems,
+}: {
+    readonly graphRows: readonly GitHistoryGraphRow[];
+    readonly range: MeasuredVirtualRange | null;
+    readonly rowPositions: Map<string, { top: number; height: number }>;
+    readonly virtualItems: readonly GitHistoryVirtualItem[];
+}): GitHistoryVisibleGraphRange | null {
+    if (!range || graphRows.length === 0) {
+        return null;
+    }
+
+    let firstRowIndex = Number.POSITIVE_INFINITY;
+    let lastRowIndex = -1;
+
+    for (
+        let itemIndex = Math.max(0, range.startIndex);
+        itemIndex <= Math.min(virtualItems.length - 1, range.endIndex);
+        itemIndex += 1
+    ) {
+        const item = virtualItems[itemIndex];
+        if (item.kind !== "commit") {
+            continue;
+        }
+
+        firstRowIndex = Math.min(firstRowIndex, item.rowIndex);
+        lastRowIndex = Math.max(lastRowIndex, item.rowIndex);
+    }
+
+    if (!Number.isFinite(firstRowIndex) || lastRowIndex < 0) {
+        return null;
+    }
+
+    const startIndex = Math.max(
+        0,
+        firstRowIndex - GIT_HISTORY_GRAPH_RANGE_OVERSCAN_COMMITS,
+    );
+    const endIndex = Math.min(
+        graphRows.length - 1,
+        lastRowIndex + GIT_HISTORY_GRAPH_RANGE_OVERSCAN_COMMITS,
+    );
+    const startPos = rowPositions.get(graphRows[startIndex]?.commit.sha ?? "");
+    const endPos = rowPositions.get(graphRows[endIndex]?.commit.sha ?? "");
+
+    if (!startPos || !endPos) {
+        return null;
+    }
+
+    const top = startPos.top;
+    const bottom = endPos.top + endPos.height;
+
+    return {
+        endIndex,
+        height: Math.max(1, bottom - top),
+        startIndex,
+        top,
+    };
+}
+
 function GitHistoryHeaderCell({
     label,
     onResizePointerDown,
@@ -1396,23 +1681,39 @@ function GitHistoryGraphSVG({
     graphRows,
     graphWidth,
     rowPositions,
+    totalHeight,
+    visibleGraphRange,
 }: {
-    readonly graphRows: readonly import("@renderer/app/git/history-presentation").GitHistoryGraphRow[];
+    readonly graphRows: readonly GitHistoryGraphRow[];
     readonly graphWidth: number;
     readonly rowPositions: Map<string, { top: number; height: number }>;
+    readonly totalHeight: number;
+    readonly visibleGraphRange: GitHistoryVisibleGraphRange | null;
 }) {
     if (rowPositions.size === 0) return null;
+
+    const rangeTop = visibleGraphRange?.top ?? 0;
+    const rangeBottom = visibleGraphRange
+        ? visibleGraphRange.top + visibleGraphRange.height
+        : totalHeight;
+    const svgHeight = visibleGraphRange
+        ? visibleGraphRange.height
+        : totalHeight;
+    const circleStartIndex = visibleGraphRange?.startIndex ?? 0;
+    const circleEndIndex = visibleGraphRange?.endIndex ?? graphRows.length - 1;
+    const pathStartIndex = Math.max(0, circleStartIndex - 1);
+    const pathEndIndex = circleEndIndex;
+    const toSvgY = (y: number): number => y - rangeTop;
+    const clampToSvgRange = (y: number): number =>
+        Math.min(Math.max(y, rangeTop), rangeBottom) - rangeTop;
+    const doesSegmentIntersectRange = (fromY: number, toY: number): boolean =>
+        Math.max(fromY, toY) >= rangeTop && Math.min(fromY, toY) <= rangeBottom;
 
     const getYCenter = (sha: string): number | null => {
         const pos = rowPositions.get(sha);
         if (!pos) return null;
-        return pos.top + pos.height / 2;
+        return toSvgY(pos.top + pos.height / 2);
     };
-
-    let totalHeight = 0;
-    for (const pos of rowPositions.values()) {
-        totalHeight = Math.max(totalHeight, pos.top + pos.height);
-    }
 
     const colorPaths = new Map<number, string[]>();
     const addPath = (colorId: number, d: string) => {
@@ -1424,7 +1725,7 @@ function GitHistoryGraphSVG({
         paths.push(d);
     };
 
-    for (let i = 0; i < graphRows.length; i++) {
+    for (let i = pathStartIndex; i <= pathEndIndex; i++) {
         const row = graphRows[i];
         const pos = rowPositions.get(row.commit.sha);
         if (!pos) continue;
@@ -1435,7 +1736,10 @@ function GitHistoryGraphSVG({
         const nextPos = nextRow ? rowPositions.get(nextRow.commit.sha) : null;
         const nextYCenter = nextPos ? nextPos.top + nextPos.height / 2 : null;
 
-        if (nextYCenter !== null) {
+        if (
+            nextYCenter !== null &&
+            doesSegmentIntersectRange(yCenter, nextYCenter)
+        ) {
             const maxLanes = Math.max(
                 row.bottomLanes.length,
                 nextRow.topLanes.length,
@@ -1447,20 +1751,30 @@ function GitHistoryGraphSVG({
                     const x = laneX(lane);
                     addPath(
                         bottomColorId,
-                        `M ${x} ${yCenter} L ${x} ${nextYCenter}`,
+                        `M ${x} ${clampToSvgRange(yCenter)} L ${x} ${clampToSvgRange(nextYCenter)}`,
                     );
                 }
             }
         }
 
-        if (i === graphRows.length - 1) {
+        if (
+            i === graphRows.length - 1 &&
+            doesSegmentIntersectRange(yCenter, yBottom)
+        ) {
             for (let lane = 0; lane < row.bottomLanes.length; lane++) {
                 const laneColorId = row.bottomLanes[lane];
                 if (laneColorId !== undefined) {
                     const x = laneX(lane);
-                    addPath(laneColorId, `M ${x} ${yCenter} L ${x} ${yBottom}`);
+                    addPath(
+                        laneColorId,
+                        `M ${x} ${clampToSvgRange(yCenter)} L ${x} ${clampToSvgRange(yBottom)}`,
+                    );
                 }
             }
+        }
+
+        if (i < circleStartIndex || i > circleEndIndex) {
+            continue;
         }
 
         const { parentColumns, laneIndex, colorId } = row;
@@ -1477,12 +1791,22 @@ function GitHistoryGraphSVG({
             if (p === 0) {
                 addPath(
                     edgeColorId,
-                    buildCheckoutPath(fromX, yCenter, toX, curveTargetY),
+                    buildCheckoutPath(
+                        fromX,
+                        toSvgY(yCenter),
+                        toX,
+                        toSvgY(curveTargetY),
+                    ),
                 );
             } else {
                 addPath(
                     edgeColorId,
-                    buildMergePath(fromX, yCenter, toX, curveTargetY),
+                    buildMergePath(
+                        fromX,
+                        toSvgY(yCenter),
+                        toX,
+                        toSvgY(curveTargetY),
+                    ),
                 );
             }
         }
@@ -1495,12 +1819,12 @@ function GitHistoryGraphSVG({
     return (
         <svg
             aria-hidden="true"
-            height={totalHeight}
+            height={svgHeight}
             style={{
                 left: 12,
                 pointerEvents: "none",
                 position: "absolute",
-                top: 0,
+                top: rangeTop,
             }}
             width={graphWidth}
         >
@@ -1518,21 +1842,23 @@ function GitHistoryGraphSVG({
                 </g>
             ))}
             <g>
-                {graphRows.map((row) => {
-                    const yCenter = getYCenter(row.commit.sha);
-                    if (yCenter === null) return null;
-                    return (
-                        <circle
-                            cx={laneX(row.laneIndex)}
-                            cy={yCenter}
-                            fill={getGraphColor(row.colorId)}
-                            key={row.commit.sha}
-                            r={COMMIT_RADIUS}
-                            stroke="var(--color-bg-primary)"
-                            strokeWidth={COMMIT_STROKE}
-                        />
-                    );
-                })}
+                {graphRows
+                    .slice(circleStartIndex, circleEndIndex + 1)
+                    .map((row) => {
+                        const yCenter = getYCenter(row.commit.sha);
+                        if (yCenter === null) return null;
+                        return (
+                            <circle
+                                cx={laneX(row.laneIndex)}
+                                cy={yCenter}
+                                fill={getGraphColor(row.colorId)}
+                                key={row.commit.sha}
+                                r={COMMIT_RADIUS}
+                                stroke="var(--color-bg-primary)"
+                                strokeWidth={COMMIT_STROKE}
+                            />
+                        );
+                    })}
             </g>
         </svg>
     );
@@ -1550,12 +1876,13 @@ function GitReferencePill({
     return (
         <span
             className={[
-                "inline-flex items-center rounded-md border px-1.5 py-0.5 font-mono text-[10px]",
+                "inline-flex max-w-[180px] shrink items-center rounded-md border px-1.5 py-0.5 font-mono text-[10px]",
                 tone.className,
             ].join(" ")}
             style={tone.style}
+            title={label}
         >
-            {label}
+            <span className="truncate">{label}</span>
         </span>
     );
 }

--- a/src/renderer/src/components/workspace/GitTabView.tsx
+++ b/src/renderer/src/components/workspace/GitTabView.tsx
@@ -71,6 +71,9 @@ const DEFAULT_GIT_DETAIL_SIDEBAR_WIDTH = 280;
 const MIN_GIT_DETAIL_SIDEBAR_WIDTH = 280;
 const MIN_GIT_HISTORY_PANE_WIDTH = 420;
 
+// Baseline threshold for enabling commit history row virtualization.
+export const GIT_HISTORY_ROW_VIRTUALIZATION_THRESHOLD = 600;
+
 type GitHistoryColumnKey =
     | "author"
     | "commit"

--- a/src/renderer/src/components/workspace/GitWorktreeDiffTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitWorktreeDiffTabView.test.tsx
@@ -1,0 +1,152 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RuntimeWorkspaceGitWorktreeDiffTab } from "@renderer/app/workspace/tree";
+import type { GitWorktreeDiffResult } from "@shared/ipc";
+
+const mockGitStoreState = vi.hoisted(() => ({
+    current: {
+        collapsedWorktreeDiffFileIds: {},
+        discardPaths: vi.fn(() => Promise.resolve(null)),
+        ensureWorktreeDiff: vi.fn(() => Promise.resolve(null)),
+        errors: {},
+        loadingWorktreeDiffContexts: {},
+        refreshProject: vi.fn(() => Promise.resolve(null)),
+        refreshWorktreeDiff: vi.fn(() => Promise.resolve(null)),
+        selectedWorktreeDiffFileIds: {},
+        selectWorktreeDiffFile: vi.fn(() => Promise.resolve(null)),
+        setWorktreeDiffCollapsedFileIds: vi.fn(),
+        snapshots: {},
+        stagePaths: vi.fn(() => Promise.resolve(null)),
+        toggleWorktreeDiffFileCollapse: vi.fn(),
+        unstagePaths: vi.fn(() => Promise.resolve(null)),
+        worktreeDiffsByContext: {},
+    },
+}));
+
+const mockProjectsStoreState = vi.hoisted(() => ({
+    current: {
+        projects: [{ id: "project-1", name: "Comando" }],
+    },
+}));
+
+const mockWorkspaceStoreState = vi.hoisted(() => ({
+    current: {
+        openFileTab: vi.fn(() => Promise.resolve(null)),
+    },
+}));
+
+vi.mock("@renderer/app/hooks/use-resolved-editor-settings", () => ({
+    useResolvedEditorSettings: () => ({
+        autoSaveDelayMs: 1000,
+        fontFamily: "system",
+        fontSize: 14,
+        lineHeight: 20,
+        minimapEnabled: true,
+        suggestionsEnabled: true,
+    }),
+}));
+
+vi.mock("@renderer/app/store/git-store", () => ({
+    useGitStore: (
+        selector: (state: typeof mockGitStoreState.current) => unknown,
+    ) => selector(mockGitStoreState.current),
+}));
+
+vi.mock("@renderer/app/store/projects-store", () => ({
+    useProjectsStore: (
+        selector: (state: typeof mockProjectsStoreState.current) => unknown,
+    ) => selector(mockProjectsStoreState.current),
+}));
+
+vi.mock("@renderer/app/store/workspace-store", () => ({
+    useWorkspaceStore: (
+        selector: (state: typeof mockWorkspaceStoreState.current) => unknown,
+    ) => selector(mockWorkspaceStoreState.current),
+}));
+
+import { GitWorktreeDiffTabView } from "./GitWorktreeDiffTabView";
+
+const TAB: RuntimeWorkspaceGitWorktreeDiffTab = {
+    createdAt: "2026-05-21T00:00:00.000Z",
+    id: "worktree-diff-tab-1",
+    kind: "git_worktree_diff",
+    projectId: "project-1",
+    title: "Changes",
+    worktreeId: null,
+};
+
+const CONTEXT_KEY = `${TAB.projectId}::primary`;
+
+function createWorktreeDiffResult(): GitWorktreeDiffResult {
+    return {
+        projectId: TAB.projectId,
+        sections: [
+            {
+                files: [
+                    {
+                        additions: 1,
+                        deletions: 0,
+                        diff: null,
+                        error: null,
+                        isBinary: false,
+                        isConflicted: false,
+                        kind: "modified",
+                        path: "src/worktree-file.ts",
+                        previousPath: null,
+                        scope: "unstaged",
+                    },
+                ],
+                scope: "unstaged",
+            },
+        ],
+        updatedAt: "2026-05-21T00:00:00.000Z",
+        worktreeId: TAB.worktreeId ?? null,
+    };
+}
+
+function resetStoreState() {
+    mockGitStoreState.current.collapsedWorktreeDiffFileIds = {};
+    mockGitStoreState.current.discardPaths.mockClear();
+    mockGitStoreState.current.ensureWorktreeDiff.mockClear();
+    mockGitStoreState.current.errors = {};
+    mockGitStoreState.current.loadingWorktreeDiffContexts = {};
+    mockGitStoreState.current.refreshProject.mockClear();
+    mockGitStoreState.current.refreshWorktreeDiff.mockClear();
+    mockGitStoreState.current.selectedWorktreeDiffFileIds = {};
+    mockGitStoreState.current.selectWorktreeDiffFile.mockClear();
+    mockGitStoreState.current.setWorktreeDiffCollapsedFileIds.mockClear();
+    mockGitStoreState.current.snapshots = {
+        [CONTEXT_KEY]: null,
+    };
+    mockGitStoreState.current.stagePaths.mockClear();
+    mockGitStoreState.current.toggleWorktreeDiffFileCollapse.mockClear();
+    mockGitStoreState.current.unstagePaths.mockClear();
+    mockGitStoreState.current.worktreeDiffsByContext = {
+        [CONTEXT_KEY]: createWorktreeDiffResult(),
+    };
+    mockWorkspaceStoreState.current.openFileTab.mockClear();
+}
+
+function renderWorktreeMarkup(): string {
+    return renderToStaticMarkup(
+        createElement(GitWorktreeDiffTabView, { tab: TAB }),
+    );
+}
+
+describe("GitWorktreeDiffTabView", () => {
+    beforeEach(() => {
+        resetStoreState();
+    });
+
+    it("keeps the persisted worktree scroll container as the diff scroll owner", () => {
+        const markup = renderWorktreeMarkup();
+
+        expect(markup).toContain(
+            'class="shell-scrollbar min-h-0 flex-1 overflow-y-auto px-3 py-3"',
+        );
+        expect(markup).toContain('class="min-h-0 flex-1 px-2 py-2"');
+        expect(markup).toContain("worktree-file.ts");
+    });
+});

--- a/src/renderer/src/components/workspace/GitWorktreeDiffTabView.tsx
+++ b/src/renderer/src/components/workspace/GitWorktreeDiffTabView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { getGitContextKey } from "@renderer/app/git/context-key";
 import {
@@ -37,6 +37,7 @@ export function GitWorktreeDiffTabView({
             surface: tab.kind,
             worktreeId,
         });
+    const diffScrollContainerRef = useRef<HTMLDivElement | null>(null);
     const editorSettings = useResolvedEditorSettings();
     const project = useProjectsStore((state) =>
         state.projects.find((candidate) => candidate.id === projectId),
@@ -229,6 +230,13 @@ export function GitWorktreeDiffTabView({
             selectWorktreeDiffFile(projectId, file.id, worktreeId),
         [projectId, selectWorktreeDiffFile, worktreeId],
     );
+    const setDiffScrollContainer = useCallback(
+        (node: HTMLDivElement | null) => {
+            diffScrollContainerRef.current = node;
+            diffScrollRef(node);
+        },
+        [diffScrollRef],
+    );
 
     useEffect(() => {
         if (!snapshot) {
@@ -336,7 +344,7 @@ export function GitWorktreeDiffTabView({
             <main
                 className="shell-scrollbar min-h-0 flex-1 overflow-y-auto px-3 py-3"
                 onScroll={handleDiffScroll}
-                ref={diffScrollRef}
+                ref={setDiffScrollContainer}
             >
                 {isLoading && !result ? (
                     <GitEmptyState>Loading project diff...</GitEmptyState>
@@ -393,6 +401,9 @@ export function GitWorktreeDiffTabView({
                                         onSelectFile={handleSelectFile}
                                         onToggleFileCollapse={
                                             handleToggleFileCollapse
+                                        }
+                                        scrollContainerRef={
+                                            diffScrollContainerRef
                                         }
                                         showFileSelector={false}
                                         surfaceVariant="flat"

--- a/src/renderer/src/components/workspace/ReviewTabView.tsx
+++ b/src/renderer/src/components/workspace/ReviewTabView.tsx
@@ -1254,6 +1254,7 @@ function ReviewTabContent({ onOpenFile, tab }: ReviewTabViewProps) {
                                         onRejectHunk={(hunkId) =>
                                             handleRejectHunk(item, hunkId)
                                         }
+                                        scrollContainerRef={scrollContainerRef}
                                         onToggle={() =>
                                             expansion.toggleFile(
                                                 item.file.identityKey,
@@ -1288,6 +1289,7 @@ function ReviewTabContent({ onOpenFile, tab }: ReviewTabViewProps) {
                                     onRejectHunk={(hunkId) =>
                                         handleRejectHunk(item, hunkId)
                                     }
+                                    scrollContainerRef={scrollContainerRef}
                                     onToggle={() =>
                                         expansion.toggleFile(
                                             item.file.identityKey,

--- a/src/renderer/src/components/workspace/review/EditedFileDiffPreview.test.tsx
+++ b/src/renderer/src/components/workspace/review/EditedFileDiffPreview.test.tsx
@@ -1,9 +1,57 @@
+import { createRef, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { AiFileDiff, AiTrackedFile } from "@shared/ipc";
 
-import { EditedFileDiffPreview } from "./EditedFileDiffPreview";
+vi.mock("@renderer/components/virtual/MeasuredVirtualList", () => ({
+    MeasuredVirtualList: <T,>({
+        enabled = true,
+        estimateSize,
+        getItemKey,
+        items,
+        renderItem,
+        scrollMarginTop = 0,
+    }: {
+        readonly enabled?: boolean;
+        readonly estimateSize: (item: T, index: number) => number;
+        readonly getItemKey: (item: T, index: number) => string;
+        readonly items: readonly T[];
+        readonly renderItem: (params: {
+            readonly index: number;
+            readonly isVisible: boolean;
+            readonly item: T;
+        }) => ReactNode;
+        readonly scrollMarginTop?: number;
+    }) => {
+        const renderedItems = enabled ? items.slice(0, 8) : items;
+
+        return (
+            <div
+                data-measured-virtual-list="true"
+                data-scroll-margin-top={scrollMarginTop}
+            >
+                {renderedItems.map((item, index) => (
+                    <div
+                        data-estimated-size={estimateSize(item, index)}
+                        key={getItemKey(item, index)}
+                    >
+                        {renderItem({
+                            index,
+                            isVisible: true,
+                            item,
+                        })}
+                    </div>
+                ))}
+            </div>
+        );
+    },
+}));
+
+import {
+    EDITED_DIFF_PREVIEW_LINE_VIRTUALIZATION_THRESHOLD,
+    EditedFileDiffPreview,
+} from "./EditedFileDiffPreview";
 
 function createDiff(): AiFileDiff {
     return {
@@ -95,6 +143,60 @@ function createTrackedFile(): AiTrackedFile {
     };
 }
 
+function createLargeExactDiff(): AiFileDiff {
+    return {
+        ...createDiff(),
+        hunks: [
+            {
+                id: "large-hunk",
+                lines: Array.from(
+                    {
+                        length: EDITED_DIFF_PREVIEW_LINE_VIRTUALIZATION_THRESHOLD,
+                    },
+                    (_, index) => ({
+                        id: `large-line-${index + 1}`,
+                        text: `large-preview-line-${index + 1}`,
+                        type: "add" as const,
+                    }),
+                ),
+                newCount: EDITED_DIFF_PREVIEW_LINE_VIRTUALIZATION_THRESHOLD,
+                newStart: 1,
+                oldCount: 0,
+                oldStart: 1,
+            },
+        ],
+        newText: null,
+        oldText: null,
+        path: "src/large-preview.ts",
+    };
+}
+
+function createLargeTrackedFile(): AiTrackedFile {
+    return {
+        ...createTrackedFile(),
+        hunks: [
+            {
+                id: "large-hunk",
+                lines: Array.from(
+                    {
+                        length: EDITED_DIFF_PREVIEW_LINE_VIRTUALIZATION_THRESHOLD,
+                    },
+                    (_, index) => ({
+                        id: `large-line-${index + 1}`,
+                        text: `large-preview-line-${index + 1}`,
+                        type: "add" as const,
+                    }),
+                ),
+                newCount: EDITED_DIFF_PREVIEW_LINE_VIRTUALIZATION_THRESHOLD,
+                newStart: 1,
+                oldCount: 0,
+                oldStart: 1,
+            },
+        ],
+        path: "src/large-preview.ts",
+    };
+}
+
 describe("EditedFileDiffPreview", () => {
     it("keeps hunk actions bound to the tracked hunk id after partial resolution", () => {
         const markup = renderToStaticMarkup(
@@ -172,5 +274,41 @@ describe("EditedFileDiffPreview", () => {
 
         expect(markup).toContain('data-line-wrapping="true"');
         expect(markup).toContain("overflow-x:hidden");
+    });
+
+    it("virtualizes giant review previews against the shared scroll container", () => {
+        const markup = renderToStaticMarkup(
+            <EditedFileDiffPreview
+                diff={createLargeExactDiff()}
+                diffZoom={0.72}
+                expanded
+                scrollContainerRef={createRef<HTMLElement>()}
+            />,
+        );
+
+        expect(markup).toContain('data-virtualized-edited-diff="true"');
+        expect(markup).toContain('data-measured-virtual-list="true"');
+        expect(markup).toContain("large-preview-line-1");
+        expect(markup).not.toContain(
+            `large-preview-line-${EDITED_DIFF_PREVIEW_LINE_VIRTUALIZATION_THRESHOLD}`,
+        );
+    });
+
+    it("keeps hunk actions available in virtualized review previews", () => {
+        const markup = renderToStaticMarkup(
+            <EditedFileDiffPreview
+                diff={createLargeExactDiff()}
+                diffZoom={0.72}
+                expanded
+                file={createLargeTrackedFile()}
+                onKeepHunk={() => {}}
+                onRejectHunk={() => {}}
+                scrollContainerRef={createRef<HTMLElement>()}
+            />,
+        );
+
+        expect(markup).toContain('data-review-hunk-key="large-hunk"');
+        expect(markup).toContain("Accept hunk 1");
+        expect(markup).toContain("Reject hunk 1");
     });
 });

--- a/src/renderer/src/components/workspace/review/EditedFileDiffPreview.tsx
+++ b/src/renderer/src/components/workspace/review/EditedFileDiffPreview.tsx
@@ -1,6 +1,15 @@
-import { useMemo } from "react";
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type CSSProperties,
+    type RefObject,
+} from "react";
 
 import type { AiFileDiff, AiTrackedFile } from "@shared/ipc";
+import { MeasuredVirtualList } from "@renderer/components/virtual/MeasuredVirtualList";
 
 import { DiffLineView } from "./DiffLineView";
 import { HunkActionBar } from "./HunkActionBar";
@@ -11,6 +20,10 @@ import {
     shouldWrapDiffPreview,
     type DiffLine,
 } from "./reviewDiff";
+
+export const EDITED_DIFF_PREVIEW_LINE_VIRTUALIZATION_THRESHOLD = 1_000;
+
+const VIRTUAL_DIFF_LINE_OVERSCAN = 32;
 
 type RenderBlock =
     | {
@@ -43,6 +56,52 @@ type VisualSegment =
           readonly kind: "decision";
           readonly lines: readonly DiffLine[];
       };
+
+type VirtualPreviewItem =
+    | {
+          readonly key: string;
+          readonly kind: "line";
+          readonly line: DiffLine;
+      }
+    | {
+          readonly key: string;
+          readonly kind: "separator";
+          readonly line: DiffLine;
+      }
+    | {
+          readonly key: string;
+          readonly kind: "visualLabel";
+      }
+    | {
+          readonly dataReviewFileKey?: string;
+          readonly dataReviewFileUpdatedAt?: string;
+          readonly dataReviewHunkKey?: string;
+          readonly decisionHunkIndex?: number;
+          readonly isFirstInDecision: boolean;
+          readonly isFirstInVisualBlock: boolean;
+          readonly isLastInVisualBlock: boolean;
+          readonly key: string;
+          readonly kind: "visualLine";
+          readonly line: DiffLine;
+      };
+
+interface RenderPreviewContext {
+    readonly compactLineNumbers: boolean;
+    readonly decisionHunks: readonly {
+        readonly lines: readonly DiffLine[];
+        readonly newEnd: number;
+        readonly newStart: number;
+        readonly oldEnd: number;
+        readonly oldStart: number;
+    }[];
+    readonly diff: AiFileDiff;
+    readonly file: AiTrackedFile | null;
+    readonly interactiveHunksEnabled: boolean;
+    readonly lineWrapping: boolean;
+    readonly onKeepHunk?: (hunkId: string) => void;
+    readonly onRejectHunk?: (hunkId: string) => void;
+    readonly visualBlockSet: ReadonlySet<number>;
+}
 
 function getDecisionHunkFingerprint(hunk: {
     readonly lines: readonly DiffLine[];
@@ -277,6 +336,322 @@ function renderDiffLines(
     ));
 }
 
+function countPreviewLines(lines: readonly DiffLine[]): number {
+    return lines.filter((line) => line.type !== "separator").length;
+}
+
+function shouldVirtualizePreviewLines({
+    hasScrollContainer,
+    lineWrapping,
+    lines,
+}: {
+    readonly hasScrollContainer: boolean;
+    readonly lineWrapping: boolean;
+    readonly lines: readonly DiffLine[];
+}): boolean {
+    return (
+        hasScrollContainer &&
+        !lineWrapping &&
+        countPreviewLines(lines) >=
+            EDITED_DIFF_PREVIEW_LINE_VIRTUALIZATION_THRESHOLD
+    );
+}
+
+function calculateScrollMarginTop(
+    element: HTMLElement | null,
+    scrollContainer: HTMLElement | null,
+): number {
+    if (!element || !scrollContainer || element === scrollContainer) {
+        return 0;
+    }
+
+    const elementRect = element.getBoundingClientRect();
+    const containerRect = scrollContainer.getBoundingClientRect();
+    return Math.max(
+        0,
+        elementRect.top - containerRect.top + scrollContainer.scrollTop,
+    );
+}
+
+function getDiffLineKey(line: DiffLine, index: number): string {
+    return `${line.type}:${line.oldLineNumber ?? "n"}:${line.newLineNumber ?? "n"}:${index}`;
+}
+
+function getPreviewMaxLineWidthCh(lines: readonly DiffLine[]): number {
+    const maxTextLength = lines.reduce(
+        (maxLength, line) => Math.max(maxLength, line.text.length),
+        0,
+    );
+    return Math.max(80, maxTextLength + 18);
+}
+
+function estimateVirtualPreviewItemHeight(
+    item: VirtualPreviewItem,
+    diffZoom: number,
+): number {
+    const lineHeight = Math.max(16, Math.ceil(18 * diffZoom));
+
+    if (item.kind === "visualLabel") {
+        return 22;
+    }
+
+    if (item.kind === "visualLine") {
+        return (
+            lineHeight +
+            (item.isFirstInVisualBlock ? 8 : 0) +
+            (item.isFirstInDecision ? 12 : 0) +
+            (item.isLastInVisualBlock ? 8 : 0)
+        );
+    }
+
+    return lineHeight;
+}
+
+function getVirtualPreviewItemKey(item: VirtualPreviewItem): string {
+    return item.key;
+}
+
+function createVirtualLineItem(
+    line: DiffLine,
+    keyPrefix: string,
+    index: number,
+): VirtualPreviewItem {
+    return {
+        key: `${keyPrefix}:line:${getDiffLineKey(line, index)}`,
+        kind: "line",
+        line,
+    };
+}
+
+function buildVirtualPreviewItems(
+    renderBlocks: readonly RenderBlock[],
+    context: RenderPreviewContext,
+): readonly VirtualPreviewItem[] {
+    const items: VirtualPreviewItem[] = [];
+
+    renderBlocks.forEach((block) => {
+        if (block.kind === "separator") {
+            items.push({
+                key: block.key,
+                kind: "separator",
+                line: block.line,
+            });
+            return;
+        }
+
+        if (
+            block.kind !== "visual" ||
+            !context.visualBlockSet.has(block.visualBlockIndex)
+        ) {
+            block.lines.forEach((line, index) => {
+                items.push(createVirtualLineItem(line, block.key, index));
+            });
+            return;
+        }
+
+        if (block.decisionHunkIndexes.length > 1) {
+            items.push({
+                key: `${block.key}:label`,
+                kind: "visualLabel",
+            });
+        }
+
+        const segments = buildVisualSegments(block.lines);
+        const visualItems: Array<
+            Extract<VirtualPreviewItem, { readonly kind: "visualLine" }>
+        > = [];
+
+        segments.forEach((segment) => {
+            const hunkId =
+                segment.kind === "decision" &&
+                context.interactiveHunksEnabled &&
+                context.file
+                    ? resolveTrackedHunkId(
+                          context.file,
+                          context.diff,
+                          context.decisionHunks,
+                          segment.decisionHunkIndex,
+                      )
+                    : null;
+
+            segment.lines.forEach((line, lineIndex) => {
+                visualItems.push({
+                    dataReviewFileKey:
+                        segment.kind === "decision" && context.file
+                            ? context.file.identityKey
+                            : undefined,
+                    dataReviewFileUpdatedAt:
+                        segment.kind === "decision" && context.file
+                            ? context.file.updatedAt
+                            : undefined,
+                    dataReviewHunkKey: hunkId ?? undefined,
+                    decisionHunkIndex:
+                        segment.kind === "decision"
+                            ? segment.decisionHunkIndex
+                            : undefined,
+                    isFirstInDecision:
+                        segment.kind === "decision" && lineIndex === 0,
+                    isFirstInVisualBlock: false,
+                    isLastInVisualBlock: false,
+                    key: `${block.key}:${segment.key}:line:${getDiffLineKey(line, lineIndex)}`,
+                    kind: "visualLine",
+                    line,
+                });
+            });
+        });
+
+        visualItems.forEach((item, index) => {
+            items.push({
+                ...item,
+                isFirstInVisualBlock: index === 0,
+                isLastInVisualBlock: index === visualItems.length - 1,
+            });
+        });
+    });
+
+    return items;
+}
+
+function renderVisualBlock(
+    block: Extract<RenderBlock, { readonly kind: "visual" }>,
+    context: RenderPreviewContext,
+) {
+    const segments = buildVisualSegments(block.lines);
+
+    return (
+        <div
+            key={block.key}
+            style={{
+                backgroundColor:
+                    "color-mix(in srgb, var(--color-bg-primary) 40%, var(--color-bg-elevated))",
+                border: "1px solid color-mix(in srgb, var(--color-border) 40%, transparent)",
+                borderRadius: 8,
+                margin: "4px 6px",
+            }}
+        >
+            {block.decisionHunkIndexes.length > 1 ? (
+                <div
+                    style={{
+                        color: "var(--color-text-secondary)",
+                        fontSize: "0.68em",
+                        fontWeight: 500,
+                        letterSpacing: "0.02em",
+                        opacity: 0.55,
+                        padding: "5px 10px 0",
+                    }}
+                >
+                    Linked changes
+                </div>
+            ) : null}
+            <div style={{ padding: 4 }}>
+                {segments.map((segment) => {
+                    if (
+                        segment.kind === "plain" ||
+                        !context.interactiveHunksEnabled ||
+                        !context.file
+                    ) {
+                        return (
+                            <div key={segment.key}>
+                                {renderDiffLines(segment.lines, {
+                                    compactLineNumbers:
+                                        context.compactLineNumbers,
+                                    filePath:
+                                        context.file?.path ?? context.diff.path,
+                                    lineWrapping: context.lineWrapping,
+                                })}
+                            </div>
+                        );
+                    }
+
+                    const hunkId = resolveTrackedHunkId(
+                        context.file,
+                        context.diff,
+                        context.decisionHunks,
+                        segment.decisionHunkIndex,
+                    );
+
+                    return (
+                        <div
+                            className="group"
+                            data-review-file-key={context.file.identityKey}
+                            data-review-file-updated-at={
+                                context.file.updatedAt
+                            }
+                            data-review-hunk-key={hunkId ?? undefined}
+                            key={segment.key}
+                            style={{
+                                margin: "16px 0 4px",
+                                position: "relative",
+                            }}
+                        >
+                            {hunkId ? (
+                                <HunkActionBar
+                                    hunkIndex={segment.decisionHunkIndex}
+                                    onAccept={() =>
+                                        context.onKeepHunk?.(hunkId)
+                                    }
+                                    onReject={() =>
+                                        context.onRejectHunk?.(hunkId)
+                                    }
+                                />
+                            ) : null}
+                            <div
+                                style={{
+                                    backgroundColor:
+                                        "color-mix(in srgb, var(--color-bg-elevated) 72%, transparent)",
+                                    border: "1px solid color-mix(in srgb, var(--color-border) 32%, transparent)",
+                                    borderRadius: 4,
+                                    overflow: "hidden",
+                                    paddingRight: 4,
+                                    paddingTop: 4,
+                                }}
+                            >
+                                {renderDiffLines(segment.lines, {
+                                    compactLineNumbers:
+                                        context.compactLineNumbers,
+                                    filePath: context.file.path,
+                                    lineWrapping: context.lineWrapping,
+                                })}
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function renderPreviewBlock(block: RenderBlock, context: RenderPreviewContext) {
+    if (block.kind === "separator") {
+        return (
+            <DiffLineView
+                compactLineNumbers={context.compactLineNumbers}
+                filePath={context.file?.path ?? context.diff.path}
+                key={block.key}
+                line={block.line}
+                lineWrapping={context.lineWrapping}
+            />
+        );
+    }
+
+    if (
+        block.kind !== "visual" ||
+        !context.visualBlockSet.has(block.visualBlockIndex)
+    ) {
+        return (
+            <div key={block.key}>
+                {renderDiffLines(block.lines, {
+                    compactLineNumbers: context.compactLineNumbers,
+                    filePath: context.file?.path ?? context.diff.path,
+                    lineWrapping: context.lineWrapping,
+                })}
+            </div>
+        );
+    }
+
+    return renderVisualBlock(block, context);
+}
+
 export interface EditedFileDiffPreviewProps {
     readonly compactLineNumbers?: boolean;
     readonly diff: AiFileDiff;
@@ -287,6 +662,7 @@ export interface EditedFileDiffPreviewProps {
     readonly lineWrapping?: boolean;
     readonly onKeepHunk?: (hunkId: string) => void;
     readonly onRejectHunk?: (hunkId: string) => void;
+    readonly scrollContainerRef?: RefObject<HTMLElement | null>;
     readonly showWhenEmpty?: boolean;
     readonly testId?: string;
 }
@@ -301,9 +677,12 @@ export function EditedFileDiffPreview({
     lineWrapping,
     onKeepHunk,
     onRejectHunk,
+    scrollContainerRef,
     showWhenEmpty = true,
     testId,
 }: EditedFileDiffPreviewProps) {
+    const listRef = useRef<HTMLDivElement | null>(null);
+    const [scrollMarginTop, setScrollMarginTop] = useState(0);
     const resolvedLineWrapping =
         lineWrapping ?? shouldWrapDiffPreview(file?.path ?? diff.path);
     const lines = useMemo(
@@ -332,6 +711,126 @@ export function EditedFileDiffPreview({
         file.hunks.length > 0 &&
         decisionHunks.length > 0,
     );
+    const previewContext = useMemo<RenderPreviewContext>(
+        () => ({
+            compactLineNumbers,
+            decisionHunks,
+            diff,
+            file,
+            interactiveHunksEnabled,
+            lineWrapping: resolvedLineWrapping,
+            onKeepHunk,
+            onRejectHunk,
+            visualBlockSet,
+        }),
+        [
+            compactLineNumbers,
+            decisionHunks,
+            diff,
+            file,
+            interactiveHunksEnabled,
+            onKeepHunk,
+            onRejectHunk,
+            resolvedLineWrapping,
+            visualBlockSet,
+        ],
+    );
+    const shouldVirtualizeLines = shouldVirtualizePreviewLines({
+        hasScrollContainer: scrollContainerRef !== undefined,
+        lineWrapping: resolvedLineWrapping,
+        lines,
+    });
+    const virtualItems = useMemo(
+        () =>
+            shouldVirtualizeLines
+                ? buildVirtualPreviewItems(renderBlocks, previewContext)
+                : [],
+        [previewContext, renderBlocks, shouldVirtualizeLines],
+    );
+    const maxLineWidthCh = useMemo(
+        () => getPreviewMaxLineWidthCh(lines),
+        [lines],
+    );
+    const contentStyle = useMemo<CSSProperties>(
+        () => ({
+            minWidth: resolvedLineWrapping
+                ? "100%"
+                : shouldVirtualizeLines
+                  ? `max(100%, ${maxLineWidthCh}ch)`
+                  : "100%",
+            width: resolvedLineWrapping ? "100%" : "max-content",
+        }),
+        [maxLineWidthCh, resolvedLineWrapping, shouldVirtualizeLines],
+    );
+
+    useEffect(() => {
+        if (
+            !shouldVirtualizeLines ||
+            !scrollContainerRef ||
+            typeof window === "undefined"
+        ) {
+            return;
+        }
+
+        const syncScrollMarginTop = () => {
+            setScrollMarginTop(
+                calculateScrollMarginTop(
+                    listRef.current,
+                    scrollContainerRef.current,
+                ),
+            );
+        };
+
+        syncScrollMarginTop();
+
+        const scrollContainer = scrollContainerRef.current;
+        let observer: ResizeObserver | null = null;
+
+        if (typeof ResizeObserver !== "undefined") {
+            observer = new ResizeObserver(syncScrollMarginTop);
+            if (listRef.current) {
+                observer.observe(listRef.current);
+            }
+            if (scrollContainer) {
+                observer.observe(scrollContainer);
+            }
+        }
+
+        window.addEventListener("resize", syncScrollMarginTop);
+
+        return () => {
+            observer?.disconnect();
+            window.removeEventListener("resize", syncScrollMarginTop);
+        };
+    }, [scrollContainerRef, shouldVirtualizeLines]);
+
+    const estimateVirtualItemSize = useCallback(
+        (item: VirtualPreviewItem) =>
+            estimateVirtualPreviewItemHeight(item, diffZoom),
+        [diffZoom],
+    );
+
+    const renderVirtualItem = useCallback(
+        ({ item }: { readonly item: VirtualPreviewItem }) => (
+            <VirtualPreviewItemView
+                compactLineNumbers={compactLineNumbers}
+                diff={diff}
+                file={file}
+                item={item}
+                lineWrapping={resolvedLineWrapping}
+                onKeepHunk={onKeepHunk}
+                onRejectHunk={onRejectHunk}
+            />
+        ),
+        [
+            compactLineNumbers,
+            diff,
+            file,
+            onKeepHunk,
+            onRejectHunk,
+            resolvedLineWrapping,
+        ],
+    );
 
     if (!expanded) {
         return null;
@@ -351,6 +850,7 @@ export function EditedFileDiffPreview({
             <div
                 data-line-wrapping={String(resolvedLineWrapping)}
                 data-testid={testId}
+                data-virtualized-edited-diff={String(shouldVirtualizeLines)}
                 style={{
                     backgroundColor:
                         "color-mix(in srgb, var(--color-bg-primary) 60%, var(--color-bg-elevated))",
@@ -361,174 +861,25 @@ export function EditedFileDiffPreview({
                     overflowY: "hidden",
                 }}
             >
-                <div
-                    style={{
-                        minWidth: "100%",
-                        width: resolvedLineWrapping ? "100%" : "max-content",
-                    }}
-                >
+                <div style={contentStyle}>
                     {lines.length > 0 ? (
-                        <div style={{ padding: "4px 0" }}>
-                            {renderBlocks.map((block) => {
-                                if (block.kind === "separator") {
-                                    return (
-                                        <DiffLineView
-                                            compactLineNumbers={
-                                                compactLineNumbers
-                                            }
-                                            filePath={file?.path ?? diff.path}
-                                            key={block.key}
-                                            line={block.line}
-                                            lineWrapping={resolvedLineWrapping}
-                                        />
-                                    );
-                                }
-
-                                if (
-                                    block.kind !== "visual" ||
-                                    !visualBlockSet.has(block.visualBlockIndex)
-                                ) {
-                                    return (
-                                        <div key={block.key}>
-                                            {renderDiffLines(block.lines, {
-                                                compactLineNumbers,
-                                                filePath:
-                                                    file?.path ?? diff.path,
-                                                lineWrapping:
-                                                    resolvedLineWrapping,
-                                            })}
-                                        </div>
-                                    );
-                                }
-
-                                const segments = buildVisualSegments(
-                                    block.lines,
-                                );
-
-                                return (
-                                    <div
-                                        key={block.key}
-                                        style={{
-                                            backgroundColor:
-                                                "color-mix(in srgb, var(--color-bg-primary) 40%, var(--color-bg-elevated))",
-                                            border: "1px solid color-mix(in srgb, var(--color-border) 40%, transparent)",
-                                            borderRadius: 8,
-                                            margin: "4px 6px",
-                                        }}
-                                    >
-                                        {block.decisionHunkIndexes.length >
-                                        1 ? (
-                                            <div
-                                                style={{
-                                                    color: "var(--color-text-secondary)",
-                                                    fontSize: "0.68em",
-                                                    fontWeight: 500,
-                                                    letterSpacing: "0.02em",
-                                                    opacity: 0.55,
-                                                    padding: "5px 10px 0",
-                                                }}
-                                            >
-                                                Linked changes
-                                            </div>
-                                        ) : null}
-                                        <div style={{ padding: 4 }}>
-                                            {segments.map((segment) => {
-                                                if (
-                                                    segment.kind === "plain" ||
-                                                    !interactiveHunksEnabled ||
-                                                    !file
-                                                ) {
-                                                    return (
-                                                        <div key={segment.key}>
-                                                            {renderDiffLines(
-                                                                segment.lines,
-                                                                {
-                                                                    compactLineNumbers,
-                                                                    filePath:
-                                                                        file?.path ??
-                                                                        diff.path,
-                                                                    lineWrapping:
-                                                                        resolvedLineWrapping,
-                                                                },
-                                                            )}
-                                                        </div>
-                                                    );
-                                                }
-
-                                                const hunkId =
-                                                    resolveTrackedHunkId(
-                                                        file,
-                                                        diff,
-                                                        decisionHunks,
-                                                        segment.decisionHunkIndex,
-                                                    );
-
-                                                return (
-                                                    <div
-                                                        className="group"
-                                                        data-review-file-key={
-                                                            file.identityKey
-                                                        }
-                                                        data-review-file-updated-at={
-                                                            file.updatedAt
-                                                        }
-                                                        data-review-hunk-key={
-                                                            hunkId ?? undefined
-                                                        }
-                                                        key={segment.key}
-                                                        style={{
-                                                            margin: "16px 0 4px",
-                                                            position:
-                                                                "relative",
-                                                        }}
-                                                    >
-                                                        {hunkId ? (
-                                                            <HunkActionBar
-                                                                hunkIndex={
-                                                                    segment.decisionHunkIndex
-                                                                }
-                                                                onAccept={() =>
-                                                                    onKeepHunk?.(
-                                                                        hunkId,
-                                                                    )
-                                                                }
-                                                                onReject={() =>
-                                                                    onRejectHunk?.(
-                                                                        hunkId,
-                                                                    )
-                                                                }
-                                                            />
-                                                        ) : null}
-                                                        <div
-                                                            style={{
-                                                                backgroundColor:
-                                                                    "color-mix(in srgb, var(--color-bg-elevated) 72%, transparent)",
-                                                                border: "1px solid color-mix(in srgb, var(--color-border) 32%, transparent)",
-                                                                borderRadius: 4,
-                                                                overflow:
-                                                                    "hidden",
-                                                                paddingRight: 4,
-                                                                paddingTop: 4,
-                                                            }}
-                                                        >
-                                                            {renderDiffLines(
-                                                                segment.lines,
-                                                                {
-                                                                    compactLineNumbers,
-                                                                    filePath:
-                                                                        file.path,
-                                                                    lineWrapping:
-                                                                        resolvedLineWrapping,
-                                                                },
-                                                            )}
-                                                        </div>
-                                                    </div>
-                                                );
-                                            })}
-                                        </div>
-                                    </div>
-                                );
-                            })}
+                        <div ref={listRef} style={{ padding: "4px 0" }}>
+                            {shouldVirtualizeLines && scrollContainerRef ? (
+                                <MeasuredVirtualList
+                                    enabled
+                                    estimateSize={estimateVirtualItemSize}
+                                    getItemKey={getVirtualPreviewItemKey}
+                                    items={virtualItems}
+                                    overscan={VIRTUAL_DIFF_LINE_OVERSCAN}
+                                    renderItem={renderVirtualItem}
+                                    scrollContainerRef={scrollContainerRef}
+                                    scrollMarginTop={scrollMarginTop}
+                                />
+                            ) : (
+                                renderBlocks.map((block) =>
+                                    renderPreviewBlock(block, previewContext),
+                                )
+                            )}
                         </div>
                     ) : (
                         <div
@@ -544,6 +895,130 @@ export function EditedFileDiffPreview({
                     )}
                 </div>
             </div>
+        </div>
+    );
+}
+
+function getVirtualVisualLineStyle(
+    item: Extract<VirtualPreviewItem, { readonly kind: "visualLine" }>,
+): CSSProperties {
+    const style: CSSProperties = {
+        backgroundColor:
+            "color-mix(in srgb, var(--color-bg-primary) 40%, var(--color-bg-elevated))",
+        borderLeft:
+            "1px solid color-mix(in srgb, var(--color-border) 40%, transparent)",
+        borderRight:
+            "1px solid color-mix(in srgb, var(--color-border) 40%, transparent)",
+        marginLeft: 6,
+        marginRight: 6,
+        paddingLeft: 4,
+        paddingRight: 4,
+        position: item.isFirstInDecision ? "relative" : undefined,
+    };
+
+    if (item.isFirstInVisualBlock) {
+        style.borderTop =
+            "1px solid color-mix(in srgb, var(--color-border) 40%, transparent)";
+        style.borderTopLeftRadius = 8;
+        style.borderTopRightRadius = 8;
+        style.marginTop = 4;
+        style.paddingTop = item.isFirstInDecision ? 16 : 4;
+    } else if (item.isFirstInDecision) {
+        style.paddingTop = 16;
+    }
+
+    if (item.isLastInVisualBlock) {
+        style.borderBottom =
+            "1px solid color-mix(in srgb, var(--color-border) 40%, transparent)";
+        style.borderBottomLeftRadius = 8;
+        style.borderBottomRightRadius = 8;
+        style.marginBottom = 4;
+        style.paddingBottom = 4;
+    }
+
+    return style;
+}
+
+function VirtualPreviewItemView({
+    compactLineNumbers,
+    diff,
+    file,
+    item,
+    lineWrapping,
+    onKeepHunk,
+    onRejectHunk,
+}: {
+    readonly compactLineNumbers: boolean;
+    readonly diff: AiFileDiff;
+    readonly file: AiTrackedFile | null;
+    readonly item: VirtualPreviewItem;
+    readonly lineWrapping: boolean;
+    readonly onKeepHunk?: (hunkId: string) => void;
+    readonly onRejectHunk?: (hunkId: string) => void;
+}) {
+    if (item.kind === "visualLabel") {
+        return (
+            <div
+                style={{
+                    color: "var(--color-text-secondary)",
+                    fontSize: "0.68em",
+                    fontWeight: 500,
+                    letterSpacing: "0.02em",
+                    margin: "4px 6px 0",
+                    opacity: 0.55,
+                    padding: "5px 10px 0",
+                }}
+            >
+                Linked changes
+            </div>
+        );
+    }
+
+    if (item.kind === "separator") {
+        return (
+            <DiffLineView
+                compactLineNumbers={compactLineNumbers}
+                filePath={file?.path ?? diff.path}
+                line={item.line}
+                lineWrapping={lineWrapping}
+            />
+        );
+    }
+
+    if (item.kind === "line") {
+        return (
+            <DiffLineView
+                compactLineNumbers={compactLineNumbers}
+                filePath={file?.path ?? diff.path}
+                line={item.line}
+                lineWrapping={lineWrapping}
+            />
+        );
+    }
+
+    const hunkId = item.dataReviewHunkKey;
+
+    return (
+        <div
+            className={hunkId && item.isFirstInDecision ? "group" : undefined}
+            data-review-file-key={item.dataReviewFileKey}
+            data-review-file-updated-at={item.dataReviewFileUpdatedAt}
+            data-review-hunk-key={hunkId}
+            style={getVirtualVisualLineStyle(item)}
+        >
+            {hunkId && item.isFirstInDecision ? (
+                <HunkActionBar
+                    hunkIndex={item.decisionHunkIndex ?? 0}
+                    onAccept={() => onKeepHunk?.(hunkId)}
+                    onReject={() => onRejectHunk?.(hunkId)}
+                />
+            ) : null}
+            <DiffLineView
+                compactLineNumbers={compactLineNumbers}
+                filePath={file?.path ?? diff.path}
+                line={item.line}
+                lineWrapping={lineWrapping}
+            />
         </div>
     );
 }

--- a/src/renderer/src/components/workspace/review/ReviewFileRow.tsx
+++ b/src/renderer/src/components/workspace/review/ReviewFileRow.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, type RefObject } from "react";
 
 import type { ReviewFileItem } from "./editedFilesPresentationModel";
 import { EditedFileDiffPreview } from "./EditedFileDiffPreview";
@@ -150,6 +150,7 @@ export interface ReviewFileRowProps {
     readonly onOpen?: () => void;
     readonly onReject: () => void;
     readonly onRejectHunk?: (hunkId: string) => void;
+    readonly scrollContainerRef?: RefObject<HTMLElement | null>;
     readonly onToggle: () => void;
     readonly variant: "compact" | "full";
 }
@@ -164,6 +165,7 @@ export const ReviewFileRow = memo(function ReviewFileRow({
     onOpen,
     onReject,
     onRejectHunk,
+    scrollContainerRef,
     onToggle,
     variant,
 }: ReviewFileRowProps) {
@@ -512,6 +514,7 @@ export const ReviewFileRow = memo(function ReviewFileRow({
                 lineWrapping={resolvedLineWrapping}
                 onKeepHunk={item.canResolveHunks ? onKeepHunk : undefined}
                 onRejectHunk={item.canResolveHunks ? onRejectHunk : undefined}
+                scrollContainerRef={scrollContainerRef}
                 testId={`review-file-diff:${item.file.identityKey}`}
             />
         </div>


### PR DESCRIPTION
## Summary

- Extends the shared measured virtual list with scroll margin and visible range reporting.
- Virtualizes GitHub issues and pull request tables while preserving sticky headers, column resize/reorder, row actions, and PR check loading by visible range.
- Virtualizes Git diff stacks by file, giant diff lines, Git history rows, and the visible Git history graph range.
- Virtualizes large review diff previews when they can use the shared review scroll container, preserving per-hunk accept/reject actions.

## Impact

Large GitHub lists, Git diffs, Git history, and expanded review previews should no longer mount every row/line at once. Small lists keep their existing full render path through conservative thresholds.

## Validation

- `pnpm vitest run src/renderer/src/components/workspace/review/EditedFileDiffPreview.test.tsx src/renderer/src/components/workspace/review/ReviewFileRow.test.tsx src/renderer/src/components/workspace/review/ReviewFileRow.compact.test.ts src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx`
- `pnpm exec eslint src/renderer/src/components/workspace/review/EditedFileDiffPreview.tsx src/renderer/src/components/workspace/review/EditedFileDiffPreview.test.tsx src/renderer/src/components/workspace/review/ReviewFileRow.tsx src/renderer/src/components/workspace/ReviewTabView.tsx`
- `pnpm run typecheck`
- `git diff --check`

Earlier phase validation also covered GitHub issues/PRs, Git diffs, Git history, and `MeasuredVirtualList` focused tests.