### PR TITLE
Add first-class Claude Code terminal support

### DIFF
--- a/src/main/ai/runtime-env.ts
+++ b/src/main/ai/runtime-env.ts
@@ -22,7 +22,7 @@ export function buildRuntimeSpawnEnv(
     return nextEnv;
 }
 
-function buildRuntimePathEntries(
+export function buildRuntimePathEntries(
     currentPath: string | undefined,
     executable: string,
 ): string[] {

--- a/src/main/db/client.ts
+++ b/src/main/db/client.ts
@@ -15,6 +15,7 @@ import type {
     AppAiChatSettings,
     AppAppearanceSettings,
     AppEditorSettings,
+    AppTerminalSettings,
     ClaudeRuntimeSettings,
     CodexRuntimeSettings,
     GeminiRuntimeSettings,
@@ -369,6 +370,18 @@ class SettingsClient implements SettingsGateway {
             aiChat: settings,
         };
         this.#dispatch("settings.saveAiChatSettings", settings);
+    }
+
+    loadAppTerminalSettings(): AppTerminalSettings {
+        return requireSetting(this.#snapshot.terminal, "terminal");
+    }
+
+    saveAppTerminalSettings(settings: AppTerminalSettings): void {
+        this.#snapshot = {
+            ...this.#snapshot,
+            terminal: settings,
+        };
+        this.#dispatch("settings.saveAppTerminalSettings", settings);
     }
 
     loadProjectSettings(projectId: string): ProjectSettingsSnapshot | null {

--- a/src/main/db/worker.ts
+++ b/src/main/db/worker.ts
@@ -512,6 +512,13 @@ function dispatchMethod(method: string, params: unknown): unknown {
                 params as Parameters<SettingsService["saveAiChatSettings"]>[0],
             );
             return null;
+        case "settings.saveAppTerminalSettings":
+            settingsService.saveAppTerminalSettings(
+                params as Parameters<
+                    SettingsService["saveAppTerminalSettings"]
+                >[0],
+            );
+            return null;
         case "settings.saveCodexRuntimeSettings":
             settingsService.saveCodexRuntimeSettings(
                 params as Parameters<

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -535,7 +535,12 @@ function persistAppAppearanceSettings(): void {
         });
     }
 
-    broadcastSettingsUpdated(appearance ?? null, snapshot.editor ?? null);
+    broadcastSettingsUpdated(
+        appearance ?? null,
+        snapshot.editor ?? null,
+        snapshot.aiChat ?? null,
+        snapshot.terminal ?? null,
+    );
 }
 
 function updateAppZoom(direction: "decrease" | "increase" | "reset"): void {

--- a/src/main/ipc/claude-code-transcript.test.ts
+++ b/src/main/ipc/claude-code-transcript.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+    encodeClaudeCodeProjectPath,
+    parseClaudeCodeTranscriptJsonl,
+    readClaudeCodeTranscript,
+} from "./claude-code-transcript";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("Claude Code transcript IPC helpers", () => {
+    it("encodes cwd like Claude Code project transcript directories", () => {
+        expect(encodeClaudeCodeProjectPath("/Users/jfg/Project A")).toBe(
+            "-Users-jfg-Project-A",
+        );
+    });
+
+    it("parses user title and latest assistant preview from JSONL", () => {
+        const parsed = parseClaudeCodeTranscriptJsonl(
+            [
+                "not-json",
+                JSON.stringify({ isMeta: true, type: "user", message: "meta" }),
+                JSON.stringify({
+                    type: "user",
+                    message: { content: "  Build   this feature\nplease " },
+                }),
+                JSON.stringify({
+                    message: {
+                        content: [{ text: "First answer" }],
+                        role: "assistant",
+                    },
+                }),
+                JSON.stringify({
+                    isSidechain: true,
+                    message: { content: "skip", role: "assistant" },
+                }),
+                JSON.stringify({
+                    message: {
+                        content: [{ text: "Latest" }, { text: " answer" }],
+                        role: "assistant",
+                    },
+                }),
+            ].join("\n"),
+        );
+
+        expect(parsed).toEqual({
+            preview: "Latest answer",
+            title: "Build this feature please",
+        });
+    });
+
+    it("rejects non-UUID session ids before touching transcript paths", async () => {
+        await expect(
+            readClaudeCodeTranscript({
+                cwd: "/workspace",
+                sessionId: "../../secret",
+            }),
+        ).rejects.toThrow(/session UUID/);
+    });
+
+    it("reads only the derived Claude Code transcript path and honors mtime cache", async () => {
+        const tempHome = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-claude-transcript-"),
+        );
+        vi.spyOn(os, "homedir").mockReturnValue(tempHome);
+        const sessionId = "11111111-1111-4111-8111-111111111111";
+        const transcriptDir = path.join(
+            tempHome,
+            ".claude",
+            "projects",
+            encodeClaudeCodeProjectPath("/workspace"),
+        );
+        await fs.mkdir(transcriptDir, { recursive: true });
+        const transcriptPath = path.join(transcriptDir, `${sessionId}.jsonl`);
+        await fs.writeFile(
+            transcriptPath,
+            JSON.stringify({
+                type: "user",
+                message: { content: "Hello Claude Code" },
+            }),
+        );
+
+        const first = await readClaudeCodeTranscript({
+            cwd: "/workspace",
+            sessionId,
+        });
+        const second = await readClaudeCodeTranscript({
+            cwd: "/workspace",
+            sessionId,
+            sinceMtimeMs: first.mtimeMs,
+        });
+
+        expect(first).toMatchObject({
+            changed: true,
+            found: true,
+            preview: null,
+            title: "Hello Claude Code",
+        });
+        expect(second).toEqual({
+            changed: false,
+            found: true,
+            mtimeMs: first.mtimeMs,
+            preview: null,
+            title: null,
+        });
+    });
+});

--- a/src/main/ipc/claude-code-transcript.ts
+++ b/src/main/ipc/claude-code-transcript.ts
@@ -1,0 +1,189 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type {
+    ReadClaudeCodeTranscriptInput,
+    ReadClaudeCodeTranscriptResult,
+} from "@shared/ipc";
+
+const UUID_PATTERN =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const MAX_TITLE_LENGTH = 80;
+const MAX_PREVIEW_LENGTH = 160;
+
+export async function readClaudeCodeTranscript(
+    input: ReadClaudeCodeTranscriptInput,
+): Promise<ReadClaudeCodeTranscriptResult> {
+    const sessionId = typeof input.sessionId === "string" ? input.sessionId : "";
+    if (!UUID_PATTERN.test(sessionId)) {
+        throw new Error("Expected a Claude Code transcript session UUID.");
+    }
+
+    const cwd = typeof input.cwd === "string" ? input.cwd : "";
+    if (cwd.trim().length === 0) {
+        return createMissingTranscriptResult();
+    }
+
+    const transcriptPath = path.join(
+        os.homedir(),
+        ".claude",
+        "projects",
+        encodeClaudeCodeProjectPath(cwd),
+        `${sessionId}.jsonl`,
+    );
+
+    let stat: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+        stat = await fs.stat(transcriptPath);
+    } catch (error) {
+        if (isNodeErrorCode(error, "ENOENT")) {
+            return createMissingTranscriptResult();
+        }
+        throw error;
+    }
+
+    const mtimeMs = stat.mtimeMs;
+    if (
+        typeof input.sinceMtimeMs === "number" &&
+        Number.isFinite(input.sinceMtimeMs) &&
+        input.sinceMtimeMs === mtimeMs
+    ) {
+        return {
+            changed: false,
+            found: true,
+            mtimeMs,
+            preview: null,
+            title: null,
+        };
+    }
+
+    const content = await fs.readFile(transcriptPath, "utf8");
+    const parsed = parseClaudeCodeTranscriptJsonl(content);
+    return {
+        changed: true,
+        found: true,
+        mtimeMs,
+        preview: parsed.preview,
+        title: parsed.title,
+    };
+}
+
+export function encodeClaudeCodeProjectPath(cwd: string): string {
+    return cwd.replace(/[^A-Za-z0-9]/g, "-");
+}
+
+export function parseClaudeCodeTranscriptJsonl(content: string): {
+    readonly preview: string | null;
+    readonly title: string | null;
+} {
+    let title: string | null = null;
+    let preview: string | null = null;
+
+    for (const line of content.split(/\r?\n/)) {
+        const trimmedLine = line.trim();
+        if (!trimmedLine) {
+            continue;
+        }
+
+        let entry: unknown;
+        try {
+            entry = JSON.parse(trimmedLine);
+        } catch {
+            continue;
+        }
+
+        if (!isRecord(entry) || entry.isSidechain === true || entry.isMeta === true) {
+            continue;
+        }
+
+        const role = getTranscriptEntryRole(entry);
+        const text = extractClaudeCodeMessageText(entry.message);
+        if (!text) {
+            continue;
+        }
+
+        if (role === "user" && !title) {
+            title = truncateCleanText(text, MAX_TITLE_LENGTH);
+        } else if (role === "assistant") {
+            preview = truncateCleanText(text, MAX_PREVIEW_LENGTH);
+        }
+    }
+
+    return { preview, title };
+}
+
+function getTranscriptEntryRole(entry: Record<string, unknown>): string | null {
+    if (typeof entry.type === "string") {
+        return entry.type;
+    }
+    if (isRecord(entry.message) && typeof entry.message.role === "string") {
+        return entry.message.role;
+    }
+    return null;
+}
+
+function extractClaudeCodeMessageText(value: unknown): string | null {
+    if (typeof value === "string") {
+        return collapseWhitespace(value);
+    }
+    if (!isRecord(value)) {
+        return null;
+    }
+
+    const content = value.content;
+    if (typeof content === "string") {
+        return collapseWhitespace(content);
+    }
+    if (!Array.isArray(content)) {
+        return null;
+    }
+
+    const text = content
+        .map((block) => {
+            if (typeof block === "string") {
+                return block;
+            }
+            if (isRecord(block) && typeof block.text === "string") {
+                return block.text;
+            }
+            return "";
+        })
+        .filter((part) => part.trim().length > 0)
+        .join(" ");
+    return collapseWhitespace(text);
+}
+
+function truncateCleanText(value: string, maxLength: number): string {
+    if (value.length <= maxLength) {
+        return value;
+    }
+    return `${value.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+function collapseWhitespace(value: string): string | null {
+    const collapsed = value.replace(/\s+/g, " ").trim();
+    return collapsed.length > 0 ? collapsed : null;
+}
+
+function createMissingTranscriptResult(): ReadClaudeCodeTranscriptResult {
+    return {
+        changed: false,
+        found: false,
+        mtimeMs: null,
+        preview: null,
+        title: null,
+    };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+    return (
+        error instanceof Error &&
+        "code" in error &&
+        (error as { readonly code?: unknown }).code === code
+    );
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -138,6 +138,7 @@ import {
     type OpenCodeRuntimeSettingsInput,
     type RevealProjectEntryInput,
     type ResizeTerminalSessionInput,
+    type ReadClaudeCodeTranscriptInput,
     type SearchProjectEntriesInput,
     type SaveProjectFileInput,
     type SendAiPromptInput,
@@ -195,6 +196,7 @@ import {
     createEmptyTsconfigResolution,
     resolveTsconfigForPath,
 } from "@main/tsconfig/resolve";
+import { readClaudeCodeTranscript } from "@main/ipc/claude-code-transcript";
 import { loadAppChangelog } from "@main/changelog";
 import {
     getAppPrivacyAccessState,
@@ -234,6 +236,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.revealGeneratedImage);
     ipcMain.removeHandler(IPC_CHANNELS.openProjectWindow);
     ipcMain.removeHandler(IPC_CHANNELS.checkCommandAvailability);
+    ipcMain.removeHandler(IPC_CHANNELS.readClaudeCodeTranscript);
     ipcMain.removeHandler(IPC_CHANNELS.getSettingsSnapshot);
     ipcMain.removeHandler(IPC_CHANNELS.getProjectSettings);
     ipcMain.removeHandler(IPC_CHANNELS.getSystemTheme);
@@ -458,6 +461,11 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             _event,
             input: CheckCommandAvailabilityInput,
         ): CheckCommandAvailabilityResult => checkCommandAvailability(input),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.readClaudeCodeTranscript,
+        (_event, input: ReadClaudeCodeTranscriptInput) =>
+            readClaudeCodeTranscript(input),
     );
     ipcMain.handle(
         IPC_CHANNELS.getSettingsSnapshot,

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -162,6 +162,7 @@ import { simpleGit } from "simple-git";
 
 import { forEachLiveWindow, refreshWindowsTitleBarOverlays } from "@main/window";
 import { createIpcInFlightLimiter } from "@main/ipc/rate-limit";
+import { resolveSettingsSnapshotSaveEffects } from "@main/ipc/settings-save-effects";
 import { debugBenignError } from "@main/observability/logging";
 import { resolveCodexGeneratedImageFilePath } from "@main/file-preview-protocol";
 
@@ -466,16 +467,19 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         IPC_CHANNELS.saveSettingsSnapshot,
         (_event, snapshot: SettingsSnapshot) => {
             options.settingsService.saveSnapshot(snapshot);
-            if (
-                snapshot.appearance !== undefined ||
-                snapshot.editor !== undefined ||
-                snapshot.aiChat !== undefined
-            ) {
+            const effects = resolveSettingsSnapshotSaveEffects(snapshot);
+            if (effects.broadcastSettingsUpdated) {
                 const persisted = options.settingsService.loadSnapshot();
-                applyAppZoomToAllWindows(persisted.appearance?.zoomFactor ?? 1);
+                if (effects.applyAppZoom) {
+                    applyAppZoomToAllWindows(
+                        persisted.appearance?.zoomFactor ?? 1,
+                    );
+                }
                 broadcastSettingsUpdated(
                     persisted.appearance ?? null,
                     persisted.editor ?? null,
+                    persisted.aiChat ?? null,
+                    persisted.terminal ?? null,
                 );
             }
         },

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -13,6 +13,8 @@ import {
     type AiRuntimeAuthDisconnectInput,
     type AiRuntimeAuthLaunchInput,
     type AiRuntimeAuthLogoutInput,
+    type CheckCommandAvailabilityInput,
+    type CheckCommandAvailabilityResult,
     type AiRuntimeId,
     type AiSessionConfigOptionMutationInput,
     type GetAiSessionTranscriptPageInput,
@@ -172,6 +174,7 @@ import {
     forgetOpenFileBuffer,
     recordOpenFileBuffer,
 } from "@main/ai/openFileBuffers";
+import { checkCommandAvailability } from "@main/shell/command-availability";
 import type { GitGateway } from "@main/git/service";
 import type { GitHubGateway } from "@main/github/service";
 import type { ProjectService } from "@main/projects/service";
@@ -230,6 +233,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.openGeneratedImage);
     ipcMain.removeHandler(IPC_CHANNELS.revealGeneratedImage);
     ipcMain.removeHandler(IPC_CHANNELS.openProjectWindow);
+    ipcMain.removeHandler(IPC_CHANNELS.checkCommandAvailability);
     ipcMain.removeHandler(IPC_CHANNELS.getSettingsSnapshot);
     ipcMain.removeHandler(IPC_CHANNELS.getProjectSettings);
     ipcMain.removeHandler(IPC_CHANNELS.getSystemTheme);
@@ -447,6 +451,13 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         (_event, input: OpenProjectWindowInput) => {
             options.openProjectWindow(input);
         },
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.checkCommandAvailability,
+        (
+            _event,
+            input: CheckCommandAvailabilityInput,
+        ): CheckCommandAvailabilityResult => checkCommandAvailability(input),
     );
     ipcMain.handle(
         IPC_CHANNELS.getSettingsSnapshot,

--- a/src/main/ipc/settings-save-effects.test.ts
+++ b/src/main/ipc/settings-save-effects.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSettingsSnapshotSaveEffects } from "./settings-save-effects";
+
+describe("resolveSettingsSnapshotSaveEffects", () => {
+    it("does not broadcast for shell-only snapshots", () => {
+        expect(
+            resolveSettingsSnapshotSaveEffects({
+                shellState: null,
+            }),
+        ).toEqual({
+            applyAppZoom: false,
+            broadcastSettingsUpdated: false,
+        });
+    });
+
+    it("broadcasts terminal updates without applying app zoom", () => {
+        expect(
+            resolveSettingsSnapshotSaveEffects({
+                shellState: null,
+                terminal: {
+                    claudeCodeContinueSession: false,
+                    claudeCodeMaxTurns: 0,
+                    claudeCodeModel: "",
+                    claudeCodeOptimized: true,
+                    claudeCodeSkipPermissions: false,
+                    terminalFontFamily: "Menlo",
+                    terminalFontSize: 14,
+                },
+            }),
+        ).toEqual({
+            applyAppZoom: false,
+            broadcastSettingsUpdated: true,
+        });
+    });
+
+    it("applies app zoom only when appearance is part of the saved snapshot", () => {
+        expect(
+            resolveSettingsSnapshotSaveEffects({
+                appearance: null,
+                shellState: null,
+            }),
+        ).toEqual({
+            applyAppZoom: true,
+            broadcastSettingsUpdated: true,
+        });
+
+        expect(
+            resolveSettingsSnapshotSaveEffects({
+                aiChat: null,
+                shellState: null,
+            }),
+        ).toEqual({
+            applyAppZoom: false,
+            broadcastSettingsUpdated: true,
+        });
+    });
+});

--- a/src/main/ipc/settings-save-effects.ts
+++ b/src/main/ipc/settings-save-effects.ts
@@ -1,0 +1,19 @@
+import type { SettingsSnapshot } from "@shared/ipc";
+
+export interface SettingsSnapshotSaveEffects {
+    readonly applyAppZoom: boolean;
+    readonly broadcastSettingsUpdated: boolean;
+}
+
+export function resolveSettingsSnapshotSaveEffects(
+    snapshot: SettingsSnapshot,
+): SettingsSnapshotSaveEffects {
+    return {
+        applyAppZoom: snapshot.appearance !== undefined,
+        broadcastSettingsUpdated:
+            snapshot.appearance !== undefined ||
+            snapshot.editor !== undefined ||
+            snapshot.aiChat !== undefined ||
+            snapshot.terminal !== undefined,
+    };
+}

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1,6 +1,8 @@
 import type Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 
+import { DEFAULT_APP_TERMINAL_SETTINGS } from "@shared/terminal-settings";
+
 import { SettingsService } from "./service";
 
 describe("SettingsService", () => {
@@ -58,6 +60,7 @@ describe("SettingsService", () => {
                 activeSurface: "workspace",
                 leftWidth: 280,
             },
+            terminal: DEFAULT_APP_TERMINAL_SETTINGS,
         });
     });
 
@@ -76,6 +79,13 @@ describe("SettingsService", () => {
                 "editor.line_height": "??",
                 "editor.minimap_enabled": "??",
                 "editor.suggestions_enabled": "??",
+                "terminal.claude_code_continue_session": "??",
+                "terminal.claude_code_max_turns": "5000",
+                "terminal.claude_code_model": "claude-opus-4-7; rm -rf /",
+                "terminal.claude_code_optimized": "??",
+                "terminal.claude_code_skip_permissions": "??",
+                "terminal.font_family": "  FiraCode\nNerd Font  ",
+                "terminal.font_size": "99",
             },
             project: {
                 "project-a": {
@@ -114,6 +124,12 @@ describe("SettingsService", () => {
                 suggestionsEnabled: true,
             },
             shellState: null,
+            terminal: {
+                ...DEFAULT_APP_TERMINAL_SETTINGS,
+                claudeCodeMaxTurns: 1000,
+                terminalFontFamily: "FiraCode Nerd Font",
+                terminalFontSize: 24,
+            },
         });
 
         expect(service.loadProjectSettings("project-a")).toEqual(null);
@@ -404,6 +420,110 @@ describe("SettingsService", () => {
             historyRetentionDays: 0,
             contextUsageBarEnabled: true,
             toolCardExpansionMode: "expanded",
+        });
+    });
+
+    it("stores and reloads terminal settings", () => {
+        const connection = createFakeSettingsConnection();
+        const service = new SettingsService(
+            connection as unknown as Database.Database,
+        );
+
+        service.saveSnapshot({
+            shellState: null,
+            terminal: {
+                claudeCodeContinueSession: true,
+                claudeCodeMaxTurns: 42,
+                claudeCodeModel: "claude-sonnet-4-6",
+                claudeCodeOptimized: true,
+                claudeCodeSkipPermissions: true,
+                terminalFontFamily: '"FiraCode Nerd Font", Menlo',
+                terminalFontSize: 16,
+            },
+        });
+
+        expect(service.loadAppTerminalSettings()).toEqual({
+            claudeCodeContinueSession: true,
+            claudeCodeMaxTurns: 42,
+            claudeCodeModel: "claude-sonnet-4-6",
+            claudeCodeOptimized: true,
+            claudeCodeSkipPermissions: true,
+            terminalFontFamily: '"FiraCode Nerd Font", Menlo',
+            terminalFontSize: 16,
+        });
+        expect(service.loadSnapshot().terminal).toEqual({
+            claudeCodeContinueSession: true,
+            claudeCodeMaxTurns: 42,
+            claudeCodeModel: "claude-sonnet-4-6",
+            claudeCodeOptimized: true,
+            claudeCodeSkipPermissions: true,
+            terminalFontFamily: '"FiraCode Nerd Font", Menlo',
+            terminalFontSize: 16,
+        });
+    });
+
+    it("normalizes terminal settings before saving", () => {
+        const connection = createFakeSettingsConnection();
+        const service = new SettingsService(
+            connection as unknown as Database.Database,
+        );
+
+        service.saveAppTerminalSettings({
+            claudeCodeContinueSession: true,
+            claudeCodeMaxTurns: 2000,
+            claudeCodeModel: "bad-model",
+            claudeCodeOptimized: true,
+            claudeCodeSkipPermissions: true,
+            terminalFontFamily: "  JetBrains Mono\nMenlo  ",
+            terminalFontSize: 4,
+        });
+
+        expect(service.loadAppTerminalSettings()).toEqual({
+            claudeCodeContinueSession: true,
+            claudeCodeMaxTurns: 1000,
+            claudeCodeModel: "",
+            claudeCodeOptimized: true,
+            claudeCodeSkipPermissions: true,
+            terminalFontFamily: "JetBrains Mono Menlo",
+            terminalFontSize: 8,
+        });
+    });
+
+    it("does not clear terminal settings when saving a snapshot without terminal", () => {
+        const connection = createFakeSettingsConnection();
+        const service = new SettingsService(
+            connection as unknown as Database.Database,
+        );
+
+        service.saveAppTerminalSettings({
+            claudeCodeContinueSession: false,
+            claudeCodeMaxTurns: 12,
+            claudeCodeModel: "claude-haiku-4-5",
+            claudeCodeOptimized: true,
+            claudeCodeSkipPermissions: false,
+            terminalFontFamily: "Menlo",
+            terminalFontSize: 18,
+        });
+        service.saveSnapshot({
+            editor: {
+                autoSaveDelayMs: 900,
+                fontFamily: "ibm-plex-mono",
+                fontSize: 14,
+                lineHeight: 1.55,
+                minimapEnabled: true,
+                suggestionsEnabled: true,
+            },
+            shellState: null,
+        });
+
+        expect(service.loadAppTerminalSettings()).toEqual({
+            claudeCodeContinueSession: false,
+            claudeCodeMaxTurns: 12,
+            claudeCodeModel: "claude-haiku-4-5",
+            claudeCodeOptimized: true,
+            claudeCodeSkipPermissions: false,
+            terminalFontFamily: "Menlo",
+            terminalFontSize: 18,
         });
     });
 });

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -13,6 +13,10 @@ import {
     FILE_TREE_SCALE_DEFAULT,
     clampFileTreeScale,
 } from "@shared/file-tree-scale";
+import {
+    normalizeAppTerminalSettings,
+    type AppTerminalSettings,
+} from "@shared/terminal-settings";
 import type {
     AppAiChatSettings,
     AppAppearanceSettings,
@@ -94,6 +98,17 @@ const APP_EDITOR_LINE_HEIGHT_KEY = "editor.line_height";
 const APP_EDITOR_AUTOSAVE_DELAY_MS_KEY = "editor.autosave_delay_ms";
 const APP_EDITOR_MINIMAP_ENABLED_KEY = "editor.minimap_enabled";
 const APP_EDITOR_SUGGESTIONS_ENABLED_KEY = "editor.suggestions_enabled";
+const APP_TERMINAL_FONT_FAMILY_KEY = "terminal.font_family";
+const APP_TERMINAL_FONT_SIZE_KEY = "terminal.font_size";
+const APP_TERMINAL_CLAUDE_CODE_OPTIMIZED_KEY =
+    "terminal.claude_code_optimized";
+const APP_TERMINAL_CLAUDE_CODE_SKIP_PERMISSIONS_KEY =
+    "terminal.claude_code_skip_permissions";
+const APP_TERMINAL_CLAUDE_CODE_MODEL_KEY = "terminal.claude_code_model";
+const APP_TERMINAL_CLAUDE_CODE_CONTINUE_SESSION_KEY =
+    "terminal.claude_code_continue_session";
+const APP_TERMINAL_CLAUDE_CODE_MAX_TURNS_KEY =
+    "terminal.claude_code_max_turns";
 const PROJECT_THEME_MODE_KEY = "appearance.theme_mode";
 const PROJECT_THEME_PRESET_KEY = "appearance.theme_preset";
 const PROJECT_EDITOR_FONT_FAMILY_KEY = "editor.font_family";
@@ -216,6 +231,8 @@ export interface SettingsGateway {
     saveAppEditorSettings(settings: AppEditorSettings): void;
     loadAiChatSettings(): AppAiChatSettings;
     saveAiChatSettings(settings: AppAiChatSettings): void;
+    loadAppTerminalSettings(): AppTerminalSettings;
+    saveAppTerminalSettings(settings: AppTerminalSettings): void;
     loadProjectSettings(projectId: string): ProjectSettingsSnapshot | null;
     saveProjectSettings(snapshot: ProjectSettingsSnapshot): void;
     loadCodexRuntimeSettings(): CodexRuntimeSettings;
@@ -255,6 +272,7 @@ export class SettingsService {
             editor: this.loadAppEditorSettings(),
             shellState:
                 this.#loadJsonSetting<PersistedShellState>("shell.state"),
+            terminal: this.loadAppTerminalSettings(),
         };
     }
 
@@ -298,6 +316,10 @@ export class SettingsService {
 
         if (snapshot.editor) {
             this.saveAppEditorSettings(snapshot.editor);
+        }
+
+        if (snapshot.terminal) {
+            this.saveAppTerminalSettings(snapshot.terminal);
         }
     }
 
@@ -493,6 +515,64 @@ export class SettingsService {
             this.#normalizeToolCardExpansionMode(
                 settings.toolCardExpansionMode,
             ),
+        );
+    }
+
+    loadAppTerminalSettings(): AppTerminalSettings {
+        return normalizeAppTerminalSettings({
+            claudeCodeContinueSession: this.#loadBooleanSetting(
+                APP_TERMINAL_CLAUDE_CODE_CONTINUE_SESSION_KEY,
+            ),
+            claudeCodeMaxTurns: this.#loadNumberSetting(
+                APP_TERMINAL_CLAUDE_CODE_MAX_TURNS_KEY,
+            ),
+            claudeCodeModel: this.#loadStringSetting(
+                APP_TERMINAL_CLAUDE_CODE_MODEL_KEY,
+            ),
+            claudeCodeOptimized: this.#loadBooleanSetting(
+                APP_TERMINAL_CLAUDE_CODE_OPTIMIZED_KEY,
+            ),
+            claudeCodeSkipPermissions: this.#loadBooleanSetting(
+                APP_TERMINAL_CLAUDE_CODE_SKIP_PERMISSIONS_KEY,
+            ),
+            terminalFontFamily: this.#loadStringSetting(
+                APP_TERMINAL_FONT_FAMILY_KEY,
+            ),
+            terminalFontSize: this.#loadNumberSetting(
+                APP_TERMINAL_FONT_SIZE_KEY,
+            ),
+        });
+    }
+
+    saveAppTerminalSettings(settings: AppTerminalSettings): void {
+        const normalized = normalizeAppTerminalSettings(settings);
+        this.#saveSetting(
+            APP_TERMINAL_FONT_FAMILY_KEY,
+            normalized.terminalFontFamily,
+        );
+        this.#saveSetting(
+            APP_TERMINAL_FONT_SIZE_KEY,
+            String(normalized.terminalFontSize),
+        );
+        this.#saveBooleanSetting(
+            APP_TERMINAL_CLAUDE_CODE_OPTIMIZED_KEY,
+            normalized.claudeCodeOptimized,
+        );
+        this.#saveBooleanSetting(
+            APP_TERMINAL_CLAUDE_CODE_SKIP_PERMISSIONS_KEY,
+            normalized.claudeCodeSkipPermissions,
+        );
+        this.#saveSetting(
+            APP_TERMINAL_CLAUDE_CODE_MODEL_KEY,
+            normalized.claudeCodeModel,
+        );
+        this.#saveBooleanSetting(
+            APP_TERMINAL_CLAUDE_CODE_CONTINUE_SESSION_KEY,
+            normalized.claudeCodeContinueSession,
+        );
+        this.#saveSetting(
+            APP_TERMINAL_CLAUDE_CODE_MAX_TURNS_KEY,
+            String(normalized.claudeCodeMaxTurns),
         );
     }
 

--- a/src/main/settings/window-zoom.test.ts
+++ b/src/main/settings/window-zoom.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IPC_EVENTS } from "@shared/ipc";
+import { DEFAULT_APP_TERMINAL_SETTINGS } from "@shared/terminal-settings";
+
+const liveWindows: Array<{
+    readonly webContents: { readonly send: ReturnType<typeof vi.fn> };
+}> = [];
+
+vi.mock("../window", () => ({
+    forEachLiveWindow: (
+        callback: (window: (typeof liveWindows)[number]) => void,
+    ) => {
+        for (const window of liveWindows) {
+            callback(window);
+        }
+    },
+}));
+
+describe("broadcastSettingsUpdated", () => {
+    beforeEach(() => {
+        liveWindows.length = 0;
+    });
+
+    it("sends appearance, editor, aiChat, and terminal settings", async () => {
+        const { broadcastSettingsUpdated } = await import("./window-zoom");
+        const send = vi.fn();
+        liveWindows.push({ webContents: { send } });
+
+        broadcastSettingsUpdated(
+            {
+                agentsSidebarScale: 1,
+                boostCodeContrast: true,
+                fileTreeScale: 1,
+                stickyFoldersEnabled: true,
+                themeMode: "dark",
+                themePreset: "default",
+                zoomFactor: 1,
+            },
+            {
+                autoSaveDelayMs: 900,
+                fontFamily: "ibm-plex-mono",
+                fontSize: 14,
+                lineHeight: 1.55,
+                minimapEnabled: true,
+                suggestionsEnabled: true,
+            },
+            {
+                chatFontFamily: "andale",
+                chatFontSize: 14,
+                composerFontFamily: "ibm-plex-mono",
+                composerFontSize: 14,
+                contextUsageBarEnabled: true,
+                historyRetentionDays: 0,
+                requireCmdEnterToSend: false,
+                reviewDiffZoom: 0.96,
+                screenshotRetentionSeconds: 0,
+                toolCardExpansionMode: "collapsed",
+            },
+            DEFAULT_APP_TERMINAL_SETTINGS,
+        );
+
+        expect(send).toHaveBeenCalledWith(IPC_EVENTS.settingsUpdated, {
+            aiChat: {
+                chatFontFamily: "andale",
+                chatFontSize: 14,
+                composerFontFamily: "ibm-plex-mono",
+                composerFontSize: 14,
+                contextUsageBarEnabled: true,
+                historyRetentionDays: 0,
+                requireCmdEnterToSend: false,
+                reviewDiffZoom: 0.96,
+                screenshotRetentionSeconds: 0,
+                toolCardExpansionMode: "collapsed",
+            },
+            appearance: {
+                agentsSidebarScale: 1,
+                boostCodeContrast: true,
+                fileTreeScale: 1,
+                stickyFoldersEnabled: true,
+                themeMode: "dark",
+                themePreset: "default",
+                zoomFactor: 1,
+            },
+            editor: {
+                autoSaveDelayMs: 900,
+                fontFamily: "ibm-plex-mono",
+                fontSize: 14,
+                lineHeight: 1.55,
+                minimapEnabled: true,
+                suggestionsEnabled: true,
+            },
+            terminal: DEFAULT_APP_TERMINAL_SETTINGS,
+        });
+    });
+});

--- a/src/main/settings/window-zoom.ts
+++ b/src/main/settings/window-zoom.ts
@@ -1,10 +1,12 @@
-import { BrowserWindow } from "electron";
+import type { BrowserWindow } from "electron";
 
 import { clampAppZoomFactor } from "@shared/app-zoom";
 import {
     IPC_EVENTS,
+    type AppAiChatSettings,
     type AppAppearanceSettings,
     type AppEditorSettings,
+    type AppTerminalSettings,
     type SettingsUpdatedEvent,
 } from "@shared/ipc";
 
@@ -26,8 +28,15 @@ export function applyAppZoomToAllWindows(zoomFactor: number): void {
 export function broadcastSettingsUpdated(
     appearance: AppAppearanceSettings | null,
     editor: AppEditorSettings | null,
+    aiChat: AppAiChatSettings | null,
+    terminal: AppTerminalSettings | null,
 ): void {
-    const payload: SettingsUpdatedEvent = { appearance, editor };
+    const payload: SettingsUpdatedEvent = {
+        aiChat,
+        appearance,
+        editor,
+        terminal,
+    };
 
     forEachLiveWindow((window) => {
         window.webContents.send(IPC_EVENTS.settingsUpdated, payload);

--- a/src/main/shell/command-availability.test.ts
+++ b/src/main/shell/command-availability.test.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { checkCommandAvailability } from "./command-availability";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+        fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+});
+
+describe("checkCommandAvailability", () => {
+    it("finds an allowed executable in PATH entries without running it", () => {
+        const binDir = createTempDir();
+        const executablePath = writeExecutable(
+            binDir,
+            "claude",
+            [
+                "#!/bin/sh",
+                `touch ${JSON.stringify(path.join(binDir, "ran"))}`,
+            ].join("\n"),
+        );
+
+        const result = checkCommandAvailability(
+            { name: "claude" },
+            { pathEntries: [binDir] },
+        );
+
+        expect(result).toEqual({
+            found: true,
+            path: executablePath,
+        });
+        expect(fs.existsSync(path.join(binDir, "ran"))).toBe(false);
+    });
+
+    it("rejects unsafe or non-allowed command names", () => {
+        const binDir = createTempDir();
+        writeExecutable(binDir, "claude");
+
+        for (const name of [
+            "claude code",
+            "./claude",
+            "claude;rm",
+            "'claude'",
+            "codex",
+        ]) {
+            expect(
+                checkCommandAvailability(
+                    { name },
+                    { pathEntries: [binDir] },
+                ),
+            ).toEqual({
+                found: false,
+                path: null,
+            });
+        }
+    });
+
+    it("respects PATHEXT when resolving on Windows", () => {
+        const binDir = createTempDir();
+        const executablePath = writeExecutable(binDir, "claude.CMD");
+
+        expect(
+            checkCommandAvailability(
+                { name: "claude" },
+                {
+                    env: { PATHEXT: ".CMD" },
+                    pathEntries: [binDir],
+                    platform: "win32",
+                },
+            ),
+        ).toEqual({
+            found: true,
+            path: executablePath,
+        });
+    });
+});
+
+function createTempDir(): string {
+    const tempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "comando-command-availability-"),
+    );
+    tempDirs.push(tempDir);
+    return tempDir;
+}
+
+function writeExecutable(
+    directory: string,
+    name: string,
+    content = "",
+): string {
+    const executablePath = path.join(directory, name);
+    fs.writeFileSync(executablePath, content, { mode: 0o755 });
+    fs.chmodSync(executablePath, 0o755);
+    return executablePath;
+}

--- a/src/main/shell/command-availability.ts
+++ b/src/main/shell/command-availability.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type {
+    CheckCommandAvailabilityInput,
+    CheckCommandAvailabilityResult,
+} from "@shared/ipc";
+
+import { buildRuntimePathEntries } from "@main/ai/runtime-env";
+import { debugBenignError } from "@main/observability/logging";
+
+const ALLOWED_COMMANDS = new Set(["claude"]);
+const SAFE_COMMAND_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
+const DEFAULT_WINDOWS_PATHEXT = ".EXE;.CMD;.BAT;.COM";
+
+interface CheckCommandAvailabilityOptions {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly pathEntries?: readonly string[];
+    readonly platform?: NodeJS.Platform;
+}
+
+export function checkCommandAvailability(
+    input: CheckCommandAvailabilityInput,
+    options: CheckCommandAvailabilityOptions = {},
+): CheckCommandAvailabilityResult {
+    const name = normalizeAllowedCommandName(input?.name);
+    if (!name) {
+        return createMissingResult();
+    }
+
+    try {
+        const env = options.env ?? process.env;
+        const platform = options.platform ?? process.platform;
+        const resolvedPath = resolveCommandFromPath(
+            name,
+            env,
+            platform,
+            options.pathEntries,
+        );
+
+        return {
+            found: resolvedPath !== null,
+            path: resolvedPath,
+        };
+    } catch (error) {
+        debugBenignError("shell.commandAvailability", error);
+        return createMissingResult();
+    }
+}
+
+function normalizeAllowedCommandName(name: unknown): string | null {
+    if (typeof name !== "string") {
+        return null;
+    }
+
+    const normalized = name.trim();
+    if (
+        !SAFE_COMMAND_NAME_PATTERN.test(normalized) ||
+        !ALLOWED_COMMANDS.has(normalized)
+    ) {
+        return null;
+    }
+
+    return normalized;
+}
+
+function resolveCommandFromPath(
+    command: string,
+    env: NodeJS.ProcessEnv,
+    platform: NodeJS.Platform,
+    inputPathEntries?: readonly string[],
+): string | null {
+    const pathEntries =
+        inputPathEntries ?? buildRuntimePathEntries(env.PATH, command);
+    const pathextEntries =
+        platform === "win32" ? getWindowsPathExtensions(env.PATHEXT) : [""];
+
+    for (const entry of pathEntries) {
+        for (const ext of pathextEntries) {
+            const candidate = path.join(
+                entry,
+                platform === "win32" &&
+                    !command.toLowerCase().endsWith(ext.toLowerCase())
+                    ? `${command}${ext}`
+                    : command,
+            );
+            if (isExecutableFile(candidate)) {
+                return path.resolve(candidate);
+            }
+        }
+    }
+
+    return null;
+}
+
+function getWindowsPathExtensions(value: string | undefined): string[] {
+    return (value ?? DEFAULT_WINDOWS_PATHEXT)
+        .split(";")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+}
+
+function isExecutableFile(candidatePath: string): boolean {
+    try {
+        fs.accessSync(candidatePath, fs.constants.X_OK);
+        return fs.statSync(candidatePath).isFile();
+    } catch (error) {
+        debugBenignError("shell.commandAvailability.isExecutableFile", error);
+        return false;
+    }
+}
+
+function createMissingResult(): CheckCommandAvailabilityResult {
+    return {
+        found: false,
+        path: null,
+    };
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -36,6 +36,8 @@ import {
     type CloneRepositoryInput,
     type CloneRepositoryResult,
     type ComandoApi,
+    type CheckCommandAvailabilityInput,
+    type CheckCommandAvailabilityResult,
     type CodexRuntimeSettingsInput,
     type CopyExternalProjectEntriesInput,
     type CopyExternalProjectEntriesResult,
@@ -203,6 +205,30 @@ function assertIpcArray<T>(channel: string, value: unknown): T[] {
         );
     }
     return value as T[];
+}
+
+function assertCommandAvailabilityResult(
+    channel: string,
+    value: unknown,
+): CheckCommandAvailabilityResult {
+    const result = assertIpcObject<Partial<CheckCommandAvailabilityResult>>(
+        channel,
+        value,
+    );
+    if (typeof result.found !== "boolean") {
+        throw new Error(
+            `IPC contract violation on "${channel}": expected found to be boolean.`,
+        );
+    }
+    if (result.path !== null && typeof result.path !== "string") {
+        throw new Error(
+            `IPC contract violation on "${channel}": expected path to be string or null.`,
+        );
+    }
+    return {
+        found: result.found,
+        path: result.path,
+    };
 }
 
 const aiSessionSnapshotListeners = new Set<(update: AiSessionUpdate) => void>();
@@ -395,6 +421,11 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.revealGeneratedImage, path),
     openProjectWindow: (input: OpenProjectWindowInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.openProjectWindow, input),
+    checkCommandAvailability: async (input: CheckCommandAvailabilityInput) =>
+        assertCommandAvailabilityResult(
+            IPC_CHANNELS.checkCommandAvailability,
+            await ipcRenderer.invoke(IPC_CHANNELS.checkCommandAvailability, input),
+        ),
     getSettingsSnapshot: async () =>
         assertIpcObject<SettingsSnapshot>(
             IPC_CHANNELS.getSettingsSnapshot,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -59,6 +59,8 @@ import {
     type PrepareAiSessionInput,
     type ProjectSettingsSnapshot,
     type ProjectSettingsUpdatedEvent,
+    type ReadClaudeCodeTranscriptInput,
+    type ReadClaudeCodeTranscriptResult,
     type ProjectAppDataSummary,
     type ProjectRelocateResult,
     type ProjectSummary,
@@ -228,6 +230,48 @@ function assertCommandAvailabilityResult(
     return {
         found: result.found,
         path: result.path,
+    };
+}
+
+function assertClaudeCodeTranscriptResult(
+    channel: string,
+    value: unknown,
+): ReadClaudeCodeTranscriptResult {
+    const result = assertIpcObject<Partial<ReadClaudeCodeTranscriptResult>>(
+        channel,
+        value,
+    );
+    if (typeof result.found !== "boolean") {
+        throw new Error(
+            `IPC contract violation on "${channel}": expected found to be boolean.`,
+        );
+    }
+    if (typeof result.changed !== "boolean") {
+        throw new Error(
+            `IPC contract violation on "${channel}": expected changed to be boolean.`,
+        );
+    }
+    if (result.mtimeMs !== null && typeof result.mtimeMs !== "number") {
+        throw new Error(
+            `IPC contract violation on "${channel}": expected mtimeMs to be number or null.`,
+        );
+    }
+    if (result.title !== null && typeof result.title !== "string") {
+        throw new Error(
+            `IPC contract violation on "${channel}": expected title to be string or null.`,
+        );
+    }
+    if (result.preview !== null && typeof result.preview !== "string") {
+        throw new Error(
+            `IPC contract violation on "${channel}": expected preview to be string or null.`,
+        );
+    }
+    return {
+        changed: result.changed,
+        found: result.found,
+        mtimeMs: result.mtimeMs,
+        preview: result.preview,
+        title: result.title,
     };
 }
 
@@ -425,6 +469,14 @@ const comandoApi: ComandoApi = {
         assertCommandAvailabilityResult(
             IPC_CHANNELS.checkCommandAvailability,
             await ipcRenderer.invoke(IPC_CHANNELS.checkCommandAvailability, input),
+        ),
+    readClaudeCodeTranscript: async (input: ReadClaudeCodeTranscriptInput) =>
+        assertClaudeCodeTranscriptResult(
+            IPC_CHANNELS.readClaudeCodeTranscript,
+            await ipcRenderer.invoke(
+                IPC_CHANNELS.readClaudeCodeTranscript,
+                input,
+            ),
         ),
     getSettingsSnapshot: async () =>
         assertIpcObject<SettingsSnapshot>(

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -9,6 +9,7 @@ import type {
     AppAiChatSettings,
     AppAppearanceSettings,
     AppPrivacyAccessState,
+    AppTerminalSettings,
     ClaudeRuntimeSettingsInput,
     CodexRuntimeSettingsInput,
     ProjectSummary,
@@ -34,6 +35,7 @@ import {
     saveAiChatSettings,
     saveAppEditorSettings,
     saveAppAppearanceSettings,
+    saveAppTerminalSettings,
 } from "./app/settings/client";
 import {
     buildSelectableFontFamilyOptions,
@@ -47,6 +49,10 @@ import {
     getDefaultAppEditorSettings,
     THEME_PRESET_OPTIONS,
 } from "./app/settings/theme";
+import {
+    DEFAULT_APP_TERMINAL_SETTINGS,
+    normalizeAppTerminalSettings,
+} from "@shared/terminal-settings";
 import { useResolvedAppearance } from "./app/hooks/use-resolved-appearance";
 import { useSettingsStore } from "./app/store/settings-store";
 import { shortcutDefinitions, formatShortcut } from "./app/shortcuts/registry";
@@ -64,6 +70,9 @@ export function SettingsApp() {
     );
     const [aiChat, setAiChat] = useState<AppAiChatSettings>(
         getDefaultAiChatSettings(),
+    );
+    const [terminal, setTerminal] = useState<AppTerminalSettings>(
+        DEFAULT_APP_TERMINAL_SETTINGS,
     );
     const [runtimeStatuses, setRuntimeStatuses] = useState<
         Record<AiRuntimeId, AiRuntimeStatus | null>
@@ -126,6 +135,7 @@ export function SettingsApp() {
     const storeAiChat = useSettingsStore((state) => state.aiChat);
     const storeAppAppearance = useSettingsStore((state) => state.appearance);
     const storeAppEditor = useSettingsStore((state) => state.editor);
+    const storeTerminal = useSettingsStore((state) => state.terminal);
     const latestSettingsRevisionRef = useRef(0);
 
     useResolvedAppearance();
@@ -321,6 +331,10 @@ export function SettingsApp() {
     }, [storeAppEditor]);
 
     useEffect(() => {
+        setTerminal(storeTerminal);
+    }, [storeTerminal]);
+
+    useEffect(() => {
         if (settingsRevision <= 0) {
             return;
         }
@@ -479,6 +493,15 @@ export function SettingsApp() {
         const next: AppAiChatSettings = { ...aiChat, ...patch };
         setAiChat(next);
         void saveAiChatSettings(next);
+    };
+
+    const updateTerminal = (patch: Partial<AppTerminalSettings>) => {
+        const next = normalizeAppTerminalSettings({
+            ...terminal,
+            ...patch,
+        });
+        setTerminal(next);
+        void saveAppTerminalSettings(next);
     };
 
     const runProviderSettingsAction = useCallback(
@@ -783,6 +806,30 @@ export function SettingsApp() {
                 onMinimapEnabledChange: handleAppEditorMinimapEnabledChange,
                 onSuggestionsEnabledChange:
                     handleAppEditorSuggestionsEnabledChange,
+            }}
+            terminal={{
+                claudeCodeAvailable: null,
+                claudeCodeContinueSession: terminal.claudeCodeContinueSession,
+                claudeCodeMaxTurns: terminal.claudeCodeMaxTurns,
+                claudeCodeModel: terminal.claudeCodeModel,
+                claudeCodeOptimized: terminal.claudeCodeOptimized,
+                claudeCodeSkipPermissions: terminal.claudeCodeSkipPermissions,
+                onClaudeCodeContinueSessionChange: (value) =>
+                    updateTerminal({ claudeCodeContinueSession: value }),
+                onClaudeCodeMaxTurnsChange: (value) =>
+                    updateTerminal({ claudeCodeMaxTurns: value }),
+                onClaudeCodeModelChange: (value) =>
+                    updateTerminal({ claudeCodeModel: value }),
+                onClaudeCodeOptimizedChange: (value) =>
+                    updateTerminal({ claudeCodeOptimized: value }),
+                onClaudeCodeSkipPermissionsChange: (value) =>
+                    updateTerminal({ claudeCodeSkipPermissions: value }),
+                onTerminalFontFamilyChange: (value) =>
+                    updateTerminal({ terminalFontFamily: value }),
+                onTerminalFontSizeChange: (value) =>
+                    updateTerminal({ terminalFontSize: value }),
+                terminalFontFamily: terminal.terminalFontFamily,
+                terminalFontSize: terminal.terminalFontSize,
             }}
             aiProviders={{
                 busyProviderId: savingRuntimeId,

--- a/src/renderer/src/app/settings/client.test.ts
+++ b/src/renderer/src/app/settings/client.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { AppEditorSettings, SettingsSnapshot } from "@shared/ipc";
+import type {
+    AppAppearanceSettings,
+    AppEditorSettings,
+    SettingsSnapshot,
+} from "@shared/ipc";
+import { DEFAULT_APP_TERMINAL_SETTINGS } from "@shared/terminal-settings";
 
 import {
     getCachedAppEditorSettings,
+    loadAppTerminalSettings,
+    saveAppTerminalSettings,
     loadAppEditorSettings,
     setCachedAppEditorSettings,
 } from "./client";
@@ -22,13 +29,30 @@ function createEditorSettings(
     };
 }
 
+function createAppearanceSettings(
+    overrides: Partial<AppAppearanceSettings> = {},
+): AppAppearanceSettings {
+    return {
+        agentsSidebarScale: 1,
+        boostCodeContrast: true,
+        fileTreeScale: 1,
+        stickyFoldersEnabled: true,
+        themeMode: "system",
+        themePreset: "default",
+        zoomFactor: 1,
+        ...overrides,
+    };
+}
+
 function stubComandoApi(snapshot: SettingsSnapshot) {
+    const saveSettingsSnapshot = vi.fn();
     vi.stubGlobal("window", {
         comando: {
             getSettingsSnapshot: vi.fn().mockResolvedValue(snapshot),
-            saveSettingsSnapshot: vi.fn(),
+            saveSettingsSnapshot,
         },
     });
+    return { saveSettingsSnapshot };
 }
 
 describe("settings client editor cache", () => {
@@ -56,5 +80,82 @@ describe("settings client editor cache", () => {
 
         expect(editor.minimapEnabled).toBe(true);
         expect(getCachedAppEditorSettings()).toBeNull();
+    });
+});
+
+describe("settings client terminal settings", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("loads defaults when the snapshot has no terminal payload", async () => {
+        stubComandoApi({ shellState: null });
+
+        await expect(loadAppTerminalSettings()).resolves.toEqual(
+            DEFAULT_APP_TERMINAL_SETTINGS,
+        );
+    });
+
+    it("loads normalized terminal settings from the snapshot", async () => {
+        stubComandoApi({
+            shellState: null,
+            terminal: {
+                claudeCodeContinueSession: true,
+                claudeCodeMaxTurns: 2000,
+                claudeCodeModel: "unknown-model",
+                claudeCodeOptimized: true,
+                claudeCodeSkipPermissions: true,
+                terminalFontFamily: "  FiraCode\nNerd Font  ",
+                terminalFontSize: 99,
+            },
+        });
+
+        await expect(loadAppTerminalSettings()).resolves.toEqual({
+            claudeCodeContinueSession: true,
+            claudeCodeMaxTurns: 1000,
+            claudeCodeModel: "",
+            claudeCodeOptimized: true,
+            claudeCodeSkipPermissions: true,
+            terminalFontFamily: "FiraCode Nerd Font",
+            terminalFontSize: 24,
+        });
+    });
+
+    it("normalizes terminal settings before saving and preserves the current snapshot", async () => {
+        const appearance = createAppearanceSettings({ zoomFactor: 1.2 });
+        const { saveSettingsSnapshot } = stubComandoApi({
+            appearance,
+            shellState: {
+                activeSurface: "workspace",
+                leftWidth: 312,
+            },
+        });
+
+        await saveAppTerminalSettings({
+            claudeCodeContinueSession: true,
+            claudeCodeMaxTurns: 2000,
+            claudeCodeModel: "not-safe",
+            claudeCodeOptimized: true,
+            claudeCodeSkipPermissions: true,
+            terminalFontFamily: "  Menlo\nmonospace  ",
+            terminalFontSize: 4,
+        });
+
+        expect(saveSettingsSnapshot).toHaveBeenCalledWith({
+            appearance,
+            shellState: {
+                activeSurface: "workspace",
+                leftWidth: 312,
+            },
+            terminal: {
+                claudeCodeContinueSession: true,
+                claudeCodeMaxTurns: 1000,
+                claudeCodeModel: "",
+                claudeCodeOptimized: true,
+                claudeCodeSkipPermissions: true,
+                terminalFontFamily: "Menlo monospace",
+                terminalFontSize: 8,
+            },
+        });
     });
 });

--- a/src/renderer/src/app/settings/client.ts
+++ b/src/renderer/src/app/settings/client.ts
@@ -2,8 +2,13 @@ import type {
     AppAiChatSettings,
     AppAppearanceSettings,
     AppEditorSettings,
+    AppTerminalSettings,
     SettingsSnapshot,
 } from "@shared/ipc";
+import {
+    DEFAULT_APP_TERMINAL_SETTINGS,
+    normalizeAppTerminalSettings,
+} from "@shared/terminal-settings";
 
 import {
     getDefaultAiChatSettings,
@@ -54,6 +59,26 @@ export async function saveAiChatSettings(
         ...currentSnapshot,
         aiChat,
         shellState: currentSnapshot.shellState,
+    };
+
+    await getComandoApi().saveSettingsSnapshot(nextSnapshot);
+}
+
+export async function loadAppTerminalSettings(): Promise<AppTerminalSettings> {
+    const snapshot = await getComandoApi().getSettingsSnapshot();
+    return normalizeAppTerminalSettings(
+        snapshot.terminal ?? DEFAULT_APP_TERMINAL_SETTINGS,
+    );
+}
+
+export async function saveAppTerminalSettings(
+    terminal: AppTerminalSettings,
+): Promise<void> {
+    const currentSnapshot = await getComandoApi().getSettingsSnapshot();
+    const nextSnapshot: SettingsSnapshot = {
+        ...currentSnapshot,
+        shellState: currentSnapshot.shellState,
+        terminal: normalizeAppTerminalSettings(terminal),
     };
 
     await getComandoApi().saveSettingsSnapshot(nextSnapshot);

--- a/src/renderer/src/app/store/settings-store.test.ts
+++ b/src/renderer/src/app/store/settings-store.test.ts
@@ -4,6 +4,7 @@ import type {
     AppAiChatSettings,
     AppAppearanceSettings,
     AppEditorSettings,
+    AppTerminalSettings,
     SettingsUpdatedEvent,
     SystemTheme,
 } from "@shared/ipc";
@@ -61,6 +62,21 @@ function createAiChatSettings(
     };
 }
 
+function createTerminalSettings(
+    overrides: Partial<AppTerminalSettings> = {},
+): AppTerminalSettings {
+    return {
+        claudeCodeContinueSession: false,
+        claudeCodeMaxTurns: 0,
+        claudeCodeModel: "",
+        claudeCodeOptimized: false,
+        claudeCodeSkipPermissions: false,
+        terminalFontFamily: "",
+        terminalFontSize: 13,
+        ...overrides,
+    };
+}
+
 function flushAsyncWork(): Promise<void> {
     return new Promise((resolve) => {
         setTimeout(resolve, 0);
@@ -108,6 +124,7 @@ describe("settings-store", () => {
             revision: 1,
             status: "ready",
             systemTheme: { isDark: true },
+            terminal: DEFAULT_APP_TERMINAL_SETTINGS,
         });
     });
 
@@ -118,6 +135,14 @@ describe("settings-store", () => {
         const nextAppearance = createAppearanceSettings({ zoomFactor: 1.2 });
         const initialEditor = createEditorSettings({ fontSize: 14 });
         const nextEditor = createEditorSettings({ fontSize: 16 });
+        const initialTerminal = createTerminalSettings({
+            terminalFontSize: 13,
+        });
+        const nextTerminal = createTerminalSettings({
+            claudeCodeOptimized: true,
+            terminalFontFamily: "Menlo",
+            terminalFontSize: 18,
+        });
         let settingsListener:
             | ((payload: SettingsUpdatedEvent) => void)
             | null = null;
@@ -129,12 +154,14 @@ describe("settings-store", () => {
                 appearance: initialAppearance,
                 editor: initialEditor,
                 shellState: null,
+                terminal: initialTerminal,
             })
             .mockResolvedValueOnce({
                 aiChat: nextAiChat,
                 appearance: nextAppearance,
                 editor: nextEditor,
                 shellState: null,
+                terminal: nextTerminal,
             });
 
         vi.stubGlobal("window", {
@@ -167,7 +194,7 @@ describe("settings-store", () => {
             aiChat: nextAiChat,
             appearance: nextAppearance,
             editor: nextEditor,
-            terminal: DEFAULT_APP_TERMINAL_SETTINGS,
+            terminal: nextTerminal,
         });
         await flushAsyncWork();
 
@@ -176,7 +203,44 @@ describe("settings-store", () => {
             appearance: nextAppearance,
             editor: nextEditor,
             revision: 2,
+            terminal: nextTerminal,
         });
         expect(getSettingsSnapshot).toHaveBeenCalledTimes(2);
+    });
+
+    it("normalizes terminal settings from hydrated snapshots", async () => {
+        vi.stubGlobal("window", {
+            comando: {
+                getSettingsSnapshot: vi.fn().mockResolvedValue({
+                    shellState: null,
+                    terminal: {
+                        claudeCodeContinueSession: true,
+                        claudeCodeMaxTurns: 5000,
+                        claudeCodeModel: "bad-model",
+                        claudeCodeOptimized: true,
+                        claudeCodeSkipPermissions: true,
+                        terminalFontFamily: "  FiraCode\nNerd Font  ",
+                        terminalFontSize: 99,
+                    },
+                }),
+                getSystemTheme: vi
+                    .fn()
+                    .mockResolvedValue({ isDark: false } satisfies SystemTheme),
+                onSettingsUpdated: vi.fn().mockReturnValue(() => {}),
+                onThemeUpdated: vi.fn().mockReturnValue(() => {}),
+            },
+        });
+
+        await useSettingsStore.getState().hydrate();
+
+        expect(useSettingsStore.getState().terminal).toEqual({
+            claudeCodeContinueSession: true,
+            claudeCodeMaxTurns: 1000,
+            claudeCodeModel: "",
+            claudeCodeOptimized: true,
+            claudeCodeSkipPermissions: true,
+            terminalFontFamily: "FiraCode Nerd Font",
+            terminalFontSize: 24,
+        });
     });
 });

--- a/src/renderer/src/app/store/settings-store.test.ts
+++ b/src/renderer/src/app/store/settings-store.test.ts
@@ -7,6 +7,7 @@ import type {
     SettingsUpdatedEvent,
     SystemTheme,
 } from "@shared/ipc";
+import { DEFAULT_APP_TERMINAL_SETTINGS } from "@shared/terminal-settings";
 
 import {
     resetSettingsStoreForTests,
@@ -163,8 +164,10 @@ describe("settings-store", () => {
             payload: SettingsUpdatedEvent,
         ) => void;
         registeredSettingsListener({
+            aiChat: nextAiChat,
             appearance: nextAppearance,
             editor: nextEditor,
+            terminal: DEFAULT_APP_TERMINAL_SETTINGS,
         });
         await flushAsyncWork();
 

--- a/src/renderer/src/app/store/settings-store.ts
+++ b/src/renderer/src/app/store/settings-store.ts
@@ -4,9 +4,14 @@ import type {
     AppAiChatSettings,
     AppAppearanceSettings,
     AppEditorSettings,
+    AppTerminalSettings,
     SettingsSnapshot,
     SystemTheme,
 } from "@shared/ipc";
+import {
+    DEFAULT_APP_TERMINAL_SETTINGS,
+    normalizeAppTerminalSettings,
+} from "@shared/terminal-settings";
 
 import { setCachedAppEditorSettings } from "../settings/client";
 import {
@@ -25,6 +30,7 @@ interface SettingsStore {
     readonly revision: number;
     readonly status: SettingsStatus;
     readonly systemTheme: SystemTheme;
+    readonly terminal: AppTerminalSettings;
     hydrate: () => Promise<void>;
 }
 
@@ -43,6 +49,7 @@ function createDefaultSettingsState() {
         revision: 0,
         status: "idle" as const,
         systemTheme: DEFAULT_SYSTEM_THEME,
+        terminal: DEFAULT_APP_TERMINAL_SETTINGS,
     };
 }
 
@@ -121,6 +128,7 @@ function applySnapshot(
     const aiChat = snapshot.aiChat ?? getDefaultAiChatSettings();
     const appearance = snapshot.appearance ?? getDefaultAppAppearance();
     const editor = snapshot.editor ?? getDefaultAppEditorSettings();
+    const terminal = normalizeAppTerminalSettings(snapshot.terminal);
 
     setCachedAppEditorSettings(snapshot.editor);
     useSettingsStore.setState((state) => ({
@@ -131,6 +139,7 @@ function applySnapshot(
         revision: state.revision + 1,
         status: "ready",
         systemTheme,
+        terminal,
     }));
 }
 

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -1606,6 +1606,102 @@ describe("workspace file opening", () => {
     });
 });
 
+describe("workspace terminal tabs", () => {
+    beforeEach(() => {
+        resetWorkspacePersistenceForTests();
+        saveWorkspaceSnapshotMock.mockClear();
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    closeAiSession: closeAiSessionMock,
+                    closeTerminalSession: closeTerminalSessionMock,
+                    notifyFileBuffer: notifyFileBufferMock,
+                    openProjectFile: openProjectFileMock,
+                    saveProjectFile: saveProjectFileMock,
+                    saveWorkspaceSnapshot: saveWorkspaceSnapshotMock,
+                },
+            },
+            writable: true,
+        });
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            ...createDefaultWorkspaceState(),
+            error: null,
+            hydrated: true,
+            lastFocusedChatTabId: null,
+            lastFocusedRuntimeId: "codex",
+            lastQuickCreateAction: "codex",
+            recentActiveTabIds: [],
+            recentClosedTabs: [],
+            recentFocusedChatTabIds: [],
+        }), true);
+    });
+
+    it("keeps Terminal and Claude Code title numbering independent", async () => {
+        await useWorkspaceStore.getState().createTerminalTab("project-1", null, {
+            title: "Claude Code 1",
+        });
+
+        const terminalTabId = await useWorkspaceStore
+            .getState()
+            .createTerminalTab("project-1");
+
+        expect(terminalTabId).toEqual(expect.any(String));
+        expect(useWorkspaceStore.getState().tabsById[terminalTabId!])
+            .toMatchObject({
+                kind: "terminal",
+                title: "Terminal 1",
+            });
+    });
+
+    it("can create an optioned terminal tab in a requested pane", async () => {
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            activePaneId: "pane-a",
+            rootNode: {
+                axis: "horizontal",
+                children: [
+                    {
+                        activeTabId: null,
+                        id: "pane-a",
+                        tabIds: [],
+                        type: "pane",
+                    },
+                    {
+                        activeTabId: null,
+                        id: "pane-b",
+                        tabIds: [],
+                        type: "pane",
+                    },
+                ],
+                id: "split-root",
+                sizes: [50, 50],
+                type: "split",
+            },
+        }));
+
+        const terminalTabId = await useWorkspaceStore
+            .getState()
+            .createTerminalTab("project-1", null, {
+                paneId: "pane-b",
+                title: "Claude Code 1",
+            });
+        const paneB = findWorkspacePane(
+            useWorkspaceStore.getState().rootNode,
+            "pane-b",
+        );
+
+        expect(paneB?.activeTabId).toBe(terminalTabId);
+        expect(paneB?.tabIds).toEqual([terminalTabId]);
+        expect(useWorkspaceStore.getState().tabsById[terminalTabId!])
+            .toMatchObject({
+                kind: "terminal",
+                title: "Claude Code 1",
+            });
+    });
+});
+
 describe("workspace runtime focus helpers", () => {
     it("returns the runtime for chat and review tabs only", () => {
         expect(

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -123,7 +123,11 @@ interface WorkspaceStore extends WorkspaceTreeState {
     createTerminalTab: (
         projectId: string | null,
         worktreeId?: string | null,
-    ) => Promise<void>;
+        options?: {
+            readonly paneId?: string | null;
+            readonly title?: string;
+        },
+    ) => Promise<string | null>;
     openChatSessionTab: (input: {
         readonly preserveSourcePaneOnMove?: boolean;
         readonly projectId: string | null;
@@ -498,7 +502,11 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         await persistWorkspaceState(get);
     },
 
-    createTerminalTab: async (projectId, worktreeId = null) => {
+    createTerminalTab: async (projectId, worktreeId = null, options) => {
+        const requestedPaneId = options?.paneId ?? get().activePaneId;
+        const paneId = findPaneById(get().rootNode, requestedPaneId)
+            ? requestedPaneId
+            : get().activePaneId;
         const terminalId = crypto.randomUUID();
         const tab: RuntimeWorkspaceTerminalTab = {
             createdAt: new Date().toISOString(),
@@ -513,12 +521,14 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             sessionId: terminalId,
             signalCode: null,
             terminalId,
-            title: `Terminal ${countTabs(get, "terminal") + 1}`,
+            title:
+                options?.title ??
+                getNextTerminalTabTitle(Object.values(get().tabsById)),
             worktreeId,
         };
 
         set((state) => ({
-            ...attachTabToPane(state, state.activePaneId, tab),
+            ...attachTabToPane(state, paneId, tab),
             error: null,
             lastQuickCreateAction: "terminal",
             recentActiveTabIds: recordRecentTabActivation(
@@ -527,6 +537,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             ),
         }));
         await persistWorkspaceState(get);
+        return tab.id;
     },
 
     openChatSessionTab: async (input) => {
@@ -2909,14 +2920,6 @@ function createRestoredTab(tab: RuntimeWorkspaceTab): RuntimeWorkspaceTab {
     };
 }
 
-function countTabs(
-    get: GetWorkspaceState,
-    kind: RuntimeWorkspaceTab["kind"],
-): number {
-    return Object.values(get().tabsById).filter((tab) => tab.kind === kind)
-        .length;
-}
-
 function countRuntimeChatTabs(
     get: GetWorkspaceState,
     runtimeId: AiRuntimeId,
@@ -2924,6 +2927,37 @@ function countRuntimeChatTabs(
     return Object.values(get().tabsById).filter(
         (tab) => tab.kind === "chat" && tab.runtimeId === runtimeId,
     ).length;
+}
+
+const TERMINAL_TITLE_PATTERN = /^Terminal(?: (\d+))?$/;
+
+function getNextTerminalTabTitle(tabs: readonly RuntimeWorkspaceTab[]): string {
+    return `Terminal ${getNextNumberedTitleValue(
+        tabs,
+        TERMINAL_TITLE_PATTERN,
+    )}`;
+}
+
+function getNextNumberedTitleValue(
+    tabs: readonly RuntimeWorkspaceTab[],
+    pattern: RegExp,
+): number {
+    let maxValue = 0;
+    for (const tab of tabs) {
+        if (tab.kind !== "terminal") {
+            continue;
+        }
+        const match = pattern.exec(tab.title.trim());
+        if (!match) {
+            continue;
+        }
+        const value = match[1] ? Number.parseInt(match[1], 10) : 1;
+        if (Number.isFinite(value)) {
+            maxValue = Math.max(maxValue, value);
+        }
+    }
+
+    return maxValue + 1;
 }
 
 function getRuntimeDisplayName(runtimeId: AiRuntimeId): string {

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -321,6 +321,7 @@ interface WorkspaceStore extends WorkspaceTreeState {
         sessionId: string,
         title: string,
     ) => Promise<void>;
+    updateTerminalTabTitle: (tabId: string, title: string) => Promise<void>;
 }
 
 type GetWorkspaceState = () => WorkspaceStore;
@@ -1871,6 +1872,27 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 }),
             ),
         }));
+        await persistWorkspaceState(get);
+    },
+
+    updateTerminalTabTitle: async (tabId, title) => {
+        set((state) => {
+            const tab = state.tabsById[tabId];
+            if (!tab || tab.kind !== "terminal" || tab.title === title) {
+                return state;
+            }
+
+            return {
+                ...state,
+                tabsById: {
+                    ...state.tabsById,
+                    [tabId]: {
+                        ...tab,
+                        title,
+                    },
+                },
+            };
+        });
         await persistWorkspaceState(get);
     },
 }));

--- a/src/renderer/src/components/context-menu/ContextMenu.tsx
+++ b/src/renderer/src/components/context-menu/ContextMenu.tsx
@@ -10,6 +10,7 @@ export type ContextMenuEntry =
           readonly action?: () => void;
           readonly danger?: boolean;
           readonly disabled?: boolean;
+          readonly title?: string;
       }
     | {
           readonly type: "separator";
@@ -119,6 +120,7 @@ export function ContextMenu<T>({
                         disabled={entry.disabled}
                         key={`${entry.label}-${index}`}
                         onClick={() => closeAndRunAction(entry.action)}
+                        title={entry.title}
                         type="button"
                     >
                         {entry.label}

--- a/src/renderer/src/components/settings/SettingsWindow.test.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.test.tsx
@@ -1,11 +1,13 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
 
 import {
     createSettingsSearchQuery,
     SettingsWindow,
     TerminalContent,
 } from "./SettingsWindow";
+import { NumberStepper, SelectField, Toggle } from "./primitives";
 import type { SettingsTerminalState, SettingsWindowProps } from "./settings-types";
 
 function createTerminalState(
@@ -183,4 +185,177 @@ describe("SettingsWindow terminal settings", () => {
         expect(turnsMarkup).toContain("--max-turns");
         expect(turnsMarkup).not.toContain("Font family");
     });
+
+    it("wires terminal control handlers and clamps numeric values", () => {
+        const handlers = {
+            onClaudeCodeContinueSessionChange: vi.fn(),
+            onClaudeCodeMaxTurnsChange: vi.fn(),
+            onClaudeCodeModelChange: vi.fn(),
+            onClaudeCodeOptimizedChange: vi.fn(),
+            onClaudeCodeSkipPermissionsChange: vi.fn(),
+            onTerminalFontFamilyChange: vi.fn(),
+            onTerminalFontSizeChange: vi.fn(),
+        };
+        const tree = createTerminalContentTree(
+            createTerminalState({
+                ...handlers,
+                claudeCodeAvailable: false,
+                terminalFontSize: 8,
+            }),
+        );
+
+        const fontFamilyInput = findIntrinsicElement<InputElementProps>(
+            tree,
+            "input",
+            {
+                "aria-label": "Terminal font family",
+            },
+        );
+        fontFamilyInput.props.onChange({
+            target: { value: "  FiraCode Nerd Font  " },
+        });
+        expect(handlers.onTerminalFontFamilyChange).toHaveBeenCalledWith(
+            "FiraCode Nerd Font",
+        );
+
+        const fontSizeStepper = findNumberStepper(tree, "Terminal font size");
+        expect(fontSizeStepper.props.min).toBe(8);
+        expect(fontSizeStepper.props.max).toBe(24);
+        fontSizeStepper.props.onChange(7);
+        fontSizeStepper.props.onChange(25);
+        expect(handlers.onTerminalFontSizeChange).toHaveBeenNthCalledWith(1, 8);
+        expect(handlers.onTerminalFontSizeChange).toHaveBeenNthCalledWith(2, 24);
+
+        const maxTurnsStepper = findNumberStepper(tree, "Claude Code max turns");
+        expect(maxTurnsStepper.props.min).toBe(0);
+        expect(maxTurnsStepper.props.max).toBe(200);
+        maxTurnsStepper.props.onChange(-1);
+        maxTurnsStepper.props.onChange(201);
+        expect(handlers.onClaudeCodeMaxTurnsChange).toHaveBeenNthCalledWith(1, 0);
+        expect(handlers.onClaudeCodeMaxTurnsChange).toHaveBeenNthCalledWith(
+            2,
+            200,
+        );
+
+        const toggles = findElementsByType<ToggleProps>(tree, Toggle);
+        expect(toggles).toHaveLength(3);
+        toggles[0].props.onChange(true);
+        toggles[1].props.onChange(true);
+        toggles[2].props.onChange(true);
+        expect(handlers.onClaudeCodeOptimizedChange).toHaveBeenCalledWith(true);
+        expect(handlers.onClaudeCodeSkipPermissionsChange).toHaveBeenCalledWith(
+            true,
+        );
+        expect(
+            handlers.onClaudeCodeContinueSessionChange,
+        ).toHaveBeenCalledWith(true);
+
+        const modelSelect = findElementsByType<SelectFieldProps>(
+            tree,
+            SelectField,
+        )[0];
+        modelSelect.props.onChange("claude-opus-4-7");
+        expect(handlers.onClaudeCodeModelChange).toHaveBeenCalledWith(
+            "claude-opus-4-7",
+        );
+    });
+
+    it("keeps Claude Code controls editable when the CLI is not found", () => {
+        const tree = createTerminalContentTree(
+            createTerminalState({ claudeCodeAvailable: false }),
+        );
+
+        expect(renderTerminal(createTerminalState({ claudeCodeAvailable: false })))
+            .toContain("Install the claude command to use the launcher.");
+        expect(findNumberStepper(tree, "Claude Code max turns")).toBeDefined();
+        expect(findElementsByType<ToggleProps>(tree, Toggle)).toHaveLength(3);
+        expect(findElementsByType<SelectFieldProps>(tree, SelectField)).toHaveLength(
+            1,
+        );
+    });
 });
+
+type NumberStepperProps = Parameters<typeof NumberStepper>[0];
+type SelectFieldProps = Parameters<typeof SelectField<string>>[0];
+type ToggleProps = Parameters<typeof Toggle>[0];
+type InputElementProps = {
+    readonly onChange: (event: {
+        readonly target: { readonly value: string };
+    }) => void;
+};
+
+function createTerminalContentTree(state: SettingsTerminalState): ReactElement {
+    return TerminalContent({
+        searchQuery: createSettingsSearchQuery(""),
+        state,
+    }) as ReactElement;
+}
+
+function findNumberStepper(
+    tree: ReactNode,
+    ariaLabel: string,
+): ReactElement<NumberStepperProps> {
+    const stepper = findElementsByType<NumberStepperProps>(
+        tree,
+        NumberStepper,
+    ).find((element) => element.props.ariaLabel === ariaLabel);
+    if (!stepper) {
+        throw new Error(`Expected NumberStepper "${ariaLabel}".`);
+    }
+    return stepper;
+}
+
+function findIntrinsicElement<TProps extends Record<string, unknown>>(
+    tree: ReactNode,
+    type: string,
+    props: Record<string, unknown>,
+): ReactElement<TProps> {
+    const match = collectElements(tree).find((element) => {
+        if (element.type !== type) {
+            return false;
+        }
+        return Object.entries(props).every(
+            ([key, value]) =>
+                (element.props as Record<string, unknown>)[key] === value,
+        );
+    });
+    if (!match) {
+        throw new Error(`Expected intrinsic element "${type}".`);
+    }
+    return match as ReactElement<TProps>;
+}
+
+function findElementsByType<TProps>(
+    tree: ReactNode,
+    type: unknown,
+): ReactElement<TProps>[] {
+    return collectElements(tree).filter(
+        (element): element is ReactElement<TProps> => element.type === type,
+    );
+}
+
+function collectElements(tree: ReactNode): ReactElement[] {
+    const elements: ReactElement[] = [];
+    const visit = (node: ReactNode): void => {
+        if (Array.isArray(node)) {
+            for (const child of node as readonly ReactNode[]) {
+                visit(child);
+            }
+            return;
+        }
+        if (!isValidElement(node)) {
+            return;
+        }
+
+        elements.push(node);
+        const props = node.props as {
+            readonly children?: ReactNode;
+            readonly control?: ReactNode;
+        };
+        visit(props.children);
+        visit(props.control);
+    };
+
+    visit(tree);
+    return elements;
+}

--- a/src/renderer/src/components/settings/SettingsWindow.test.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.test.tsx
@@ -1,0 +1,186 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+    createSettingsSearchQuery,
+    SettingsWindow,
+    TerminalContent,
+} from "./SettingsWindow";
+import type { SettingsTerminalState, SettingsWindowProps } from "./settings-types";
+
+function createTerminalState(
+    overrides: Partial<SettingsTerminalState> = {},
+): SettingsTerminalState {
+    return {
+        claudeCodeAvailable: null,
+        claudeCodeContinueSession: false,
+        claudeCodeMaxTurns: 0,
+        claudeCodeModel: "",
+        claudeCodeOptimized: false,
+        claudeCodeSkipPermissions: false,
+        terminalFontFamily: "",
+        terminalFontSize: 13,
+        ...overrides,
+    };
+}
+
+function createSettingsWindowProps(
+    overrides: Partial<SettingsWindowProps> = {},
+): SettingsWindowProps {
+    return {
+        aiChat: {
+            chatFontFamilies: [],
+            chatFontFamily: "geist",
+            chatFontSize: 14,
+            composerFontFamilies: [],
+            composerFontFamily: "geist",
+            composerFontSize: 14,
+            contextUsageBarEnabled: true,
+            historyRetentionDays: 0,
+            requireCmdEnterToSend: false,
+            screenshotRetentionSeconds: 0,
+            toolCardExpansionMode: "collapsed",
+        },
+        aiProviders: {
+            runtimeStatuses: {},
+        },
+        appAppearance: {
+            boostCodeContrast: false,
+            mode: "system",
+            presetId: "default",
+            presets: [],
+            stickyFoldersEnabled: true,
+        },
+        appEditor: {
+            autoSaveDelayMs: 900,
+            fontFamilies: [],
+            fontFamilyId: "ibm-plex-mono",
+            fontSize: 14,
+            lineHeight: 1.55,
+            minimapEnabled: true,
+            suggestionsEnabled: true,
+        },
+        github: {
+            error: null,
+            loading: false,
+            notice: null,
+            saving: false,
+            status: {
+                canReadActions: false,
+                canWriteActions: false,
+                canWriteIssues: false,
+                canWritePullRequests: false,
+                checkedAt: "2026-06-01T00:00:00.000Z",
+                errorCode: "missing_auth",
+                host: "github.com",
+                readOnly: true,
+                state: "missing",
+                tokenSource: null,
+                user: null,
+            },
+            tokenDraft: "",
+        },
+        privacy: {
+            state: {
+                canOpenFullDiskAccessSettings: false,
+                lastDeniedPath: null,
+                lastUpdatedAt: null,
+                message: "Not applicable.",
+                status: "not-applicable",
+            },
+        },
+        projects: {
+            error: null,
+            loading: false,
+            projects: [],
+        },
+        terminal: createTerminalState(),
+        updates: {
+            changelog: [],
+            state: {
+                autoUpdatesEnabled: false,
+                availableVersion: null,
+                canCheckForUpdates: false,
+                canInstallUpdate: false,
+                currentVersion: "0.1.0",
+                downloadedVersion: null,
+                lastCheckedAt: null,
+                message: "Updates unavailable.",
+                progressPercent: null,
+                status: "unsupported",
+            },
+        },
+        ...overrides,
+    };
+}
+
+function renderTerminal(
+    state: SettingsTerminalState,
+    search = "",
+): string {
+    return renderToStaticMarkup(
+        <TerminalContent
+            searchQuery={createSettingsSearchQuery(search)}
+            state={state}
+        />,
+    );
+}
+
+describe("SettingsWindow terminal settings", () => {
+    it("renders the Terminal category in the settings sidebar", () => {
+        const markup = renderToStaticMarkup(
+            <SettingsWindow {...createSettingsWindowProps()} />,
+        );
+
+        expect(markup).toContain("Terminal");
+    });
+
+    it("renders terminal controls and the Claude Code CLI notice", () => {
+        const markup = renderTerminal(
+            createTerminalState({ claudeCodeAvailable: false }),
+        );
+
+        expect(markup).toContain("Font family");
+        expect(markup).toContain("Font size");
+        expect(markup).toContain("Fullscreen rendering (experimental)");
+        expect(markup).toContain("CLAUDE_CODE_NO_FLICKER=1");
+        expect(markup).toContain("disables scrollback");
+        expect(markup).toContain("Claude Code CLI");
+        expect(markup).toContain("Install the claude command to use the launcher.");
+        expect(markup).toContain("Skip permissions");
+        expect(markup).toContain("--dangerously-skip-permissions");
+        expect(markup).toContain("will not ask for approval");
+        expect(markup).toContain("Default (Claude Code decides)");
+        expect(markup).toContain("Continue last session");
+        expect(markup).toContain("Max turns");
+    });
+
+    it("renders the selected Claude Code model label", () => {
+        const markup = renderTerminal(
+            createTerminalState({ claudeCodeModel: "claude-opus-4-7" }),
+        );
+
+        expect(markup).toContain("Opus 4.7 - most capable");
+    });
+
+    it("filters terminal rows by search terms", () => {
+        const flickerMarkup = renderTerminal(
+            createTerminalState(),
+            "CLAUDE_CODE_NO_FLICKER",
+        );
+        expect(flickerMarkup).toContain("Fullscreen rendering");
+        expect(flickerMarkup).not.toContain("Skip permissions");
+
+        const permissionsMarkup = renderTerminal(
+            createTerminalState(),
+            "dangerously-skip-permissions",
+        );
+        expect(permissionsMarkup).toContain("Skip permissions");
+        expect(permissionsMarkup).not.toContain("Font family");
+
+        const turnsMarkup = renderTerminal(createTerminalState(), "Max turns");
+        expect(turnsMarkup).toContain("Max turns");
+        expect(turnsMarkup).toContain("--max-turns");
+        expect(turnsMarkup).not.toContain("Font family");
+    });
+});

--- a/src/renderer/src/components/settings/SettingsWindow.test.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.test.tsx
@@ -154,7 +154,8 @@ describe("SettingsWindow terminal settings", () => {
         expect(markup).toContain("will not ask for approval");
         expect(markup).toContain("Default (Claude Code decides)");
         expect(markup).toContain("Continue last session");
-        expect(markup).toContain("Max turns");
+        expect(markup).not.toContain("Max turns");
+        expect(markup).not.toContain("--max-turns");
     });
 
     it("renders the selected Claude Code model label", () => {
@@ -181,9 +182,8 @@ describe("SettingsWindow terminal settings", () => {
         expect(permissionsMarkup).not.toContain("Font family");
 
         const turnsMarkup = renderTerminal(createTerminalState(), "Max turns");
-        expect(turnsMarkup).toContain("Max turns");
-        expect(turnsMarkup).toContain("--max-turns");
-        expect(turnsMarkup).not.toContain("Font family");
+        expect(turnsMarkup).toContain("No matching settings in this panel.");
+        expect(turnsMarkup).not.toContain("--max-turns");
     });
 
     it("wires terminal control handlers and clamps numeric values", () => {
@@ -226,17 +226,6 @@ describe("SettingsWindow terminal settings", () => {
         expect(handlers.onTerminalFontSizeChange).toHaveBeenNthCalledWith(1, 8);
         expect(handlers.onTerminalFontSizeChange).toHaveBeenNthCalledWith(2, 24);
 
-        const maxTurnsStepper = findNumberStepper(tree, "Claude Code max turns");
-        expect(maxTurnsStepper.props.min).toBe(0);
-        expect(maxTurnsStepper.props.max).toBe(200);
-        maxTurnsStepper.props.onChange(-1);
-        maxTurnsStepper.props.onChange(201);
-        expect(handlers.onClaudeCodeMaxTurnsChange).toHaveBeenNthCalledWith(1, 0);
-        expect(handlers.onClaudeCodeMaxTurnsChange).toHaveBeenNthCalledWith(
-            2,
-            200,
-        );
-
         const toggles = findElementsByType<ToggleProps>(tree, Toggle);
         expect(toggles).toHaveLength(3);
         toggles[0].props.onChange(true);
@@ -267,7 +256,6 @@ describe("SettingsWindow terminal settings", () => {
 
         expect(renderTerminal(createTerminalState({ claudeCodeAvailable: false })))
             .toContain("Install the claude command to use the launcher.");
-        expect(findNumberStepper(tree, "Claude Code max turns")).toBeDefined();
         expect(findElementsByType<ToggleProps>(tree, Toggle)).toHaveLength(3);
         expect(findElementsByType<SelectFieldProps>(tree, SelectField)).toHaveLength(
             1,

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -30,6 +30,15 @@ import {
     EDITOR_FONT_SIZE_MAX,
     EDITOR_FONT_SIZE_MIN,
 } from "@shared/typography";
+import {
+    CLAUDE_CODE_MAX_TURNS_UI_MAX,
+    CLAUDE_CODE_MODEL_OPTIONS,
+    TERMINAL_FONT_SIZE_MAX,
+    TERMINAL_FONT_SIZE_MIN,
+    normalizeClaudeCodeMaxTurns,
+    normalizeTerminalFontFamily,
+    normalizeTerminalFontSize,
+} from "@shared/terminal-settings";
 
 import {
     IdeActionButton,
@@ -58,6 +67,7 @@ import type {
     SettingsPrivacyState,
     SettingsProjectOption,
     SettingsProjectsState,
+    SettingsTerminalState,
     SettingsThemeControlState,
     SettingsUpdatesState,
     SettingsWindowProps,
@@ -67,6 +77,7 @@ import type {
 type Category =
     | "appearance"
     | "editor"
+    | "terminal"
     | "projects"
     | "github"
     | "ai"
@@ -78,6 +89,7 @@ type Category =
 const CATEGORIES: { id: Category; label: string }[] = [
     { id: "appearance", label: "Appearance" },
     { id: "editor", label: "Editor" },
+    { id: "terminal", label: "Terminal" },
     { id: "ai", label: "AI" },
     { id: "runtimes", label: "AI Runtimes" },
     { id: "projects", label: "Projects" },
@@ -90,6 +102,7 @@ const CATEGORIES: { id: Category; label: string }[] = [
 const CATEGORY_DESCRIPTIONS: Record<Category, string> = {
     appearance: "Theme mode and visual presets",
     editor: "Typography and editor behavior",
+    terminal: "Font, size, and shell environment settings",
     projects: "Project locations and saved app data",
     github: "Issues, pull requests, and repository auth",
     ai: "Chat, composer, and AI behavior",
@@ -110,6 +123,7 @@ interface SettingsSearchContext {
     readonly aiChat: SettingsAiChatState;
     readonly appAppearance: SettingsThemeControlState;
     readonly appEditor: SettingsEditorControlState;
+    readonly terminal: SettingsTerminalState;
     readonly github: SettingsGitHubState;
     readonly privacy: SettingsPrivacyState;
     readonly projects: SettingsProjectsState;
@@ -159,6 +173,28 @@ const STATIC_CATEGORY_SEARCH_VALUES: Record<Category, readonly SearchValue[]> = 
         "Show Monaco code minimap on the side of the editor.",
         "Autocomplete suggestions",
         "Show Monaco suggestions automatically while typing trigger manually.",
+    ],
+    terminal: [
+        "Terminal",
+        "Font",
+        "Font family",
+        "Nerd Fonts",
+        "FiraCode",
+        "Font size",
+        "Shell Environment",
+        "Fullscreen rendering",
+        "CLAUDE_CODE_NO_FLICKER",
+        "Claude Code",
+        "Claude Code CLI",
+        "claude command",
+        "Skip permissions",
+        "dangerously-skip-permissions",
+        "--dangerously-skip-permissions",
+        "Model",
+        "Continue",
+        "Continue last session",
+        "Max turns",
+        "--max-turns",
     ],
     projects: [
         "Projects",
@@ -268,7 +304,7 @@ const STATIC_CATEGORY_SEARCH_VALUES: Record<Category, readonly SearchValue[]> = 
     ],
 };
 
-function createSettingsSearchQuery(value: string): SettingsSearchQuery {
+export function createSettingsSearchQuery(value: string): SettingsSearchQuery {
     const normalized = normalizeSearchText(value);
 
     if (!normalized) {
@@ -352,6 +388,20 @@ function getDynamicCategorySearchValues(
                 font.description,
                 font.preview,
             ]);
+        case "terminal":
+            return [
+                context.terminal.terminalFontFamily,
+                context.terminal.terminalFontSize,
+                context.terminal.claudeCodeModel,
+                context.terminal.claudeCodeMaxTurns,
+                context.terminal.claudeCodeAvailable === false
+                    ? "Install the claude command to use the launcher."
+                    : null,
+                ...CLAUDE_CODE_MODEL_OPTIONS.flatMap((option) => [
+                    option.label,
+                    option.value,
+                ]),
+            ];
         case "projects":
             return [
                 context.projects.error,
@@ -451,6 +501,7 @@ export function SettingsWindow({
     aiChat,
     appAppearance,
     appEditor,
+    terminal,
     github,
     privacy,
     projects,
@@ -465,6 +516,7 @@ export function SettingsWindow({
         aiChat,
         appAppearance,
         appEditor,
+        terminal,
         github,
         privacy,
         projects,
@@ -754,6 +806,13 @@ export function SettingsWindow({
                                     <EditorContent
                                         searchQuery={activeSearchQuery}
                                         state={appEditor}
+                                    />
+                                )}
+                            {filteredCategories.length > 0 &&
+                                activeCategory === "terminal" && (
+                                    <TerminalContent
+                                        searchQuery={activeSearchQuery}
+                                        state={terminal}
                                     />
                                 )}
                             {filteredCategories.length > 0 &&
@@ -1981,6 +2040,251 @@ function EditorContent({
                     <Toggle
                         value={state.suggestionsEnabled}
                         onChange={(v) => state.onSuggestionsEnabledChange?.(v)}
+                    />
+                }
+            />
+        </div>
+    );
+}
+
+export function TerminalContent({
+    searchQuery,
+    state,
+}: {
+    searchQuery: SettingsSearchQuery;
+    state: SettingsTerminalState;
+}) {
+    const modelOptions = CLAUDE_CODE_MODEL_OPTIONS.map((option) => ({
+        label: option.label,
+        value: option.value,
+    }));
+    const showFont = sectionHasMatches(searchQuery, "Font", [
+        [
+            "Font family",
+            "Font used by integrated terminals. Leave blank to use Comando's default terminal font stack.",
+            "Nerd Fonts",
+            "FiraCode",
+            state.terminalFontFamily,
+        ],
+        ["Font size", "Text size in integrated terminals, in pixels."],
+    ]);
+    const showShellEnvironment = sectionHasMatches(
+        searchQuery,
+        "Shell Environment",
+        [
+            [
+                "Fullscreen rendering (experimental)",
+                "Sets CLAUDE_CODE_NO_FLICKER=1. Reduces flicker in Claude Code but disables scrollback. Applies to new terminals only.",
+                "CLAUDE_CODE_NO_FLICKER",
+            ],
+        ],
+    );
+    const showClaudeCode = sectionHasMatches(searchQuery, "Claude Code", [
+        [
+            "Claude Code CLI",
+            "Install the claude command to use the launcher.",
+            "claude command",
+        ],
+        [
+            "Skip permissions",
+            "Passes --dangerously-skip-permissions. Claude Code will not ask for approval before running tools or writing files.",
+            "--dangerously-skip-permissions",
+            "dangerously-skip-permissions",
+        ],
+        [
+            "Model",
+            "Model passed to Claude Code when launching from Comando.",
+            ...CLAUDE_CODE_MODEL_OPTIONS.flatMap((option) => [
+                option.label,
+                option.value,
+            ]),
+        ],
+        ["Continue last session", "Passes --continue to Claude Code."],
+        [
+            "Max turns",
+            "Passes --max-turns N when greater than 0. Use 0 for no Comando override.",
+            "--max-turns",
+        ],
+    ]);
+
+    if (!showFont && !showShellEnvironment && !showClaudeCode) {
+        return <EmptyPanelSearchResult />;
+    }
+
+    return (
+        <div>
+            {showFont ? <SectionLabel>Font</SectionLabel> : null}
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Font"
+                label="Font family"
+                description="Font used by integrated terminals. Leave blank to use Comando's default terminal font stack."
+                keywords={["Nerd Fonts", "FiraCode", state.terminalFontFamily]}
+                control={
+                    <input
+                        aria-label="Terminal font family"
+                        autoCapitalize="off"
+                        autoCorrect="off"
+                        onChange={(event) =>
+                            state.onTerminalFontFamilyChange?.(
+                                normalizeTerminalFontFamily(
+                                    event.target.value,
+                                ),
+                            )
+                        }
+                        placeholder="e.g. FiraCode Nerd Font"
+                        spellCheck={false}
+                        style={{
+                            backgroundColor: "var(--color-bg-tertiary)",
+                            border: "1px solid var(--color-border)",
+                            borderRadius: 6,
+                            color: "var(--color-text-primary)",
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 12,
+                            height: 28,
+                            outline: "none",
+                            padding: "0 9px",
+                            width: 240,
+                        }}
+                        type="text"
+                        value={state.terminalFontFamily}
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Font"
+                label="Font size"
+                description="Text size in integrated terminals, in pixels."
+                control={
+                    <NumberStepper
+                        value={state.terminalFontSize}
+                        min={TERMINAL_FONT_SIZE_MIN}
+                        max={TERMINAL_FONT_SIZE_MAX}
+                        onChange={(value) =>
+                            state.onTerminalFontSizeChange?.(
+                                normalizeTerminalFontSize(value),
+                            )
+                        }
+                    />
+                }
+            />
+
+            {showShellEnvironment ? (
+                <SectionLabel>Shell Environment</SectionLabel>
+            ) : null}
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Shell Environment"
+                label="Fullscreen rendering (experimental)"
+                description="Sets CLAUDE_CODE_NO_FLICKER=1. Reduces flicker in Claude Code but disables scrollback. Applies to new terminals only."
+                keywords={["CLAUDE_CODE_NO_FLICKER"]}
+                control={
+                    <Toggle
+                        value={state.claudeCodeOptimized}
+                        onChange={(value) =>
+                            state.onClaudeCodeOptimizedChange?.(value)
+                        }
+                    />
+                }
+            />
+
+            {showClaudeCode ? <SectionLabel>Claude Code</SectionLabel> : null}
+            {state.claudeCodeAvailable === false ? (
+                <SearchableRow
+                    searchQuery={searchQuery}
+                    section="Claude Code"
+                    label="Claude Code CLI"
+                    description="Install the claude command to use the launcher."
+                    keywords={["claude command", "launcher"]}
+                    control={
+                        <span
+                            style={{
+                                color: "var(--color-text-secondary)",
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 11,
+                            }}
+                        >
+                            not found
+                        </span>
+                    }
+                />
+            ) : null}
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Claude Code"
+                label="Skip permissions"
+                description="Passes --dangerously-skip-permissions. Claude Code will not ask for approval before running tools or writing files."
+                keywords={[
+                    "--dangerously-skip-permissions",
+                    "dangerously-skip-permissions",
+                    "approval",
+                    "tools",
+                    "write files",
+                ]}
+                control={
+                    <Toggle
+                        value={state.claudeCodeSkipPermissions}
+                        onChange={(value) =>
+                            state.onClaudeCodeSkipPermissionsChange?.(value)
+                        }
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Claude Code"
+                label="Model"
+                description="Model passed to Claude Code when launching from Comando."
+                keywords={CLAUDE_CODE_MODEL_OPTIONS.flatMap((option) => [
+                    option.label,
+                    option.value,
+                ])}
+                control={
+                    <SelectField
+                        value={state.claudeCodeModel}
+                        options={modelOptions}
+                        onChange={(value) =>
+                            state.onClaudeCodeModelChange?.(value)
+                        }
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Claude Code"
+                label="Continue last session"
+                description="Passes --continue to Claude Code."
+                keywords={["--continue", "continue"]}
+                control={
+                    <Toggle
+                        value={state.claudeCodeContinueSession}
+                        onChange={(value) =>
+                            state.onClaudeCodeContinueSessionChange?.(value)
+                        }
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Claude Code"
+                label="Max turns"
+                description="Passes --max-turns N when greater than 0. Use 0 for no Comando override."
+                keywords={["--max-turns", "turns"]}
+                control={
+                    <NumberStepper
+                        value={state.claudeCodeMaxTurns}
+                        min={0}
+                        max={CLAUDE_CODE_MAX_TURNS_UI_MAX}
+                        inputWidth={42}
+                        onChange={(value) =>
+                            state.onClaudeCodeMaxTurnsChange?.(
+                                normalizeClaudeCodeMaxTurns(
+                                    value,
+                                    CLAUDE_CODE_MAX_TURNS_UI_MAX,
+                                ),
+                            )
+                        }
                     />
                 }
             />

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -31,11 +31,9 @@ import {
     EDITOR_FONT_SIZE_MIN,
 } from "@shared/typography";
 import {
-    CLAUDE_CODE_MAX_TURNS_UI_MAX,
     CLAUDE_CODE_MODEL_OPTIONS,
     TERMINAL_FONT_SIZE_MAX,
     TERMINAL_FONT_SIZE_MIN,
-    normalizeClaudeCodeMaxTurns,
     normalizeTerminalFontFamily,
     normalizeTerminalFontSize,
 } from "@shared/terminal-settings";
@@ -193,8 +191,6 @@ const STATIC_CATEGORY_SEARCH_VALUES: Record<Category, readonly SearchValue[]> = 
         "Model",
         "Continue",
         "Continue last session",
-        "Max turns",
-        "--max-turns",
     ],
     projects: [
         "Projects",
@@ -393,7 +389,6 @@ function getDynamicCategorySearchValues(
                 context.terminal.terminalFontFamily,
                 context.terminal.terminalFontSize,
                 context.terminal.claudeCodeModel,
-                context.terminal.claudeCodeMaxTurns,
                 context.terminal.claudeCodeAvailable === false
                     ? "Install the claude command to use the launcher."
                     : null,
@@ -2100,11 +2095,6 @@ export function TerminalContent({
             ]),
         ],
         ["Continue last session", "Passes --continue to Claude Code."],
-        [
-            "Max turns",
-            "Passes --max-turns N when greater than 0. Use 0 for no Comando override.",
-            "--max-turns",
-        ],
     ]);
 
     if (!showFont && !showShellEnvironment && !showClaudeCode) {
@@ -2262,30 +2252,6 @@ export function TerminalContent({
                         value={state.claudeCodeContinueSession}
                         onChange={(value) =>
                             state.onClaudeCodeContinueSessionChange?.(value)
-                        }
-                    />
-                }
-            />
-            <SearchableRow
-                searchQuery={searchQuery}
-                section="Claude Code"
-                label="Max turns"
-                description="Passes --max-turns N when greater than 0. Use 0 for no Comando override."
-                keywords={["--max-turns", "turns"]}
-                control={
-                    <NumberStepper
-                        ariaLabel="Claude Code max turns"
-                        value={state.claudeCodeMaxTurns}
-                        min={0}
-                        max={CLAUDE_CODE_MAX_TURNS_UI_MAX}
-                        inputWidth={42}
-                        onChange={(value) =>
-                            state.onClaudeCodeMaxTurnsChange?.(
-                                normalizeClaudeCodeMaxTurns(
-                                    value,
-                                    CLAUDE_CODE_MAX_TURNS_UI_MAX,
-                                ),
-                            )
                         }
                     />
                 }

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -2158,6 +2158,7 @@ export function TerminalContent({
                 description="Text size in integrated terminals, in pixels."
                 control={
                     <NumberStepper
+                        ariaLabel="Terminal font size"
                         value={state.terminalFontSize}
                         min={TERMINAL_FONT_SIZE_MIN}
                         max={TERMINAL_FONT_SIZE_MAX}
@@ -2273,6 +2274,7 @@ export function TerminalContent({
                 keywords={["--max-turns", "turns"]}
                 control={
                     <NumberStepper
+                        ariaLabel="Claude Code max turns"
                         value={state.claudeCodeMaxTurns}
                         min={0}
                         max={CLAUDE_CODE_MAX_TURNS_UI_MAX}

--- a/src/renderer/src/components/settings/primitives.tsx
+++ b/src/renderer/src/components/settings/primitives.tsx
@@ -400,12 +400,14 @@ export function SelectField<T extends string | number | null>({
 }
 
 export function NumberStepper({
+    ariaLabel,
     value,
     min,
     max,
     inputWidth,
     onChange,
 }: {
+    ariaLabel?: string;
     value: number;
     min: number;
     max: number;
@@ -467,6 +469,7 @@ export function NumberStepper({
                 −
             </button>
             <input
+                aria-label={ariaLabel}
                 ref={inputRef}
                 value={isEditing ? local : String(value)}
                 onFocus={() => {

--- a/src/renderer/src/components/settings/settings-types.ts
+++ b/src/renderer/src/components/settings/settings-types.ts
@@ -64,6 +64,24 @@ export interface SettingsEditorControlState {
     readonly onSuggestionsEnabledChange?: (enabled: boolean) => void;
 }
 
+export interface SettingsTerminalState {
+    readonly terminalFontFamily: string;
+    readonly terminalFontSize: number;
+    readonly claudeCodeOptimized: boolean;
+    readonly claudeCodeSkipPermissions: boolean;
+    readonly claudeCodeModel: string;
+    readonly claudeCodeContinueSession: boolean;
+    readonly claudeCodeMaxTurns: number;
+    readonly claudeCodeAvailable?: boolean | null;
+    readonly onTerminalFontFamilyChange?: (value: string) => void;
+    readonly onTerminalFontSizeChange?: (value: number) => void;
+    readonly onClaudeCodeOptimizedChange?: (value: boolean) => void;
+    readonly onClaudeCodeSkipPermissionsChange?: (value: boolean) => void;
+    readonly onClaudeCodeModelChange?: (value: string) => void;
+    readonly onClaudeCodeContinueSessionChange?: (value: boolean) => void;
+    readonly onClaudeCodeMaxTurnsChange?: (value: number) => void;
+}
+
 export interface ShortcutEntryOption {
     readonly description: string;
     readonly id: string;
@@ -107,6 +125,7 @@ export interface SettingsAiChatState {
 export interface SettingsWindowProps {
     readonly appAppearance: SettingsThemeControlState;
     readonly appEditor: SettingsEditorControlState;
+    readonly terminal: SettingsTerminalState;
     readonly aiChat: SettingsAiChatState;
     readonly github: SettingsGitHubState;
     readonly privacy: SettingsPrivacyState;

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
@@ -1,9 +1,12 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AiHistorySessionSummary } from "@shared/ipc";
 
-import { SidebarAgentsPanel } from "./SidebarAgentsPanel";
+import {
+    buildSidebarAgentsNewAgentMenuEntries,
+    SidebarAgentsPanel,
+} from "./SidebarAgentsPanel";
 import {
     clearSidebarAgentsHistoryCache,
     writeSidebarAgentsHistoryCache,
@@ -141,5 +144,76 @@ describe("SidebarAgentsPanel history cache", () => {
         );
         expect(markup).toContain('data-subagent="true"');
         expect(markup).toContain("Agent");
+    });
+});
+
+describe("SidebarAgentsPanel new agent menu", () => {
+    it("includes a Claude Code terminal entry without replacing Claude threads", () => {
+        const createAgent = vi.fn();
+        const openClaudeCodeTerminal = vi.fn();
+
+        const entries = buildSidebarAgentsNewAgentMenuEntries({
+            claudeCodeAvailable: true,
+            onCreateNewAgentTab: createAgent,
+            onOpenClaudeCodeTerminal: openClaudeCodeTerminal,
+        });
+
+        expect(entries.map((entry) => entry.type === "separator" ? "" : entry.label))
+            .toEqual([
+                "New Codex thread",
+                "New Claude thread",
+                "New Gemini thread",
+                "New Kilo thread",
+                "New OpenCode thread",
+                "New Claude Code Terminal",
+            ]);
+
+        const claudeEntry = entries.find(
+            (entry) =>
+                entry.type !== "separator" &&
+                entry.label === "New Claude thread",
+        );
+        const claudeCodeEntry = entries.find(
+            (entry) =>
+                entry.type !== "separator" &&
+                entry.label === "New Claude Code Terminal",
+        );
+
+        if (claudeEntry?.type === "separator" || !claudeEntry?.action) {
+            throw new Error("Expected Claude thread entry.");
+        }
+        if (
+            claudeCodeEntry?.type === "separator" ||
+            !claudeCodeEntry?.action
+        ) {
+            throw new Error("Expected Claude Code terminal entry.");
+        }
+
+        claudeEntry.action();
+        claudeCodeEntry.action();
+
+        expect(createAgent).toHaveBeenCalledWith("claude");
+        expect(createAgent).toHaveBeenCalledTimes(1);
+        expect(openClaudeCodeTerminal).toHaveBeenCalledTimes(1);
+    });
+
+    it("surfaces the non-blocking missing CLI state", () => {
+        const entries = buildSidebarAgentsNewAgentMenuEntries({
+            claudeCodeAvailable: false,
+            onCreateNewAgentTab: vi.fn(),
+            onOpenClaudeCodeTerminal: vi.fn(),
+        });
+
+        const claudeCodeEntry = entries.find(
+            (entry) =>
+                entry.type !== "separator" &&
+                entry.label === "New Claude Code Terminal",
+        );
+
+        expect(claudeCodeEntry).not.toHaveProperty("disabled");
+        expect(claudeCodeEntry).toMatchObject({
+            title:
+                "The claude command was not found in Comando's PATH. Your shell may still resolve it.",
+        });
     });
 });

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
@@ -2,6 +2,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AiHistorySessionSummary } from "@shared/ipc";
+import {
+    registerClaudeCodeSidebarSession,
+    resetClaudeCodeSidebarSessionsForTests,
+} from "@renderer/features/terminal/claudeCodeSidebarSession";
 
 import {
     buildSidebarAgentsNewAgentMenuEntries,
@@ -60,6 +64,7 @@ function createSummary(
 describe("SidebarAgentsPanel history cache", () => {
     beforeEach(() => {
         clearSidebarAgentsHistoryCache();
+        resetClaudeCodeSidebarSessionsForTests();
         Object.defineProperty(globalThis, "localStorage", {
             configurable: true,
             value: new MemoryStorage(),
@@ -144,6 +149,42 @@ describe("SidebarAgentsPanel history cache", () => {
         );
         expect(markup).toContain('data-subagent="true"');
         expect(markup).toContain("Agent");
+    });
+
+    it("renders live Claude Code terminal agents alongside real history", () => {
+        writeSidebarAgentsHistoryCache(
+            "project-1",
+            "worktree-1",
+            [
+                createSummary({
+                    runtimeId: "claude",
+                    sessionId: "claude-thread",
+                    title: "Claude Thread",
+                }),
+            ],
+            100,
+        );
+        registerClaudeCodeSidebarSession({
+            cwd: "/workspace",
+            projectId: "project-1",
+            terminalId: "terminal-1",
+            terminalTabId: "terminal-tab-1",
+            title: "Claude Code 1",
+            transcriptSessionId: null,
+            worktreeId: "worktree-1",
+        });
+
+        const markup = renderToStaticMarkup(
+            <SidebarAgentsPanel
+                projectId="project-1"
+                worktreeId="worktree-1"
+            />,
+        );
+
+        expect(markup).toContain("Claude Thread");
+        expect(markup).toContain("Claude Code 1");
+        expect(markup).toContain("Claude Code");
+        expect(markup).toContain("Terminal");
     });
 });
 

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -20,6 +20,10 @@ import { truncateChatTitle } from "@shared/chatTitle";
 import { useAiStore } from "@renderer/app/store/ai-store";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
 import { collectPaneNodes } from "@renderer/app/workspace/tree";
+import {
+    checkClaudeCodeInstalled,
+    launchClaudeCodeTerminal,
+} from "@renderer/features/terminal/claudeCodeTerminal";
 
 import {
     ContextMenu,
@@ -90,6 +94,10 @@ const SIDEBAR_AGENTS_NEW_RUNTIMES: readonly AiRuntimeId[] = [
     "opencode",
 ];
 const SIDEBAR_AGENT_DRAG_THRESHOLD_PX = 6;
+const CLAUDE_CODE_TERMINAL_DESCRIPTION =
+    "Open the claude CLI in a workspace terminal.";
+const CLAUDE_CODE_NOT_FOUND_MESSAGE =
+    "The claude command was not found in Comando's PATH. Your shell may still resolve it.";
 
 export function SidebarAgentsPanel({
     filter,
@@ -144,6 +152,9 @@ export function SidebarAgentsPanel({
         null,
     );
     const [renameDraft, setRenameDraft] = useState("");
+    const [claudeCodeAvailable, setClaudeCodeAvailable] = useState<
+        boolean | null
+    >(null);
     const [collapsedSessionIds, setCollapsedSessionIds] = useState<
         ReadonlySet<string>
     >(() => readSidebarAgentsCollapsedSessionIds(projectId, worktreeId));
@@ -382,6 +393,25 @@ export function SidebarAgentsPanel({
         },
         [createChatTab, projectId, worktreeId],
     );
+    const handleOpenClaudeCodeTerminal = useCallback(() => {
+        void launchClaudeCodeTerminal({
+            projectId,
+            worktreeId,
+        });
+    }, [projectId, worktreeId]);
+
+    useEffect(() => {
+        let cancelled = false;
+        void checkClaudeCodeInstalled().then((available) => {
+            if (!cancelled) {
+                setClaudeCodeAvailable(available);
+            }
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
 
     const handleContextMenu = useCallback(
         (event: ReactMouseEvent, session: AiHistorySessionSummary) => {
@@ -588,11 +618,16 @@ export function SidebarAgentsPanel({
 
     const newAgentMenuEntries = useMemo<readonly ContextMenuEntry[]>(
         () =>
-            SIDEBAR_AGENTS_NEW_RUNTIMES.map((runtimeId) => ({
-                action: () => handleCreateNewAgentTab(runtimeId),
-                label: `New ${getHistoryRuntimeLabel(runtimeId)} thread`,
-            })),
-        [handleCreateNewAgentTab],
+            buildSidebarAgentsNewAgentMenuEntries({
+                claudeCodeAvailable,
+                onCreateNewAgentTab: handleCreateNewAgentTab,
+                onOpenClaudeCodeTerminal: handleOpenClaudeCodeTerminal,
+            }),
+        [
+            claudeCodeAvailable,
+            handleCreateNewAgentTab,
+            handleOpenClaudeCodeTerminal,
+        ],
     );
 
     const contextMenuEntries = useMemo<readonly ContextMenuEntry[]>(() => {
@@ -960,6 +995,31 @@ export function SidebarAgentsPanel({
             ) : null}
         </div>
     );
+}
+
+export function buildSidebarAgentsNewAgentMenuEntries({
+    claudeCodeAvailable,
+    onCreateNewAgentTab,
+    onOpenClaudeCodeTerminal,
+}: {
+    readonly claudeCodeAvailable: boolean | null;
+    readonly onCreateNewAgentTab: (runtimeId: AiRuntimeId) => void;
+    readonly onOpenClaudeCodeTerminal: () => void;
+}): readonly ContextMenuEntry[] {
+    return [
+        ...SIDEBAR_AGENTS_NEW_RUNTIMES.map((runtimeId) => ({
+            action: () => onCreateNewAgentTab(runtimeId),
+            label: `New ${getHistoryRuntimeLabel(runtimeId)} thread`,
+        })),
+        {
+            action: onOpenClaudeCodeTerminal,
+            label: "New Claude Code Terminal",
+            title:
+                claudeCodeAvailable === false
+                    ? CLAUDE_CODE_NOT_FOUND_MESSAGE
+                    : CLAUDE_CODE_TERMINAL_DESCRIPTION,
+        },
+    ];
 }
 
 function SidebarAgentsSection({

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -24,6 +24,19 @@ import {
     checkClaudeCodeInstalled,
     launchClaudeCodeTerminal,
 } from "@renderer/features/terminal/claudeCodeTerminal";
+import {
+    CLAUDE_CODE_TERMINAL_RUNTIME_ID,
+    closeClaudeCodeSidebarSession,
+    focusClaudeCodeSidebarSession,
+    getClaudeCodeSidebarSessionByTerminalId,
+    getClaudeCodeSidebarSessions,
+    isClaudeCodeSidebarSession,
+    reconcileClaudeCodeSidebarSessions,
+    refreshClaudeCodeSidebarSessionTranscript,
+    renameClaudeCodeSidebarSession,
+    subscribeClaudeCodeSidebarSessions,
+    type SidebarAgentSessionSummary,
+} from "@renderer/features/terminal/claudeCodeSidebarSession";
 
 import {
     ContextMenu,
@@ -128,9 +141,16 @@ export function SidebarAgentsPanel({
             ? state.tabsById[activePane.activeTabId]
             : null;
 
-        return activeTab?.kind === "chat" || activeTab?.kind === "review"
-            ? activeTab.sessionId
-            : null;
+        if (activeTab?.kind === "chat" || activeTab?.kind === "review") {
+            return activeTab.sessionId;
+        }
+        if (activeTab?.kind === "terminal") {
+            return (
+                getClaudeCodeSidebarSessionByTerminalId(activeTab.terminalId)
+                    ?.sessionId ?? null
+            );
+        }
+        return null;
     });
     const historyScopeKey = useMemo(
         () => getSidebarAgentsHistoryCacheKey(projectId, worktreeId),
@@ -139,6 +159,9 @@ export function SidebarAgentsPanel({
 
     const [sessions, setSessions] = useState<readonly AiHistorySessionSummary[]>(
         () => readSidebarAgentsHistoryCache(projectId, worktreeId)?.sessions ?? [],
+    );
+    const [terminalAgentSessions, setTerminalAgentSessions] = useState(
+        () => getClaudeCodeSidebarSessions(),
     );
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -175,10 +198,33 @@ export function SidebarAgentsPanel({
         loadedHistoryScopeKey === historyScopeKey
             ? null
             : readSidebarAgentsHistoryCache(projectId, worktreeId);
-    const visibleSessions =
+    const visibleHistorySessions =
         loadedHistoryScopeKey === historyScopeKey
             ? sessions
             : pendingHistoryCache?.sessions ?? EMPTY_AGENTS_SESSIONS;
+    const scopedTerminalAgentSessions = useMemo(
+        () =>
+            terminalAgentSessions.filter(
+                (session) =>
+                    session.projectId === projectId &&
+                    (session.worktreeId ?? null) === (worktreeId ?? null),
+        ),
+        [projectId, terminalAgentSessions, worktreeId],
+    );
+    const terminalAgentSessionByTerminalId = useMemo(
+        () =>
+            new Map(
+                terminalAgentSessions.map((session) => [
+                    session.terminalId,
+                    session,
+                ]),
+            ),
+        [terminalAgentSessions],
+    );
+    const visibleSessions = useMemo<readonly SidebarAgentSessionSummary[]>(
+        () => [...scopedTerminalAgentSessions, ...visibleHistorySessions],
+        [scopedTerminalAgentSessions, visibleHistorySessions],
+    );
     const visibleError =
         loadedHistoryScopeKey === historyScopeKey ? error : null;
     const showBlockingLoading =
@@ -299,6 +345,41 @@ export function SidebarAgentsPanel({
     }, [projectId, worktreeId]);
 
     useEffect(() => {
+        return subscribeClaudeCodeSidebarSessions(() => {
+            setTerminalAgentSessions(getClaudeCodeSidebarSessions());
+        });
+    }, []);
+
+    useEffect(() => {
+        reconcileClaudeCodeSidebarSessions(Object.values(tabsById));
+    }, [tabsById]);
+
+    useEffect(() => {
+        const refreshableSessions = terminalAgentSessions.filter(
+            (session) => session.cwd && session.transcriptSessionId,
+        );
+        if (refreshableSessions.length === 0) {
+            return;
+        }
+
+        const refresh = () => {
+            for (const session of getClaudeCodeSidebarSessions()) {
+                if (!session.cwd || !session.transcriptSessionId) {
+                    continue;
+                }
+                void refreshClaudeCodeSidebarSessionTranscript(session).catch(
+                    () => undefined,
+                );
+            }
+        };
+        refresh();
+        const intervalId = window.setInterval(refresh, 4_000);
+        return () => {
+            window.clearInterval(intervalId);
+        };
+    }, [terminalAgentSessions]);
+
+    useEffect(() => {
         const api = getComandoApi();
         if (!api) {
             return;
@@ -357,10 +438,15 @@ export function SidebarAgentsPanel({
     ]);
 
     const handleOpenSession = useCallback(
-        (session: AiHistorySessionSummary) => {
+        (session: SidebarAgentSessionSummary) => {
+            if (isClaudeCodeSidebarSession(session)) {
+                void focusClaudeCodeSidebarSession(session);
+                return;
+            }
+
             void openChatSessionTab({
                 projectId: session.projectId,
-                runtimeId: session.runtimeId,
+                runtimeId: session.runtimeId as AiRuntimeId,
                 sessionId: session.sessionId,
                 title: session.title,
                 worktreeId: session.worktreeId ?? null,
@@ -414,7 +500,7 @@ export function SidebarAgentsPanel({
     }, []);
 
     const handleContextMenu = useCallback(
-        (event: ReactMouseEvent, session: AiHistorySessionSummary) => {
+        (event: ReactMouseEvent, session: SidebarAgentSessionSummary) => {
             event.preventDefault();
             event.stopPropagation();
             setContextMenu({
@@ -427,8 +513,8 @@ export function SidebarAgentsPanel({
     );
 
     const startRename = useCallback(
-        (session: AiHistorySessionSummary) => {
-            if (isSubagentSession(session)) {
+        (session: SidebarAgentSessionSummary) => {
+            if (!isClaudeCodeSidebarSession(session) && isSubagentSession(session)) {
                 return;
             }
 
@@ -462,6 +548,11 @@ export function SidebarAgentsPanel({
             trimmedTitle.length === 0 ||
             trimmedTitle === session.title
         ) {
+            return;
+        }
+
+        if (isClaudeCodeSidebarSession(session)) {
+            await renameClaudeCodeSidebarSession(session, trimmedTitle);
             return;
         }
 
@@ -507,15 +598,21 @@ export function SidebarAgentsPanel({
     ]);
 
     const handleDelete = useCallback(
-        async (session: AiHistorySessionSummary) => {
+        async (session: SidebarAgentSessionSummary) => {
+            if (isClaudeCodeSidebarSession(session)) {
+                await closeClaudeCodeSidebarSession(session);
+                return;
+            }
+            const historySession = session as AiHistorySessionSummary;
+
             const childCount = countAiHistorySessionChildren(
-                session,
-                visibleSessions,
+                historySession,
+                visibleHistorySessions,
             );
             const confirmed = window.confirm(
                 childCount > 0
-                    ? `Delete "${session.title}" from threads? ${childCount} child agent${childCount === 1 ? "" : "s"} will stay in history as detached. This cannot be undone.`
-                    : `Delete "${session.title}" from threads? This cannot be undone.`,
+                    ? `Delete "${historySession.title}" from threads? ${childCount} child agent${childCount === 1 ? "" : "s"} will stay in history as detached. This cannot be undone.`
+                    : `Delete "${historySession.title}" from threads? This cannot be undone.`,
             );
             if (!confirmed) {
                 return;
@@ -526,16 +623,16 @@ export function SidebarAgentsPanel({
                 return;
             }
 
-            const previousSessions = visibleSessions;
-            deletedSessionIdsRef.current.add(session.sessionId);
+            const previousSessions = visibleHistorySessions;
+            deletedSessionIdsRef.current.add(historySession.sessionId);
             setSessionsAndCache((current) =>
                 current
                     .filter(
                         (candidate) =>
-                            candidate.sessionId !== session.sessionId,
+                            candidate.sessionId !== historySession.sessionId,
                     )
                     .map((candidate) =>
-                        isAiHistorySessionChildOfParent(session, candidate)
+                        isAiHistorySessionChildOfParent(historySession, candidate)
                             ? { ...candidate, parentSessionId: null }
                             : candidate,
                     ),
@@ -548,17 +645,17 @@ export function SidebarAgentsPanel({
                         (candidate) =>
                             (candidate.kind === "chat" ||
                                 candidate.kind === "review") &&
-                            candidate.sessionId === session.sessionId,
+                            candidate.sessionId === historySession.sessionId,
                     )
                     .map((candidate) => candidate.id);
 
-                await api.deleteAiSession(session.sessionId);
+                await api.deleteAiSession(historySession.sessionId);
 
                 for (const tabId of matchingTabIds) {
                     await closeTab(tabId);
                 }
             } catch (err) {
-                deletedSessionIdsRef.current.delete(session.sessionId);
+                deletedSessionIdsRef.current.delete(historySession.sessionId);
                 setSessionsAndCache(() => previousSessions);
                 setError(
                     err instanceof Error
@@ -567,17 +664,22 @@ export function SidebarAgentsPanel({
                 );
             }
         },
-        [closeTab, setSessionsAndCache, visibleSessions],
+        [closeTab, setSessionsAndCache, visibleHistorySessions],
     );
 
     const handleTogglePinned = useCallback(
-        async (session: AiHistorySessionSummary) => {
+        async (session: SidebarAgentSessionSummary) => {
+            if (isClaudeCodeSidebarSession(session)) {
+                return;
+            }
+            const historySession = session as AiHistorySessionSummary;
+
             const api = getComandoApi();
             if (!api) {
                 return;
             }
 
-            const previousPinnedAt = session.pinnedAt ?? null;
+            const previousPinnedAt = historySession.pinnedAt ?? null;
             const nextPinned = previousPinnedAt === null;
             const optimisticPinnedAt = nextPinned
                 ? new Date().toISOString()
@@ -594,7 +696,7 @@ export function SidebarAgentsPanel({
             try {
                 await api.setAiSessionPinned({
                     pinned: nextPinned,
-                    sessionId: session.sessionId,
+                    sessionId: historySession.sessionId,
                 });
             } catch (err) {
                 setSessionsAndCache((current) =>
@@ -643,16 +745,18 @@ export function SidebarAgentsPanel({
             return [];
         }
 
-        const entries: ContextMenuEntry[] = [
-            {
+        const entries: ContextMenuEntry[] = [];
+
+        if (!isClaudeCodeSidebarSession(session)) {
+            entries.push({
                 label: isSessionPinned(session)
                     ? "Unpin from Sidebar"
                     : "Pin to Sidebar",
                 action: () => void handleTogglePinned(session),
-            },
-        ];
+            });
+        }
 
-        if (!isSubagentSession(session)) {
+        if (isClaudeCodeSidebarSession(session) || !isSubagentSession(session)) {
             entries.push({
                 label: "Rename",
                 action: () => startRename(session),
@@ -661,7 +765,9 @@ export function SidebarAgentsPanel({
 
         entries.push(
             {
-                label: "Delete",
+                label: isClaudeCodeSidebarSession(session)
+                    ? "Close Terminal"
+                    : "Delete",
                 danger: true,
                 action: () => void handleDelete(session),
             },
@@ -681,10 +787,17 @@ export function SidebarAgentsPanel({
         for (const tab of Object.values(tabsById)) {
             if (tab.kind === "chat" || tab.kind === "review") {
                 ids.add(tab.sessionId);
+            } else if (tab.kind === "terminal") {
+                const terminalSession = terminalAgentSessionByTerminalId.get(
+                    tab.terminalId,
+                );
+                if (terminalSession) {
+                    ids.add(terminalSession.sessionId);
+                }
             }
         }
         return ids;
-    }, [tabsById]);
+    }, [tabsById, terminalAgentSessionByTerminalId]);
 
     const aiSessions = useAiStore((state) => state.sessions);
     const workingOrderRef = useRef<Map<string, number>>(new Map());
@@ -1043,16 +1156,16 @@ function SidebarAgentsSection({
     readonly collapsedSessionIds: ReadonlySet<string>;
     readonly collapseEnabled: boolean;
     readonly commitRename: () => void;
-    readonly groups: readonly AiSessionHierarchyGroup[];
+    readonly groups: readonly AiSessionHierarchyGroup<SidebarAgentSessionSummary>[];
     readonly onContextMenu: (
         event: ReactMouseEvent,
-        session: AiHistorySessionSummary,
+        session: SidebarAgentSessionSummary,
     ) => void;
-    readonly onOpen: (session: AiHistorySessionSummary) => void;
+    readonly onOpen: (session: SidebarAgentSessionSummary) => void;
     readonly onRenameDraftChange: (value: string) => void;
     readonly onToggleCollapsed: (sessionId: string) => void;
     readonly onTogglePinned: (
-        session: AiHistorySessionSummary,
+        session: SidebarAgentSessionSummary,
     ) => Promise<void> | void;
     readonly renameDraft: string;
     readonly renamingSessionId: string | null;
@@ -1153,16 +1266,16 @@ function SidebarAgentsItem({
     readonly onCommitRename: () => void;
     readonly onContextMenu: (
         event: ReactMouseEvent,
-        session: AiHistorySessionSummary,
+        session: SidebarAgentSessionSummary,
     ) => void;
-    readonly onOpen: (session: AiHistorySessionSummary) => void;
+    readonly onOpen: (session: SidebarAgentSessionSummary) => void;
     readonly onRenameDraftChange: (value: string) => void;
     readonly onToggleCollapsed: (sessionId: string) => void;
     readonly onTogglePinned: (
-        session: AiHistorySessionSummary,
+        session: SidebarAgentSessionSummary,
     ) => Promise<void> | void;
     readonly renameDraft: string;
-    readonly session: AiHistorySessionSummary;
+    readonly session: SidebarAgentSessionSummary;
 }) {
     const dragStateRef = useRef<{
         readonly pointerId: number;
@@ -1177,6 +1290,7 @@ function SidebarAgentsItem({
     const preview = getHistoryPreviewText(session);
     const title = truncateChatTitle(session.title, SIDEBAR_AGENTS_TITLE_MAX_CHARS);
     const isPinned = isSessionPinned(session);
+    const isTerminalAgent = isClaudeCodeSidebarSession(session);
     const activity = useAgentActivityIndicator(session.sessionId);
     const timestampLabel = activity
         ? activity.tone === "danger"
@@ -1201,7 +1315,7 @@ function SidebarAgentsItem({
             emitSidebarAgentDrag({
                 phase,
                 projectId: session.projectId,
-                runtimeId: session.runtimeId,
+                runtimeId: session.runtimeId as AiRuntimeId,
                 sessionId: session.sessionId,
                 title: session.title,
                 worktreeId: session.worktreeId ?? null,
@@ -1216,13 +1330,13 @@ function SidebarAgentsItem({
         (event: Pick<ReactPointerEvent<HTMLElement>, "clientX" | "clientY">) => {
             setDragPreview({
                 activity,
-                runtimeLabel: getHistoryRuntimeLabel(session.runtimeId),
+                runtimeLabel: getSidebarAgentRuntimeLabel(session),
                 title: session.title,
                 x: event.clientX,
                 y: event.clientY,
             });
         },
-        [activity, session.runtimeId, session.title],
+        [activity, session],
     );
 
     const clearDragState = useCallback(
@@ -1339,6 +1453,7 @@ function SidebarAgentsItem({
             onPointerDown={(event) => {
                 if (
                     isRenaming ||
+                    isTerminalAgent ||
                     event.button !== 0 ||
                     isInteractiveSidebarAgentDragTarget(
                         event.target,
@@ -1475,7 +1590,7 @@ function SidebarAgentsItem({
                         {title}
                     </span>
                 )}
-                {isRenaming ? null : (
+                {isRenaming || isTerminalAgent ? null : (
                     <button
                         aria-label={
                             isPinned
@@ -1526,13 +1641,15 @@ function SidebarAgentsItem({
                     </>
                 ) : null}
                 <span className="shrink-0">
-                    {getHistoryRuntimeLabel(session.runtimeId)}
+                    {getSidebarAgentRuntimeLabel(session)}
                 </span>
                 <span aria-hidden="true" className="shrink-0">
                     ·
                 </span>
                 <span className="shrink-0">
-                    {formatHistoryMessageCount(session.messageCount)}
+                    {isTerminalAgent
+                        ? "Terminal"
+                        : formatHistoryMessageCount(session.messageCount)}
                 </span>
             </div>
             </div>
@@ -1760,25 +1877,31 @@ function buildUnknownSessionSeed(
     };
 }
 
-function isSessionPinned(session: AiHistorySessionSummary): boolean {
+function isSessionPinned(session: SidebarAgentSessionSummary): boolean {
     return (session.pinnedAt ?? null) !== null;
 }
 
-function isSubagentSession(session: AiHistorySessionSummary): boolean {
+function getSidebarAgentRuntimeLabel(session: SidebarAgentSessionSummary): string {
+    return session.runtimeId === CLAUDE_CODE_TERMINAL_RUNTIME_ID
+        ? "Claude Code"
+        : getHistoryRuntimeLabel(session.runtimeId);
+}
+
+function isSubagentSession(session: SidebarAgentSessionSummary): boolean {
     const parentSessionId = (session.parentSessionId ?? "").trim();
     return parentSessionId.length > 0 && parentSessionId !== session.sessionId;
 }
 
 function countHierarchyGroupRows(
-    groups: readonly AiSessionHierarchyGroup[],
+    groups: readonly AiSessionHierarchyGroup<SidebarAgentSessionSummary>[],
 ): number {
     return groups.reduce((count, group) => count + group.rows.length, 0);
 }
 
 function getVisibleSidebarHierarchyRows(
-    group: AiSessionHierarchyGroup,
+    group: AiSessionHierarchyGroup<SidebarAgentSessionSummary>,
     collapsedSessionIds: ReadonlySet<string>,
-): readonly AiSessionHierarchyRow[] {
+): readonly AiSessionHierarchyRow<SidebarAgentSessionSummary>[] {
     return filterAiSessionHierarchyRowsForCollapsedParents(
         group.rows,
         collapsedSessionIds,
@@ -1786,8 +1909,8 @@ function getVisibleSidebarHierarchyRows(
 }
 
 function comparePinnedHierarchyGroups(
-    left: AiSessionHierarchyGroup,
-    right: AiSessionHierarchyGroup,
+    left: AiSessionHierarchyGroup<SidebarAgentSessionSummary>,
+    right: AiSessionHierarchyGroup<SidebarAgentSessionSummary>,
 ): number {
     const pinnedComparison = getLatestPinnedAt(right).localeCompare(
         getLatestPinnedAt(left),
@@ -1799,7 +1922,9 @@ function comparePinnedHierarchyGroups(
     return getLatestUpdatedAt(right).localeCompare(getLatestUpdatedAt(left));
 }
 
-function getLatestPinnedAt(group: AiSessionHierarchyGroup): string {
+function getLatestPinnedAt(
+    group: AiSessionHierarchyGroup<SidebarAgentSessionSummary>,
+): string {
     return group.rows.reduce(
         (latest, row) =>
             (row.session.pinnedAt ?? "").localeCompare(latest) > 0
@@ -1809,7 +1934,9 @@ function getLatestPinnedAt(group: AiSessionHierarchyGroup): string {
     );
 }
 
-function getLatestUpdatedAt(group: AiSessionHierarchyGroup): string {
+function getLatestUpdatedAt(
+    group: AiSessionHierarchyGroup<SidebarAgentSessionSummary>,
+): string {
     return group.rows.reduce(
         (latest, row) =>
             row.session.updatedAt.localeCompare(latest) > 0
@@ -1820,8 +1947,8 @@ function getLatestUpdatedAt(group: AiSessionHierarchyGroup): string {
 }
 
 function compareSidebarHierarchySiblings(
-    left: AiHistorySessionSummary,
-    right: AiHistorySessionSummary,
+    left: SidebarAgentSessionSummary,
+    right: SidebarAgentSessionSummary,
     workingOrder: ReadonlyMap<string, number>,
 ): number {
     const leftOrder = workingOrder.get(left.sessionId);
@@ -1840,7 +1967,7 @@ function compareSidebarHierarchySiblings(
 }
 
 function getHierarchyGroupWorkingOrder(
-    group: AiSessionHierarchyGroup,
+    group: AiSessionHierarchyGroup<SidebarAgentSessionSummary>,
     workingOrder: ReadonlyMap<string, number>,
 ): number | undefined {
     let order: number | undefined;

--- a/src/renderer/src/components/workspace/WorkspaceView.quick-create.test.ts
+++ b/src/renderer/src/components/workspace/WorkspaceView.quick-create.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildWorkspaceAgentsQuickCreateEntries } from "./WorkspaceView";
+
+describe("WorkspaceView quick create agents menu", () => {
+    it("includes Claude Code after Claude and keeps Claude as a runtime thread", () => {
+        const createChatTab = vi.fn();
+        const openClaudeCodeTerminal = vi.fn();
+
+        const entries = buildWorkspaceAgentsQuickCreateEntries({
+            claudeCodeAvailable: true,
+            defaultProjectId: "project-1",
+            defaultWorktreeId: "worktree-1",
+            onCreateChatTab: createChatTab,
+            onOpenClaudeCodeTerminal: openClaudeCodeTerminal,
+        });
+
+        expect(entries.map((entry) => entry.type === "separator" ? "" : entry.label))
+            .toEqual([
+                "Codex",
+                "Claude",
+                "Claude Code",
+                "Gemini",
+                "Kilo",
+                "OpenCode",
+            ]);
+
+        const claudeEntry = entries.find(
+            (entry) => entry.type !== "separator" && entry.label === "Claude",
+        );
+        const claudeCodeEntry = entries.find(
+            (entry) =>
+                entry.type !== "separator" && entry.label === "Claude Code",
+        );
+
+        if (claudeEntry?.type === "separator" || !claudeEntry?.action) {
+            throw new Error("Expected Claude entry.");
+        }
+        if (
+            claudeCodeEntry?.type === "separator" ||
+            !claudeCodeEntry?.action
+        ) {
+            throw new Error("Expected Claude Code entry.");
+        }
+
+        claudeEntry.action();
+        claudeCodeEntry.action();
+
+        expect(createChatTab).toHaveBeenCalledWith(
+            "project-1",
+            "worktree-1",
+            "claude",
+        );
+        expect(createChatTab).toHaveBeenCalledTimes(1);
+        expect(openClaudeCodeTerminal).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows the missing CLI tooltip without disabling the action", () => {
+        const entries = buildWorkspaceAgentsQuickCreateEntries({
+            claudeCodeAvailable: false,
+            defaultProjectId: "project-1",
+            defaultWorktreeId: null,
+            onCreateChatTab: vi.fn(),
+            onOpenClaudeCodeTerminal: vi.fn(),
+        });
+
+        const claudeCodeEntry = entries.find(
+            (entry) =>
+                entry.type !== "separator" && entry.label === "Claude Code",
+        );
+
+        expect(claudeCodeEntry).not.toHaveProperty("disabled");
+        expect(claudeCodeEntry).toMatchObject({
+            title:
+                "The claude command was not found in Comando's PATH. Your shell may still resolve it.",
+        });
+    });
+});

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -158,6 +158,10 @@ import {
     SIDEBAR_GITHUB_DRAG_EVENT,
     type SidebarGitHubDragDetail,
 } from "@renderer/components/sidebar/sidebarGitHubDragEvents";
+import {
+    checkClaudeCodeInstalled,
+    launchClaudeCodeTerminal,
+} from "@renderer/features/terminal/claudeCodeTerminal";
 
 interface WorkspaceViewProps {
     readonly defaultProjectId: string | null;
@@ -185,6 +189,7 @@ type QuickCreateMenuItem = {
     readonly children?: readonly QuickCreateMenuEntry[];
     readonly disabled?: boolean;
     readonly label: string;
+    readonly title?: string;
     readonly type?: "item";
 };
 
@@ -193,6 +198,10 @@ type QuickCreateMenuSeparator = {
 };
 
 type QuickCreateMenuEntry = QuickCreateMenuItem | QuickCreateMenuSeparator;
+const CLAUDE_CODE_TERMINAL_DESCRIPTION =
+    "Open the claude CLI in a workspace terminal.";
+const CLAUDE_CODE_NOT_FOUND_MESSAGE =
+    "The claude command was not found in Comando's PATH. Your shell may still resolve it.";
 
 type QuickCreateSubmenuState = {
     readonly anchorRect: MenuAnchorRect;
@@ -502,6 +511,49 @@ function isQuickCreateMenuSeparator(
     entry: QuickCreateMenuEntry,
 ): entry is QuickCreateMenuSeparator {
     return entry.type === "separator";
+}
+
+export function buildWorkspaceAgentsQuickCreateEntries({
+    claudeCodeAvailable,
+    defaultProjectId,
+    defaultWorktreeId,
+    onCreateChatTab,
+    onOpenClaudeCodeTerminal,
+}: {
+    readonly claudeCodeAvailable: boolean | null;
+    readonly defaultProjectId: string | null;
+    readonly defaultWorktreeId: string | null;
+    readonly onCreateChatTab: (
+        projectId: string | null,
+        worktreeId: string | null,
+        runtimeId: AiRuntimeId,
+    ) => void;
+    readonly onOpenClaudeCodeTerminal: () => void;
+}): readonly QuickCreateMenuEntry[] {
+    const createRuntimeEntry = (
+        label: string,
+        runtimeId: AiRuntimeId,
+    ): QuickCreateMenuEntry => ({
+        action: () =>
+            onCreateChatTab(defaultProjectId, defaultWorktreeId, runtimeId),
+        label,
+    });
+
+    return [
+        createRuntimeEntry("Codex", "codex"),
+        createRuntimeEntry("Claude", "claude"),
+        {
+            action: onOpenClaudeCodeTerminal,
+            label: "Claude Code",
+            title:
+                claudeCodeAvailable === false
+                    ? CLAUDE_CODE_NOT_FOUND_MESSAGE
+                    : CLAUDE_CODE_TERMINAL_DESCRIPTION,
+        },
+        createRuntimeEntry("Gemini", "gemini"),
+        createRuntimeEntry("Kilo", "kilo"),
+        createRuntimeEntry("OpenCode", "opencode"),
+    ];
 }
 
 export function WorkspaceView({
@@ -1466,6 +1518,9 @@ function WorkspacePaneView({
         useState<ContextMenuState<TabContextMenuPayload> | null>(null);
     const [quickCreateMenu, setQuickCreateMenu] =
         useState<QuickCreateMenuState>(null);
+    const [claudeCodeAvailable, setClaudeCodeAvailable] = useState<
+        boolean | null
+    >(null);
     const contextTabId = tabContextMenu?.payload.tabId ?? null;
     const contextTab = useWorkspaceStore(
         useCallback(
@@ -1638,6 +1693,26 @@ function WorkspacePaneView({
 
         onRequestCreateFile();
     }, [defaultProjectId, onRequestCreateFile]);
+    const handleOpenClaudeCodeTerminal = useCallback(() => {
+        void launchClaudeCodeTerminal({
+            paneId: paneNodeId,
+            projectId: defaultProjectId,
+            worktreeId: defaultWorktreeId ?? null,
+        });
+    }, [defaultProjectId, defaultWorktreeId, paneNodeId]);
+
+    useEffect(() => {
+        let cancelled = false;
+        void checkClaudeCodeInstalled().then((available) => {
+            if (!cancelled) {
+                setClaudeCodeAvailable(available);
+            }
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
 
     const handleOpenWorkspaceFile = useCallback(
         async (
@@ -1891,53 +1966,15 @@ function WorkspacePaneView({
         () => [
             {
                 label: "Agents",
-                children: [
-                    {
-                        action: () =>
-                            void createChatTab(
-                                defaultProjectId,
-                                defaultWorktreeId ?? null,
-                                "codex",
-                            ),
-                        label: "Codex",
+                children: buildWorkspaceAgentsQuickCreateEntries({
+                    claudeCodeAvailable,
+                    defaultProjectId,
+                    defaultWorktreeId,
+                    onCreateChatTab: (projectId, worktreeId, runtimeId) => {
+                        void createChatTab(projectId, worktreeId, runtimeId);
                     },
-                    {
-                        action: () =>
-                            void createChatTab(
-                                defaultProjectId,
-                                defaultWorktreeId ?? null,
-                                "claude",
-                            ),
-                        label: "Claude",
-                    },
-                    {
-                        action: () =>
-                            void createChatTab(
-                                defaultProjectId,
-                                defaultWorktreeId ?? null,
-                                "gemini",
-                            ),
-                        label: "Gemini",
-                    },
-                    {
-                        action: () =>
-                            void createChatTab(
-                                defaultProjectId,
-                                defaultWorktreeId ?? null,
-                                "kilo",
-                            ),
-                        label: "Kilo",
-                    },
-                    {
-                        action: () =>
-                            void createChatTab(
-                                defaultProjectId,
-                                defaultWorktreeId ?? null,
-                                "opencode",
-                            ),
-                        label: "OpenCode",
-                    },
-                ],
+                    onOpenClaudeCodeTerminal: handleOpenClaudeCodeTerminal,
+                }),
             },
             { type: "separator" },
             {
@@ -1979,9 +2016,11 @@ function WorkspacePaneView({
         [
             createChatTab,
             createTerminalTab,
+            claudeCodeAvailable,
             defaultProjectId,
             defaultWorktreeId,
             handleCreateFile,
+            handleOpenClaudeCodeTerminal,
             openChatHistoryTab,
             openGitTab,
         ],
@@ -2800,6 +2839,7 @@ function QuickCreateMenu({
                             setSubmenuPosition(null);
                         }
                     }}
+                    title={entry.title}
                     type="button"
                 >
                     <span>{entry.label}</span>

--- a/src/renderer/src/components/workspace/chat-history/sessionHierarchy.ts
+++ b/src/renderer/src/components/workspace/chat-history/sessionHierarchy.ts
@@ -1,25 +1,36 @@
 import type { AiHistorySessionSummary } from "@shared/ipc";
 
-export interface AiSessionHierarchyRow {
+type HierarchySessionBase = Pick<
+    AiHistorySessionSummary,
+    "parentSessionId" | "preview" | "runtimeSessionId" | "sessionId" | "title"
+>;
+
+export interface AiSessionHierarchyRow<
+    TSession extends HierarchySessionBase = AiHistorySessionSummary,
+> {
     readonly depth: number;
     readonly hasChildren: boolean;
     readonly isSubagent: boolean;
-    readonly parentSession: AiHistorySessionSummary | null;
-    readonly session: AiHistorySessionSummary;
+    readonly parentSession: TSession | null;
+    readonly session: TSession;
 }
 
-export interface AiSessionHierarchyGroup {
-    readonly rows: readonly AiSessionHierarchyRow[];
-    readonly rootSession: AiHistorySessionSummary;
+export interface AiSessionHierarchyGroup<
+    TSession extends HierarchySessionBase = AiHistorySessionSummary,
+> {
+    readonly rows: readonly AiSessionHierarchyRow<TSession>[];
+    readonly rootSession: TSession;
 }
 
-export type AiSessionHierarchySiblingComparator = (
-    left: AiHistorySessionSummary,
-    right: AiHistorySessionSummary,
+export type AiSessionHierarchySiblingComparator<
+    TSession extends HierarchySessionBase = AiHistorySessionSummary,
+> = (
+    left: TSession,
+    right: TSession,
 ) => number;
 
 export function getAiHistorySessionLookupKeys(
-    session: Pick<AiHistorySessionSummary, "runtimeSessionId" | "sessionId">,
+    session: Pick<HierarchySessionBase, "runtimeSessionId" | "sessionId">,
 ): readonly string[] {
     return [
         normalizeSessionRef(session.sessionId),
@@ -28,9 +39,9 @@ export function getAiHistorySessionLookupKeys(
 }
 
 export function isAiHistorySessionChildOfParent(
-    parent: Pick<AiHistorySessionSummary, "runtimeSessionId" | "sessionId">,
+    parent: Pick<HierarchySessionBase, "runtimeSessionId" | "sessionId">,
     candidate: Pick<
-        AiHistorySessionSummary,
+        HierarchySessionBase,
         "parentSessionId" | "runtimeSessionId" | "sessionId"
     >,
 ): boolean {
@@ -69,19 +80,21 @@ export function findAiHistorySessionParent(
     return null;
 }
 
-export function buildAiSessionHierarchyGroups(
-    sessions: readonly AiHistorySessionSummary[],
+export function buildAiSessionHierarchyGroups<
+    TSession extends HierarchySessionBase = AiHistorySessionSummary,
+>(
+    sessions: readonly TSession[],
     options: {
-        readonly compareSiblings?: AiSessionHierarchySiblingComparator | null;
+        readonly compareSiblings?: AiSessionHierarchySiblingComparator<TSession> | null;
         readonly filterQuery?: string | null;
     } = {},
-): readonly AiSessionHierarchyGroup[] {
+): readonly AiSessionHierarchyGroup<TSession>[] {
     if (sessions.length === 0) {
         return [];
     }
 
     const query = normalizeHierarchyQuery(options.filterQuery);
-    const sessionByRef = new Map<string, AiHistorySessionSummary>();
+    const sessionByRef = new Map<string, TSession>();
     for (const session of sessions) {
         for (const key of getAiHistorySessionLookupKeys(session)) {
             if (!sessionByRef.has(key)) {
@@ -96,8 +109,8 @@ export function buildAiSessionHierarchyGroups(
         options.compareSiblings,
         indexBySessionId,
     );
-    const childrenByParentId = new Map<string, AiHistorySessionSummary[]>();
-    const roots: AiHistorySessionSummary[] = [];
+    const childrenByParentId = new Map<string, TSession[]>();
+    const roots: TSession[] = [];
 
     for (const session of sessions) {
         const parentSessionId = normalizeSessionRef(session.parentSessionId);
@@ -122,13 +135,13 @@ export function buildAiSessionHierarchyGroups(
     }
 
     const appendedSessionIds = new Set<string>();
-    const groups: AiSessionHierarchyGroup[] = [];
-    const appendGroup = (rootSession: AiHistorySessionSummary) => {
+    const groups: AiSessionHierarchyGroup<TSession>[] = [];
+    const appendGroup = (rootSession: TSession) => {
         if (appendedSessionIds.has(rootSession.sessionId)) {
             return;
         }
 
-        const rows: AiSessionHierarchyRow[] = [];
+        const rows: AiSessionHierarchyRow<TSession>[] = [];
         appendHierarchyRows({
             appendedSessionIds,
             childrenByParentId,
@@ -164,15 +177,17 @@ export function buildAiSessionHierarchyGroups(
     return groups;
 }
 
-export function filterAiSessionHierarchyRowsForCollapsedParents(
-    rows: readonly AiSessionHierarchyRow[],
+export function filterAiSessionHierarchyRowsForCollapsedParents<
+    TSession extends HierarchySessionBase = AiHistorySessionSummary,
+>(
+    rows: readonly AiSessionHierarchyRow<TSession>[],
     collapsedSessionIds: ReadonlySet<string>,
-): readonly AiSessionHierarchyRow[] {
+): readonly AiSessionHierarchyRow<TSession>[] {
     if (rows.length === 0 || collapsedSessionIds.size === 0) {
         return rows;
     }
 
-    const visibleRows: AiSessionHierarchyRow[] = [];
+    const visibleRows: AiSessionHierarchyRow<TSession>[] = [];
     const collapsedAncestorDepths: number[] = [];
 
     for (const row of rows) {
@@ -200,7 +215,7 @@ export function filterAiSessionHierarchyRowsForCollapsedParents(
     return visibleRows;
 }
 
-function appendHierarchyRows({
+function appendHierarchyRows<TSession extends HierarchySessionBase>({
     appendedSessionIds,
     childrenByParentId,
     compareSiblings,
@@ -210,12 +225,12 @@ function appendHierarchyRows({
     sessionByRef,
 }: {
     readonly appendedSessionIds: Set<string>;
-    readonly childrenByParentId: Map<string, AiHistorySessionSummary[]>;
-    readonly compareSiblings: AiSessionHierarchySiblingComparator;
+    readonly childrenByParentId: Map<string, TSession[]>;
+    readonly compareSiblings: AiSessionHierarchySiblingComparator<TSession>;
     readonly depth: number;
-    readonly rows: AiSessionHierarchyRow[];
-    readonly session: AiHistorySessionSummary;
-    readonly sessionByRef: Map<string, AiHistorySessionSummary>;
+    readonly rows: AiSessionHierarchyRow<TSession>[];
+    readonly session: TSession;
+    readonly sessionByRef: Map<string, TSession>;
 }) {
     if (appendedSessionIds.has(session.sessionId)) {
         return;
@@ -256,10 +271,13 @@ function normalizeHierarchyQuery(value: string | null | undefined): string {
     return (value ?? "").trim().toLowerCase();
 }
 
-function createSiblingComparator(
-    compareSiblings: AiSessionHierarchySiblingComparator | null | undefined,
+function createSiblingComparator<TSession extends HierarchySessionBase>(
+    compareSiblings:
+        | AiSessionHierarchySiblingComparator<TSession>
+        | null
+        | undefined,
     indexBySessionId: ReadonlyMap<string, number>,
-): AiSessionHierarchySiblingComparator {
+): AiSessionHierarchySiblingComparator<TSession> {
     return (left, right) => {
         const customComparison = compareSiblings?.(left, right) ?? 0;
         if (customComparison !== 0) {
@@ -279,7 +297,7 @@ function normalizeSessionRef(value: string | null | undefined): string | null {
 }
 
 function sessionMatchesHierarchyQuery(
-    session: AiHistorySessionSummary,
+    session: HierarchySessionBase,
     query: string,
 ): boolean {
     return (

--- a/src/renderer/src/features/terminal/TerminalViewport.tsx
+++ b/src/renderer/src/features/terminal/TerminalViewport.tsx
@@ -22,6 +22,7 @@ import {
     type ContextMenuState,
 } from "@renderer/components/context-menu/ContextMenu";
 import { openExternalUrl } from "@renderer/app/utils/external-url";
+import { useSettingsStore } from "@renderer/app/store/settings-store";
 
 import { getTerminalTheme, type TerminalTheme } from "./terminalTheme";
 import type {
@@ -78,9 +79,15 @@ function buildSearchSummary(resultIndex: number, resultCount: number): string {
     return `${Math.max(resultIndex + 1, 1)} / ${resultCount}`;
 }
 
-function useTerminalTheme(): TerminalTheme {
+interface TerminalThemeOptions {
+    readonly fontFamily: string;
+    readonly fontSize: number;
+}
+
+function useTerminalTheme(options: TerminalThemeOptions): TerminalTheme {
+    const { fontFamily, fontSize } = options;
     const [theme, setTheme] = useState<TerminalTheme>(() =>
-        getTerminalTheme(null),
+        getTerminalTheme(null, { fontFamily, fontSize }),
     );
 
     useEffect(() => {
@@ -88,7 +95,7 @@ function useTerminalTheme(): TerminalTheme {
 
         const updateTheme = () => {
             frameHandle = 0;
-            const nextTheme = getTerminalTheme(null);
+            const nextTheme = getTerminalTheme(null, { fontFamily, fontSize });
             setTheme((currentTheme) =>
                 JSON.stringify(currentTheme) === JSON.stringify(nextTheme)
                     ? currentTheme
@@ -116,9 +123,21 @@ function useTerminalTheme(): TerminalTheme {
                 window.cancelAnimationFrame(frameHandle);
             }
         };
-    }, []);
+    }, [fontFamily, fontSize]);
 
     return theme;
+}
+
+async function loadTerminalFontForTheme(theme: TerminalTheme): Promise<void> {
+    if (!document.fonts?.load) {
+        return;
+    }
+
+    try {
+        await document.fonts.load(`${theme.fontSize}px ${theme.fontFamily}`);
+    } catch {
+        // Font loading is best-effort; xterm can still refit with fallbacks.
+    }
 }
 
 async function readClipboardText(): Promise<string> {
@@ -206,7 +225,16 @@ export function TerminalViewport({
     const [searchResultCount, setSearchResultCount] = useState(0);
     const [contextMenu, setContextMenu] =
         useState<ContextMenuState<void> | null>(null);
-    const theme = useTerminalTheme();
+    const terminalFontFamily = useSettingsStore(
+        (state) => state.terminal.terminalFontFamily,
+    );
+    const terminalFontSize = useSettingsStore(
+        (state) => state.terminal.terminalFontSize,
+    );
+    const theme = useTerminalTheme({
+        fontFamily: terminalFontFamily,
+        fontSize: terminalFontSize,
+    });
 
     const focusTerminal = useCallback(() => {
         shouldRestoreFocusRef.current = true;
@@ -640,7 +668,18 @@ export function TerminalViewport({
         terminal.options.fontSize = theme.fontSize;
         terminal.options.lineHeight = theme.lineHeight;
         terminal.options.theme = createXtermTheme(theme);
-        fitAddonRef.current?.fit();
+
+        let cancelled = false;
+        void loadTerminalFontForTheme(theme).finally(() => {
+            if (cancelled) {
+                return;
+            }
+            syncSizeRef.current();
+        });
+
+        return () => {
+            cancelled = true;
+        };
     }, [theme]);
 
     useEffect(() => {

--- a/src/renderer/src/features/terminal/claudeCodeSidebarSession.test.ts
+++ b/src/renderer/src/features/terminal/claudeCodeSidebarSession.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+    resetWorkspacePersistenceForTests,
+    useWorkspaceStore,
+} from "@renderer/app/store/workspace-store";
+import {
+    collectPaneNodes,
+    createDefaultWorkspaceState,
+} from "@renderer/app/workspace/tree";
+import { resetTerminalRuntimeStoreForTests } from "./terminalRuntimeStore";
+import {
+    closeClaudeCodeSidebarSession,
+    focusClaudeCodeSidebarSession,
+    getClaudeCodeSidebarSessions,
+    reconcileClaudeCodeSidebarSessions,
+    refreshClaudeCodeSidebarSessionTranscript,
+    registerClaudeCodeSidebarSession,
+    renameClaudeCodeSidebarSession,
+    resetClaudeCodeSidebarSessionsForTests,
+} from "./claudeCodeSidebarSession";
+
+const saveWorkspaceSnapshotMock = vi.fn(async () => {});
+const closeTerminalSessionMock = vi.fn(async () => {});
+const readClaudeCodeTranscriptMock = vi.fn();
+
+beforeEach(() => {
+    resetClaudeCodeSidebarSessionsForTests();
+    resetTerminalRuntimeStoreForTests();
+    resetWorkspacePersistenceForTests();
+    saveWorkspaceSnapshotMock.mockClear();
+    closeTerminalSessionMock.mockClear();
+    readClaudeCodeTranscriptMock.mockReset();
+    useWorkspaceStore.setState((state) => ({
+        ...state,
+        ...createDefaultWorkspaceState(),
+        error: null,
+        hydrated: true,
+        lastFocusedChatTabId: null,
+        lastFocusedRuntimeId: "codex",
+        lastQuickCreateAction: "codex",
+        recentActiveTabIds: [],
+        recentClosedTabs: [],
+        recentFocusedChatTabIds: [],
+    }), true);
+    Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: {
+            comando: {
+                closeTerminalSession: closeTerminalSessionMock,
+                readClaudeCodeTranscript: readClaudeCodeTranscriptMock,
+                saveWorkspaceSnapshot: saveWorkspaceSnapshotMock,
+            },
+        },
+        writable: true,
+    });
+});
+
+describe("Claude Code sidebar session registry", () => {
+    it("registers a terminal agent once per terminal id", () => {
+        registerClaudeCodeSidebarSession(createRegistryInput());
+        registerClaudeCodeSidebarSession(
+            createRegistryInput({ title: "Claude Code 2" }),
+        );
+
+        expect(getClaudeCodeSidebarSessions()).toMatchObject([
+            {
+                isTerminalAgent: true,
+                runtimeId: "claude-code-terminal",
+                sessionId: "claude-code-terminal:terminal-1",
+                terminalId: "terminal-1",
+                title: "Claude Code 1",
+            },
+        ]);
+    });
+
+    it("focuses the matching terminal tab", async () => {
+        const firstTabId = await createTerminalTab("Claude Code 1");
+        await createTerminalTab("Terminal 1");
+        const session = registerClaudeCodeSidebarSession(
+            createRegistryInput({ terminalTabId: firstTabId }),
+        );
+
+        await focusClaudeCodeSidebarSession(session);
+
+        expect(getActiveTabId()).toBe(firstTabId);
+    });
+
+    it("closes the matching terminal tab and removes the item", async () => {
+        const terminalTabId = await createTerminalTab("Claude Code 1");
+        const session = registerClaudeCodeSidebarSession(
+            createRegistryInput({ terminalTabId }),
+        );
+
+        await closeClaudeCodeSidebarSession(session);
+
+        expect(useWorkspaceStore.getState().tabsById[terminalTabId]).toBeUndefined();
+        expect(getClaudeCodeSidebarSessions()).toEqual([]);
+    });
+
+    it("reconciles away sessions whose terminal tab disappeared", () => {
+        registerClaudeCodeSidebarSession(createRegistryInput());
+
+        reconcileClaudeCodeSidebarSessions([]);
+
+        expect(getClaudeCodeSidebarSessions()).toEqual([]);
+    });
+
+    it("hydrates title, preview, updatedAt, and automatic tab title from transcript", async () => {
+        const terminalTabId = await createTerminalTab("Claude Code 1");
+        const session = registerClaudeCodeSidebarSession(
+            createRegistryInput({ terminalTabId }),
+        );
+        readClaudeCodeTranscriptMock.mockResolvedValue({
+            changed: true,
+            found: true,
+            mtimeMs: 123,
+            preview: "Here is the implementation plan.",
+            title: "Build the launcher",
+        });
+
+        await refreshClaudeCodeSidebarSessionTranscript(session);
+
+        expect(getClaudeCodeSidebarSessions()).toMatchObject([
+            {
+                preview: "Here is the implementation plan.",
+                title: "Build the launcher",
+                transcriptMtimeMs: 123,
+            },
+        ]);
+        expect(useWorkspaceStore.getState().tabsById[terminalTabId]?.title).toBe(
+            "Build the launcher",
+        );
+    });
+
+    it("keeps manual sidebar and tab titles when transcript refreshes later", async () => {
+        const terminalTabId = await createTerminalTab("Claude Code 1");
+        const session = registerClaudeCodeSidebarSession(
+            createRegistryInput({ terminalTabId }),
+        );
+        await renameClaudeCodeSidebarSession(session, "Manual title");
+        readClaudeCodeTranscriptMock.mockResolvedValue({
+            changed: true,
+            found: true,
+            mtimeMs: 456,
+            preview: "Fresh preview",
+            title: "Transcript title",
+        });
+
+        await refreshClaudeCodeSidebarSessionTranscript(session);
+
+        expect(getClaudeCodeSidebarSessions()).toMatchObject([
+            {
+                preview: "Fresh preview",
+                title: "Manual title",
+                transcriptMtimeMs: 456,
+            },
+        ]);
+        expect(useWorkspaceStore.getState().tabsById[terminalTabId]?.title).toBe(
+            "Manual title",
+        );
+    });
+});
+
+function createRegistryInput(
+    overrides: Partial<Parameters<typeof registerClaudeCodeSidebarSession>[0]> = {},
+): Parameters<typeof registerClaudeCodeSidebarSession>[0] {
+    return {
+        cwd: "/workspace",
+        projectId: "project-1",
+        terminalId: "terminal-1",
+        terminalTabId: "terminal-tab-1",
+        title: "Claude Code 1",
+        transcriptSessionId: "11111111-1111-4111-8111-111111111111",
+        worktreeId: "worktree-1",
+        ...overrides,
+    };
+}
+
+async function createTerminalTab(title: string): Promise<string> {
+    const tabId = await useWorkspaceStore.getState().createTerminalTab(
+        "project-1",
+        "worktree-1",
+        { title },
+    );
+    if (!tabId) {
+        throw new Error("Expected terminal tab id.");
+    }
+    return tabId;
+}
+
+function getActiveTabId(): string | null {
+    const state = useWorkspaceStore.getState();
+    const activePane = collectPaneNodes(state.rootNode).find(
+        (pane) => pane.id === state.activePaneId,
+    );
+    return activePane?.activeTabId ?? null;
+}

--- a/src/renderer/src/features/terminal/claudeCodeSidebarSession.ts
+++ b/src/renderer/src/features/terminal/claudeCodeSidebarSession.ts
@@ -1,0 +1,306 @@
+import type { AiHistorySessionSummary, AiRuntimeId } from "@shared/ipc";
+
+import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
+import {
+    collectPaneNodes,
+    type RuntimeWorkspaceTerminalTab,
+    type RuntimeWorkspaceTab,
+} from "@renderer/app/workspace/tree";
+
+export const CLAUDE_CODE_TERMINAL_RUNTIME_ID = "claude-code-terminal" as const;
+
+export type SidebarAgentRuntimeId =
+    | AiRuntimeId
+    | typeof CLAUDE_CODE_TERMINAL_RUNTIME_ID;
+
+export type SidebarAgentSessionSummary = Omit<
+    AiHistorySessionSummary,
+    "runtimeId"
+> & {
+    readonly runtimeId: SidebarAgentRuntimeId;
+    readonly isTerminalAgent?: boolean;
+    readonly terminalId?: string;
+};
+
+export interface ClaudeCodeSidebarSessionSummary
+    extends Omit<AiHistorySessionSummary, "runtimeId"> {
+    readonly cwd: string;
+    readonly defaultTitle: string;
+    readonly isTerminalAgent: true;
+    readonly runtimeId: typeof CLAUDE_CODE_TERMINAL_RUNTIME_ID;
+    readonly terminalId: string;
+    readonly terminalTabId: string;
+    readonly transcriptMtimeMs: number | null;
+    readonly transcriptSessionId: string | null;
+}
+
+export interface RegisterClaudeCodeSidebarSessionInput {
+    readonly cwd: string;
+    readonly projectId: string | null;
+    readonly terminalId: string;
+    readonly terminalTabId: string;
+    readonly title: string;
+    readonly transcriptSessionId: string | null;
+    readonly worktreeId: string | null;
+}
+
+type MutableClaudeCodeSidebarSession = ClaudeCodeSidebarSessionSummary & {
+    readonly customTitle: string | null;
+};
+
+const sessionsByTerminalId = new Map<string, MutableClaudeCodeSidebarSession>();
+const listeners = new Set<() => void>();
+
+export function registerClaudeCodeSidebarSession(
+    input: RegisterClaudeCodeSidebarSessionInput,
+): ClaudeCodeSidebarSessionSummary {
+    const now = new Date().toISOString();
+    const existing = sessionsByTerminalId.get(input.terminalId);
+    const next: MutableClaudeCodeSidebarSession = {
+        createdAt: existing?.createdAt ?? now,
+        customTitle: existing?.customTitle ?? null,
+        cwd: input.cwd,
+        defaultTitle: input.title,
+        isTerminalAgent: true,
+        messageCount: 0,
+        preview: existing?.preview ?? null,
+        projectId: input.projectId,
+        runtimeId: CLAUDE_CODE_TERMINAL_RUNTIME_ID,
+        runtimeSessionId: input.transcriptSessionId,
+        sessionId: createSidebarSessionId(input.terminalId),
+        terminalId: input.terminalId,
+        terminalTabId: input.terminalTabId,
+        title: existing?.title ?? input.title,
+        transcriptMtimeMs: existing?.transcriptMtimeMs ?? null,
+        transcriptSessionId: input.transcriptSessionId,
+        updatedAt: existing?.updatedAt ?? now,
+        worktreeId: input.worktreeId,
+    };
+
+    sessionsByTerminalId.set(input.terminalId, next);
+    notifyClaudeCodeSidebarSessionListeners();
+    return toPublicSession(next);
+}
+
+export function subscribeClaudeCodeSidebarSessions(
+    listener: () => void,
+): () => void {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+export function getClaudeCodeSidebarSessions(): readonly ClaudeCodeSidebarSessionSummary[] {
+    return [...sessionsByTerminalId.values()].map(toPublicSession);
+}
+
+export function getClaudeCodeSidebarSessionByTerminalId(
+    terminalId: string,
+): ClaudeCodeSidebarSessionSummary | null {
+    const session = sessionsByTerminalId.get(terminalId);
+    return session ? toPublicSession(session) : null;
+}
+
+export function isClaudeCodeSidebarSession(
+    session: SidebarAgentSessionSummary,
+): session is ClaudeCodeSidebarSessionSummary {
+    return (
+        session.runtimeId === CLAUDE_CODE_TERMINAL_RUNTIME_ID &&
+        session.isTerminalAgent === true &&
+        typeof session.terminalId === "string"
+    );
+}
+
+export async function focusClaudeCodeSidebarSession(
+    session: ClaudeCodeSidebarSessionSummary,
+): Promise<void> {
+    const tab = findTerminalTabForSession(session);
+    if (!tab) {
+        removeClaudeCodeSidebarSession(session.terminalId);
+        return;
+    }
+
+    const pane = collectPaneNodes(useWorkspaceStore.getState().rootNode).find(
+        (candidate) => candidate.tabIds.includes(tab.id),
+    );
+    if (!pane) {
+        return;
+    }
+
+    await useWorkspaceStore.getState().selectTab(pane.id, tab.id);
+}
+
+export async function closeClaudeCodeSidebarSession(
+    session: ClaudeCodeSidebarSessionSummary,
+): Promise<void> {
+    const tab = findTerminalTabForSession(session);
+    if (tab) {
+        await useWorkspaceStore.getState().closeTab(tab.id);
+    }
+    removeClaudeCodeSidebarSession(session.terminalId);
+}
+
+export async function renameClaudeCodeSidebarSession(
+    session: ClaudeCodeSidebarSessionSummary,
+    title: string,
+): Promise<void> {
+    const current = sessionsByTerminalId.get(session.terminalId);
+    if (!current) {
+        return;
+    }
+
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle || trimmedTitle === current.title) {
+        return;
+    }
+
+    sessionsByTerminalId.set(session.terminalId, {
+        ...current,
+        customTitle: trimmedTitle,
+        title: trimmedTitle,
+        updatedAt: new Date().toISOString(),
+    });
+    notifyClaudeCodeSidebarSessionListeners();
+
+    await useWorkspaceStore
+        .getState()
+        .updateTerminalTabTitle(current.terminalTabId, trimmedTitle);
+}
+
+export function reconcileClaudeCodeSidebarSessions(
+    tabs: readonly RuntimeWorkspaceTab[],
+): void {
+    let changed = false;
+
+    for (const [terminalId, session] of sessionsByTerminalId) {
+        const tab = tabs.find(
+            (candidate) =>
+                candidate.kind === "terminal" &&
+                candidate.terminalId === terminalId,
+        );
+        if (!tab) {
+            sessionsByTerminalId.delete(terminalId);
+            changed = true;
+            continue;
+        }
+        if (tab.id !== session.terminalTabId) {
+            sessionsByTerminalId.set(terminalId, {
+                ...session,
+                terminalTabId: tab.id,
+            });
+            changed = true;
+        }
+    }
+
+    if (changed) {
+        notifyClaudeCodeSidebarSessionListeners();
+    }
+}
+
+export async function refreshClaudeCodeSidebarSessionTranscript(
+    session: ClaudeCodeSidebarSessionSummary,
+): Promise<void> {
+    if (!session.transcriptSessionId || !session.cwd) {
+        return;
+    }
+
+    const current = sessionsByTerminalId.get(session.terminalId);
+    if (!current) {
+        return;
+    }
+
+    const api = getComandoApi();
+    if (!api) {
+        return;
+    }
+
+    const result = await api.readClaudeCodeTranscript({
+        cwd: current.cwd,
+        sessionId: session.transcriptSessionId,
+        sinceMtimeMs: current.transcriptMtimeMs,
+    });
+    if (!result.found || !result.changed) {
+        return;
+    }
+
+    const previousTitle = current.title;
+    const nextTitle =
+        current.customTitle ?? normalizeTranscriptText(result.title) ?? current.title;
+    const nextPreview = normalizeTranscriptText(result.preview) ?? current.preview;
+    const nextSession: MutableClaudeCodeSidebarSession = {
+        ...current,
+        preview: nextPreview,
+        title: nextTitle,
+        transcriptMtimeMs: result.mtimeMs,
+        updatedAt: new Date().toISOString(),
+    };
+    sessionsByTerminalId.set(current.terminalId, nextSession);
+    notifyClaudeCodeSidebarSessionListeners();
+
+    if (current.customTitle || nextTitle === previousTitle) {
+        return;
+    }
+
+    const tab = useWorkspaceStore.getState().tabsById[current.terminalTabId];
+    if (
+        tab?.kind === "terminal" &&
+        (tab.title === previousTitle || tab.title === current.defaultTitle)
+    ) {
+        await useWorkspaceStore
+            .getState()
+            .updateTerminalTabTitle(current.terminalTabId, nextTitle);
+    }
+}
+
+export function resetClaudeCodeSidebarSessionsForTests(): void {
+    sessionsByTerminalId.clear();
+    listeners.clear();
+}
+
+function findTerminalTabForSession(
+    session: ClaudeCodeSidebarSessionSummary,
+): RuntimeWorkspaceTerminalTab | null {
+    const tabs = Object.values(useWorkspaceStore.getState().tabsById);
+    return (
+        tabs.find(
+            (tab): tab is RuntimeWorkspaceTerminalTab =>
+                tab.kind === "terminal" &&
+                (tab.id === session.terminalTabId ||
+                    tab.terminalId === session.terminalId),
+        ) ?? null
+    );
+}
+
+function removeClaudeCodeSidebarSession(terminalId: string): void {
+    if (sessionsByTerminalId.delete(terminalId)) {
+        notifyClaudeCodeSidebarSessionListeners();
+    }
+}
+
+function notifyClaudeCodeSidebarSessionListeners(): void {
+    for (const listener of listeners) {
+        listener();
+    }
+}
+
+function toPublicSession(
+    session: MutableClaudeCodeSidebarSession,
+): ClaudeCodeSidebarSessionSummary {
+    const { customTitle, ...publicSession } = session;
+    void customTitle;
+    return publicSession;
+}
+
+function createSidebarSessionId(terminalId: string): string {
+    return `${CLAUDE_CODE_TERMINAL_RUNTIME_ID}:${terminalId}`;
+}
+
+function normalizeTranscriptText(value: string | null): string | null {
+    const trimmed = (value ?? "").trim();
+    return trimmed.length > 0 ? trimmed : null;
+}
+
+function getComandoApi() {
+    return typeof window !== "undefined" ? (window.comando ?? null) : null;
+}

--- a/src/renderer/src/features/terminal/claudeCodeTerminal.test.ts
+++ b/src/renderer/src/features/terminal/claudeCodeTerminal.test.ts
@@ -136,27 +136,23 @@ describe("Claude Code terminal launcher", () => {
             data: "claude --session-id transcript-session-1\n",
             sessionId: "pty-terminal-id-1",
         });
-        expect(getClaudeCodeTerminalSidebarItemsForTests()).toEqual([
+        expect(getClaudeCodeTerminalSidebarItemsForTests()).toMatchObject([
             {
                 cwd: "/workspace",
+                isTerminalAgent: true,
                 projectId: "project-1",
+                runtimeId: "claude-code-terminal",
+                runtimeSessionId: "transcript-session-1",
+                sessionId: "claude-code-terminal:terminal-id-1",
                 terminalId: "terminal-id-1",
                 terminalTabId: "terminal-tab-1",
                 title: "Claude Code 1",
+                transcriptMtimeMs: null,
                 transcriptSessionId: "transcript-session-1",
                 worktreeId: "worktree-1",
             },
         ]);
-        expect(
-            useAiStore.getState().sessions["transcript-session-1"]?.snapshot,
-        ).toMatchObject({
-            projectId: "project-1",
-            runtimeId: "claude",
-            runtimeSessionId: "transcript-session-1",
-            sessionId: "transcript-session-1",
-            title: "Claude Code 1",
-            worktreeId: "worktree-1",
-        });
+        expect(useAiStore.getState().sessions).toEqual({});
     });
 
     it("uses --continue without adding a transcript session id", async () => {
@@ -184,12 +180,14 @@ describe("Claude Code terminal launcher", () => {
             data: "claude --continue\n",
             sessionId: "pty-terminal-id-1",
         });
-        expect(useAiStore.getState().sessions["terminal-id-1"]?.snapshot)
-            .toMatchObject({
+        expect(getClaudeCodeTerminalSidebarItemsForTests()).toMatchObject([
+            {
                 runtimeSessionId: null,
-                sessionId: "terminal-id-1",
+                sessionId: "claude-code-terminal:terminal-id-1",
+                transcriptSessionId: null,
                 title: "Claude Code 1",
-            });
+            },
+        ]);
     });
 
     it("adds skip-permissions, model, and max-turns flags when configured", async () => {

--- a/src/renderer/src/features/terminal/claudeCodeTerminal.test.ts
+++ b/src/renderer/src/features/terminal/claudeCodeTerminal.test.ts
@@ -190,7 +190,7 @@ describe("Claude Code terminal launcher", () => {
         ]);
     });
 
-    it("adds skip-permissions, model, and max-turns flags when configured", async () => {
+    it("adds supported Claude Code flags and ignores interactive-only max turns", async () => {
         useSettingsStore.setState({
             terminal: createTerminalSettings({
                 claudeCodeMaxTurns: 12,
@@ -214,7 +214,7 @@ describe("Claude Code terminal launcher", () => {
 
         expect(writeTerminalInputMock).toHaveBeenCalledWith({
             data:
-                "claude --dangerously-skip-permissions --session-id transcript-session-1 --model claude-sonnet-4-6 --max-turns 12\n",
+                "claude --dangerously-skip-permissions --session-id transcript-session-1 --model claude-sonnet-4-6\n",
             sessionId: "pty-terminal-id-1",
         });
     });

--- a/src/renderer/src/features/terminal/claudeCodeTerminal.test.ts
+++ b/src/renderer/src/features/terminal/claudeCodeTerminal.test.ts
@@ -1,15 +1,40 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { AppTerminalSettings } from "@shared/terminal-settings";
+import { DEFAULT_APP_TERMINAL_SETTINGS } from "@shared/terminal-settings";
+import { useAiStore } from "@renderer/app/store/ai-store";
+import { useSettingsStore } from "@renderer/app/store/settings-store";
 import {
+    resetWorkspacePersistenceForTests,
+    useWorkspaceStore,
+} from "@renderer/app/store/workspace-store";
+import { createDefaultWorkspaceState } from "@renderer/app/workspace/tree";
+import {
+    resetTerminalRuntimeStoreForTests,
+    useTerminalRuntimeStore,
+    type WorkspaceTerminalRuntime,
+} from "./terminalRuntimeStore";
+import {
+    buildShellCommand,
     checkClaudeCodeInstalled,
-    resetClaudeCodeInstalledCacheForTests,
+    getClaudeCodeTerminalSidebarItemsForTests,
+    getNextClaudeCodeTerminalTitle,
+    getSafeClaudeCodeModel,
+    launchClaudeCodeTerminal,
+    resetClaudeCodeTerminalStateForTests,
 } from "./claudeCodeTerminal";
 
 const checkCommandAvailabilityMock = vi.fn();
+const saveWorkspaceSnapshotMock = vi.fn(async () => {});
+const writeTerminalInputMock = vi.fn(async () => {});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
 
 describe("checkClaudeCodeInstalled", () => {
     beforeEach(() => {
-        resetClaudeCodeInstalledCacheForTests();
+        resetClaudeCodeTerminalStateForTests();
         checkCommandAvailabilityMock.mockReset();
         Object.defineProperty(globalThis, "window", {
             configurable: true,
@@ -45,3 +70,273 @@ describe("checkClaudeCodeInstalled", () => {
         expect(checkCommandAvailabilityMock).toHaveBeenCalledTimes(1);
     });
 });
+
+describe("Claude Code terminal launcher", () => {
+    beforeEach(() => {
+        resetClaudeCodeTerminalStateForTests();
+        resetTerminalRuntimeStoreForTests();
+        resetWorkspacePersistenceForTests();
+        saveWorkspaceSnapshotMock.mockClear();
+        writeTerminalInputMock.mockClear();
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            ...createDefaultWorkspaceState(),
+            error: null,
+            hydrated: true,
+            lastFocusedChatTabId: null,
+            lastFocusedRuntimeId: "codex",
+            lastQuickCreateAction: "codex",
+            recentActiveTabIds: [],
+            recentClosedTabs: [],
+            recentFocusedChatTabIds: [],
+        }), true);
+        useAiStore.setState((state) => ({
+            ...state,
+            runtimeCatalogById: {},
+            runtimeStatusById: {},
+            sessions: {},
+        }));
+        useSettingsStore.setState({
+            terminal: DEFAULT_APP_TERMINAL_SETTINGS,
+        });
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    saveWorkspaceSnapshot: saveWorkspaceSnapshotMock,
+                    writeTerminalInput: writeTerminalInputMock,
+                },
+            },
+            writable: true,
+        });
+    });
+
+    it("launches Claude Code with a pinned transcript session id by default", async () => {
+        mockRandomUuids([
+            "terminal-id-1",
+            "terminal-tab-1",
+            "transcript-session-1",
+        ]);
+
+        const launchPromise = launchClaudeCodeTerminal({
+            projectId: "project-1",
+            timeoutMs: 1000,
+            worktreeId: "worktree-1",
+        });
+        await flushPromises();
+        markLatestTerminalRunning("/workspace");
+
+        await expect(launchPromise).resolves.toEqual({
+            commandWritten: true,
+            terminalId: "terminal-id-1",
+            terminalTabId: "terminal-tab-1",
+            transcriptSessionId: "transcript-session-1",
+        });
+        expect(writeTerminalInputMock).toHaveBeenCalledWith({
+            data: "claude --session-id transcript-session-1\n",
+            sessionId: "pty-terminal-id-1",
+        });
+        expect(getClaudeCodeTerminalSidebarItemsForTests()).toEqual([
+            {
+                cwd: "/workspace",
+                projectId: "project-1",
+                terminalId: "terminal-id-1",
+                terminalTabId: "terminal-tab-1",
+                title: "Claude Code 1",
+                transcriptSessionId: "transcript-session-1",
+                worktreeId: "worktree-1",
+            },
+        ]);
+        expect(
+            useAiStore.getState().sessions["transcript-session-1"]?.snapshot,
+        ).toMatchObject({
+            projectId: "project-1",
+            runtimeId: "claude",
+            runtimeSessionId: "transcript-session-1",
+            sessionId: "transcript-session-1",
+            title: "Claude Code 1",
+            worktreeId: "worktree-1",
+        });
+    });
+
+    it("uses --continue without adding a transcript session id", async () => {
+        useSettingsStore.setState({
+            terminal: createTerminalSettings({
+                claudeCodeContinueSession: true,
+            }),
+        });
+        mockRandomUuids(["terminal-id-1", "terminal-tab-1"]);
+
+        const launchPromise = launchClaudeCodeTerminal({
+            projectId: "project-1",
+            timeoutMs: 1000,
+        });
+        await flushPromises();
+        markLatestTerminalRunning("/workspace");
+
+        await expect(launchPromise).resolves.toMatchObject({
+            commandWritten: true,
+            terminalId: "terminal-id-1",
+            terminalTabId: "terminal-tab-1",
+            transcriptSessionId: null,
+        });
+        expect(writeTerminalInputMock).toHaveBeenCalledWith({
+            data: "claude --continue\n",
+            sessionId: "pty-terminal-id-1",
+        });
+        expect(useAiStore.getState().sessions["terminal-id-1"]?.snapshot)
+            .toMatchObject({
+                runtimeSessionId: null,
+                sessionId: "terminal-id-1",
+                title: "Claude Code 1",
+            });
+    });
+
+    it("adds skip-permissions, model, and max-turns flags when configured", async () => {
+        useSettingsStore.setState({
+            terminal: createTerminalSettings({
+                claudeCodeMaxTurns: 12,
+                claudeCodeModel: "claude-sonnet-4-6",
+                claudeCodeSkipPermissions: true,
+            }),
+        });
+        mockRandomUuids([
+            "terminal-id-1",
+            "terminal-tab-1",
+            "transcript-session-1",
+        ]);
+
+        const launchPromise = launchClaudeCodeTerminal({
+            projectId: "project-1",
+            timeoutMs: 1000,
+        });
+        await flushPromises();
+        markLatestTerminalRunning("/workspace");
+        await launchPromise;
+
+        expect(writeTerminalInputMock).toHaveBeenCalledWith({
+            data:
+                "claude --dangerously-skip-permissions --session-id transcript-session-1 --model claude-sonnet-4-6 --max-turns 12\n",
+            sessionId: "pty-terminal-id-1",
+        });
+    });
+
+    it("does not write the command when the terminal never reaches running", async () => {
+        mockRandomUuids(["terminal-id-1", "terminal-tab-1"]);
+
+        await expect(
+            launchClaudeCodeTerminal({
+                projectId: "project-1",
+                timeoutMs: 0,
+            }),
+        ).resolves.toEqual({
+            commandWritten: false,
+            terminalId: "terminal-id-1",
+            terminalTabId: "terminal-tab-1",
+            transcriptSessionId: null,
+        });
+        expect(writeTerminalInputMock).not.toHaveBeenCalled();
+        expect(getClaudeCodeTerminalSidebarItemsForTests()).toEqual([]);
+    });
+
+    it("ignores unsafe models and rejects unsafe shell tokens", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        expect(getSafeClaudeCodeModel("claude-opus-4-7")).toBe(
+            "claude-opus-4-7",
+        );
+        for (const model of ["bad\nmodel", "bad;model", "`bad`", '"bad"']) {
+            expect(getSafeClaudeCodeModel(model)).toBeNull();
+        }
+        expect(() => buildShellCommand(["claude", "hello;world"])).toThrow(
+            /Unsafe shell token/,
+        );
+        expect(buildShellCommand(["claude", "--max-turns", "1"])).toBe(
+            "claude --max-turns 1\n",
+        );
+        expect(warnSpy).toHaveBeenCalledTimes(4);
+    });
+
+    it("increments Claude Code titles independently from normal terminals", async () => {
+        await useWorkspaceStore.getState().createTerminalTab("project-1", null, {
+            title: "Terminal 1",
+        });
+        await useWorkspaceStore.getState().createTerminalTab("project-1", null, {
+            title: "Claude Code 1",
+        });
+
+        expect(
+            getNextClaudeCodeTerminalTitle(
+                Object.values(useWorkspaceStore.getState().tabsById),
+            ),
+        ).toBe("Claude Code 2");
+    });
+});
+
+function createTerminalSettings(
+    overrides: Partial<AppTerminalSettings>,
+): AppTerminalSettings {
+    return {
+        ...DEFAULT_APP_TERMINAL_SETTINGS,
+        ...overrides,
+    };
+}
+
+async function flushPromises(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+function mockRandomUuids(values: readonly string[]): void {
+    let index = 0;
+    vi.spyOn(globalThis.crypto, "randomUUID").mockImplementation(() => {
+        const value = values[index];
+        index += 1;
+        return (value ?? `uuid-${index}`) as ReturnType<
+            Crypto["randomUUID"]
+        >;
+    });
+}
+
+function markLatestTerminalRunning(cwd: string): void {
+    const terminalTab = Object.values(useWorkspaceStore.getState().tabsById)
+        .filter((tab) => tab.kind === "terminal")
+        .at(-1);
+    if (!terminalTab || terminalTab.kind !== "terminal") {
+        throw new Error("Expected a terminal tab.");
+    }
+
+    useTerminalRuntimeStore.setState({
+        runtimesById: {
+            [terminalTab.terminalId]: createRuntime(terminalTab.terminalId, cwd),
+        },
+    });
+}
+
+function createRuntime(
+    terminalId: string,
+    cwd: string,
+): WorkspaceTerminalRuntime {
+    return {
+        busy: false,
+        hasOutput: false,
+        launchError: null,
+        projectId: "project-1",
+        sessionGeneration: 1,
+        sessionId: `pty-${terminalId}`,
+        snapshot: {
+            cols: 120,
+            cwd,
+            displayName: "Shell",
+            errorMessage: null,
+            exitCode: null,
+            program: "",
+            rows: 24,
+            sessionId: `pty-${terminalId}`,
+            status: "running",
+        },
+        tabId: `${terminalId}-tab`,
+        terminalId,
+        worktreeId: "worktree-1",
+    };
+}

--- a/src/renderer/src/features/terminal/claudeCodeTerminal.test.ts
+++ b/src/renderer/src/features/terminal/claudeCodeTerminal.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+    checkClaudeCodeInstalled,
+    resetClaudeCodeInstalledCacheForTests,
+} from "./claudeCodeTerminal";
+
+const checkCommandAvailabilityMock = vi.fn();
+
+describe("checkClaudeCodeInstalled", () => {
+    beforeEach(() => {
+        resetClaudeCodeInstalledCacheForTests();
+        checkCommandAvailabilityMock.mockReset();
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    checkCommandAvailability: checkCommandAvailabilityMock,
+                },
+            },
+            writable: true,
+        });
+    });
+
+    it("checks Claude Code availability through IPC and caches the result", async () => {
+        checkCommandAvailabilityMock
+            .mockResolvedValueOnce({ found: true, path: "/usr/local/bin/claude" })
+            .mockResolvedValueOnce({ found: false, path: null });
+
+        await expect(checkClaudeCodeInstalled()).resolves.toBe(true);
+        await expect(checkClaudeCodeInstalled()).resolves.toBe(true);
+
+        expect(checkCommandAvailabilityMock).toHaveBeenCalledTimes(1);
+        expect(checkCommandAvailabilityMock).toHaveBeenCalledWith({
+            name: "claude",
+        });
+    });
+
+    it("caches false when the bridge check fails", async () => {
+        checkCommandAvailabilityMock.mockRejectedValueOnce(new Error("boom"));
+
+        await expect(checkClaudeCodeInstalled()).resolves.toBe(false);
+        await expect(checkClaudeCodeInstalled()).resolves.toBe(false);
+
+        expect(checkCommandAvailabilityMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/renderer/src/features/terminal/claudeCodeTerminal.ts
+++ b/src/renderer/src/features/terminal/claudeCodeTerminal.ts
@@ -1,12 +1,15 @@
-import type { AiSessionSnapshot } from "@shared/ipc";
 import {
     ALLOWED_CLAUDE_CODE_MODELS,
     DEFAULT_APP_TERMINAL_SETTINGS,
 } from "@shared/terminal-settings";
 import type { RuntimeWorkspaceTab } from "@renderer/app/workspace/tree";
-import { useAiStore } from "@renderer/app/store/ai-store";
 import { useSettingsStore } from "@renderer/app/store/settings-store";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
+import {
+    getClaudeCodeSidebarSessions,
+    registerClaudeCodeSidebarSession,
+    resetClaudeCodeSidebarSessionsForTests,
+} from "./claudeCodeSidebarSession";
 import { useTerminalRuntimeStore } from "./terminalRuntimeStore";
 
 let claudeCodeInstalledCache: boolean | null = null;
@@ -28,21 +31,6 @@ export interface LaunchClaudeCodeTerminalResult {
     readonly terminalTabId: string | null;
     readonly transcriptSessionId: string | null;
 }
-
-export interface ClaudeCodeTerminalSidebarItem {
-    readonly cwd: string;
-    readonly projectId: string | null;
-    readonly terminalId: string;
-    readonly terminalTabId: string;
-    readonly title: string;
-    readonly transcriptSessionId: string | null;
-    readonly worktreeId: string | null;
-}
-
-const sidebarItemsByTerminalId = new Map<
-    string,
-    ClaudeCodeTerminalSidebarItem
->();
 
 export async function checkClaudeCodeInstalled(): Promise<boolean> {
     if (claudeCodeInstalledCache !== null) {
@@ -112,19 +100,11 @@ export async function launchClaudeCodeTerminal(
         }),
     );
 
-    registerClaudeCodeTerminalSidebarItem({
+    registerClaudeCodeSidebarSession({
         cwd: runtime?.snapshot.cwd ?? "",
         projectId: terminalTab.projectId,
         terminalId,
         terminalTabId,
-        title,
-        transcriptSessionId,
-        worktreeId: terminalTab.worktreeId ?? null,
-    });
-    applyClaudeCodeTerminalSessionSnapshot({
-        cwd: runtime?.snapshot.cwd ?? "",
-        projectId: terminalTab.projectId,
-        sessionId: transcriptSessionId ?? terminalId,
         title,
         transcriptSessionId,
         worktreeId: terminalTab.worktreeId ?? null,
@@ -198,13 +178,13 @@ export function getPinnedTranscriptSessionId(
     return continueSession ? null : createUuid();
 }
 
-export function getClaudeCodeTerminalSidebarItemsForTests(): readonly ClaudeCodeTerminalSidebarItem[] {
-    return [...sidebarItemsByTerminalId.values()];
+export function getClaudeCodeTerminalSidebarItemsForTests() {
+    return getClaudeCodeSidebarSessions();
 }
 
 export function resetClaudeCodeTerminalStateForTests(): void {
     claudeCodeInstalledCache = null;
-    sidebarItemsByTerminalId.clear();
+    resetClaudeCodeSidebarSessionsForTests();
 }
 
 interface BuildClaudeCodeCommandArgsInput {
@@ -281,62 +261,6 @@ function isTerminalRunning(terminalId: string): boolean {
         useTerminalRuntimeStore.getState().runtimesById[terminalId]?.snapshot
             .status === "running"
     );
-}
-
-function registerClaudeCodeTerminalSidebarItem(
-    item: ClaudeCodeTerminalSidebarItem,
-): void {
-    sidebarItemsByTerminalId.set(item.terminalId, item);
-}
-
-function applyClaudeCodeTerminalSessionSnapshot(input: {
-    readonly cwd: string;
-    readonly projectId: string | null;
-    readonly sessionId: string;
-    readonly title: string;
-    readonly transcriptSessionId: string | null;
-    readonly worktreeId: string | null;
-}): void {
-    useAiStore.getState().applySessionSnapshot(
-        createClaudeCodeTerminalSessionSnapshot(input),
-    );
-}
-
-function createClaudeCodeTerminalSessionSnapshot(input: {
-    readonly cwd: string;
-    readonly projectId: string | null;
-    readonly sessionId: string;
-    readonly title: string;
-    readonly transcriptSessionId: string | null;
-    readonly worktreeId: string | null;
-}): AiSessionSnapshot {
-    const now = new Date().toISOString();
-    return {
-        activeTurnStartedAt: null,
-        availableCommands: [],
-        closedAt: null,
-        configOptions: [],
-        lastError: null,
-        messages: [],
-        modeId: null,
-        modes: [],
-        modelId: null,
-        models: [],
-        pendingPermission: null,
-        pendingUserInput: null,
-        plan: null,
-        projectId: input.projectId,
-        runtimeId: "claude",
-        runtimeSessionId: input.transcriptSessionId,
-        sessionId: input.sessionId,
-        status: "idle",
-        title: input.title,
-        tokenUsage: null,
-        toolActivity: [],
-        trackedFiles: [],
-        updatedAt: now,
-        worktreeId: input.worktreeId,
-    };
 }
 
 function createLaunchResult(

--- a/src/renderer/src/features/terminal/claudeCodeTerminal.ts
+++ b/src/renderer/src/features/terminal/claudeCodeTerminal.ts
@@ -1,4 +1,48 @@
+import type { AiSessionSnapshot } from "@shared/ipc";
+import {
+    ALLOWED_CLAUDE_CODE_MODELS,
+    DEFAULT_APP_TERMINAL_SETTINGS,
+} from "@shared/terminal-settings";
+import type { RuntimeWorkspaceTab } from "@renderer/app/workspace/tree";
+import { useAiStore } from "@renderer/app/store/ai-store";
+import { useSettingsStore } from "@renderer/app/store/settings-store";
+import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
+import { useTerminalRuntimeStore } from "./terminalRuntimeStore";
+
 let claudeCodeInstalledCache: boolean | null = null;
+
+const CLAUDE_CODE_TITLE_PATTERN = /^Claude Code(?: (\d+))?$/;
+const SAFE_SHELL_TOKEN_PATTERN = /^[A-Za-z0-9_./:@%+=,-]+$/;
+const DEFAULT_TERMINAL_RUNNING_TIMEOUT_MS = 10_000;
+
+export interface LaunchClaudeCodeTerminalInput {
+    readonly paneId?: string | null;
+    readonly projectId: string | null;
+    readonly timeoutMs?: number;
+    readonly worktreeId?: string | null;
+}
+
+export interface LaunchClaudeCodeTerminalResult {
+    readonly commandWritten: boolean;
+    readonly terminalId: string | null;
+    readonly terminalTabId: string | null;
+    readonly transcriptSessionId: string | null;
+}
+
+export interface ClaudeCodeTerminalSidebarItem {
+    readonly cwd: string;
+    readonly projectId: string | null;
+    readonly terminalId: string;
+    readonly terminalTabId: string;
+    readonly title: string;
+    readonly transcriptSessionId: string | null;
+    readonly worktreeId: string | null;
+}
+
+const sidebarItemsByTerminalId = new Map<
+    string,
+    ClaudeCodeTerminalSidebarItem
+>();
 
 export async function checkClaudeCodeInstalled(): Promise<boolean> {
     if (claudeCodeInstalledCache !== null) {
@@ -18,6 +62,302 @@ export async function checkClaudeCodeInstalled(): Promise<boolean> {
 
 export function resetClaudeCodeInstalledCacheForTests(): void {
     claudeCodeInstalledCache = null;
+}
+
+export async function launchClaudeCodeTerminal(
+    input: LaunchClaudeCodeTerminalInput,
+): Promise<LaunchClaudeCodeTerminalResult> {
+    const title = getNextClaudeCodeTerminalTitle(
+        Object.values(useWorkspaceStore.getState().tabsById),
+    );
+    const terminalTabId = await useWorkspaceStore
+        .getState()
+        .createTerminalTab(input.projectId, input.worktreeId ?? null, {
+            paneId: input.paneId ?? null,
+            title,
+        });
+
+    if (!terminalTabId) {
+        return createLaunchResult(null, null, null, false);
+    }
+
+    const terminalTab = useWorkspaceStore.getState().tabsById[terminalTabId];
+    if (!terminalTab || terminalTab.kind !== "terminal") {
+        return createLaunchResult(terminalTabId, null, null, false);
+    }
+
+    const terminalId = terminalTab.terminalId;
+    const running = await waitForTerminalRunning(
+        terminalId,
+        input.timeoutMs ?? DEFAULT_TERMINAL_RUNNING_TIMEOUT_MS,
+    );
+    if (!running) {
+        return createLaunchResult(terminalTabId, terminalId, null, false);
+    }
+
+    const runtime =
+        useTerminalRuntimeStore.getState().runtimesById[terminalId] ?? null;
+    const terminalSettings =
+        useSettingsStore.getState().terminal ?? DEFAULT_APP_TERMINAL_SETTINGS;
+    const transcriptSessionId = getPinnedTranscriptSessionId(
+        terminalSettings.claudeCodeContinueSession,
+    );
+    const command = buildShellCommand(
+        buildClaudeCodeCommandArgs({
+            continueSession: terminalSettings.claudeCodeContinueSession,
+            maxTurns: terminalSettings.claudeCodeMaxTurns,
+            model: terminalSettings.claudeCodeModel,
+            skipPermissions: terminalSettings.claudeCodeSkipPermissions,
+            transcriptSessionId,
+        }),
+    );
+
+    registerClaudeCodeTerminalSidebarItem({
+        cwd: runtime?.snapshot.cwd ?? "",
+        projectId: terminalTab.projectId,
+        terminalId,
+        terminalTabId,
+        title,
+        transcriptSessionId,
+        worktreeId: terminalTab.worktreeId ?? null,
+    });
+    applyClaudeCodeTerminalSessionSnapshot({
+        cwd: runtime?.snapshot.cwd ?? "",
+        projectId: terminalTab.projectId,
+        sessionId: transcriptSessionId ?? terminalId,
+        title,
+        transcriptSessionId,
+        worktreeId: terminalTab.worktreeId ?? null,
+    });
+
+    await useTerminalRuntimeStore.getState().writeInput(terminalId, command);
+
+    return createLaunchResult(
+        terminalTabId,
+        terminalId,
+        transcriptSessionId,
+        true,
+    );
+}
+
+export function buildShellCommand(args: readonly string[]): string {
+    if (args.length === 0) {
+        throw new Error("Expected at least one command token.");
+    }
+
+    for (const arg of args) {
+        if (!SAFE_SHELL_TOKEN_PATTERN.test(arg)) {
+            throw new Error(`Unsafe shell token: ${arg}`);
+        }
+    }
+
+    return `${args.join(" ")}\n`;
+}
+
+export function getSafeClaudeCodeModel(model: string): string | null {
+    const normalized = model.trim();
+    if (!normalized) {
+        return null;
+    }
+    if (
+        ALLOWED_CLAUDE_CODE_MODELS.includes(
+            normalized as (typeof ALLOWED_CLAUDE_CODE_MODELS)[number],
+        )
+    ) {
+        return normalized;
+    }
+
+    console.warn("[claude-code-terminal] Ignoring unsafe Claude Code model.");
+    return null;
+}
+
+export function getNextClaudeCodeTerminalTitle(
+    tabs: readonly RuntimeWorkspaceTab[],
+): string {
+    let maxValue = 0;
+    for (const tab of tabs) {
+        if (tab.kind !== "terminal") {
+            continue;
+        }
+        const match = CLAUDE_CODE_TITLE_PATTERN.exec(tab.title.trim());
+        if (!match) {
+            continue;
+        }
+        const value = match[1] ? Number.parseInt(match[1], 10) : 1;
+        if (Number.isFinite(value)) {
+            maxValue = Math.max(maxValue, value);
+        }
+    }
+
+    return `Claude Code ${maxValue + 1}`;
+}
+
+export function getPinnedTranscriptSessionId(
+    continueSession: boolean,
+): string | null {
+    return continueSession ? null : createUuid();
+}
+
+export function getClaudeCodeTerminalSidebarItemsForTests(): readonly ClaudeCodeTerminalSidebarItem[] {
+    return [...sidebarItemsByTerminalId.values()];
+}
+
+export function resetClaudeCodeTerminalStateForTests(): void {
+    claudeCodeInstalledCache = null;
+    sidebarItemsByTerminalId.clear();
+}
+
+interface BuildClaudeCodeCommandArgsInput {
+    readonly continueSession: boolean;
+    readonly maxTurns: number;
+    readonly model: string;
+    readonly skipPermissions: boolean;
+    readonly transcriptSessionId: string | null;
+}
+
+function buildClaudeCodeCommandArgs({
+    continueSession,
+    maxTurns,
+    model,
+    skipPermissions,
+    transcriptSessionId,
+}: BuildClaudeCodeCommandArgsInput): readonly string[] {
+    const args = ["claude"];
+    if (skipPermissions) {
+        args.push("--dangerously-skip-permissions");
+    }
+    if (transcriptSessionId) {
+        args.push("--session-id", transcriptSessionId);
+    }
+    const safeModel = getSafeClaudeCodeModel(model);
+    if (safeModel) {
+        args.push("--model", safeModel);
+    }
+    if (continueSession) {
+        args.push("--continue");
+    }
+    const safeMaxTurns = Math.max(0, Math.floor(maxTurns));
+    if (safeMaxTurns > 0) {
+        args.push("--max-turns", String(safeMaxTurns));
+    }
+    return args;
+}
+
+function waitForTerminalRunning(
+    terminalId: string,
+    timeoutMs = DEFAULT_TERMINAL_RUNNING_TIMEOUT_MS,
+): Promise<boolean> {
+    if (isTerminalRunning(terminalId)) {
+        return Promise.resolve(true);
+    }
+    if (timeoutMs <= 0) {
+        return Promise.resolve(false);
+    }
+
+    return new Promise((resolve) => {
+        let settled = false;
+        let unsubscribe: (() => void) | null = null;
+        const cleanup = (value: boolean) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            unsubscribe?.();
+            clearTimeout(timeout);
+            resolve(value);
+        };
+        const timeout = setTimeout(() => cleanup(false), timeoutMs);
+
+        unsubscribe = useTerminalRuntimeStore.subscribe((state) => {
+            if (state.runtimesById[terminalId]?.snapshot.status === "running") {
+                cleanup(true);
+            }
+        });
+    });
+}
+
+function isTerminalRunning(terminalId: string): boolean {
+    return (
+        useTerminalRuntimeStore.getState().runtimesById[terminalId]?.snapshot
+            .status === "running"
+    );
+}
+
+function registerClaudeCodeTerminalSidebarItem(
+    item: ClaudeCodeTerminalSidebarItem,
+): void {
+    sidebarItemsByTerminalId.set(item.terminalId, item);
+}
+
+function applyClaudeCodeTerminalSessionSnapshot(input: {
+    readonly cwd: string;
+    readonly projectId: string | null;
+    readonly sessionId: string;
+    readonly title: string;
+    readonly transcriptSessionId: string | null;
+    readonly worktreeId: string | null;
+}): void {
+    useAiStore.getState().applySessionSnapshot(
+        createClaudeCodeTerminalSessionSnapshot(input),
+    );
+}
+
+function createClaudeCodeTerminalSessionSnapshot(input: {
+    readonly cwd: string;
+    readonly projectId: string | null;
+    readonly sessionId: string;
+    readonly title: string;
+    readonly transcriptSessionId: string | null;
+    readonly worktreeId: string | null;
+}): AiSessionSnapshot {
+    const now = new Date().toISOString();
+    return {
+        activeTurnStartedAt: null,
+        availableCommands: [],
+        closedAt: null,
+        configOptions: [],
+        lastError: null,
+        messages: [],
+        modeId: null,
+        modes: [],
+        modelId: null,
+        models: [],
+        pendingPermission: null,
+        pendingUserInput: null,
+        plan: null,
+        projectId: input.projectId,
+        runtimeId: "claude",
+        runtimeSessionId: input.transcriptSessionId,
+        sessionId: input.sessionId,
+        status: "idle",
+        title: input.title,
+        tokenUsage: null,
+        toolActivity: [],
+        trackedFiles: [],
+        updatedAt: now,
+        worktreeId: input.worktreeId,
+    };
+}
+
+function createLaunchResult(
+    terminalTabId: string | null,
+    terminalId: string | null,
+    transcriptSessionId: string | null,
+    commandWritten: boolean,
+): LaunchClaudeCodeTerminalResult {
+    return {
+        commandWritten,
+        terminalId,
+        terminalTabId,
+        transcriptSessionId,
+    };
+}
+
+function createUuid(): string {
+    return (
+        globalThis.crypto?.randomUUID?.() ??
+        "00000000-0000-4000-8000-000000000000"
+    );
 }
 
 function getComandoApi() {

--- a/src/renderer/src/features/terminal/claudeCodeTerminal.ts
+++ b/src/renderer/src/features/terminal/claudeCodeTerminal.ts
@@ -1,0 +1,32 @@
+let claudeCodeInstalledCache: boolean | null = null;
+
+export async function checkClaudeCodeInstalled(): Promise<boolean> {
+    if (claudeCodeInstalledCache !== null) {
+        return claudeCodeInstalledCache;
+    }
+
+    try {
+        const api = getComandoApi();
+        const result = await api.checkCommandAvailability({ name: "claude" });
+        claudeCodeInstalledCache = result.found;
+    } catch {
+        claudeCodeInstalledCache = false;
+    }
+
+    return claudeCodeInstalledCache;
+}
+
+export function resetClaudeCodeInstalledCacheForTests(): void {
+    claudeCodeInstalledCache = null;
+}
+
+function getComandoApi() {
+    const comandoWindow = globalThis.window;
+    if (!comandoWindow?.comando) {
+        throw new Error(
+            "The desktop bridge is not available yet. Restart the Electron app and try again.",
+        );
+    }
+
+    return comandoWindow.comando;
+}

--- a/src/renderer/src/features/terminal/claudeCodeTerminal.ts
+++ b/src/renderer/src/features/terminal/claudeCodeTerminal.ts
@@ -93,7 +93,6 @@ export async function launchClaudeCodeTerminal(
     const command = buildShellCommand(
         buildClaudeCodeCommandArgs({
             continueSession: terminalSettings.claudeCodeContinueSession,
-            maxTurns: terminalSettings.claudeCodeMaxTurns,
             model: terminalSettings.claudeCodeModel,
             skipPermissions: terminalSettings.claudeCodeSkipPermissions,
             transcriptSessionId,
@@ -189,7 +188,6 @@ export function resetClaudeCodeTerminalStateForTests(): void {
 
 interface BuildClaudeCodeCommandArgsInput {
     readonly continueSession: boolean;
-    readonly maxTurns: number;
     readonly model: string;
     readonly skipPermissions: boolean;
     readonly transcriptSessionId: string | null;
@@ -197,7 +195,6 @@ interface BuildClaudeCodeCommandArgsInput {
 
 function buildClaudeCodeCommandArgs({
     continueSession,
-    maxTurns,
     model,
     skipPermissions,
     transcriptSessionId,
@@ -215,10 +212,6 @@ function buildClaudeCodeCommandArgs({
     }
     if (continueSession) {
         args.push("--continue");
-    }
-    const safeMaxTurns = Math.max(0, Math.floor(maxTurns));
-    if (safeMaxTurns > 0) {
-        args.push("--max-turns", String(safeMaxTurns));
     }
     return args;
 }

--- a/src/renderer/src/features/terminal/terminalRuntimeStore.test.ts
+++ b/src/renderer/src/features/terminal/terminalRuntimeStore.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TerminalSession } from "@shared/ipc";
+import { DEFAULT_APP_TERMINAL_SETTINGS } from "@shared/terminal-settings";
+import { useSettingsStore } from "@renderer/app/store/settings-store";
 import type { RuntimeWorkspaceTerminalTab } from "@renderer/app/workspace/tree";
 
 import {
@@ -67,6 +69,9 @@ describe("terminalRuntimeStore", () => {
         writeTerminalInputMock.mockClear();
         resizeTerminalSessionMock.mockClear();
         closeTerminalSessionMock.mockClear();
+        useSettingsStore.setState({
+            terminal: DEFAULT_APP_TERMINAL_SETTINGS,
+        });
 
         Object.defineProperty(globalThis, "window", {
             configurable: true,
@@ -115,6 +120,32 @@ describe("terminalRuntimeStore", () => {
         expect(writeTerminalInputMock).toHaveBeenCalledWith({
             data: "pwd\r",
             sessionId: "live-session-1",
+        });
+    });
+
+    it("passes the Claude Code no-flicker env flag for optimized terminals", async () => {
+        useSettingsStore.setState({
+            terminal: {
+                ...DEFAULT_APP_TERMINAL_SETTINGS,
+                claudeCodeOptimized: true,
+            },
+        });
+        createTerminalSessionMock.mockResolvedValueOnce(
+            createSession("live-session-1"),
+        );
+
+        useTerminalRuntimeStore.getState().ensureTerminal(createTerminalTab());
+        await flushPromises();
+
+        expect(createTerminalSessionMock).toHaveBeenCalledWith({
+            cols: 120,
+            extraEnv: {
+                CLAUDE_CODE_NO_FLICKER: "1",
+            },
+            projectId: "project-1",
+            rows: 24,
+            terminalId: "terminal-1",
+            worktreeId: "worktree-1",
         });
     });
 

--- a/src/renderer/src/features/terminal/terminalRuntimeStore.ts
+++ b/src/renderer/src/features/terminal/terminalRuntimeStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 import type { TerminalSession } from "@shared/ipc";
+import { useSettingsStore } from "@renderer/app/store/settings-store";
 import type { RuntimeWorkspaceTerminalTab } from "@renderer/app/workspace/tree";
 
 import {
@@ -303,9 +304,10 @@ async function createSessionForTerminal(
     const requestVersion = allocateSessionVersion(terminalId);
 
     try {
+        const extraEnv = buildTerminalSessionExtraEnv(input.extraEnv);
         const nextSession = await getComandoApi().createTerminalSession({
             cols: input.cols,
-            extraEnv: input.extraEnv,
+            extraEnv,
             projectId: input.projectId,
             rows: input.rows,
             terminalId: input.terminalId ?? terminalId,
@@ -396,6 +398,20 @@ async function createSessionForTerminal(
         });
         return null;
     }
+}
+
+function buildTerminalSessionExtraEnv(
+    inputExtraEnv: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+    const { claudeCodeOptimized } = useSettingsStore.getState().terminal;
+    if (!claudeCodeOptimized) {
+        return inputExtraEnv;
+    }
+
+    return {
+        CLAUDE_CODE_NO_FLICKER: "1",
+        ...inputExtraEnv,
+    };
 }
 
 function updateRuntimeBySessionId(

--- a/src/renderer/src/features/terminal/terminalTheme.test.ts
+++ b/src/renderer/src/features/terminal/terminalTheme.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getTerminalTheme } from "./terminalTheme";
+
+const FALLBACK_FONT_STACK =
+    '"SF Mono", "SFMono-Regular", "JetBrains Mono", "Cascadia Code", Menlo, Monaco, Consolas, monospace';
+
+function stubStyleEnvironment(
+    values: Record<string, string> = {},
+): void {
+    const documentElement = {};
+    vi.stubGlobal("document", { documentElement });
+    vi.stubGlobal("window", {
+        getComputedStyle: () => ({
+            getPropertyValue: (name: string) => values[name] ?? "",
+        }),
+    });
+}
+
+describe("getTerminalTheme", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("uses the fallback terminal font when the configured font is empty", () => {
+        stubStyleEnvironment();
+
+        expect(getTerminalTheme(null, { fontFamily: "", fontSize: 16 }))
+            .toMatchObject({
+                fontFamily: FALLBACK_FONT_STACK,
+                fontSize: 16,
+            });
+    });
+
+    it("uses configured terminal font settings", () => {
+        stubStyleEnvironment({
+            "--color-accent": "#abcdef",
+            "--color-editor": "#101010",
+        });
+
+        expect(
+            getTerminalTheme(null, {
+                fontFamily: "FiraCode Nerd Font",
+                fontSize: 18,
+            }),
+        ).toMatchObject({
+            accent: "#abcdef",
+            background: "#101010",
+            fontFamily: "FiraCode Nerd Font",
+            fontSize: 18,
+        });
+    });
+});

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -22,6 +22,7 @@ export const IPC_CHANNELS = {
     openGeneratedImage: "app:open-generated-image",
     revealGeneratedImage: "app:reveal-generated-image",
     openProjectWindow: "app:open-project-window",
+    checkCommandAvailability: "app:check-command-availability",
     getSettingsSnapshot: "settings:get-snapshot",
     getProjectSettings: "settings:get-project-settings",
     saveCodexRuntimeSettings: "settings:save-codex-runtime-settings",
@@ -284,6 +285,15 @@ export interface PersistedShellState {
         | "agents"
         | "issues"
         | "pull_requests";
+}
+
+export interface CheckCommandAvailabilityInput {
+    readonly name: string;
+}
+
+export interface CheckCommandAvailabilityResult {
+    readonly found: boolean;
+    readonly path: string | null;
 }
 
 export type AiRuntimeId =
@@ -2695,6 +2705,9 @@ export interface ComandoApi {
     openGeneratedImage: (path: string) => Promise<void>;
     revealGeneratedImage: (path: string) => Promise<void>;
     openProjectWindow: (input: OpenProjectWindowInput) => Promise<void>;
+    checkCommandAvailability: (
+        input: CheckCommandAvailabilityInput,
+    ) => Promise<CheckCommandAvailabilityResult>;
     getSettingsSnapshot: () => Promise<SettingsSnapshot>;
     getProjectSettings: (
         projectId: string,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -23,6 +23,7 @@ export const IPC_CHANNELS = {
     revealGeneratedImage: "app:reveal-generated-image",
     openProjectWindow: "app:open-project-window",
     checkCommandAvailability: "app:check-command-availability",
+    readClaudeCodeTranscript: "app:read-claude-code-transcript",
     getSettingsSnapshot: "settings:get-snapshot",
     getProjectSettings: "settings:get-project-settings",
     saveCodexRuntimeSettings: "settings:save-codex-runtime-settings",
@@ -294,6 +295,20 @@ export interface CheckCommandAvailabilityInput {
 export interface CheckCommandAvailabilityResult {
     readonly found: boolean;
     readonly path: string | null;
+}
+
+export interface ReadClaudeCodeTranscriptInput {
+    readonly cwd: string;
+    readonly sessionId: string;
+    readonly sinceMtimeMs?: number | null;
+}
+
+export interface ReadClaudeCodeTranscriptResult {
+    readonly changed: boolean;
+    readonly found: boolean;
+    readonly mtimeMs: number | null;
+    readonly preview: string | null;
+    readonly title: string | null;
 }
 
 export type AiRuntimeId =
@@ -2708,6 +2723,9 @@ export interface ComandoApi {
     checkCommandAvailability: (
         input: CheckCommandAvailabilityInput,
     ) => Promise<CheckCommandAvailabilityResult>;
+    readClaudeCodeTranscript: (
+        input: ReadClaudeCodeTranscriptInput,
+    ) => Promise<ReadClaudeCodeTranscriptResult>;
     getSettingsSnapshot: () => Promise<SettingsSnapshot>;
     getProjectSettings: (
         projectId: string,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,6 +1,8 @@
 import type { AppIdentity } from "@shared/app-identity";
+import type { AppTerminalSettings } from "./terminal-settings";
 import type { ChatFontFamily, EditorFontFamily } from "./typography";
 
+export type { AppTerminalSettings } from "./terminal-settings";
 export type { ChatFontFamily, EditorFontFamily } from "./typography";
 
 export const IPC_CHANNELS = {
@@ -559,6 +561,7 @@ export interface SettingsSnapshot {
     readonly appearance?: AppAppearanceSettings | null;
     readonly editor?: AppEditorSettings | null;
     readonly shellState: PersistedShellState | null;
+    readonly terminal?: AppTerminalSettings | null;
 }
 
 export interface ProjectSettingsSnapshot {
@@ -568,8 +571,10 @@ export interface ProjectSettingsSnapshot {
 }
 
 export interface SettingsUpdatedEvent {
+    readonly aiChat: AppAiChatSettings | null;
     readonly appearance: AppAppearanceSettings | null;
     readonly editor: AppEditorSettings | null;
+    readonly terminal: AppTerminalSettings | null;
 }
 
 export type AppUpdateStatus =

--- a/src/shared/terminal-settings.test.ts
+++ b/src/shared/terminal-settings.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    CLAUDE_CODE_MAX_TURNS_STORAGE_MAX,
+    CLAUDE_CODE_MAX_TURNS_UI_MAX,
+    DEFAULT_APP_TERMINAL_SETTINGS,
+    TERMINAL_FONT_FAMILY_MAX_LENGTH,
+    TERMINAL_FONT_SIZE_DEFAULT,
+    TERMINAL_FONT_SIZE_MAX,
+    TERMINAL_FONT_SIZE_MIN,
+    normalizeAppTerminalSettings,
+    normalizeClaudeCodeMaxTurns,
+    normalizeClaudeCodeModel,
+    normalizeTerminalFontFamily,
+    normalizeTerminalFontSize,
+} from "./terminal-settings";
+
+describe("normalizeTerminalFontFamily", () => {
+    it("returns an empty string for non-string values", () => {
+        expect(normalizeTerminalFontFamily(null)).toBe("");
+        expect(normalizeTerminalFontFamily(13)).toBe("");
+    });
+
+    it("removes line breaks while preserving spaces, quotes, and commas", () => {
+        expect(
+            normalizeTerminalFontFamily(
+                '  "FiraCode Nerd Font", Menlo\r\nmonospace  ',
+            ),
+        ).toBe('"FiraCode Nerd Font", Menlo monospace');
+    });
+
+    it("limits the persisted length", () => {
+        expect(normalizeTerminalFontFamily("a".repeat(200))).toHaveLength(
+            TERMINAL_FONT_FAMILY_MAX_LENGTH,
+        );
+    });
+});
+
+describe("normalizeTerminalFontSize", () => {
+    it("returns the default for corrupt values", () => {
+        expect(normalizeTerminalFontSize("")).toBe(TERMINAL_FONT_SIZE_DEFAULT);
+        expect(normalizeTerminalFontSize(Number.NaN)).toBe(
+            TERMINAL_FONT_SIZE_DEFAULT,
+        );
+    });
+
+    it("rounds and clamps values to the terminal font range", () => {
+        expect(normalizeTerminalFontSize(7)).toBe(TERMINAL_FONT_SIZE_MIN);
+        expect(normalizeTerminalFontSize(25)).toBe(TERMINAL_FONT_SIZE_MAX);
+        expect(normalizeTerminalFontSize(14.6)).toBe(15);
+    });
+
+    it("accepts numeric strings from persisted settings", () => {
+        expect(normalizeTerminalFontSize("16")).toBe(16);
+    });
+});
+
+describe("normalizeClaudeCodeModel", () => {
+    it("allows the empty default model", () => {
+        expect(normalizeClaudeCodeModel("")).toBe("");
+    });
+
+    it("allows only known Claude Code models", () => {
+        expect(normalizeClaudeCodeModel("claude-opus-4-7")).toBe(
+            "claude-opus-4-7",
+        );
+        expect(normalizeClaudeCodeModel(" claude-sonnet-4-6 ")).toBe(
+            "claude-sonnet-4-6",
+        );
+    });
+
+    it("returns the default for unknown or unsafe values", () => {
+        expect(normalizeClaudeCodeModel("claude-opus-4-7; rm -rf /")).toBe("");
+        expect(normalizeClaudeCodeModel("not-a-model")).toBe("");
+        expect(normalizeClaudeCodeModel(null)).toBe("");
+    });
+});
+
+describe("normalizeClaudeCodeMaxTurns", () => {
+    it("returns the default for corrupt values", () => {
+        expect(normalizeClaudeCodeMaxTurns("")).toBe(0);
+        expect(normalizeClaudeCodeMaxTurns(Number.POSITIVE_INFINITY)).toBe(0);
+    });
+
+    it("rounds and clamps to the storage range by default", () => {
+        expect(normalizeClaudeCodeMaxTurns(-1)).toBe(0);
+        expect(normalizeClaudeCodeMaxTurns(42.5)).toBe(43);
+        expect(normalizeClaudeCodeMaxTurns(5000)).toBe(
+            CLAUDE_CODE_MAX_TURNS_STORAGE_MAX,
+        );
+    });
+
+    it("supports a lower UI max when requested", () => {
+        expect(normalizeClaudeCodeMaxTurns(500, CLAUDE_CODE_MAX_TURNS_UI_MAX))
+            .toBe(CLAUDE_CODE_MAX_TURNS_UI_MAX);
+    });
+});
+
+describe("normalizeAppTerminalSettings", () => {
+    it("returns defaults when settings are missing", () => {
+        expect(normalizeAppTerminalSettings(null)).toEqual(
+            DEFAULT_APP_TERMINAL_SETTINGS,
+        );
+        expect(normalizeAppTerminalSettings(undefined)).toEqual(
+            DEFAULT_APP_TERMINAL_SETTINGS,
+        );
+    });
+
+    it("normalizes a complete settings object", () => {
+        expect(
+            normalizeAppTerminalSettings({
+                claudeCodeContinueSession: true,
+                claudeCodeMaxTurns: 3000,
+                claudeCodeModel: "claude-haiku-4-5",
+                claudeCodeOptimized: true,
+                claudeCodeSkipPermissions: true,
+                terminalFontFamily: " FiraCode Nerd Font ",
+                terminalFontSize: 20,
+            }),
+        ).toEqual({
+            claudeCodeContinueSession: true,
+            claudeCodeMaxTurns: CLAUDE_CODE_MAX_TURNS_STORAGE_MAX,
+            claudeCodeModel: "claude-haiku-4-5",
+            claudeCodeOptimized: true,
+            claudeCodeSkipPermissions: true,
+            terminalFontFamily: "FiraCode Nerd Font",
+            terminalFontSize: 20,
+        });
+    });
+
+    it("falls back defensively for unsafe persisted values", () => {
+        expect(
+            normalizeAppTerminalSettings({
+                claudeCodeContinueSession: false,
+                claudeCodeMaxTurns: "bad" as unknown as number,
+                claudeCodeModel: "`claude-opus-4-7`",
+                claudeCodeOptimized: false,
+                claudeCodeSkipPermissions: false,
+                terminalFontFamily: 12 as unknown as string,
+                terminalFontSize: "large" as unknown as number,
+            }),
+        ).toEqual(DEFAULT_APP_TERMINAL_SETTINGS);
+    });
+});

--- a/src/shared/terminal-settings.ts
+++ b/src/shared/terminal-settings.ts
@@ -59,6 +59,10 @@ export const DEFAULT_APP_TERMINAL_SETTINGS: AppTerminalSettings = {
     terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
 };
 
+export type AppTerminalSettingsInput = {
+    readonly [Key in keyof AppTerminalSettings]?: unknown;
+};
+
 function isAllowedClaudeCodeModel(
     value: string,
 ): value is ClaudeCodeModel {
@@ -136,7 +140,7 @@ export function normalizeClaudeCodeMaxTurns(
 }
 
 export function normalizeAppTerminalSettings(
-    value: Partial<AppTerminalSettings> | null | undefined,
+    value: AppTerminalSettingsInput | null | undefined,
 ): AppTerminalSettings {
     return {
         claudeCodeContinueSession:

--- a/src/shared/terminal-settings.ts
+++ b/src/shared/terminal-settings.ts
@@ -1,0 +1,156 @@
+export const TERMINAL_FONT_SIZE_MIN = 8;
+export const TERMINAL_FONT_SIZE_MAX = 24;
+export const TERMINAL_FONT_SIZE_DEFAULT = 13;
+export const TERMINAL_FONT_FAMILY_MAX_LENGTH = 160;
+
+export const CLAUDE_CODE_MAX_TURNS_MIN = 0;
+export const CLAUDE_CODE_MAX_TURNS_UI_MAX = 200;
+export const CLAUDE_CODE_MAX_TURNS_STORAGE_MAX = 1000;
+
+export const ALLOWED_CLAUDE_CODE_MODELS = [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+] as const;
+
+export type ClaudeCodeModel = (typeof ALLOWED_CLAUDE_CODE_MODELS)[number];
+
+export interface ClaudeCodeModelOption {
+    readonly value: "" | ClaudeCodeModel;
+    readonly label: string;
+}
+
+export const CLAUDE_CODE_MODEL_OPTIONS: readonly ClaudeCodeModelOption[] = [
+    {
+        label: "Default (Claude Code decides)",
+        value: "",
+    },
+    {
+        label: "Opus 4.7 - most capable",
+        value: "claude-opus-4-7",
+    },
+    {
+        label: "Sonnet 4.6 - balanced",
+        value: "claude-sonnet-4-6",
+    },
+    {
+        label: "Haiku 4.5 - fast",
+        value: "claude-haiku-4-5",
+    },
+];
+
+export interface AppTerminalSettings {
+    readonly terminalFontFamily: string;
+    readonly terminalFontSize: number;
+    readonly claudeCodeOptimized: boolean;
+    readonly claudeCodeSkipPermissions: boolean;
+    readonly claudeCodeModel: string;
+    readonly claudeCodeContinueSession: boolean;
+    readonly claudeCodeMaxTurns: number;
+}
+
+export const DEFAULT_APP_TERMINAL_SETTINGS: AppTerminalSettings = {
+    claudeCodeContinueSession: false,
+    claudeCodeMaxTurns: 0,
+    claudeCodeModel: "",
+    claudeCodeOptimized: false,
+    claudeCodeSkipPermissions: false,
+    terminalFontFamily: "",
+    terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
+};
+
+function isAllowedClaudeCodeModel(
+    value: string,
+): value is ClaudeCodeModel {
+    return ALLOWED_CLAUDE_CODE_MODELS.includes(value as ClaudeCodeModel);
+}
+
+function normalizeNumber(value: unknown): number | null {
+    if (typeof value === "number") {
+        return Number.isFinite(value) ? value : null;
+    }
+
+    if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return null;
+        }
+        const parsed = Number(trimmed);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    return null;
+}
+
+function clampInteger(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+export function normalizeTerminalFontFamily(value: unknown): string {
+    if (typeof value !== "string") {
+        return "";
+    }
+
+    return value
+        .replace(/[\r\n]+/g, " ")
+        .trim()
+        .slice(0, TERMINAL_FONT_FAMILY_MAX_LENGTH);
+}
+
+export function normalizeTerminalFontSize(value: unknown): number {
+    const normalizedValue = normalizeNumber(value);
+    if (normalizedValue === null) {
+        return TERMINAL_FONT_SIZE_DEFAULT;
+    }
+
+    return clampInteger(
+        normalizedValue,
+        TERMINAL_FONT_SIZE_MIN,
+        TERMINAL_FONT_SIZE_MAX,
+    );
+}
+
+export function normalizeClaudeCodeModel(value: unknown): string {
+    if (typeof value !== "string") {
+        return "";
+    }
+
+    const trimmed = value.trim();
+    return trimmed === "" || isAllowedClaudeCodeModel(trimmed) ? trimmed : "";
+}
+
+export function normalizeClaudeCodeMaxTurns(
+    value: unknown,
+    max = CLAUDE_CODE_MAX_TURNS_STORAGE_MAX,
+): number {
+    const normalizedValue = normalizeNumber(value);
+    if (normalizedValue === null) {
+        return DEFAULT_APP_TERMINAL_SETTINGS.claudeCodeMaxTurns;
+    }
+
+    return clampInteger(
+        normalizedValue,
+        CLAUDE_CODE_MAX_TURNS_MIN,
+        Math.max(CLAUDE_CODE_MAX_TURNS_MIN, Math.round(max)),
+    );
+}
+
+export function normalizeAppTerminalSettings(
+    value: Partial<AppTerminalSettings> | null | undefined,
+): AppTerminalSettings {
+    return {
+        claudeCodeContinueSession:
+            value?.claudeCodeContinueSession === true,
+        claudeCodeMaxTurns: normalizeClaudeCodeMaxTurns(
+            value?.claudeCodeMaxTurns,
+        ),
+        claudeCodeModel: normalizeClaudeCodeModel(value?.claudeCodeModel),
+        claudeCodeOptimized: value?.claudeCodeOptimized === true,
+        claudeCodeSkipPermissions:
+            value?.claudeCodeSkipPermissions === true,
+        terminalFontFamily: normalizeTerminalFontFamily(
+            value?.terminalFontFamily,
+        ),
+        terminalFontSize: normalizeTerminalFontSize(value?.terminalFontSize),
+    };
+}


### PR DESCRIPTION
## Summary

- Add terminal settings for font controls and Claude Code launch options.
- Add a Claude Code terminal launcher with sidebar session tracking and transcript-derived titles/previews.
- Add command availability and transcript IPC support.
- Apply terminal fullscreen rendering through `CLAUDE_CODE_NO_FLICKER=1` for newly created terminal sessions when enabled.
- Avoid passing `--max-turns` to interactive Claude Code sessions because that flag is for print-mode runs.

## Validation

- `pnpm run typecheck`
- Focused Vitest suite: 16 files, 127 tests
- `git diff --check`