### PR TITLE
Add Grok ACP runtime support

### DIFF
--- a/src/main/ai/ACP.md
+++ b/src/main/ai/ACP.md
@@ -1,27 +1,28 @@
 # ACP (Agent Client Protocol) — Architecture Reference
 
-Comando currently integrates five AI runtimes through the Agent Client Protocol:
+Comando currently integrates six AI runtimes through the Agent Client Protocol:
 
 - **Claude**
 - **Codex**
 - **Gemini**
+- **Grok**
 - **Kilo**
 - **OpenCode**
 
-All five communicate with the app over ACP / JSON-RPC on stdio.
+All six communicate with the app over ACP / JSON-RPC on stdio.
 
 ---
 
 ## Runtimes at a Glance
 
-| | Claude | Codex | Gemini | Kilo | OpenCode |
-|---|---|---|---|---|---|
-| **Source** | TypeScript (`@agentclientprotocol/claude-agent-acp` `0.37.0`, vendored upstream snapshot) | Rust (`codex-acp` `0.15.0`, vendored on top of `openai/codex` `rust-v0.133.0` + local patches) | External Gemini CLI binary | External Kilo CLI binary | External OpenCode CLI binary |
-| **Runtime command** | `node .../claude-agent-acp/dist/index.js` or `claude-agent-acp` | `codex-acp` | `gemini --acp` | `kilo acp` | `opencode acp` |
-| **Release packaging** | Embedded Node runtime + embedded vendor JS project | Bundled native binary under `resources/ai/binaries/` | Not bundled today | Not bundled today | Not bundled today |
-| **Auth methods exposed by Comando** | `claude-ai-login`, `claude-login`, `console-login`, `gateway` | `chatgpt`, `codex-api-key`, `openai-api-key` | `login_with_google`, `use_gemini` | `kilo-login` | `opencode-login` |
-| **Runtime discovery** | env, settings, vendor JS, embedded bundle, PATH fallback | env, settings, bundled binary, embedded target cache, legacy vendor target cache, PATH fallback | env, settings, PATH | env, settings, PATH | env, settings, PATH |
-| **Notes** | Debug builds prefer vendored JS directly. Gateway auth is supported. | Detects and rejects plain `codex` CLI because current integration still expects ACP. | Login readiness is inferred from `~/.gemini/settings.json`. | Login readiness is inferred from system-level Kilo auth stores (`XDG_DATA_HOME`, `LOCALAPPDATA`, `~/.local/share`). | Auth is owned by the OpenCode CLI. Comando treats `OPENCODE_API_KEY`, `auth.json`, and selected external auth as valid setup signals without storing OpenCode secrets. |
+| | Claude | Codex | Gemini | Grok | Kilo | OpenCode |
+|---|---|---|---|---|---|---|
+| **Source** | TypeScript (`@agentclientprotocol/claude-agent-acp` `0.37.0`, vendored upstream snapshot) | Rust (`codex-acp` `0.15.0`, vendored on top of `openai/codex` `rust-v0.133.0` + local patches) | External Gemini CLI binary | External Grok CLI binary | External Kilo CLI binary | External OpenCode CLI binary |
+| **Runtime command** | `node .../claude-agent-acp/dist/index.js` or `claude-agent-acp` | `codex-acp` | `gemini --acp` | `grok --no-auto-update agent stdio` | `kilo acp` | `opencode acp` |
+| **Release packaging** | Embedded Node runtime + embedded vendor JS project | Bundled native binary under `resources/ai/binaries/` | Not bundled today | Not bundled today | Not bundled today | Not bundled today |
+| **Auth methods exposed by Comando** | `claude-ai-login`, `claude-login`, `console-login`, `gateway` | `chatgpt`, `codex-api-key`, `openai-api-key` | `login_with_google`, `use_gemini` | `grok-login`, `xai-api-key` | `kilo-login` | `opencode-login` |
+| **Runtime discovery** | env, settings, vendor JS, embedded bundle, PATH fallback | env, settings, bundled binary, embedded target cache, legacy vendor target cache, PATH fallback | env, settings, PATH | env, settings, PATH, macOS Homebrew fallbacks | env, settings, PATH | env, settings, PATH |
+| **Notes** | Debug builds prefer vendored JS directly. Gateway auth is supported. | Detects and rejects plain `codex` CLI because current integration still expects ACP. | Login readiness is inferred from `~/.gemini/settings.json`. | API-key auth uses `XAI_API_KEY`; login readiness is inferred from Grok's external CLI auth store under `~/.grok/auth`. | Login readiness is inferred from system-level Kilo auth stores (`XDG_DATA_HOME`, `LOCALAPPDATA`, `~/.local/share`). | Auth is owned by the OpenCode CLI. Comando treats `OPENCODE_API_KEY`, `auth.json`, and selected external auth as valid setup signals without storing OpenCode secrets. |
 
 Notes:
 
@@ -32,7 +33,7 @@ Notes:
 - The vendored Codex ACP snapshot currently includes a local Fast Mode patch carried over into Comando. It exposes the ACP session config option `service_tier`, the `/fast` slash command, and rehydrates `service_tier` when a session is resumed.
 - The vendored Codex ACP snapshot also carries a local image-generation bridge: live Codex `ImageGenerationBegin` / `ImageGenerationEnd` events and replayed `ResponseItem::ImageGenerationCall` items are emitted as ACP tool updates with `codexAcpEventType = "image_generation"` and `codex-acp:image:` IDs so Comando can render generated images inline instead of as generic status activity. `TurnItem::ImageGeneration` is intentionally ignored for the live bridge because Codex also emits the begin/end events, and handling both would duplicate image cards.
 - The current Codex vendor also carries compatibility glue for the `rust-v0.133.0` runtime API shape, including state DB/thread-store wiring, installation IDs, async auth reload/logout, permission-profile modes, newer event payloads, and local custom prompt handling.
-- Gemini, Kilo and OpenCode are integrated in the UI and service layer, but they are not part of the staging/bundling pipeline today.
+- Gemini, Grok, Kilo and OpenCode are integrated in the UI and service layer, but they are not part of the staging/bundling pipeline today.
 - Status metadata currently uses `codexAcp*` names while Comando keeps app-branded `comando*` aliases for compatibility paths it owns.
 
 ---
@@ -42,7 +43,7 @@ Notes:
 Comando separates provider authentication into two user-visible actions:
 
 - **Log out from provider** is a remote/runtime logout. In this iteration only Codex exposes a real ACP logout capability. If remote logout fails, Comando keeps local settings and secrets intact.
-- **Disconnect from Comando** is local cleanup. It removes Comando-managed secrets or marks external runtime login as signed out, but it never deletes external CLI stores such as `~/.claude.json`, `~/.gemini/settings.json`, or Kilo's own auth databases.
+- **Disconnect from Comando** is local cleanup. It removes Comando-managed secrets or marks external runtime login as signed out, but it never deletes external CLI stores such as `~/.claude.json`, `~/.gemini/settings.json`, `~/.grok/auth`, Kilo's own auth databases, or OpenCode's own auth state.
 
 Disconnect/logout affect new runtime sessions. Active ACP sessions may continue using credentials that were already loaded when their process launched.
 
@@ -64,6 +65,8 @@ Credential precedence is runtime-specific:
 | Claude | login methods | External Claude CLI login |
 | Gemini | `use_gemini` | `GEMINI_API_KEY`/`GOOGLE_API_KEY` environment variables, then Comando-managed secrets |
 | Gemini | `login_with_google` | External Gemini CLI login |
+| Grok | `xai-api-key` | `XAI_API_KEY` environment variable, then `secret.ai.grok.xai_api_key` |
+| Grok | `grok-login` | External Grok CLI login |
 | Kilo | `kilo-login` | External Kilo auth stores |
 | OpenCode | `opencode-login` | External OpenCode auth state, `OPENCODE_API_KEY`, provider env vars, project `.env`, or providers configured with `/connect` |
 
@@ -127,6 +130,48 @@ so the effective command is:
 ```text
 gemini --acp
 ```
+
+### Grok (`grok/setup.ts` → `resolveGrokRuntime`)
+
+1. `COMANDO_GROK_ACP_BIN`
+2. Custom path from settings
+3. `grok` in PATH
+4. On macOS, common Homebrew installs such as `/opt/homebrew/bin/grok` and `/usr/local/bin/grok`
+
+When spawned, Comando appends:
+
+```text
+--no-auto-update agent stdio
+```
+
+so the effective command is:
+
+```text
+grok --no-auto-update agent stdio
+```
+
+Grok supports two Comando auth methods:
+
+- `xai-api-key`
+  - uses `XAI_API_KEY` from the environment when present
+  - otherwise injects the Comando-managed `secret.ai.grok.xai_api_key`
+  - authenticates with ACP method `xai.api_key`
+- `grok-login`
+  - opens a detached terminal and runs:
+
+```text
+grok login
+```
+
+  - readiness is inferred from non-empty files in:
+
+```text
+~/.grok/auth
+```
+
+  - authenticates with ACP method `cached_token`
+
+The runtime auth handshake is headless. After `initialize`, Comando selects `xai.api_key` for environment or Comando-stored API-key credentials and `cached_token` for external Grok login credentials. If Grok does not advertise the expected ACP auth method, Comando surfaces an actionable setup error before creating or loading a session.
 
 ### Kilo (`kilo/setup.ts` → `resolveKiloBinary`)
 
@@ -192,7 +237,7 @@ Today `stage:ai` stages:
 - **Codex**
 - **Claude**
 
-It does **not** stage Gemini, Kilo, or OpenCode.
+It does **not** stage Gemini, Grok, Kilo, or OpenCode. Those external CLIs are resolved from the user's machine at runtime.
 
 ### Codex staging (`scripts/ai/stage-codex-runtime.mjs`)
 
@@ -292,7 +337,7 @@ The macOS packaging flow builds a packaged AI payload under `build/package-resou
 ]
 ```
 
-Gemini and Kilo are still expected to come from the user's machine at runtime.
+Gemini, Grok, Kilo and OpenCode are still expected to come from the user's machine at runtime.
 
 ### Windows packaging (`scripts/package-windows-app.mjs`)
 
@@ -468,6 +513,36 @@ $XDG_DATA_HOME/kilo/kilo.db
 
 For the SQLite store, Comando inspects `account_state`, `account`, and `control_account` when those tables exist.
 
+### Grok
+
+Configured through SQLite settings keys under the `ai.grok.*` namespace.
+
+Secrets stored by Comando:
+
+- `secret.ai.grok.xai_api_key`
+
+Supported methods:
+
+- **`grok-login`**
+  - Opens a detached terminal and runs:
+
+```text
+grok login
+```
+
+  - Readiness is inferred from non-empty files under:
+
+```text
+~/.grok/auth
+```
+
+  - Uses the ACP auth method `cached_token` before creating or loading a session
+
+- **`xai-api-key`**
+  - Uses `XAI_API_KEY` when it already exists in the environment
+  - Otherwise injects Comando's stored `secret.ai.grok.xai_api_key`
+  - Uses the ACP auth method `xai.api_key` before creating or loading a session
+
 ---
 
 ## ACP Protocol Basics
@@ -477,7 +552,7 @@ For the SQLite store, Comando inspects `account_state`, `account`, and `control_
 ### Client → Agent requests used by Comando
 
 - `initialize`
-- `authenticate` during Codex auth launch
+- `authenticate` during Codex auth launch and Grok session startup
 - `session/new`
 - `session/load`
 - `session/close` through `closeSession`
@@ -596,8 +671,12 @@ src/main/
 │   │   └── setup.ts                  # Codex auth methods and env injection
 │   ├── gemini/
 │   │   └── setup.ts                  # Gemini runtime resolution and auth detection
-│   └── kilo/
-│       └── setup.ts                  # Kilo runtime resolution and auth detection
+│   ├── grok/
+│   │   └── setup.ts                  # Grok runtime resolution, auth handshake and env injection
+│   ├── kilo/
+│   │   └── setup.ts                  # Kilo runtime resolution and auth detection
+│   └── opencode/
+│       └── setup.ts                  # OpenCode runtime resolution and auth detection
 │
 ├── db/
 │   ├── awaitable.ts                  # Promise coordination helpers for the DB worker
@@ -664,12 +743,13 @@ External auth state also used:
 ```text
 ~/.claude.json
 ~/.gemini/settings.json
+~/.grok/auth
 ~/.local/share/kilo/auth.json
 ~/.local/share/kilo/kilo.db
 ~/.local/share/opencode/auth.json
 ```
 
-On Linux and Windows, Kilo and OpenCode paths can vary through `XDG_DATA_HOME` and `LOCALAPPDATA`.
+On Linux and Windows, Kilo and OpenCode paths can vary through `XDG_DATA_HOME` and `LOCALAPPDATA`. Grok login remains owned by the Grok CLI and is treated as external runtime auth.
 
 ---
 
@@ -681,6 +761,7 @@ On Linux and Windows, Kilo and OpenCode paths can vary through `XDG_DATA_HOME` a
 | `COMANDO_CODEX_ACP_BIN` | Codex runtime / staging | Override Codex runtime path |
 | `COMANDO_CODEX_ACP_BUNDLE_BIN` | Codex staging | Override the binary copied into bundled resources |
 | `COMANDO_GEMINI_ACP_BIN` | Gemini runtime | Override Gemini CLI path or command |
+| `COMANDO_GROK_ACP_BIN` | Grok runtime | Override Grok CLI path or command |
 | `COMANDO_KILO_ACP_BIN` | Kilo runtime | Override Kilo CLI path or command |
 | `COMANDO_OPENCODE_ACP_BIN` | OpenCode runtime | Override OpenCode CLI path or command |
 | `COMANDO_EMBEDDED_NODE_BIN` | Claude staging | Override the Node binary embedded for Claude |
@@ -695,6 +776,7 @@ On Linux and Windows, Kilo and OpenCode paths can vary through `XDG_DATA_HOME` a
 | `GOOGLE_CLOUD_PROJECT` | Gemini process | Google Cloud project hint |
 | `GOOGLE_CLOUD_LOCATION` | Gemini process | Google Cloud location hint |
 | `GEMINI_DEFAULT_AUTH_TYPE` | Gemini process | Default Gemini auth mode |
+| `XAI_API_KEY` | Grok process | xAI API key; environment value wins over Comando's stored Grok secret |
 | `OPENCODE_API_KEY` | OpenCode process | External OpenCode API key recognized by diagnostics/status but not stored by Comando |
 | `OPENAI_API_KEY` | OpenCode process | Provider API key recognized by OpenCode readiness when OpenCode owns provider selection |
 | `ANTHROPIC_API_KEY` | OpenCode process | Provider API key recognized by OpenCode readiness when OpenCode owns provider selection |
@@ -712,7 +794,7 @@ On Linux and Windows, Kilo and OpenCode paths can vary through `XDG_DATA_HOME` a
 ## Current Caveats
 
 - Only **Claude** and **Codex** are staged and packaged by Comando today.
-- **Gemini** and **Kilo** are integrated end-to-end in the app layer, but the user must provide those CLIs on the machine.
+- **Gemini**, **Grok**, **Kilo** and **OpenCode** are integrated end-to-end in the app layer, but the user must provide those CLIs on the machine.
 - Claude runtime resolution still keeps a legacy standalone `claude-agent-acp` binary fallback even though the normal path prefers embedded Node + vendored JS.
 - Codex PATH fallback explicitly rejects plain `codex` because Comando still targets ACP, not the App Server / MCP surface.
 - The current vendored Codex runtime includes newer upstream support for MCP approval elicitation, `RequestUserInput`, guardian-assessment activity and cleaner shutdown handling, while Comando keeps legacy metadata fallbacks so older sessions can still be replayed safely.

--- a/src/main/ai/contracts.ts
+++ b/src/main/ai/contracts.ts
@@ -250,6 +250,11 @@ export interface LiveAcpTerminal {
 
 export interface ResolvedAcpRuntime {
     readonly args: readonly string[];
+    readonly authHandshake?: {
+        readonly envMethodId: string;
+        readonly externalMethodId: string;
+        readonly meta?: Record<string, unknown>;
+    };
     readonly command: string;
     readonly env: NodeJS.ProcessEnv;
     readonly executable: string;

--- a/src/main/ai/environment-diagnostics.test.ts
+++ b/src/main/ai/environment-diagnostics.test.ts
@@ -249,6 +249,12 @@ function createSettings(
             hasGeminiApiKey: false,
             hasGoogleApiKey: false,
         },
+        grok: {
+            authInvalidatedAtMs: null,
+            authMethod: null,
+            binaryPath: null,
+            hasXaiApiKey: false,
+        },
         kilo: {
             authInvalidatedAtMs: null,
             authMethod: null,

--- a/src/main/ai/environment-diagnostics.test.ts
+++ b/src/main/ai/environment-diagnostics.test.ts
@@ -25,6 +25,7 @@ describe("AI environment diagnostics", () => {
             const claudePath = writeExecutable(binDir, "claude-agent-acp");
             const codexPath = writeExecutable(binDir, "codex-acp");
             const geminiPath = writeExecutable(binDir, "gemini");
+            const grokPath = writeExecutable(binDir, "grok");
             const kiloPath = writeExecutable(binDir, "kilo");
             const opencodePath = writeExecutable(binDir, "opencode");
             const diagnostics = createAiEnvironmentDiagnostics({
@@ -33,12 +34,14 @@ describe("AI environment diagnostics", () => {
                     COMANDO_CLAUDE_ACP_BIN: claudePath,
                     COMANDO_CODEX_ACP_BIN: codexPath,
                     COMANDO_GEMINI_ACP_BIN: geminiPath,
+                    COMANDO_GROK_ACP_BIN: grokPath,
                     COMANDO_KILO_ACP_BIN: kiloPath,
                     COMANDO_OPENCODE_ACP_BIN: opencodePath,
                     GEMINI_API_KEY: "gemini-secret-value",
                     HOME: homeDir,
                     OPENAI_API_KEY: "openai-secret-value",
                     PATH: binDir,
+                    XAI_API_KEY: "xai-secret-value",
                 },
                 now: () => new Date("2026-05-19T12:00:00.000Z"),
                 secretStore: createSecretStore(),
@@ -57,6 +60,12 @@ describe("AI environment diagnostics", () => {
                         googleCloudProject: null,
                         hasGeminiApiKey: false,
                         hasGoogleApiKey: false,
+                    },
+                    grok: {
+                        authInvalidatedAtMs: null,
+                        authMethod: "xai-api-key",
+                        binaryPath: null,
+                        hasXaiApiKey: false,
                     },
                 }),
             });
@@ -81,6 +90,15 @@ describe("AI environment diagnostics", () => {
                 pathOrCommand: geminiPath,
                 present: true,
                 runtimeId: "gemini",
+            });
+            expect(
+                diagnostics.runtimePathOverrides.find(
+                    (entry) => entry.name === "COMANDO_GROK_ACP_BIN",
+                ),
+            ).toMatchObject({
+                pathOrCommand: grokPath,
+                present: true,
+                runtimeId: "grok",
             });
             expect(
                 diagnostics.credentialEnvironment.find(
@@ -123,6 +141,29 @@ describe("AI environment diagnostics", () => {
             ).toBe(binDir);
             expect(
                 diagnostics.runtimes.find(
+                    (runtime) => runtime.runtimeId === "grok",
+                ),
+            ).toMatchObject({
+                authCredentialSource: "environment",
+                authMethod: "xai-api-key",
+                authReady: true,
+                command: `${grokPath} --no-auto-update agent stdio`,
+                executablePath: grokPath,
+                source: "env",
+                state: "ready",
+            });
+            expect(
+                diagnostics.credentialEnvironment.find(
+                    (entry) =>
+                        entry.name === "XAI_API_KEY" &&
+                        entry.runtimeId === "grok",
+                ),
+            ).toMatchObject({
+                present: true,
+                runtimeId: "grok",
+            });
+            expect(
+                diagnostics.runtimes.find(
                     (runtime) => runtime.runtimeId === "opencode",
                 ),
             ).toMatchObject({
@@ -153,6 +194,9 @@ describe("AI environment diagnostics", () => {
             expect(JSON.stringify(diagnostics)).not.toContain(
                 "openai-secret-value",
             );
+            expect(JSON.stringify(diagnostics)).not.toContain(
+                "xai-secret-value",
+            );
             expect(process.env.PATH).toBe(previousPath);
         } finally {
             fs.rmSync(tempDir, { force: true, recursive: true });
@@ -174,6 +218,7 @@ describe("AI environment diagnostics", () => {
                 secretStore: createSecretStore({
                     "ai.codex:codex_api_key": "stored-codex-secret",
                     "ai.gemini:gemini_api_key": "stored-gemini-secret",
+                    "ai.grok:xai_api_key": "stored-xai-secret",
                 }),
                 settings: createSettings({
                     codex: {
@@ -191,12 +236,19 @@ describe("AI environment diagnostics", () => {
                         hasGeminiApiKey: true,
                         hasGoogleApiKey: false,
                     },
+                    grok: {
+                        authInvalidatedAtMs: null,
+                        authMethod: "xai-api-key",
+                        binaryPath: path.join(tempDir, "missing-grok"),
+                        hasXaiApiKey: true,
+                    },
                 }),
             });
             const payload = JSON.stringify(diagnostics);
 
             expect(payload).not.toContain("stored-codex-secret");
             expect(payload).not.toContain("stored-gemini-secret");
+            expect(payload).not.toContain("stored-xai-secret");
             expect(
                 diagnostics.credentialEnvironment.find(
                     (entry) => entry.name === "CODEX_API_KEY",

--- a/src/main/ai/environment-diagnostics.ts
+++ b/src/main/ai/environment-diagnostics.ts
@@ -21,6 +21,7 @@ import {
     type ResolveClaudeRuntimeOptions,
 } from "./claude/setup";
 import { getGeminiRuntimeStatus, resolveGeminiRuntime } from "./gemini/setup";
+import { getGrokRuntimeStatus, resolveGrokRuntime } from "./grok/setup";
 import { getKiloRuntimeStatus, resolveKiloRuntime } from "./kilo/setup";
 import {
     getOpenCodeRuntimeStatus,
@@ -49,6 +50,7 @@ const EXECUTABLE_PROBES = [
     "codex-acp",
     "codex",
     "gemini",
+    "grok",
     "kilo",
     "opencode",
     "node",
@@ -69,6 +71,10 @@ const RUNTIME_PATH_OVERRIDES: readonly {
     {
         name: "COMANDO_GEMINI_ACP_BIN",
         runtimeId: "gemini",
+    },
+    {
+        name: "COMANDO_GROK_ACP_BIN",
+        runtimeId: "grok",
     },
     {
         name: "COMANDO_KILO_ACP_BIN",
@@ -119,6 +125,10 @@ const CREDENTIAL_ENVIRONMENT: readonly {
     {
         name: "GOOGLE_API_KEY",
         runtimeId: "gemini",
+    },
+    {
+        name: "XAI_API_KEY",
+        runtimeId: "grok",
     },
     {
         name: "KILO_API_KEY",
@@ -220,6 +230,9 @@ function createRuntimeDiagnostics(
     const geminiStatus = readRuntimeStatus("gemini", settings.gemini, () =>
         getGeminiRuntimeStatus(settings.gemini, secretStore),
     );
+    const grokStatus = readRuntimeStatus("grok", settings.grok, () =>
+        getGrokRuntimeStatus(settings.grok, secretStore),
+    );
     const kiloStatus = readRuntimeStatus("kilo", settings.kilo, () =>
         getKiloRuntimeStatus(settings.kilo, secretStore),
     );
@@ -243,6 +256,11 @@ function createRuntimeDiagnostics(
         toRuntimeDiagnostic(
             geminiStatus,
             resolveRuntimeExecutable("gemini", input),
+            env,
+        ),
+        toRuntimeDiagnostic(
+            grokStatus,
+            resolveRuntimeExecutable("grok", input),
             env,
         ),
         toRuntimeDiagnostic(
@@ -307,7 +325,10 @@ function resolveRuntimeExecutable(
                     input.secretStore,
                 ).program;
             case "grok":
-                return null;
+                return resolveGrokRuntime(
+                    input.settings.grok,
+                    input.secretStore,
+                ).program;
             case "kilo":
                 return resolveKiloRuntime(
                     input.settings.kilo,

--- a/src/main/ai/environment-diagnostics.ts
+++ b/src/main/ai/environment-diagnostics.ts
@@ -306,6 +306,8 @@ function resolveRuntimeExecutable(
                     input.settings.gemini,
                     input.secretStore,
                 ).program;
+            case "grok":
+                return null;
             case "kilo":
                 return resolveKiloRuntime(
                     input.settings.kilo,

--- a/src/main/ai/grok/setup.test.ts
+++ b/src/main/ai/grok/setup.test.ts
@@ -1,0 +1,387 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { GrokRuntimeSettings } from "@shared/ipc";
+import type { SecretStoreGateway } from "../secret-store";
+import {
+    applyGrokAuthEnv,
+    buildGrokSecretPatches,
+    detectGrokAuthMethod,
+    getGrokAuthMethods,
+    getGrokRuntimeStatus,
+    isGrokAuthenticationError,
+    loadGrokSecretBundle,
+    markGrokAuthInvalidated,
+    resolveGrokRuntime,
+} from "./setup";
+
+const originalGrokEnv = process.env.COMANDO_GROK_ACP_BIN;
+const originalHome = process.env.HOME;
+const originalPath = process.env.PATH;
+const originalUserProfile = process.env.USERPROFILE;
+const originalXaiApiKey = process.env.XAI_API_KEY;
+
+beforeEach(() => {
+    delete process.env.COMANDO_GROK_ACP_BIN;
+    delete process.env.XAI_API_KEY;
+});
+
+afterEach(() => {
+    process.env.PATH = originalPath;
+
+    if (typeof originalGrokEnv === "string") {
+        process.env.COMANDO_GROK_ACP_BIN = originalGrokEnv;
+    } else {
+        delete process.env.COMANDO_GROK_ACP_BIN;
+    }
+
+    if (typeof originalHome === "string") {
+        process.env.HOME = originalHome;
+    } else {
+        delete process.env.HOME;
+    }
+
+    if (typeof originalUserProfile === "string") {
+        process.env.USERPROFILE = originalUserProfile;
+    } else {
+        delete process.env.USERPROFILE;
+    }
+
+    if (typeof originalXaiApiKey === "string") {
+        process.env.XAI_API_KEY = originalXaiApiKey;
+    } else {
+        delete process.env.XAI_API_KEY;
+    }
+});
+
+describe("Grok setup", () => {
+    it("exposes Grok login and xAI API key auth methods", () => {
+        expect(getGrokAuthMethods().map((method) => method.id)).toEqual([
+            "grok-login",
+            "xai-api-key",
+        ]);
+    });
+
+    it("resolves Grok from COMANDO_GROK_ACP_BIN with ACP stdio args", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-env-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "custom-grok");
+            process.env.COMANDO_GROK_ACP_BIN = binaryPath;
+            process.env.PATH = "";
+
+            const resolved = resolveGrokRuntime(createEmptyGrokSettings());
+
+            expect(resolved.program).toBe(binaryPath);
+            expect(resolved.args).toEqual([
+                "--no-auto-update",
+                "agent",
+                "stdio",
+            ]);
+            expect(resolved.command).toBe(
+                `${binaryPath} --no-auto-update agent stdio`,
+            );
+            expect(resolved.status.source).toBe("env");
+            expect(resolved.status.state).toBe("ready");
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("resolves Grok from configured path and falls back to PATH", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-path-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            process.env.PATH = tempDir;
+
+            const fromSettings = resolveGrokRuntime({
+                ...createEmptyGrokSettings(),
+                binaryPath,
+            });
+            const fromPath = resolveGrokRuntime(createEmptyGrokSettings());
+
+            expect(fromSettings.program).toBe(binaryPath);
+            expect(fromSettings.status.source).toBe("settings");
+            expect(fromPath.program).toBe(binaryPath);
+            expect(fromPath.status.source).toBe("path");
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("reports missing and non-executable Grok runtimes", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-missing-"),
+        );
+
+        try {
+            const nonExecutablePath = path.join(tempDir, "grok");
+            fs.writeFileSync(nonExecutablePath, "#!/bin/sh\nexit 0\n", "utf8");
+            process.env.PATH = "";
+
+            const missing = getGrokRuntimeStatus(createEmptyGrokSettings());
+            const notExecutable = getGrokRuntimeStatus({
+                ...createEmptyGrokSettings(),
+                binaryPath: nonExecutablePath,
+            });
+
+            expect(missing.state).toBe("missing");
+            expect(missing.message).toBe(
+                "Grok CLI was not found. Install `grok` or provide a custom runtime path.",
+            );
+            expect(notExecutable.state).toBe("error");
+            expect(notExecutable.message).toContain(
+                "Could not execute the configured Grok runtime",
+            );
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("loads and patches the stored xAI API key secret", () => {
+        const secretStore = createSecretStore({
+            "ai.grok:xai_api_key": "stored-xai-key",
+        });
+
+        expect(loadGrokSecretBundle(secretStore)).toEqual({
+            xaiApiKey: "stored-xai-key",
+        });
+
+        const unchanged = buildGrokSecretPatches(secretStore, {
+            xaiApiKey: "stored-xai-key",
+        });
+        const changed = buildGrokSecretPatches(secretStore, {
+            xaiApiKey: "next-xai-key",
+        });
+        const cleared = buildGrokSecretPatches(secretStore, {
+            xaiApiKey: null,
+        });
+
+        expect(unchanged).toEqual({
+            flags: { hasXaiApiKey: true },
+            patches: [],
+        });
+        expect(changed).toEqual({
+            flags: { hasXaiApiKey: true },
+            patches: [
+                {
+                    key: "secret.ai.grok.xai_api_key",
+                    value: "next-xai-key",
+                },
+            ],
+        });
+        expect(cleared).toEqual({
+            flags: { hasXaiApiKey: false },
+            patches: [
+                {
+                    key: "secret.ai.grok.xai_api_key",
+                    value: null,
+                },
+            ],
+        });
+    });
+
+    it("respects XAI_API_KEY from the environment over stored credentials", () => {
+        process.env.XAI_API_KEY = "env-xai-key";
+        const secretStore = createSecretStore({
+            "ai.grok:xai_api_key": "stored-xai-key",
+        });
+        const settings = createEmptyGrokSettings({
+            authMethod: "grok-login",
+        });
+
+        expect(detectGrokAuthMethod(settings, secretStore)).toBe(
+            "xai-api-key",
+        );
+        expect(
+            applyGrokAuthEnv(
+                {
+                    XAI_API_KEY: "env-xai-key",
+                },
+                settings,
+                secretStore,
+            ).XAI_API_KEY,
+        ).toBe("env-xai-key");
+    });
+
+    it("applies stored xAI API key unless Grok login is explicitly selected", () => {
+        const secretStore = createSecretStore({
+            "ai.grok:xai_api_key": "stored-xai-key",
+        });
+
+        expect(
+            applyGrokAuthEnv(
+                {},
+                createEmptyGrokSettings({
+                    authMethod: "xai-api-key",
+                }),
+                secretStore,
+            ).XAI_API_KEY,
+        ).toBe("stored-xai-key");
+        expect(
+            applyGrokAuthEnv(
+                {},
+                createEmptyGrokSettings({
+                    authMethod: "grok-login",
+                }),
+                secretStore,
+            ).XAI_API_KEY,
+        ).toBeUndefined();
+    });
+
+    it("reports stored xAI API key as ready Comando credentials", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-secret-status-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            const secretStore = createSecretStore({
+                "ai.grok:xai_api_key": "stored-xai-key",
+            });
+            process.env.COMANDO_GROK_ACP_BIN = binaryPath;
+            process.env.PATH = "";
+
+            const status = getGrokRuntimeStatus(
+                createEmptyGrokSettings(),
+                secretStore,
+            );
+
+            expect(status.authMethod).toBe("xai-api-key");
+            expect(status.authReady).toBe(true);
+            expect(status.authCredentialSource).toBe("comando-secret");
+            expect(status.authCredentialSourceLabel).toBe(
+                "Using Comando stored credentials",
+            );
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("allows selected Grok login while noting unverifiable local credentials", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-selected-login-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            process.env.COMANDO_GROK_ACP_BIN = binaryPath;
+            process.env.HOME = tempDir;
+            process.env.PATH = "";
+
+            const status = getGrokRuntimeStatus(
+                createEmptyGrokSettings({
+                    authMethod: "grok-login",
+                }),
+            );
+
+            expect(status.authMethod).toBe("grok-login");
+            expect(status.authReady).toBe(true);
+            expect(status.authCredentialSource).toBe("external-runtime");
+            expect(status.message).toContain(
+                "could not verify local Grok credentials",
+            );
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("detects Grok login from ~/.grok/auth and respects invalidation", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-auth-store-"),
+        );
+
+        try {
+            writeGrokAuthStore(tempDir);
+            process.env.HOME = tempDir;
+            delete process.env.USERPROFILE;
+
+            const readySettings = createEmptyGrokSettings();
+            const invalidatedSettings = createEmptyGrokSettings({
+                authInvalidatedAtMs: Date.now() + 60_000,
+            });
+
+            expect(detectGrokAuthMethod(readySettings)).toBe("grok-login");
+            expect(detectGrokAuthMethod(invalidatedSettings)).toBeNull();
+            expect(markGrokAuthInvalidated(readySettings)).toMatchObject({
+                authMethod: null,
+                binaryPath: null,
+                hasXaiApiKey: false,
+            });
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("recognizes Grok authentication errors that should invalidate setup", () => {
+        expect(isGrokAuthenticationError("Run grok login to continue")).toBe(
+            true,
+        );
+        expect(isGrokAuthenticationError("cached_token is expired")).toBe(true);
+        expect(isGrokAuthenticationError("invalid api key")).toBe(true);
+        expect(isGrokAuthenticationError("Some unrelated error")).toBe(false);
+    });
+});
+
+type GrokSettingsForTest = {
+    readonly authInvalidatedAtMs: number | null;
+    readonly authMethod: "grok-login" | "xai-api-key" | null;
+    readonly binaryPath: string | null;
+    readonly hasXaiApiKey: boolean;
+};
+
+function createEmptyGrokSettings(
+    overrides: Partial<GrokSettingsForTest> = {},
+): GrokRuntimeSettings {
+    return {
+        authInvalidatedAtMs: null,
+        authMethod: null,
+        binaryPath: null,
+        hasXaiApiKey: false,
+        ...overrides,
+    };
+}
+
+function createSecretStore(
+    initialSecrets: Record<string, string | null> = {},
+): SecretStoreGateway {
+    const secrets = new Map<string, string | null>(
+        Object.entries(initialSecrets),
+    );
+
+    return {
+        getStorageStatus: () => ({
+            encryptionAvailable: true,
+            isWeakBackend: false,
+            message: null,
+            platform: process.platform,
+            selectedBackend: null,
+        }),
+        loadSecret: (namespace, secretId) =>
+            secrets.get(`${namespace}:${secretId}`) ?? null,
+        saveSecret: (namespace, secretId, value) => {
+            secrets.set(`${namespace}:${secretId}`, value);
+        },
+    };
+}
+
+function writeExecutable(directory: string, name: string): string {
+    const binaryPath = path.join(directory, name);
+    fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
+    fs.chmodSync(binaryPath, 0o755);
+    return binaryPath;
+}
+
+function writeGrokAuthStore(homeDir: string): void {
+    const authDir = path.join(homeDir, ".grok", "auth");
+    fs.mkdirSync(authDir, { recursive: true });
+    fs.writeFileSync(path.join(authDir, "token"), "cached-token", "utf8");
+}

--- a/src/main/ai/grok/setup.ts
+++ b/src/main/ai/grok/setup.ts
@@ -309,6 +309,18 @@ export function applyGrokAuthEnv(
     return env;
 }
 
+export function isGrokEnvironmentCredentialReady(
+    env: NodeJS.ProcessEnv = process.env,
+): boolean {
+    return envSecretPresent(env, XAI_API_KEY_ENV);
+}
+
+export function isGrokExternalCredentialReady(
+    settings: GrokRuntimeSettings,
+): boolean {
+    return grokLoginAvailable(settings);
+}
+
 export function markGrokAuthInvalidated(
     settings: GrokRuntimeSettings,
 ): GrokRuntimeSettings {

--- a/src/main/ai/grok/setup.ts
+++ b/src/main/ai/grok/setup.ts
@@ -391,7 +391,20 @@ export async function probeGrokCachedTokenAuth(
         );
         const advertisedMethodIds =
             initializeResponse.authMethods?.map((method) => method.id) ?? [];
-        return advertisedMethodIds.includes("cached_token");
+        if (!advertisedMethodIds.includes("cached_token")) {
+            return false;
+        }
+
+        await withTimeout(
+            connection.authenticate({
+                _meta: {
+                    headless: true,
+                },
+                methodId: "cached_token",
+            }),
+            options.timeoutMs ?? GROK_AUTH_PROBE_TIMEOUT_MS,
+        );
+        return true;
     } catch (error) {
         debugBenignError("ai.grok.probeCachedTokenAuth", error);
         return false;

--- a/src/main/ai/grok/setup.ts
+++ b/src/main/ai/grok/setup.ts
@@ -1,5 +1,14 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { Readable, Writable } from "node:stream";
+
+import {
+    ClientSideConnection,
+    PROTOCOL_VERSION,
+    ndJsonStream,
+    type Client,
+} from "@agentclientprotocol/sdk";
 
 import type {
     AiAuthCredentialSource,
@@ -30,6 +39,7 @@ const GROK_MACOS_FALLBACK_DIRS = [
     "/opt/homebrew/bin",
     "/usr/local/bin",
 ] as const;
+const GROK_AUTH_PROBE_TIMEOUT_MS = 2_000;
 
 interface ResolvedGrokBinary {
     readonly args: readonly string[];
@@ -321,6 +331,78 @@ export function isGrokExternalCredentialReady(
     return grokLoginAvailable(settings);
 }
 
+export async function probeGrokCachedTokenAuth(
+    settings: GrokRuntimeSettings,
+    secretStore?: SecretStoreGateway | null,
+    options: {
+        readonly cwd?: string | null;
+        readonly timeoutMs?: number;
+    } = {},
+): Promise<boolean> {
+    let resolved: ResolvedGrokRuntimeCommand;
+    try {
+        resolved = resolveGrokRuntime(settings, secretStore);
+    } catch {
+        return false;
+    }
+
+    const child = spawn(resolved.program, [...resolved.args], {
+        cwd: options.cwd ?? undefined,
+        env: applyGrokAuthEnv(process.env, settings, secretStore),
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    const client: Client = {
+        readTextFile: () => {
+            throw new Error("Grok auth probe does not support file reads.");
+        },
+        requestPermission: () => {
+            throw new Error(
+                "Grok auth probe does not support permission requests.",
+            );
+        },
+        sessionUpdate: () => Promise.resolve(undefined),
+        writeTextFile: () => {
+            throw new Error("Grok auth probe does not support file writes.");
+        },
+    };
+    const stream = ndJsonStream(
+        toWebByteWritable(child.stdin),
+        toWebByteReadable(child.stdout),
+    );
+    const connection = new ClientSideConnection(() => client, stream);
+
+    try {
+        const initializeResponse = await withTimeout(
+            connection.initialize({
+                clientCapabilities: {
+                    fs: {
+                        readTextFile: true,
+                        writeTextFile: true,
+                    },
+                },
+                clientInfo: {
+                    name: "comando",
+                    title: "Comando",
+                    version: process.versions.electron,
+                },
+                protocolVersion: PROTOCOL_VERSION,
+            }),
+            options.timeoutMs ?? GROK_AUTH_PROBE_TIMEOUT_MS,
+        );
+        const advertisedMethodIds =
+            initializeResponse.authMethods?.map((method) => method.id) ?? [];
+        return advertisedMethodIds.includes("cached_token");
+    } catch (error) {
+        debugBenignError("ai.grok.probeCachedTokenAuth", error);
+        return false;
+    } finally {
+        child.kill();
+        child.stdin.destroy();
+        child.stdout.destroy();
+        child.stderr.destroy();
+    }
+}
+
 export function markGrokAuthInvalidated(
     settings: GrokRuntimeSettings,
 ): GrokRuntimeSettings {
@@ -488,6 +570,39 @@ function readGrokAuthStoreStatus(authDir: string): GrokAuthStoreStatus {
 
 function envSecretPresent(env: NodeJS.ProcessEnv, key: typeof XAI_API_KEY_ENV) {
     return Boolean(env[key]?.trim());
+}
+
+function toWebByteWritable(stream: Writable): WritableStream<Uint8Array> {
+    return Writable.toWeb(stream) as WritableStream<Uint8Array>;
+}
+
+function toWebByteReadable(stream: Readable): ReadableStream<Uint8Array> {
+    return Readable.toWeb(stream) as ReadableStream<Uint8Array>;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+    return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+            reject(new Error("Grok auth probe timed out."));
+        }, timeoutMs);
+
+        promise.then(
+            (value) => {
+                clearTimeout(timeout);
+                resolve(value);
+            },
+            (error: unknown) => {
+                clearTimeout(timeout);
+                reject(
+                    error instanceof Error
+                        ? error
+                        : new Error("Grok auth probe failed.", {
+                              cause: error,
+                          }),
+                );
+            },
+        );
+    });
 }
 
 function getCredentialSourceLabel(source: AiAuthCredentialSource): string {

--- a/src/main/ai/grok/setup.ts
+++ b/src/main/ai/grok/setup.ts
@@ -1,0 +1,676 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type {
+    AiAuthCredentialSource,
+    AiAuthMethod,
+    AiRuntimeStatus,
+    GrokAuthMethodId,
+    GrokRuntimeSettings,
+} from "@shared/ipc";
+
+import { launchTerminalLoginCommand } from "../auth/terminal-login";
+import {
+    buildSecretStorageKey,
+    type SecretRecordPatch,
+    type SecretStoreGateway,
+} from "../secret-store";
+import { debugBenignError } from "../../observability/logging";
+
+const GROK_PROGRAM_NAME = "grok";
+const GROK_ACP_ARGS = ["--no-auto-update", "agent", "stdio"] as const;
+const GROK_AUTH_LOGIN_SUBCOMMAND = ["login"] as const;
+const GROK_ENV_BIN = "COMANDO_GROK_ACP_BIN";
+const XAI_API_KEY_ENV = "XAI_API_KEY";
+const GROK_LOGIN_METHOD_ID = "grok-login" satisfies GrokAuthMethodId;
+const XAI_API_KEY_METHOD_ID = "xai-api-key" satisfies GrokAuthMethodId;
+const GROK_SECRET_NAMESPACE = "ai.grok";
+const XAI_API_KEY_SECRET = "xai_api_key";
+const GROK_MACOS_FALLBACK_DIRS = [
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+] as const;
+
+interface ResolvedGrokBinary {
+    readonly args: readonly string[];
+    readonly command: string | null;
+    readonly message: string | null;
+    readonly program: string | null;
+    readonly source: AiRuntimeStatus["source"];
+    readonly state: AiRuntimeStatus["state"];
+}
+
+export interface ResolvedGrokRuntimeCommand {
+    readonly args: readonly string[];
+    readonly command: string;
+    readonly program: string;
+    readonly status: AiRuntimeStatus;
+}
+
+interface GrokAuthStoreStatus {
+    readonly hasActiveAuth: boolean;
+    readonly modifiedAtMs: number | null;
+}
+
+export interface GrokSecretBundle {
+    readonly xaiApiKey: string | null;
+}
+
+export function getGrokRuntimeStatus(
+    settings: GrokRuntimeSettings,
+    secretStore?: SecretStoreGateway | null,
+): AiRuntimeStatus {
+    const resolved = resolveGrokBinary(settings);
+    const authMethods = getGrokAuthMethods();
+    const authMethod = detectGrokAuthMethod(settings, secretStore);
+    const secrets = loadGrokSecretBundle(secretStore);
+    const credentialSource = getGrokCredentialSource(
+        authMethod,
+        secrets,
+        process.env,
+    );
+    const storageStatus = secretStore?.getStorageStatus?.() ?? {
+        encryptionAvailable: true,
+        isWeakBackend: false,
+        message: null,
+        platform: process.platform,
+        selectedBackend: null,
+    };
+    const binaryReady = resolved.state === "ready" && Boolean(resolved.program);
+    const authReady = authMethod !== null;
+
+    let message = resolved.message;
+    if (binaryReady && !authReady) {
+        message = "Run Grok login or add an xAI API key to finish setup.";
+    } else if (
+        binaryReady &&
+        authMethod === GROK_LOGIN_METHOD_ID &&
+        !grokLoginAvailable(settings) &&
+        !envSecretPresent(process.env, XAI_API_KEY_ENV)
+    ) {
+        message =
+            "Grok login is selected. Comando could not verify local Grok credentials, but Grok may still load credentials from its CLI login state.";
+    }
+
+    return {
+        authMethod,
+        authMethods,
+        authReady,
+        authCredentialSource: credentialSource,
+        authCredentialSourceLabel: getCredentialSourceLabel(credentialSource),
+        authSessionMessage:
+            "This affects new sessions. Active sessions may keep using credentials loaded at launch.",
+        authStorageMessage: storageStatus.message,
+        canDisconnectAuth:
+            readSelectedGrokAuthMethod(settings) !== null ||
+            Boolean(secrets.xaiApiKey) ||
+            (credentialSource !== "environment" && authMethod !== null) ||
+            settings.authInvalidatedAtMs !== null,
+        canLogoutAuth: false,
+        checkedAt: new Date().toISOString(),
+        command: resolved.command,
+        hasCustomBinaryPath: Boolean(settings.binaryPath?.trim()),
+        hasGatewayConfig: false,
+        hasGatewayUrl: false,
+        message,
+        onboardingRequired: !binaryReady || !authReady,
+        runtimeId: "grok",
+        source: resolved.source,
+        state: resolved.state,
+    };
+}
+
+export function resolveGrokRuntime(
+    settings: GrokRuntimeSettings,
+    secretStore?: SecretStoreGateway | null,
+): ResolvedGrokRuntimeCommand {
+    const resolved = resolveGrokBinary(settings);
+    const status = getGrokRuntimeStatus(settings, secretStore);
+
+    if (resolved.program === null || resolved.command === null) {
+        throw new Error(
+            status.message ?? "Grok ACP is not available on this machine.",
+        );
+    }
+
+    return {
+        args: resolved.args,
+        command: resolved.command,
+        program: resolved.program,
+        status,
+    };
+}
+
+export function detectGrokAuthMethod(
+    settings: GrokRuntimeSettings,
+    secretStore?: SecretStoreGateway | null,
+): GrokAuthMethodId | null {
+    const secrets = loadGrokSecretBundle(secretStore);
+    const selectedAuthMethod = readSelectedGrokAuthMethod(settings);
+
+    if (envSecretPresent(process.env, XAI_API_KEY_ENV)) {
+        return XAI_API_KEY_METHOD_ID;
+    }
+
+    if (
+        selectedAuthMethod === XAI_API_KEY_METHOD_ID &&
+        Boolean(secrets.xaiApiKey)
+    ) {
+        return XAI_API_KEY_METHOD_ID;
+    }
+
+    if (
+        selectedAuthMethod === GROK_LOGIN_METHOD_ID &&
+        settings.authInvalidatedAtMs === null
+    ) {
+        return GROK_LOGIN_METHOD_ID;
+    }
+
+    if (selectedAuthMethod !== null) {
+        return null;
+    }
+
+    if (secrets.xaiApiKey) {
+        return XAI_API_KEY_METHOD_ID;
+    }
+
+    if (grokLoginAvailable(settings)) {
+        return GROK_LOGIN_METHOD_ID;
+    }
+
+    return null;
+}
+
+export function getGrokAuthMethods(): readonly AiAuthMethod[] {
+    return [
+        {
+            description:
+                "Open Grok CLI in a system terminal and complete sign-in there.",
+            id: GROK_LOGIN_METHOD_ID,
+            name: "Grok login",
+        },
+        {
+            description:
+                "Use an xAI API key stored only for Comando on this machine.",
+            id: XAI_API_KEY_METHOD_ID,
+            name: "xAI API key",
+        },
+    ];
+}
+
+export function getGrokCredentialSource(
+    authMethod: GrokAuthMethodId | null,
+    secrets: GrokSecretBundle,
+    env: NodeJS.ProcessEnv = process.env,
+): AiAuthCredentialSource {
+    if (authMethod === XAI_API_KEY_METHOD_ID) {
+        if (envSecretPresent(env, XAI_API_KEY_ENV)) {
+            return "environment";
+        }
+
+        if (secrets.xaiApiKey) {
+            return "comando-secret";
+        }
+    }
+
+    if (authMethod === GROK_LOGIN_METHOD_ID) {
+        return "external-runtime";
+    }
+
+    return "none";
+}
+
+export function loadGrokSecretBundle(
+    secretStore?: SecretStoreGateway | null,
+): GrokSecretBundle {
+    return {
+        xaiApiKey:
+            secretStore?.loadSecret(
+                GROK_SECRET_NAMESPACE,
+                XAI_API_KEY_SECRET,
+            ) ?? null,
+    };
+}
+
+export function saveGrokSecrets(
+    secretStore: SecretStoreGateway,
+    input: GrokSecretBundle,
+): {
+    readonly hasXaiApiKey: boolean;
+} {
+    const xaiApiKey = normalizeOptionalText(input.xaiApiKey);
+    saveSecretIfChanged(
+        secretStore,
+        GROK_SECRET_NAMESPACE,
+        XAI_API_KEY_SECRET,
+        normalizeOptionalText(
+            secretStore.loadSecret(GROK_SECRET_NAMESPACE, XAI_API_KEY_SECRET),
+        ),
+        xaiApiKey,
+    );
+
+    return {
+        hasXaiApiKey: Boolean(xaiApiKey),
+    };
+}
+
+export function buildGrokSecretPatches(
+    secretStore: SecretStoreGateway,
+    input: GrokSecretBundle,
+): {
+    readonly flags: {
+        readonly hasXaiApiKey: boolean;
+    };
+    readonly patches: readonly SecretRecordPatch[];
+} {
+    const xaiApiKey = normalizeOptionalText(input.xaiApiKey);
+    const patches: SecretRecordPatch[] = [];
+
+    pushSecretPatchIfChanged(
+        patches,
+        GROK_SECRET_NAMESPACE,
+        XAI_API_KEY_SECRET,
+        normalizeOptionalText(
+            secretStore.loadSecret(GROK_SECRET_NAMESPACE, XAI_API_KEY_SECRET),
+        ),
+        xaiApiKey,
+    );
+
+    return {
+        flags: {
+            hasXaiApiKey: Boolean(xaiApiKey),
+        },
+        patches,
+    };
+}
+
+export function applyGrokAuthEnv(
+    baseEnv: NodeJS.ProcessEnv,
+    settings: GrokRuntimeSettings,
+    secretStore?: SecretStoreGateway | null,
+): NodeJS.ProcessEnv {
+    const env = { ...baseEnv };
+
+    if (envSecretPresent(baseEnv, XAI_API_KEY_ENV)) {
+        return env;
+    }
+
+    delete env[XAI_API_KEY_ENV];
+
+    if (readSelectedGrokAuthMethod(settings) === GROK_LOGIN_METHOD_ID) {
+        return env;
+    }
+
+    const secrets = loadGrokSecretBundle(secretStore);
+    if (secrets.xaiApiKey) {
+        env[XAI_API_KEY_ENV] = secrets.xaiApiKey;
+    }
+
+    return env;
+}
+
+export function markGrokAuthInvalidated(
+    settings: GrokRuntimeSettings,
+): GrokRuntimeSettings {
+    return {
+        ...settings,
+        authInvalidatedAtMs: Date.now(),
+    };
+}
+
+export function launchGrokLogin(
+    settings: GrokRuntimeSettings,
+    cwd?: string | null,
+): Promise<void> {
+    const resolved = resolveGrokBinary(settings);
+    if (!resolved.program) {
+        throw new Error(
+            resolved.message ??
+                "Grok CLI was not found. Install `grok` or provide a custom runtime path.",
+        );
+    }
+
+    return launchTerminalLoginCommand({
+        commandParts: [resolved.program, ...GROK_AUTH_LOGIN_SUBCOMMAND],
+        cwd,
+        missingTerminalMessage:
+            "No compatible terminal launcher was found for Grok login.",
+        scriptPrefix: "comando-grok-login",
+    });
+}
+
+export function isGrokAuthenticationError(message: string): boolean {
+    const normalized = message.trim().toLowerCase();
+    return (
+        normalized.includes("run grok login") ||
+        normalized.includes("set xai_api_key") ||
+        normalized.includes("authentication required") ||
+        normalized.includes("auth_required") ||
+        normalized.includes("unauthorized") ||
+        normalized.includes("401") ||
+        normalized.includes("invalid api key") ||
+        normalized.includes("cached_token")
+    );
+}
+
+function saveSecretIfChanged(
+    secretStore: SecretStoreGateway,
+    namespace: string,
+    secretId: string,
+    currentValue: string | null,
+    nextValue: string | null,
+): void {
+    if (currentValue === nextValue) {
+        return;
+    }
+
+    void secretStore.saveSecret(namespace, secretId, nextValue);
+}
+
+function pushSecretPatchIfChanged(
+    patches: SecretRecordPatch[],
+    namespace: string,
+    secretId: string,
+    currentValue: string | null,
+    nextValue: string | null,
+): void {
+    if (currentValue === nextValue) {
+        return;
+    }
+
+    patches.push({
+        key: buildSecretStorageKey(namespace, secretId),
+        value: nextValue,
+    });
+}
+
+function normalizeOptionalText(
+    value: string | null | undefined,
+): string | null {
+    const trimmed = value?.trim() ?? "";
+    return trimmed.length > 0 ? trimmed : null;
+}
+
+function readSelectedGrokAuthMethod(
+    settings: GrokRuntimeSettings,
+): GrokAuthMethodId | null {
+    const authMethod = (settings as { readonly authMethod?: unknown })
+        .authMethod;
+    if (
+        authMethod === GROK_LOGIN_METHOD_ID ||
+        authMethod === XAI_API_KEY_METHOD_ID
+    ) {
+        return authMethod;
+    }
+
+    return null;
+}
+
+function grokLoginAvailable(settings: GrokRuntimeSettings): boolean {
+    const status = getGrokAuthStoreStatus();
+    if (!status?.hasActiveAuth) {
+        return false;
+    }
+
+    if (
+        settings.authInvalidatedAtMs !== null &&
+        status.modifiedAtMs !== null &&
+        status.modifiedAtMs <= settings.authInvalidatedAtMs
+    ) {
+        return false;
+    }
+
+    return true;
+}
+
+function getGrokAuthStoreStatus(): GrokAuthStoreStatus | null {
+    const authDir = getGrokAuthStorePath();
+    if (!authDir || !isDirectory(authDir)) {
+        return null;
+    }
+
+    return readGrokAuthStoreStatus(authDir);
+}
+
+function getGrokAuthStorePath(): string | null {
+    const homeDir =
+        process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || "";
+    if (!homeDir) {
+        return null;
+    }
+
+    return path.join(homeDir, ".grok", "auth");
+}
+
+function readGrokAuthStoreStatus(authDir: string): GrokAuthStoreStatus {
+    try {
+        const entries = fs.readdirSync(authDir, { withFileTypes: true });
+        let hasActiveAuth = false;
+        let modifiedAtMs = getFileModifiedAtMs(authDir);
+
+        for (const entry of entries) {
+            const entryPath = path.join(authDir, entry.name);
+            if (!entry.isFile()) {
+                continue;
+            }
+
+            const stat = fs.statSync(entryPath);
+            modifiedAtMs = Math.max(modifiedAtMs ?? 0, stat.mtimeMs);
+            if (stat.size > 0) {
+                hasActiveAuth = true;
+            }
+        }
+
+        return {
+            hasActiveAuth,
+            modifiedAtMs,
+        };
+    } catch (error) {
+        debugBenignError("ai.grok.readAuthStoreStatus", error);
+        return {
+            hasActiveAuth: false,
+            modifiedAtMs: getFileModifiedAtMs(authDir),
+        };
+    }
+}
+
+function envSecretPresent(env: NodeJS.ProcessEnv, key: typeof XAI_API_KEY_ENV) {
+    return Boolean(env[key]?.trim());
+}
+
+function getCredentialSourceLabel(source: AiAuthCredentialSource): string {
+    switch (source) {
+        case "comando-secret":
+            return "Using Comando stored credentials";
+        case "environment":
+            return "Using environment variable";
+        case "external-runtime":
+            return "Using external Grok login";
+        case "none":
+        default:
+            return "Needs authentication";
+    }
+}
+
+function resolveGrokBinary(settings: GrokRuntimeSettings): ResolvedGrokBinary {
+    const envPath = process.env[GROK_ENV_BIN]?.trim() ?? "";
+    const configuredPath = settings.binaryPath?.trim() ?? "";
+
+    if (envPath) {
+        return resolveCommandCandidate(envPath, "env");
+    }
+
+    if (configuredPath) {
+        return resolveCommandCandidate(configuredPath, "settings");
+    }
+
+    const pathResolved = resolveFromPath(GROK_PROGRAM_NAME);
+    if (pathResolved) {
+        return commandFromExistingPath(pathResolved, "path");
+    }
+
+    const macOsResolved = resolveFromMacOsFallbackDirs(GROK_PROGRAM_NAME);
+    if (macOsResolved) {
+        return commandFromExistingPath(macOsResolved, "path");
+    }
+
+    return {
+        args: [],
+        command: null,
+        message:
+            "Grok CLI was not found. Install `grok` or provide a custom runtime path.",
+        program: null,
+        source: null,
+        state: "missing",
+    };
+}
+
+function resolveCommandCandidate(
+    raw: string,
+    source: AiRuntimeStatus["source"],
+): ResolvedGrokBinary {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+        return {
+            args: [],
+            command: null,
+            message: "Grok runtime path is empty.",
+            program: null,
+            source,
+            state: "missing",
+        };
+    }
+
+    const looksLikePath =
+        path.isAbsolute(trimmed) ||
+        trimmed.includes(path.sep) ||
+        trimmed.includes("/") ||
+        trimmed.includes("\\");
+
+    if (looksLikePath) {
+        const candidate = path.resolve(trimmed);
+        if (!isExecutableFile(candidate)) {
+            return {
+                args: [],
+                command: candidate,
+                message: `Could not execute the configured Grok runtime: ${candidate}`,
+                program: null,
+                source,
+                state: "error",
+            };
+        }
+
+        return commandFromExistingPath(candidate, source);
+    }
+
+    const found = resolveFromPath(trimmed);
+    if (!found) {
+        return {
+            args: [],
+            command: trimmed,
+            message: `Configured command was not found: ${trimmed}`,
+            program: null,
+            source,
+            state: "missing",
+        };
+    }
+
+    return commandFromExistingPath(found, source);
+}
+
+function commandFromExistingPath(
+    candidatePath: string,
+    source: AiRuntimeStatus["source"],
+): ResolvedGrokBinary {
+    if (!isExecutableFile(candidatePath)) {
+        return {
+            args: [],
+            command: candidatePath,
+            message: `Grok runtime is not executable: ${candidatePath}`,
+            program: null,
+            source,
+            state: "error",
+        };
+    }
+
+    return {
+        args: GROK_ACP_ARGS,
+        command: `${candidatePath} ${GROK_ACP_ARGS.join(" ")}`,
+        message: null,
+        program: candidatePath,
+        source,
+        state: "ready",
+    };
+}
+
+function getFileModifiedAtMs(filePath: string): number | null {
+    try {
+        return fs.statSync(filePath).mtimeMs;
+    } catch (error) {
+        debugBenignError("ai.grok.getFileModifiedAtMs", error);
+        return null;
+    }
+}
+
+function resolveFromPath(command: string): string | null {
+    const pathEntries = (process.env.PATH ?? "")
+        .split(path.delimiter)
+        .filter(Boolean);
+    const pathextEntries =
+        process.platform === "win32"
+            ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+                  .split(";")
+                  .filter(Boolean)
+            : [""];
+
+    for (const entry of pathEntries) {
+        for (const ext of pathextEntries) {
+            const candidate = path.join(
+                entry,
+                process.platform === "win32" &&
+                    !command.toLowerCase().endsWith(ext.toLowerCase())
+                    ? `${command}${ext}`
+                    : command,
+            );
+            if (isExecutableFile(candidate)) {
+                return candidate;
+            }
+        }
+    }
+
+    return null;
+}
+
+function resolveFromMacOsFallbackDirs(command: string): string | null {
+    if (process.platform !== "darwin") {
+        return null;
+    }
+
+    for (const entry of GROK_MACOS_FALLBACK_DIRS) {
+        const candidate = path.join(entry, command);
+        if (isExecutableFile(candidate)) {
+            return candidate;
+        }
+    }
+
+    return null;
+}
+
+function isExecutableFile(candidatePath: string): boolean {
+    try {
+        fs.accessSync(candidatePath, fs.constants.X_OK);
+        return fs.statSync(candidatePath).isFile();
+    } catch (error) {
+        debugBenignError("ai.grok.isExecutableFile", error);
+        return false;
+    }
+}
+
+function isDirectory(candidatePath: string): boolean {
+    try {
+        return fs.statSync(candidatePath).isDirectory();
+    } catch (error) {
+        debugBenignError("ai.grok.isDirectory", error);
+        return false;
+    }
+}

--- a/src/main/ai/service.grok.test.ts
+++ b/src/main/ai/service.grok.test.ts
@@ -1,0 +1,502 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+    AiRuntimeStatus,
+    AiSessionSnapshot,
+    GrokRuntimeSettings,
+} from "@shared/ipc";
+
+import { launchTerminalLoginCommand } from "./auth/terminal-login";
+import type { AiWorkerGateway } from "./contracts";
+import { AiService } from "./service";
+
+vi.mock("./auth/terminal-login", () => ({
+    launchTerminalLoginCommand: vi.fn(() => Promise.resolve()),
+}));
+
+const originalXaiApiKey = process.env.XAI_API_KEY;
+const originalGrokBin = process.env.COMANDO_GROK_ACP_BIN;
+
+beforeEach(() => {
+    delete process.env.XAI_API_KEY;
+    delete process.env.COMANDO_GROK_ACP_BIN;
+    vi.mocked(launchTerminalLoginCommand).mockClear();
+});
+
+afterEach(() => {
+    restoreEnv("XAI_API_KEY", originalXaiApiKey);
+    restoreEnv("COMANDO_GROK_ACP_BIN", originalGrokBin);
+});
+
+describe("AiService Grok branch", () => {
+    it("stores Grok settings, persists the xAI API key, and emits runtime status", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-save-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            let savedSettings: GrokRuntimeSettings | null = null;
+            const runtimeStatusEvents: AiRuntimeStatus[] = [];
+            const secretValues = new Map<string, string>();
+            const service = createService({
+                onRuntimeStatus: (status) => runtimeStatusEvents.push(status),
+                secretValues,
+                settingsService: createSettingsService({
+                    loadGrokRuntimeSettings: vi.fn(() =>
+                        createGrokSettings(),
+                    ),
+                    saveGrokRuntimeSettings: (
+                        settings: GrokRuntimeSettings,
+                    ) => {
+                        savedSettings = settings;
+                    },
+                }),
+            });
+
+            const status = await service.saveGrokRuntimeSettings({
+                authMethod: "xai-api-key",
+                binaryPath,
+                xaiApiKey: {
+                    kind: "set",
+                    value: "xai-key-123",
+                },
+            });
+
+            expect(savedSettings).toEqual({
+                authInvalidatedAtMs: null,
+                authMethod: "xai-api-key",
+                binaryPath,
+                hasXaiApiKey: true,
+            });
+            expect(secretValues.get("ai.grok:xai_api_key")).toBe(
+                "xai-key-123",
+            );
+            expect(status.runtimeId).toBe("grok");
+            expect(status.authCredentialSource).toBe("comando-secret");
+            expect(runtimeStatusEvents.at(-1)?.runtimeId).toBe("grok");
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("prefers XAI_API_KEY from the environment over saved Grok settings", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-env-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            process.env.XAI_API_KEY = "env-xai-key";
+            const service = createService({
+                settingsService: createSettingsService({
+                    loadGrokRuntimeSettings: vi.fn(() =>
+                        createGrokSettings({
+                            authInvalidatedAtMs: 12345,
+                            authMethod: "grok-login",
+                            binaryPath,
+                        }),
+                    ),
+                }),
+            });
+
+            const status = service.getRuntimeStatus("grok");
+
+            expect(status.authMethod).toBe("xai-api-key");
+            expect(status.authCredentialSource).toBe("environment");
+            expect(status.authReady).toBe(true);
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("opens Grok login in a terminal and marks previous login state invalid", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-login-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            let savedSettings: GrokRuntimeSettings | null = null;
+            const service = createService({
+                settingsService: createSettingsService({
+                    loadGrokRuntimeSettings: vi.fn(() =>
+                        createGrokSettings({ binaryPath }),
+                    ),
+                    saveGrokRuntimeSettings: (
+                        settings: GrokRuntimeSettings,
+                    ) => {
+                        savedSettings = settings;
+                    },
+                }),
+            });
+
+            await service.launchRuntimeAuth({
+                methodId: "grok-login",
+                projectId: null,
+                runtimeId: "grok",
+                worktreeId: null,
+            });
+
+            expect(savedSettings).toMatchObject({
+                authMethod: "grok-login",
+                binaryPath,
+            });
+            const nextSettings = savedSettings as unknown as GrokRuntimeSettings;
+            expect(nextSettings.authInvalidatedAtMs).toEqual(
+                expect.any(Number),
+            );
+            expect(launchTerminalLoginCommand).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    commandParts: [binaryPath, "login"],
+                    scriptPrefix: "comando-grok-login",
+                }),
+            );
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("rejects terminal login for the xAI API key method", async () => {
+        const service = createService({
+            settingsService: createSettingsService({
+                loadGrokRuntimeSettings: vi.fn(() =>
+                    createGrokSettings({ authMethod: "xai-api-key" }),
+                ),
+            }),
+        });
+
+        await expect(
+            service.launchRuntimeAuth({
+                methodId: "xai-api-key",
+                projectId: null,
+                runtimeId: "grok",
+                worktreeId: null,
+            }),
+        ).rejects.toThrow(
+            "The xAI API key does not need a login terminal. Save the API key from settings.",
+        );
+        expect(launchTerminalLoginCommand).not.toHaveBeenCalled();
+    });
+
+    it("disconnects Grok by clearing the API key and invalidating external login", async () => {
+        let savedSettings: GrokRuntimeSettings | null = null;
+        const secretValues = new Map<string, string>([
+            ["ai.grok:xai_api_key", "xai-key"],
+        ]);
+        const service = createService({
+            secretValues,
+            settingsService: createSettingsService({
+                loadGrokRuntimeSettings: vi.fn(() =>
+                    createGrokSettings({
+                        authMethod: "grok-login",
+                        binaryPath: "/opt/homebrew/bin/grok",
+                        hasXaiApiKey: true,
+                    }),
+                ),
+                saveGrokRuntimeSettings: (settings: GrokRuntimeSettings) => {
+                    savedSettings = settings;
+                },
+            }),
+        });
+
+        await service.disconnectRuntimeAuth({ runtimeId: "grok" });
+
+        expect(savedSettings).not.toBeNull();
+        const nextSettings = savedSettings as unknown as GrokRuntimeSettings;
+        expect(nextSettings.binaryPath).toBe("/opt/homebrew/bin/grok");
+        expect(nextSettings.authMethod).toBeNull();
+        expect(nextSettings.hasXaiApiKey).toBe(false);
+        expect(nextSettings.authInvalidatedAtMs).toEqual(expect.any(Number));
+        expect(secretValues.has("ai.grok:xai_api_key")).toBe(false);
+    });
+
+    it("prepares Grok sessions with ACP launch details and stored xAI API key", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-session-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            const preparedSnapshot = createSessionSnapshot();
+            const prepareSession = vi.fn<AiWorkerGateway["prepareSession"]>(
+                () => Promise.resolve(preparedSnapshot),
+            );
+            const aiWorker = createAiWorker({ prepareSession });
+            const service = createService({
+                aiWorker,
+                secretValues: new Map([["ai.grok:xai_api_key", "xai-key"]]),
+                settingsService: createSettingsService({
+                    loadGrokRuntimeSettings: vi.fn(() =>
+                        createGrokSettings({
+                            authMethod: "xai-api-key",
+                            binaryPath,
+                            hasXaiApiKey: true,
+                        }),
+                    ),
+                }),
+            });
+
+            await service.prepareSession(
+                {
+                    projectId: null,
+                    runtimeId: "grok",
+                    sessionId: "session-grok",
+                    title: "Grok 1",
+                    worktreeId: null,
+                },
+                "window-1",
+            );
+
+            const launch = prepareSession.mock.calls[0][0].launch;
+            expect(launch.resolvedRuntime.executable).toBe(binaryPath);
+            expect(launch.resolvedRuntime.args).toEqual([
+                "--no-auto-update",
+                "agent",
+                "stdio",
+            ]);
+            expect(launch.resolvedRuntime.command).toBe(
+                `${binaryPath} --no-auto-update agent stdio`,
+            );
+            expect(launch.resolvedRuntime.env.XAI_API_KEY).toBe("xai-key");
+            expect(launch.resolvedRuntime.status.runtimeId).toBe("grok");
+            expect(launch.resolvedRuntime.status.onboardingRequired).toBe(
+                false,
+            );
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("invalidates Grok login after an authentication error", () => {
+        let savedSettings: GrokRuntimeSettings | null = null;
+        const service = createService({
+            settingsService: createSettingsService({
+                loadGrokRuntimeSettings: vi.fn(() =>
+                    createGrokSettings({
+                        authMethod: "grok-login",
+                        binaryPath: "/opt/homebrew/bin/grok",
+                    }),
+                ),
+                saveGrokRuntimeSettings: (settings: GrokRuntimeSettings) => {
+                    savedSettings = settings;
+                },
+            }),
+        });
+
+        service.handleWorkerSessionSnapshot("window-1", {
+            kind: "snapshot",
+            snapshot: {
+                ...createSessionSnapshot(),
+                lastError: "Unauthorized: cached_token expired",
+            },
+        });
+
+        expect(savedSettings).toMatchObject({
+            authMethod: "grok-login",
+            binaryPath: "/opt/homebrew/bin/grok",
+        });
+        const nextSettings = savedSettings as unknown as GrokRuntimeSettings;
+        expect(nextSettings.authInvalidatedAtMs).toEqual(expect.any(Number));
+    });
+});
+
+function createService(overrides: {
+    readonly aiWorker?: AiWorkerGateway;
+    readonly onRuntimeStatus?: (status: AiRuntimeStatus) => void;
+    readonly secretValues?: Map<string, string>;
+    readonly settingsService?: unknown;
+}): AiService {
+    return new AiService({
+        aiWorker: overrides.aiWorker ?? null,
+        onRuntimeStatus: overrides.onRuntimeStatus ?? vi.fn(),
+        onSessionSnapshot: vi.fn(),
+        persistence: {
+            loadLatestRuntimeCatalog: vi.fn(() => null),
+            loadRuntimeSelectionPreferences: vi.fn(() => ({
+                configOptions: {},
+                modeId: null,
+                modelId: null,
+            })),
+            loadSessionSnapshot: vi.fn(() => null),
+            saveRuntimeModePreference: vi.fn(),
+            saveRuntimeModelPreference: vi.fn(),
+            saveRuntimeSelectionPreferenceOption: vi.fn(),
+            saveSessionSnapshot: vi.fn(),
+        } as never,
+        projectService: {
+            getProjectRootPath: vi.fn(() => process.cwd()),
+            listProjectWorktrees: vi.fn(() => []),
+        } as never,
+        secretStore: createSecretStore(
+            overrides.secretValues ?? new Map<string, string>(),
+        ),
+        settingsService: (overrides.settingsService ??
+            createSettingsService({})) as never,
+    });
+}
+
+function createSettingsService(overrides: Record<string, unknown>) {
+    return {
+        loadClaudeRuntimeSettings: vi.fn(() => ({
+            authInvalidatedAtMs: null,
+            authMethod: null,
+            bedrockGatewayBaseUrl: null,
+            binaryPath: null,
+            gatewayBaseUrl: null,
+            hasAnthropicApiKey: false,
+            hasGatewayAuthToken: false,
+            hasGatewayCustomHeaders: false,
+        })),
+        loadCodexRuntimeSettings: vi.fn(() => ({
+            authMethod: null,
+            binaryPath: null,
+            hasCodexApiKey: false,
+            hasOpenAiApiKey: false,
+        })),
+        loadGeminiRuntimeSettings: vi.fn(() => ({
+            authInvalidatedAtMs: null,
+            authMethod: null,
+            binaryPath: null,
+            googleCloudLocation: null,
+            googleCloudProject: null,
+            hasGeminiApiKey: false,
+            hasGoogleApiKey: false,
+        })),
+        loadGrokRuntimeSettings: vi.fn(() => createGrokSettings()),
+        loadKiloRuntimeSettings: vi.fn(() => ({
+            authInvalidatedAtMs: null,
+            authMethod: null,
+            binaryPath: null,
+            hasKiloApiKey: false,
+        })),
+        loadOpenCodeRuntimeSettings: vi.fn(() => ({
+            authInvalidatedAtMs: null,
+            authMethod: null,
+            binaryPath: null,
+        })),
+        saveClaudeRuntimeSettings: vi.fn(),
+        saveCodexRuntimeSettings: vi.fn(),
+        saveGeminiRuntimeSettings: vi.fn(),
+        saveGrokRuntimeSettings: vi.fn(),
+        saveKiloRuntimeSettings: vi.fn(),
+        saveOpenCodeRuntimeSettings: vi.fn(),
+        ...overrides,
+    } as never;
+}
+
+function createSecretStore(secretValues: Map<string, string>) {
+    return {
+        cacheSecretPatches: vi.fn(),
+        getStorageStatus: vi.fn(() => ({
+            encryptionAvailable: true,
+            isWeakBackend: false,
+            message: null,
+            platform: process.platform,
+            selectedBackend: null,
+        })),
+        loadSecret: (namespace: string, secretId: string) =>
+            secretValues.get(`${namespace}:${secretId}`) ?? null,
+        saveSecret: (
+            namespace: string,
+            secretId: string,
+            value: string | null,
+        ) => {
+            const key = `${namespace}:${secretId}`;
+            const normalized = value?.trim() ?? "";
+            if (!normalized) {
+                secretValues.delete(key);
+                return;
+            }
+
+            secretValues.set(key, normalized);
+        },
+    };
+}
+
+function createAiWorker(overrides: Partial<AiWorkerGateway>): AiWorkerGateway {
+    return {
+        cancelSession: vi.fn(),
+        close: vi.fn(),
+        closeOwnedByWindow: vi.fn(),
+        closeSession: vi.fn(),
+        keepAllTrackedFiles: vi.fn(),
+        keepTrackedFile: vi.fn(),
+        keepTrackedFileHunks: vi.fn(),
+        notifyFileBuffer: vi.fn(),
+        prepareSession: vi.fn(),
+        refreshProjectScopes: vi.fn(),
+        rejectAllTrackedFiles: vi.fn(),
+        rejectTrackedFile: vi.fn(),
+        rejectTrackedFileHunks: vi.fn(),
+        renameSession: vi.fn(),
+        respondPermission: vi.fn(),
+        respondUserInput: vi.fn(),
+        sendPrompt: vi.fn(),
+        setSessionConfigOption: vi.fn(),
+        setSessionMode: vi.fn(),
+        setSessionModel: vi.fn(),
+        ...overrides,
+    };
+}
+
+function createGrokSettings(
+    overrides: Partial<GrokRuntimeSettings> = {},
+): GrokRuntimeSettings {
+    return {
+        authInvalidatedAtMs: null,
+        authMethod: null,
+        binaryPath: null,
+        hasXaiApiKey: false,
+        ...overrides,
+    };
+}
+
+function createSessionSnapshot(): AiSessionSnapshot {
+    return {
+        activeTurnStartedAt: null,
+        availableCommands: [],
+        configOptions: [],
+        lastError: null,
+        messages: [],
+        modeId: null,
+        modes: [],
+        modelId: null,
+        models: [],
+        parentSessionId: null,
+        pendingPermission: null,
+        pendingUserInput: null,
+        plan: null,
+        projectId: null,
+        runtimeId: "grok",
+        runtimeSessionId: "runtime-grok",
+        sessionId: "session-grok",
+        status: "idle",
+        title: "Grok 1",
+        toolActivity: [],
+        tokenUsage: null,
+        trackedFiles: [],
+        updatedAt: new Date().toISOString(),
+        worktreeId: null,
+    };
+}
+
+function writeExecutable(directory: string, name: string): string {
+    const binaryPath = path.join(directory, name);
+    fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
+    fs.chmodSync(binaryPath, 0o755);
+    return binaryPath;
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+    if (value === undefined) {
+        delete process.env[name];
+        return;
+    }
+
+    process.env[name] = value;
+}

--- a/src/main/ai/service.grok.test.ts
+++ b/src/main/ai/service.grok.test.ts
@@ -129,6 +129,156 @@ describe("AiService Grok branch", () => {
         }
     });
 
+    it("keeps saved Grok login pending until local credentials are verified", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-pending-login-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            let savedSettings: GrokRuntimeSettings | null = null;
+            const service = createService({
+                settingsService: createSettingsService({
+                    loadGrokRuntimeSettings: vi.fn(() =>
+                        createGrokSettings(),
+                    ),
+                    saveGrokRuntimeSettings: (
+                        settings: GrokRuntimeSettings,
+                    ) => {
+                        savedSettings = settings;
+                    },
+                }),
+            });
+
+            const status = await service.saveGrokRuntimeSettings({
+                authMethod: "grok-login",
+                binaryPath,
+                xaiApiKey: {
+                    kind: "unchanged",
+                },
+            });
+
+            expect(savedSettings).toMatchObject({
+                authMethod: "grok-login",
+                binaryPath,
+                hasXaiApiKey: false,
+            });
+            expect(
+                (savedSettings as unknown as GrokRuntimeSettings)
+                    .authInvalidatedAtMs,
+            ).toEqual(expect.any(Number));
+            expect(status).toMatchObject({
+                authCredentialSource: "none",
+                authMethod: null,
+                authReady: false,
+                onboardingRequired: true,
+                runtimeId: "grok",
+            });
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("does not treat XAI_API_KEY as verified Grok login state", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-env-login-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            process.env.XAI_API_KEY = "env-xai-key";
+            let savedSettings: GrokRuntimeSettings | null = null;
+            const service = createService({
+                settingsService: createSettingsService({
+                    loadGrokRuntimeSettings: vi.fn(() =>
+                        createGrokSettings(),
+                    ),
+                    saveGrokRuntimeSettings: (
+                        settings: GrokRuntimeSettings,
+                    ) => {
+                        savedSettings = settings;
+                    },
+                }),
+            });
+
+            const status = await service.saveGrokRuntimeSettings({
+                authMethod: "grok-login",
+                binaryPath,
+                xaiApiKey: {
+                    kind: "unchanged",
+                },
+            });
+
+            expect(
+                (savedSettings as unknown as GrokRuntimeSettings)
+                    .authInvalidatedAtMs,
+            ).toEqual(expect.any(Number));
+            expect(status).toMatchObject({
+                authCredentialSource: "environment",
+                authMethod: "xai-api-key",
+                authReady: true,
+                runtimeId: "grok",
+            });
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("trusts saved Grok login when local credentials are already present", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-trusted-login-"),
+        );
+        const originalHome = process.env.HOME;
+        const originalUserProfile = process.env.USERPROFILE;
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            writeGrokAuthStore(tempDir);
+            process.env.HOME = tempDir;
+            delete process.env.USERPROFILE;
+            let savedSettings: GrokRuntimeSettings | null = null;
+            const service = createService({
+                settingsService: createSettingsService({
+                    loadGrokRuntimeSettings: vi.fn(() =>
+                        createGrokSettings({
+                            authInvalidatedAtMs: Date.now() - 60_000,
+                        }),
+                    ),
+                    saveGrokRuntimeSettings: (
+                        settings: GrokRuntimeSettings,
+                    ) => {
+                        savedSettings = settings;
+                    },
+                }),
+            });
+
+            const status = await service.saveGrokRuntimeSettings({
+                authMethod: "grok-login",
+                binaryPath,
+                xaiApiKey: {
+                    kind: "unchanged",
+                },
+            });
+
+            expect(savedSettings).toMatchObject({
+                authInvalidatedAtMs: null,
+                authMethod: "grok-login",
+                binaryPath,
+            });
+            expect(status).toMatchObject({
+                authCredentialSource: "external-runtime",
+                authMethod: "grok-login",
+                authReady: true,
+                onboardingRequired: false,
+                runtimeId: "grok",
+            });
+        } finally {
+            restoreEnv("HOME", originalHome);
+            restoreEnv("USERPROFILE", originalUserProfile);
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
     it("hydrates Grok login from the ACP cached token probe", async () => {
         const tempDir = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-grok-probe-"),
@@ -740,6 +890,12 @@ function writeExecutable(directory: string, name: string): string {
     fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
     fs.chmodSync(binaryPath, 0o755);
     return binaryPath;
+}
+
+function writeGrokAuthStore(homeDir: string): void {
+    const authDir = path.join(homeDir, ".grok", "auth");
+    fs.mkdirSync(authDir, { recursive: true });
+    fs.writeFileSync(path.join(authDir, "token"), "cached-token", "utf8");
 }
 
 function restoreEnv(name: string, value: string | undefined): void {

--- a/src/main/ai/service.grok.test.ts
+++ b/src/main/ai/service.grok.test.ts
@@ -371,6 +371,79 @@ describe("AiService Grok branch", () => {
         const nextSettings = savedSettings as unknown as GrokRuntimeSettings;
         expect(nextSettings.authInvalidatedAtMs).toEqual(expect.any(Number));
     });
+
+    it("clears a stored xAI API key after a Grok API key authentication error", async () => {
+        let savedSettings: GrokRuntimeSettings | null = null;
+        const runtimeStatusEvents: AiRuntimeStatus[] = [];
+        const secretValues = new Map<string, string>([
+            ["ai.grok:xai_api_key", "invalid-xai-key"],
+        ]);
+        const service = createService({
+            onRuntimeStatus: (status) => runtimeStatusEvents.push(status),
+            secretValues,
+            settingsService: createSettingsService({
+                loadGrokRuntimeSettings: vi.fn(() =>
+                    createGrokSettings({
+                        authMethod: "xai-api-key",
+                        binaryPath: "/opt/homebrew/bin/grok",
+                        hasXaiApiKey: true,
+                    }),
+                ),
+                saveGrokRuntimeSettings: (settings: GrokRuntimeSettings) => {
+                    savedSettings = settings;
+                },
+            }),
+        });
+
+        service.handleWorkerSessionSnapshot("window-1", {
+            kind: "snapshot",
+            snapshot: {
+                ...createSessionSnapshot(),
+                lastError: "invalid api key",
+            },
+        });
+        await flushAsyncWork();
+
+        expect(savedSettings).toMatchObject({
+            authMethod: null,
+            hasXaiApiKey: false,
+        });
+        expect(secretValues.has("ai.grok:xai_api_key")).toBe(false);
+        expect(runtimeStatusEvents.at(-1)).toMatchObject({
+            authCredentialSource: "none",
+            authMethod: null,
+            authReady: false,
+            runtimeId: "grok",
+        });
+    });
+
+    it("does not rewrite environment xAI API key errors to Grok login", () => {
+        process.env.XAI_API_KEY = "invalid-env-key";
+        let savedSettings: GrokRuntimeSettings | null = null;
+        const service = createService({
+            settingsService: createSettingsService({
+                loadGrokRuntimeSettings: vi.fn(() =>
+                    createGrokSettings({
+                        authMethod: "xai-api-key",
+                        binaryPath: "/opt/homebrew/bin/grok",
+                    }),
+                ),
+                saveGrokRuntimeSettings: (settings: GrokRuntimeSettings) => {
+                    savedSettings = settings;
+                },
+            }),
+        });
+
+        service.handleWorkerSessionSnapshot("window-1", {
+            kind: "snapshot",
+            snapshot: {
+                ...createSessionSnapshot(),
+                lastError: "Unauthorized: invalid api key",
+            },
+        });
+
+        expect(savedSettings).toBeNull();
+    });
 });
 
 function createService(overrides: {
@@ -459,7 +532,30 @@ function createSettingsService(overrides: Record<string, unknown>) {
 
 function createSecretStore(secretValues: Map<string, string>) {
     return {
-        cacheSecretPatches: vi.fn(),
+        cacheSecretPatches: vi.fn(
+            (
+                patches: readonly {
+                    readonly key: string;
+                    readonly value: string | null;
+                }[],
+            ) => {
+                for (const patch of patches) {
+                    const parsed = parseTestSecretStorageKey(patch.key);
+                    if (!parsed) {
+                        continue;
+                    }
+
+                    const normalized = patch.value?.trim() ?? "";
+                    const key = `${parsed.namespace}:${parsed.secretId}`;
+                    if (!normalized) {
+                        secretValues.delete(key);
+                        continue;
+                    }
+
+                    secretValues.set(key, normalized);
+                }
+            },
+        ),
         getStorageStatus: vi.fn(() => ({
             encryptionAvailable: true,
             isWeakBackend: false,
@@ -483,6 +579,26 @@ function createSecretStore(secretValues: Map<string, string>) {
 
             secretValues.set(key, normalized);
         },
+    };
+}
+
+function parseTestSecretStorageKey(
+    key: string,
+): { readonly namespace: string; readonly secretId: string } | null {
+    const prefix = "secret.";
+    if (!key.startsWith(prefix)) {
+        return null;
+    }
+
+    const body = key.slice(prefix.length);
+    const separatorIndex = body.lastIndexOf(".");
+    if (separatorIndex <= 0 || separatorIndex === body.length - 1) {
+        return null;
+    }
+
+    return {
+        namespace: body.slice(0, separatorIndex),
+        secretId: body.slice(separatorIndex + 1),
     };
 }
 
@@ -567,4 +683,9 @@ function restoreEnv(name: string, value: string | undefined): void {
     }
 
     process.env[name] = value;
+}
+
+async function flushAsyncWork(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
 }

--- a/src/main/ai/service.grok.test.ts
+++ b/src/main/ai/service.grok.test.ts
@@ -340,6 +340,72 @@ describe("AiService Grok branch", () => {
         }
     });
 
+    it("hydrates Grok login during session preparation after terminal login", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-prepare-probe-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            const invalidatedAtMs = Date.now();
+            let grokSettings = createGrokSettings({
+                authInvalidatedAtMs: invalidatedAtMs,
+                authMethod: "grok-login",
+                binaryPath,
+            });
+            const preparedSnapshot = createSessionSnapshot();
+            const prepareSession = vi.fn<AiWorkerGateway["prepareSession"]>(
+                () => Promise.resolve(preparedSnapshot),
+            );
+            const aiWorker = createAiWorker({ prepareSession });
+            probeGrokCachedTokenAuthMock.mockResolvedValueOnce(true);
+
+            const service = createService({
+                aiWorker,
+                settingsService: createSettingsService({
+                    loadGrokRuntimeSettings: vi.fn(() => grokSettings),
+                    saveGrokRuntimeSettings: (
+                        settings: GrokRuntimeSettings,
+                    ) => {
+                        grokSettings = settings;
+                    },
+                }),
+            });
+
+            await service.prepareSession(
+                {
+                    projectId: null,
+                    runtimeId: "grok",
+                    sessionId: "session-grok",
+                    title: "Grok 1",
+                    worktreeId: null,
+                },
+                "window-1",
+            );
+
+            expect(probeGrokCachedTokenAuthMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    authInvalidatedAtMs: invalidatedAtMs,
+                    authMethod: "grok-login",
+                    binaryPath,
+                }),
+                expect.any(Object),
+            );
+            expect(grokSettings).toMatchObject({
+                authInvalidatedAtMs: null,
+                authMethod: "grok-login",
+                binaryPath,
+            });
+            expect(prepareSession).toHaveBeenCalledOnce();
+            expect(
+                prepareSession.mock.calls[0][0].launch.resolvedRuntime.status
+                    .onboardingRequired,
+            ).toBe(false);
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
     it("invalidates Grok login after an authentication error", () => {
         let savedSettings: GrokRuntimeSettings | null = null;
         const service = createService({

--- a/src/main/ai/service.grok.test.ts
+++ b/src/main/ai/service.grok.test.ts
@@ -14,9 +14,21 @@ import { launchTerminalLoginCommand } from "./auth/terminal-login";
 import type { AiWorkerGateway } from "./contracts";
 import { AiService } from "./service";
 
+const probeGrokCachedTokenAuthMock = vi.hoisted(() =>
+    vi.fn(() => Promise.resolve(false)),
+);
+
 vi.mock("./auth/terminal-login", () => ({
     launchTerminalLoginCommand: vi.fn(() => Promise.resolve()),
 }));
+
+vi.mock("./grok/setup", async (importOriginal) => {
+    const original = await importOriginal<typeof import("./grok/setup")>();
+    return {
+        ...original,
+        probeGrokCachedTokenAuth: probeGrokCachedTokenAuthMock,
+    };
+});
 
 const originalXaiApiKey = process.env.XAI_API_KEY;
 const originalGrokBin = process.env.COMANDO_GROK_ACP_BIN;
@@ -25,6 +37,8 @@ beforeEach(() => {
     delete process.env.XAI_API_KEY;
     delete process.env.COMANDO_GROK_ACP_BIN;
     vi.mocked(launchTerminalLoginCommand).mockClear();
+    probeGrokCachedTokenAuthMock.mockReset();
+    probeGrokCachedTokenAuthMock.mockResolvedValue(false);
 });
 
 afterEach(() => {
@@ -84,7 +98,7 @@ describe("AiService Grok branch", () => {
         }
     });
 
-    it("prefers XAI_API_KEY from the environment over saved Grok settings", () => {
+    it("prefers XAI_API_KEY from the environment over saved Grok settings", async () => {
         const tempDir = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-grok-env-"),
         );
@@ -104,11 +118,65 @@ describe("AiService Grok branch", () => {
                 }),
             });
 
-            const status = service.getRuntimeStatus("grok");
+            const status = await service.getRuntimeStatus("grok");
 
             expect(status.authMethod).toBe("xai-api-key");
             expect(status.authCredentialSource).toBe("environment");
             expect(status.authReady).toBe(true);
+            expect(probeGrokCachedTokenAuthMock).not.toHaveBeenCalled();
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("hydrates Grok login from the ACP cached token probe", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-probe-"),
+        );
+
+        try {
+            const binaryPath = writeExecutable(tempDir, "grok");
+            const invalidatedAtMs = Date.now();
+            let savedSettings: GrokRuntimeSettings | null = null;
+            const runtimeStatusEvents: AiRuntimeStatus[] = [];
+            probeGrokCachedTokenAuthMock.mockResolvedValueOnce(true);
+
+            const service = createService({
+                onRuntimeStatus: (status) => runtimeStatusEvents.push(status),
+                settingsService: createSettingsService({
+                    loadGrokRuntimeSettings: vi.fn(() =>
+                        createGrokSettings({
+                            authInvalidatedAtMs: invalidatedAtMs,
+                            binaryPath,
+                        }),
+                    ),
+                    saveGrokRuntimeSettings: (
+                        settings: GrokRuntimeSettings,
+                    ) => {
+                        savedSettings = settings;
+                    },
+                }),
+            });
+
+            const status = await service.getRuntimeStatus("grok");
+
+            expect(probeGrokCachedTokenAuthMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    authInvalidatedAtMs: invalidatedAtMs,
+                    binaryPath,
+                }),
+                expect.any(Object),
+            );
+            expect(savedSettings).toMatchObject({
+                authInvalidatedAtMs: null,
+                authMethod: "grok-login",
+                binaryPath,
+            });
+            expect(status.authMethod).toBe("grok-login");
+            expect(status.authCredentialSource).toBe("external-runtime");
+            expect(status.authReady).toBe(true);
+            expect(status.onboardingRequired).toBe(false);
+            expect(runtimeStatusEvents.at(-1)?.authMethod).toBe("grok-login");
         } finally {
             fs.rmSync(tempDir, { force: true, recursive: true });
         }

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -34,6 +34,8 @@ import type {
     CodexRuntimeSettingsInput,
     CodexRuntimeSettings,
     GeminiRuntimeSettingsInput,
+    GrokRuntimeSettings,
+    GrokRuntimeSettingsInput,
     GetAiSessionTranscriptPageInput,
     KiloRuntimeSettingsInput,
     ListAiSessionHistoryInput,
@@ -133,6 +135,18 @@ import {
     markKiloAuthInvalidated,
     resolveKiloRuntime,
 } from "./kilo/setup";
+import {
+    applyGrokAuthEnv,
+    buildGrokSecretPatches,
+    getGrokRuntimeStatus,
+    isGrokAuthenticationError,
+    isGrokEnvironmentCredentialReady,
+    isGrokExternalCredentialReady,
+    launchGrokLogin,
+    loadGrokSecretBundle,
+    markGrokAuthInvalidated,
+    resolveGrokRuntime,
+} from "./grok/setup";
 import {
     applyOpenCodeAuthEnv,
     getOpenCodeRuntimeStatus,
@@ -420,6 +434,46 @@ export class AiService {
         await this.#saveGeminiAuthSettings(nextSettings, secretPatch.patches);
         const status = this.#withPersistedRuntimeCatalog(
             getGeminiRuntimeStatus(nextSettings, this.#secretStore),
+        );
+        this.#onRuntimeStatus(status);
+        return status;
+    }
+
+    async saveGrokRuntimeSettings(
+        settings: GrokRuntimeSettingsInput,
+    ): Promise<AiRuntimeStatus> {
+        const currentSettings = this.#settingsService.loadGrokRuntimeSettings();
+        const xaiApiKey = applySecretValuePatch(
+            loadGrokSecretBundle(this.#secretStore).xaiApiKey,
+            settings.xaiApiKey,
+        );
+        const secretPatch = buildGrokSecretPatches(this.#secretStore, {
+            xaiApiKey,
+        });
+        const nextSettings = {
+            authInvalidatedAtMs: currentSettings.authInvalidatedAtMs,
+            authMethod: settings.authMethod,
+            binaryPath: normalizeOptionalText(settings.binaryPath),
+            hasXaiApiKey: secretPatch.flags.hasXaiApiKey,
+        } satisfies GrokRuntimeSettings;
+        const shouldClearInvalidation =
+            settings.authMethod === "grok-login" &&
+            (isGrokEnvironmentCredentialReady(process.env) ||
+                isGrokExternalCredentialReady(nextSettings));
+        const persistedSettings = {
+            ...nextSettings,
+            authInvalidatedAtMs:
+                shouldClearInvalidation
+                    ? null
+                    : nextSettings.authInvalidatedAtMs,
+        } satisfies GrokRuntimeSettings;
+
+        await this.#saveGrokAuthSettings(
+            persistedSettings,
+            secretPatch.patches,
+        );
+        const status = this.#withPersistedRuntimeCatalog(
+            getGrokRuntimeStatus(persistedSettings, this.#secretStore),
         );
         this.#onRuntimeStatus(status);
         return status;
@@ -868,6 +922,34 @@ export class AiService {
             return;
         }
 
+        if (input.runtimeId === "grok") {
+            if (input.methodId === "xai-api-key") {
+                throw new Error(
+                    "The xAI API key does not need a login terminal. Save the API key from settings.",
+                );
+            }
+
+            if (input.methodId !== "grok-login") {
+                throw new Error(
+                    "Select Grok login before opening authentication.",
+                );
+            }
+
+            const nextSettings = markGrokAuthInvalidated({
+                ...this.#settingsService.loadGrokRuntimeSettings(),
+                authMethod: "grok-login",
+            });
+            await this.#saveGrokAuthSettings(nextSettings);
+
+            await launchGrokLogin(nextSettings, cwd);
+            this.#onRuntimeStatus(
+                this.#withPersistedRuntimeCatalog(
+                    getGrokRuntimeStatus(nextSettings, this.#secretStore),
+                ),
+            );
+            return;
+        }
+
         if (input.runtimeId === "opencode") {
             if (input.methodId !== "opencode-login") {
                 throw new Error(
@@ -1114,6 +1196,25 @@ export class AiService {
             await this.#saveOpenCodeAuthSettings(nextSettings);
             const status = this.#withPersistedRuntimeCatalog(
                 getOpenCodeRuntimeStatus(nextSettings, this.#secretStore),
+            );
+            this.#onRuntimeStatus(status);
+            return status;
+        }
+
+        if (input.runtimeId === "grok") {
+            const currentSettings =
+                this.#settingsService.loadGrokRuntimeSettings();
+            const secretPatch = buildGrokSecretPatches(this.#secretStore, {
+                xaiApiKey: null,
+            });
+            const nextSettings = {
+                ...markGrokAuthInvalidated(currentSettings),
+                authMethod: null,
+                hasXaiApiKey: secretPatch.flags.hasXaiApiKey,
+            } satisfies GrokRuntimeSettings;
+            await this.#saveGrokAuthSettings(nextSettings, secretPatch.patches);
+            const status = this.#withPersistedRuntimeCatalog(
+                getGrokRuntimeStatus(nextSettings, this.#secretStore),
             );
             this.#onRuntimeStatus(status);
             return status;
@@ -1747,6 +1848,13 @@ export class AiService {
             );
         }
 
+        if (runtimeId === "grok") {
+            return getGrokRuntimeStatus(
+                this.#settingsService.loadGrokRuntimeSettings(),
+                this.#secretStore,
+            );
+        }
+
         if (runtimeId === "kilo") {
             return getKiloRuntimeStatus(
                 this.#settingsService.loadKiloRuntimeSettings(),
@@ -1807,6 +1915,20 @@ export class AiService {
 
         await this.#saveSecretPatches(secrets);
         this.#settingsService.saveGeminiRuntimeSettings(settings);
+    }
+
+    async #saveGrokAuthSettings(
+        settings: GrokRuntimeSettings,
+        secrets: readonly SecretRecordPatch[] = [],
+    ): Promise<void> {
+        if (this.#settingsService.saveGrokAuth) {
+            await this.#settingsService.saveGrokAuth(settings, secrets);
+            this.#secretStore.cacheSecretPatches?.(secrets);
+            return;
+        }
+
+        await this.#saveSecretPatches(secrets);
+        this.#settingsService.saveGrokRuntimeSettings(settings);
     }
 
     async #saveKiloAuthSettings(
@@ -1904,6 +2026,22 @@ export class AiService {
                         settings,
                         this.#secretStore,
                     ),
+                    resolved.program,
+                ),
+                executable: resolved.program,
+                status: resolved.status,
+            };
+        }
+
+        if (runtimeId === "grok") {
+            const settings = this.#settingsService.loadGrokRuntimeSettings();
+            const resolved = resolveGrokRuntime(settings, this.#secretStore);
+
+            return {
+                args: resolved.args,
+                command: resolved.command,
+                env: buildRuntimeSpawnEnv(
+                    applyGrokAuthEnv(process.env, settings, this.#secretStore),
                     resolved.program,
                 ),
                 executable: resolved.program,
@@ -2087,6 +2225,20 @@ export class AiService {
             this.#settingsService.saveGeminiRuntimeSettings(nextSettings);
             this.#onRuntimeStatus(
                 getGeminiRuntimeStatus(nextSettings, this.#secretStore),
+            );
+            return;
+        }
+
+        if (runtimeId === "grok" && isGrokAuthenticationError(message)) {
+            const nextSettings = markGrokAuthInvalidated({
+                ...this.#settingsService.loadGrokRuntimeSettings(),
+                authMethod: "grok-login",
+            });
+            this.#settingsService.saveGrokRuntimeSettings(nextSettings);
+            this.#onRuntimeStatus(
+                this.#withPersistedRuntimeCatalog(
+                    getGrokRuntimeStatus(nextSettings, this.#secretStore),
+                ),
             );
             return;
         }

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -145,6 +145,7 @@ import {
     launchGrokLogin,
     loadGrokSecretBundle,
     markGrokAuthInvalidated,
+    probeGrokCachedTokenAuth,
     resolveGrokRuntime,
 } from "./grok/setup";
 import {
@@ -306,10 +307,14 @@ export class AiService {
         await Promise.allSettled(relaunches);
     }
 
-    getRuntimeStatus(runtimeId: AiRuntimeId): AiRuntimeStatus {
-        const status = this.#withPersistedRuntimeCatalog(
+    async getRuntimeStatus(runtimeId: AiRuntimeId): Promise<AiRuntimeStatus> {
+        const resolvedStatus = this.#withPersistedRuntimeCatalog(
             this.#resolveRuntimeStatus(runtimeId),
         );
+        const status =
+            runtimeId === "grok"
+                ? await this.#resolveGrokRuntimeStatusWithProbe(resolvedStatus)
+                : resolvedStatus;
         this.#onRuntimeStatus(status);
         return status;
     }
@@ -1990,6 +1995,39 @@ export class AiService {
             modelId: catalog.modelId,
             models: catalog.models,
         };
+    }
+
+    async #resolveGrokRuntimeStatusWithProbe(
+        status: AiRuntimeStatus,
+    ): Promise<AiRuntimeStatus> {
+        if (
+            status.state !== "ready" ||
+            status.authReady ||
+            status.authCredentialSource === "environment" ||
+            status.authCredentialSource === "comando-secret"
+        ) {
+            return status;
+        }
+
+        const settings = this.#settingsService.loadGrokRuntimeSettings();
+        const hasCachedToken = await probeGrokCachedTokenAuth(
+            settings,
+            this.#secretStore,
+        );
+        if (!hasCachedToken) {
+            return status;
+        }
+
+        const nextSettings = {
+            ...settings,
+            authInvalidatedAtMs: null,
+            authMethod: "grok-login",
+        } satisfies GrokRuntimeSettings;
+        await this.#saveGrokAuthSettings(nextSettings);
+
+        return this.#withPersistedRuntimeCatalog(
+            getGrokRuntimeStatus(nextSettings, this.#secretStore),
+        );
     }
 
     #resolveRuntimeCommand(

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -307,6 +307,7 @@ export class AiService {
                 claude: this.#settingsService.loadClaudeRuntimeSettings(),
                 codex: this.#settingsService.loadCodexRuntimeSettings(),
                 gemini: this.#settingsService.loadGeminiRuntimeSettings(),
+                grok: this.#settingsService.loadGrokRuntimeSettings(),
                 kilo: this.#settingsService.loadKiloRuntimeSettings(),
                 opencode: this.#settingsService.loadOpenCodeRuntimeSettings(),
             },

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -140,7 +140,6 @@ import {
     buildGrokSecretPatches,
     getGrokRuntimeStatus,
     isGrokAuthenticationError,
-    isGrokEnvironmentCredentialReady,
     isGrokExternalCredentialReady,
     launchGrokLogin,
     loadGrokSecretBundle,
@@ -461,15 +460,16 @@ export class AiService {
             binaryPath: normalizeOptionalText(settings.binaryPath),
             hasXaiApiKey: secretPatch.flags.hasXaiApiKey,
         } satisfies GrokRuntimeSettings;
-        const shouldClearInvalidation =
-            settings.authMethod === "grok-login" &&
-            (isGrokEnvironmentCredentialReady(process.env) ||
-                isGrokExternalCredentialReady(nextSettings));
+        const selectedGrokLogin = settings.authMethod === "grok-login";
+        const shouldTrustGrokLogin =
+            selectedGrokLogin && isGrokExternalCredentialReady(nextSettings);
         const persistedSettings = {
             ...nextSettings,
             authInvalidatedAtMs:
-                shouldClearInvalidation
+                shouldTrustGrokLogin
                     ? null
+                    : selectedGrokLogin
+                      ? Date.now()
                     : nextSettings.authInvalidatedAtMs,
         } satisfies GrokRuntimeSettings;
 

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -1504,6 +1504,7 @@ export class AiService {
             input,
             projectRoot,
         );
+        await this.#hydrateGrokRuntimeAuthBeforeLaunch(input.runtimeId);
         const resolvedRuntime = this.#resolveRuntimeCommand(input.runtimeId);
         this.#onRuntimeStatus(resolvedRuntime.status);
         if (
@@ -2027,6 +2028,18 @@ export class AiService {
 
         return this.#withPersistedRuntimeCatalog(
             getGrokRuntimeStatus(nextSettings, this.#secretStore),
+        );
+    }
+
+    async #hydrateGrokRuntimeAuthBeforeLaunch(
+        runtimeId: AiRuntimeId,
+    ): Promise<void> {
+        if (runtimeId !== "grok") {
+            return;
+        }
+
+        await this.#resolveGrokRuntimeStatusWithProbe(
+            this.#resolveRuntimeStatus(runtimeId),
         );
     }
 

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -2275,10 +2275,45 @@ export class AiService {
         }
 
         if (runtimeId === "grok" && isGrokAuthenticationError(message)) {
-            const nextSettings = markGrokAuthInvalidated({
-                ...this.#settingsService.loadGrokRuntimeSettings(),
-                authMethod: "grok-login",
+            const currentSettings =
+                this.#settingsService.loadGrokRuntimeSettings();
+            const currentStatus = getGrokRuntimeStatus(
+                currentSettings,
+                this.#secretStore,
+            );
+
+            if (currentStatus.authCredentialSource === "external-runtime") {
+                const nextSettings = markGrokAuthInvalidated({
+                    ...currentSettings,
+                    authMethod: "grok-login",
+                });
+                this.#settingsService.saveGrokRuntimeSettings(nextSettings);
+                this.#onRuntimeStatus(
+                    this.#withPersistedRuntimeCatalog(
+                        getGrokRuntimeStatus(nextSettings, this.#secretStore),
+                    ),
+                );
+                return;
+            }
+
+            if (currentStatus.authCredentialSource !== "comando-secret") {
+                return;
+            }
+
+            const secretPatch = buildGrokSecretPatches(this.#secretStore, {
+                xaiApiKey: null,
             });
+            const nextSettings = {
+                ...currentSettings,
+                authMethod: null,
+                hasXaiApiKey: secretPatch.flags.hasXaiApiKey,
+            } satisfies GrokRuntimeSettings;
+            this.#secretStore.cacheSecretPatches?.(secretPatch.patches);
+            void this.#saveSecretPatches(secretPatch.patches).catch(
+                (error: unknown) => {
+                    debugBenignError("ai.grok.invalidateStoredApiKey", error);
+                },
+            );
             this.#settingsService.saveGrokRuntimeSettings(nextSettings);
             this.#onRuntimeStatus(
                 this.#withPersistedRuntimeCatalog(

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -2039,6 +2039,13 @@ export class AiService {
 
             return {
                 args: resolved.args,
+                authHandshake: {
+                    envMethodId: "xai.api_key",
+                    externalMethodId: "cached_token",
+                    meta: {
+                        headless: true,
+                    },
+                },
                 command: resolved.command,
                 env: buildRuntimeSpawnEnv(
                     applyGrokAuthEnv(process.env, settings, this.#secretStore),

--- a/src/main/ai/session-core.ts
+++ b/src/main/ai/session-core.ts
@@ -120,6 +120,8 @@ export function getRuntimeDisplayName(runtimeId: AiRuntimeId): string {
             return "Claude";
         case "gemini":
             return "Gemini";
+        case "grok":
+            return "Grok";
         case "kilo":
             return "Kilo";
         case "opencode":

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -29,7 +29,8 @@ import {
     type AiWorkerSessionLaunchInput,
 } from "./contracts";
 
-const initializeMock = vi.fn(() => Promise.resolve(undefined));
+const initializeMock = vi.fn(() => Promise.resolve({}));
+const authenticateMock = vi.fn(() => Promise.resolve({}));
 type MockSessionCatalogResponse = {
     readonly configOptions: readonly Record<string, unknown>[];
     readonly modes: unknown;
@@ -190,6 +191,7 @@ vi.mock("@agentclientprotocol/sdk", () => ({
         }
 
         initialize = initializeMock;
+        authenticate = authenticateMock;
         cancel = cancelRuntimeSessionMock;
         loadSession = loadSessionMock;
         newSession = newSessionMock;
@@ -205,6 +207,9 @@ const { AiWorkerRuntime } = await import("./worker-runtime");
 describe("AiWorkerRuntime prepareSession", () => {
     beforeEach(() => {
         initializeMock.mockClear();
+        initializeMock.mockResolvedValue({});
+        authenticateMock.mockClear();
+        authenticateMock.mockResolvedValue({});
         loadSessionMock.mockClear();
         loadSessionMock.mockResolvedValue({
             configOptions: [],
@@ -318,6 +323,88 @@ describe("AiWorkerRuntime prepareSession", () => {
                     event.payload.event.kind === "session-info",
             ),
         ).toBe(true);
+    });
+
+    it("authenticates Grok with the xAI API key ACP method before opening a session", async () => {
+        initializeMock.mockResolvedValueOnce({
+            authMethods: [{ id: "xai.api_key" }, { id: "cached_token" }],
+        });
+        const runtime = new AiWorkerRuntime({
+            emitEvent: vi.fn(),
+        });
+        const launch = createGrokLaunch({
+            authCredentialSource: "comando-secret",
+            authMethod: "xai-api-key",
+            cwd: process.cwd(),
+            projectRoot: null,
+            title: "Grok 1",
+        });
+
+        await runtime.dispatchMethod("ai.prepareSession", {
+            input: launch.input,
+            launch,
+        });
+
+        expect(authenticateMock).toHaveBeenCalledWith({
+            _meta: { headless: true },
+            methodId: "xai.api_key",
+        });
+        expect(authenticateMock.mock.invocationCallOrder[0]).toBeLessThan(
+            loadSessionMock.mock.invocationCallOrder[0],
+        );
+    });
+
+    it("authenticates Grok with the cached token ACP method for external login", async () => {
+        initializeMock.mockResolvedValueOnce({
+            authMethods: [{ id: "xai.api_key" }, { id: "cached_token" }],
+        });
+        const runtime = new AiWorkerRuntime({
+            emitEvent: vi.fn(),
+        });
+        const launch = createGrokLaunch({
+            authCredentialSource: "external-runtime",
+            authMethod: "grok-login",
+            cwd: process.cwd(),
+            projectRoot: null,
+            title: "Grok 1",
+        });
+
+        await runtime.dispatchMethod("ai.prepareSession", {
+            input: launch.input,
+            launch,
+        });
+
+        expect(authenticateMock).toHaveBeenCalledWith({
+            _meta: { headless: true },
+            methodId: "cached_token",
+        });
+    });
+
+    it("fails Grok startup when the expected ACP auth method is missing", async () => {
+        initializeMock.mockResolvedValueOnce({
+            authMethods: [{ id: "cached_token" }],
+        });
+        const runtime = new AiWorkerRuntime({
+            emitEvent: vi.fn(),
+        });
+        const launch = createGrokLaunch({
+            authCredentialSource: "comando-secret",
+            authMethod: "xai-api-key",
+            cwd: process.cwd(),
+            projectRoot: null,
+            title: "Grok 1",
+        });
+
+        await expect(
+            runtime.dispatchMethod("ai.prepareSession", {
+                input: launch.input,
+                launch,
+            }),
+        ).rejects.toThrow(
+            "Grok does not advertise the expected authentication method `xai.api_key` on this machine.",
+        );
+        expect(authenticateMock).not.toHaveBeenCalled();
+        expect(loadSessionMock).not.toHaveBeenCalled();
     });
 
     it("does not reactivate a restored subagent from replayed turn lifecycle events", async () => {
@@ -6306,5 +6393,55 @@ function createLaunch(
             status: readyStatus,
         },
         ...rest,
+    };
+}
+
+function createGrokLaunch(input: {
+    readonly authCredentialSource: NonNullable<
+        AiRuntimeStatus["authCredentialSource"]
+    >;
+    readonly authMethod: string;
+    readonly cwd: string;
+    readonly projectRoot: string | null;
+    readonly title: string;
+}): AiWorkerSessionLaunchInput {
+    const launch = createLaunch({
+        cwd: input.cwd,
+        projectRoot: input.projectRoot,
+        title: input.title,
+    });
+    const status = {
+        ...launch.resolvedRuntime.status,
+        authCredentialSource: input.authCredentialSource,
+        authMethod: input.authMethod,
+        command: "mock-grok-acp",
+        runtimeId: "grok",
+    } satisfies AiRuntimeStatus;
+
+    return {
+        ...launch,
+        input: {
+            ...launch.input,
+            runtimeId: "grok",
+            title: input.title,
+        },
+        persistedSnapshot: {
+            ...launch.persistedSnapshot,
+            runtimeId: "grok",
+            title: input.title,
+        },
+        resolvedRuntime: {
+            ...launch.resolvedRuntime,
+            authHandshake: {
+                envMethodId: "xai.api_key",
+                externalMethodId: "cached_token",
+                meta: {
+                    headless: true,
+                },
+            },
+            command: "mock-grok-acp",
+            executable: "mock-grok-acp",
+            status,
+        },
     };
 }

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -407,6 +407,58 @@ describe("AiWorkerRuntime prepareSession", () => {
         expect(loadSessionMock).not.toHaveBeenCalled();
     });
 
+    it("fails Grok startup when ACP auth methods are not advertised", async () => {
+        initializeMock.mockResolvedValueOnce({
+            authMethods: [],
+        });
+        const runtime = new AiWorkerRuntime({
+            emitEvent: vi.fn(),
+        });
+        const launch = createGrokLaunch({
+            authCredentialSource: "external-runtime",
+            authMethod: "grok-login",
+            cwd: process.cwd(),
+            projectRoot: null,
+            title: "Grok 1",
+        });
+
+        await expect(
+            runtime.dispatchMethod("ai.prepareSession", {
+                input: launch.input,
+                launch,
+            }),
+        ).rejects.toThrow(
+            "Grok does not advertise authentication methods on this machine.",
+        );
+        expect(authenticateMock).not.toHaveBeenCalled();
+        expect(loadSessionMock).not.toHaveBeenCalled();
+    });
+
+    it("fails Grok startup when ACP auth methods are missing", async () => {
+        initializeMock.mockResolvedValueOnce({});
+        const runtime = new AiWorkerRuntime({
+            emitEvent: vi.fn(),
+        });
+        const launch = createGrokLaunch({
+            authCredentialSource: "external-runtime",
+            authMethod: "grok-login",
+            cwd: process.cwd(),
+            projectRoot: null,
+            title: "Grok 1",
+        });
+
+        await expect(
+            runtime.dispatchMethod("ai.prepareSession", {
+                input: launch.input,
+                launch,
+            }),
+        ).rejects.toThrow(
+            "Grok does not advertise authentication methods on this machine.",
+        );
+        expect(authenticateMock).not.toHaveBeenCalled();
+        expect(loadSessionMock).not.toHaveBeenCalled();
+    });
+
     it("does not reactivate a restored subagent from replayed turn lifecycle events", async () => {
         const tempDir = await fs.mkdtemp(
             path.join(os.tmpdir(), "comando-ai-worker-"),

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -1460,9 +1460,6 @@ export class AiWorkerRuntime {
 
         const advertisedMethodIds =
             initializeResponse.authMethods?.map((method) => method.id) ?? [];
-        if (advertisedMethodIds.length === 0) {
-            return;
-        }
 
         const credentialSource =
             liveConnection.resolvedRuntime.status.authCredentialSource ?? "none";
@@ -1477,6 +1474,12 @@ export class AiWorkerRuntime {
         if (!methodId) {
             throw new Error(
                 `${getRuntimeDisplayName(liveConnection.runtimeId)} needs authentication before starting a session. Open Settings and choose a login method or save an API key.`,
+            );
+        }
+
+        if (advertisedMethodIds.length === 0) {
+            throw new Error(
+                `${getRuntimeDisplayName(liveConnection.runtimeId)} does not advertise authentication methods on this machine.`,
             );
         }
 

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -1373,7 +1373,7 @@ export class AiWorkerRuntime {
         this.#queueSnapshotFlush(liveSession);
 
         try {
-            await connection.initialize({
+            const initializeResponse = await connection.initialize({
                 clientCapabilities: {
                     fs: {
                         readTextFile: true,
@@ -1388,6 +1388,10 @@ export class AiWorkerRuntime {
                 },
                 protocolVersion: PROTOCOL_VERSION,
             });
+            await this.#authenticateRuntimeIfNeeded(
+                liveConnection,
+                initializeResponse,
+            );
 
             const openedSession = await this.#openRuntimeSession(liveSession);
             liveSession.snapshot = {
@@ -1441,6 +1445,51 @@ export class AiWorkerRuntime {
             });
             throw error;
         }
+    }
+
+    async #authenticateRuntimeIfNeeded(
+        liveConnection: LiveAcpConnection,
+        initializeResponse: Awaited<
+            ReturnType<LiveAcpConnection["connection"]["initialize"]>
+        >,
+    ): Promise<void> {
+        const handshake = liveConnection.resolvedRuntime.authHandshake;
+        if (!handshake) {
+            return;
+        }
+
+        const advertisedMethodIds =
+            initializeResponse.authMethods?.map((method) => method.id) ?? [];
+        if (advertisedMethodIds.length === 0) {
+            return;
+        }
+
+        const credentialSource =
+            liveConnection.resolvedRuntime.status.authCredentialSource ?? "none";
+        const methodId =
+            credentialSource === "environment" ||
+            credentialSource === "comando-secret"
+                ? handshake.envMethodId
+                : credentialSource === "external-runtime"
+                  ? handshake.externalMethodId
+                  : null;
+
+        if (!methodId) {
+            throw new Error(
+                `${getRuntimeDisplayName(liveConnection.runtimeId)} needs authentication before starting a session. Open Settings and choose a login method or save an API key.`,
+            );
+        }
+
+        if (!advertisedMethodIds.includes(methodId)) {
+            throw new Error(
+                `${getRuntimeDisplayName(liveConnection.runtimeId)} does not advertise the expected authentication method \`${methodId}\` on this machine.`,
+            );
+        }
+
+        await liveConnection.connection.authenticate({
+            methodId,
+            ...(handshake.meta ? { _meta: handshake.meta } : {}),
+        });
     }
 
     async #openRuntimeSession(

--- a/src/main/db/client.ts
+++ b/src/main/db/client.ts
@@ -19,6 +19,7 @@ import type {
     ClaudeRuntimeSettings,
     CodexRuntimeSettings,
     GeminiRuntimeSettings,
+    GrokRuntimeSettings,
     KiloRuntimeSettings,
     OpenCodeRuntimeSettings,
     PersistedShellState,
@@ -420,6 +421,15 @@ class SettingsClient implements SettingsGateway {
         this.#dispatch("settings.saveGeminiRuntimeSettings", settings);
     }
 
+    loadGrokRuntimeSettings(): GrokRuntimeSettings {
+        return requireAiSettings(this.#snapshot.ai).grok;
+    }
+
+    saveGrokRuntimeSettings(settings: GrokRuntimeSettings): void {
+        this.#setGrokRuntimeSettings(settings);
+        this.#dispatch("settings.saveGrokRuntimeSettings", settings);
+    }
+
     loadKiloRuntimeSettings(): KiloRuntimeSettings {
         return requireAiSettings(this.#snapshot.ai).kilo;
     }
@@ -554,6 +564,16 @@ class SettingsClient implements SettingsGateway {
             ai: {
                 ...requireAiSettings(this.#snapshot.ai),
                 gemini: settings,
+            },
+        };
+    }
+
+    #setGrokRuntimeSettings(settings: GrokRuntimeSettings): void {
+        this.#snapshot = {
+            ...this.#snapshot,
+            ai: {
+                ...requireAiSettings(this.#snapshot.ai),
+                grok: settings,
             },
         };
     }

--- a/src/main/db/client.ts
+++ b/src/main/db/client.ts
@@ -96,6 +96,7 @@ const runtimeIds = [
     "claude",
     "codex",
     "gemini",
+    "grok",
     "kilo",
     "opencode",
 ] as const satisfies readonly AiRuntimeId[];
@@ -498,6 +499,24 @@ class SettingsClient implements SettingsGateway {
             });
         } catch (error) {
             this.#setGeminiRuntimeSettings(previousSettings);
+            throw error;
+        }
+    }
+
+    async saveGrokAuth(
+        settings: GrokRuntimeSettings,
+        secrets: readonly SecretRecordPatch[],
+    ): Promise<void> {
+        const records = serializeSecretRecordPatches(secrets);
+        const previousSettings = this.loadGrokRuntimeSettings();
+        this.#setGrokRuntimeSettings(settings);
+        try {
+            await this.#rpc.call("ai.saveGrokAuth", {
+                secrets: records,
+                settings,
+            });
+        } catch (error) {
+            this.#setGrokRuntimeSettings(previousSettings);
             throw error;
         }
     }

--- a/src/main/db/worker.test.ts
+++ b/src/main/db/worker.test.ts
@@ -13,6 +13,7 @@ describe("db worker bootstrap", () => {
                 "secret.ai.codex.openai_api_key",
                 "secret.ai.gemini.gemini_api_key",
                 "secret.ai.gemini.google_api_key",
+                "secret.ai.grok.xai_api_key",
                 "secret.ai.kilo.kilo_api_key",
             ]),
         );

--- a/src/main/db/worker.ts
+++ b/src/main/db/worker.ts
@@ -7,6 +7,7 @@ import type {
     DatabaseStatus,
     GeminiRuntimeSettings,
     GetAiSessionTranscriptPageInput,
+    GrokRuntimeSettings,
     KiloRuntimeSettings,
     ListAiSessionHistoryInput,
     OpenCodeRuntimeSettings,
@@ -77,6 +78,7 @@ const runtimeIds = [
     "claude",
     "codex",
     "gemini",
+    "grok",
     "kilo",
     "opencode",
 ] as const satisfies readonly AiRuntimeId[];
@@ -89,6 +91,7 @@ export const bootstrapSecretKeys = [
     "secret.ai.codex.openai_api_key",
     "secret.ai.gemini.gemini_api_key",
     "secret.ai.gemini.google_api_key",
+    "secret.ai.grok.xai_api_key",
     "secret.ai.kilo.kilo_api_key",
     "secret.github.token",
 ] as const;
@@ -459,6 +462,17 @@ function dispatchMethod(method: string, params: unknown): unknown {
             });
             return null;
         }
+        case "ai.saveGrokAuth": {
+            const settings = requireSettingsService();
+            const input = params as {
+                readonly secrets: readonly SecretRecordMutation[];
+                readonly settings: GrokRuntimeSettings;
+            };
+            runAuthSettingsTransaction(input.secrets, () => {
+                settings.saveGrokRuntimeSettings(input.settings);
+            });
+            return null;
+        }
         case "ai.saveKiloAuth": {
             const settings = requireSettingsService();
             const input = params as {
@@ -537,6 +551,13 @@ function dispatchMethod(method: string, params: unknown): unknown {
             settingsService.saveGeminiRuntimeSettings(
                 params as Parameters<
                     SettingsService["saveGeminiRuntimeSettings"]
+                >[0],
+            );
+            return null;
+        case "settings.saveGrokRuntimeSettings":
+            settingsService.saveGrokRuntimeSettings(
+                params as Parameters<
+                    SettingsService["saveGrokRuntimeSettings"]
                 >[0],
             );
             return null;

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -133,6 +133,7 @@ import {
     type ProjectSettingsSnapshot,
     type ProjectSettingsUpdatedEvent,
     type GeminiRuntimeSettingsInput,
+    type GrokRuntimeSettingsInput,
     type KiloRuntimeSettingsInput,
     type RenameProjectEntryInput,
     type OpenCodeRuntimeSettingsInput,
@@ -361,6 +362,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.saveCodexRuntimeSettings);
     ipcMain.removeHandler(IPC_CHANNELS.saveClaudeRuntimeSettings);
     ipcMain.removeHandler(IPC_CHANNELS.saveGeminiRuntimeSettings);
+    ipcMain.removeHandler(IPC_CHANNELS.saveGrokRuntimeSettings);
     ipcMain.removeHandler(IPC_CHANNELS.saveKiloRuntimeSettings);
     ipcMain.removeHandler(IPC_CHANNELS.saveOpenCodeRuntimeSettings);
     ipcMain.removeHandler(IPC_CHANNELS.verifyCodexRuntimeSettings);
@@ -1829,6 +1831,11 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         IPC_CHANNELS.saveGeminiRuntimeSettings,
         (_event, settings: GeminiRuntimeSettingsInput) =>
             options.aiService.saveGeminiRuntimeSettings(settings),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.saveGrokRuntimeSettings,
+        (_event, settings: GrokRuntimeSettingsInput) =>
+            options.aiService.saveGrokRuntimeSettings(settings),
     );
     ipcMain.handle(
         IPC_CHANNELS.saveKiloRuntimeSettings,

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -204,6 +204,50 @@ describe("SettingsService", () => {
         });
     });
 
+    it("returns empty Grok settings by default", () => {
+        const connection = createFakeSettingsConnection();
+        const service = new SettingsService(
+            connection as unknown as Database.Database,
+        );
+
+        expect(service.loadGrokRuntimeSettings()).toEqual(
+            createEmptyGrokSettings(),
+        );
+        expect(service.loadSnapshot().ai).toMatchObject({
+            grok: createEmptyGrokSettings(),
+        });
+    });
+
+    it("stores and reloads Grok settings", () => {
+        const connection = createFakeSettingsConnection();
+        const service = new SettingsService(
+            connection as unknown as Database.Database,
+        );
+
+        service.saveGrokRuntimeSettings({
+            authInvalidatedAtMs: 2345,
+            authMethod: "xai-api-key",
+            binaryPath: "/opt/homebrew/bin/grok",
+            hasXaiApiKey: true,
+        });
+
+        expect(service.loadGrokRuntimeSettings()).toEqual({
+            authInvalidatedAtMs: 2345,
+            authMethod: "xai-api-key",
+            binaryPath: "/opt/homebrew/bin/grok",
+            hasXaiApiKey: true,
+        });
+        expect(service.loadSnapshot().ai).toEqual({
+            ...createEmptyAiSettings(),
+            grok: {
+                authInvalidatedAtMs: 2345,
+                authMethod: "xai-api-key",
+                binaryPath: "/opt/homebrew/bin/grok",
+                hasXaiApiKey: true,
+            },
+        });
+    });
+
     it("stores and reloads Claude provider settings", () => {
         const connection = createFakeSettingsConnection();
         const service = new SettingsService(
@@ -553,6 +597,15 @@ function createEmptyGeminiSettings() {
     };
 }
 
+function createEmptyGrokSettings() {
+    return {
+        authInvalidatedAtMs: null,
+        authMethod: null,
+        binaryPath: null,
+        hasXaiApiKey: false,
+    };
+}
+
 function createEmptyAiSettings() {
     return {
         claude: createEmptyClaudeSettings(),
@@ -563,6 +616,7 @@ function createEmptyAiSettings() {
             hasOpenAiApiKey: false,
         },
         gemini: createEmptyGeminiSettings(),
+        grok: createEmptyGrokSettings(),
         kilo: {
             authInvalidatedAtMs: null,
             authMethod: null,

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -220,6 +220,10 @@ export interface SettingsGateway {
         settings: GeminiRuntimeSettings,
         secrets: readonly SecretRecordPatch[],
     ): Promise<void>;
+    saveGrokAuth?(
+        settings: GrokRuntimeSettings,
+        secrets: readonly SecretRecordPatch[],
+    ): Promise<void>;
     saveKiloAuth?(
         settings: KiloRuntimeSettings,
         secrets: readonly SecretRecordPatch[],

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -27,6 +27,7 @@ import type {
     CodexRuntimeSettings,
     EditorFontFamily,
     GeminiRuntimeSettings,
+    GrokRuntimeSettings,
     KiloRuntimeSettings,
     OpenCodeRuntimeSettings,
     PersistedShellState,
@@ -77,6 +78,10 @@ const GEMINI_GOOGLE_CLOUD_LOCATION_KEY = "ai.gemini.google_cloud_location";
 const GEMINI_GOOGLE_CLOUD_PROJECT_KEY = "ai.gemini.google_cloud_project";
 const GEMINI_HAS_GEMINI_API_KEY_KEY = "ai.gemini.has_gemini_api_key";
 const GEMINI_HAS_GOOGLE_API_KEY_KEY = "ai.gemini.has_google_api_key";
+const GROK_AUTH_INVALIDATED_AT_KEY = "ai.grok.auth_invalidated_at_ms";
+const GROK_AUTH_METHOD_KEY = "ai.grok.auth_method";
+const GROK_BINARY_PATH_KEY = "ai.grok.binary_path";
+const GROK_HAS_XAI_API_KEY_KEY = "ai.grok.has_xai_api_key";
 const KILO_AUTH_INVALIDATED_AT_KEY = "ai.kilo.auth_invalidated_at_ms";
 const KILO_AUTH_METHOD_KEY = "ai.kilo.auth_method";
 const KILO_BINARY_PATH_KEY = "ai.kilo.binary_path";
@@ -241,6 +246,8 @@ export interface SettingsGateway {
     saveClaudeRuntimeSettings(settings: ClaudeRuntimeSettings): void;
     loadGeminiRuntimeSettings(): GeminiRuntimeSettings;
     saveGeminiRuntimeSettings(settings: GeminiRuntimeSettings): void;
+    loadGrokRuntimeSettings(): GrokRuntimeSettings;
+    saveGrokRuntimeSettings(settings: GrokRuntimeSettings): void;
     loadKiloRuntimeSettings(): KiloRuntimeSettings;
     saveKiloRuntimeSettings(settings: KiloRuntimeSettings): void;
     loadOpenCodeRuntimeSettings(): OpenCodeRuntimeSettings;
@@ -264,6 +271,7 @@ export class SettingsService {
                 claude: this.loadClaudeRuntimeSettings(),
                 codex: this.loadCodexRuntimeSettings(),
                 gemini: this.loadGeminiRuntimeSettings(),
+                grok: this.loadGrokRuntimeSettings(),
                 kilo: this.loadKiloRuntimeSettings(),
                 opencode: this.loadOpenCodeRuntimeSettings(),
             },
@@ -296,6 +304,10 @@ export class SettingsService {
 
         if (snapshot.ai?.gemini) {
             this.saveGeminiRuntimeSettings(snapshot.ai.gemini);
+        }
+
+        if (snapshot.ai?.grok) {
+            this.saveGrokRuntimeSettings(snapshot.ai.grok);
         }
 
         if (snapshot.ai?.kilo) {
@@ -734,6 +746,40 @@ export class SettingsService {
         this.#saveBooleanSetting(
             GEMINI_HAS_GOOGLE_API_KEY_KEY,
             settings.hasGoogleApiKey,
+        );
+    }
+
+    loadGrokRuntimeSettings(): GrokRuntimeSettings {
+        return {
+            authInvalidatedAtMs: this.#loadNumberSetting(
+                GROK_AUTH_INVALIDATED_AT_KEY,
+            ),
+            authMethod:
+                (this.#loadStringSetting(
+                    GROK_AUTH_METHOD_KEY,
+                ) as GrokRuntimeSettings["authMethod"]) ?? null,
+            binaryPath: this.#loadStringSetting(GROK_BINARY_PATH_KEY) ?? null,
+            hasXaiApiKey:
+                this.#loadBooleanSetting(GROK_HAS_XAI_API_KEY_KEY) ?? false,
+        };
+    }
+
+    saveGrokRuntimeSettings(settings: GrokRuntimeSettings): void {
+        this.#saveOptionalTrimmedStringSetting(
+            GROK_BINARY_PATH_KEY,
+            settings.binaryPath,
+        );
+        this.#saveOptionalTrimmedStringSetting(
+            GROK_AUTH_METHOD_KEY,
+            settings.authMethod,
+        );
+        this.#saveOptionalNumberSetting(
+            GROK_AUTH_INVALIDATED_AT_KEY,
+            settings.authInvalidatedAtMs,
+        );
+        this.#saveBooleanSetting(
+            GROK_HAS_XAI_API_KEY_KEY,
+            settings.hasXaiApiKey,
         );
     }
 

--- a/src/main/workspace/service.test.ts
+++ b/src/main/workspace/service.test.ts
@@ -67,6 +67,39 @@ describe("WorkspaceService", () => {
         expect(chatSessionState?.updatedAt).toEqual(expect.any(String));
     });
 
+    it("preserves Grok chat runtime tabs when restoring a workspace", () => {
+        const connection = createTestConnection();
+        const service = new WorkspaceService(connection);
+        const workspaceId = "workspace-grok-chat";
+
+        const snapshot: WorkspaceSnapshot = {
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: "grok-chat-tab",
+                id: "pane-root",
+                tabIds: ["grok-chat-tab"],
+                type: "pane",
+            },
+            tabs: [
+                {
+                    createdAt: "2026-06-02T00:00:00.000Z",
+                    draft: "",
+                    id: "grok-chat-tab",
+                    kind: "chat",
+                    projectId: null,
+                    runtimeId: "grok",
+                    sessionId: "grok-session",
+                    title: "Grok chat",
+                    worktreeId: null,
+                },
+            ],
+        };
+
+        service.saveSnapshot(workspaceId, snapshot);
+
+        expect(service.loadSnapshot(workspaceId)).toEqual(snapshot);
+    });
+
     it("tolerates corrupt layout and tabs when restoring a specific workspace", () => {
         const connection = createTestConnection();
         connection

--- a/src/main/workspace/service.ts
+++ b/src/main/workspace/service.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import type Database from "better-sqlite3";
 
 import type {
+    AiRuntimeId,
     PersistedChatSessionState,
     GitHubRepositoryRef,
     WorkspaceChatHistoryTab,
@@ -444,14 +445,7 @@ function deserializeTabRow(row: WorkspaceTabRow): WorkspaceTab | null {
                 chatPayload.projectId === null
                     ? chatPayload.projectId
                     : null,
-            runtimeId:
-                chatPayload.runtimeId === "claude" ||
-                chatPayload.runtimeId === "codex" ||
-                chatPayload.runtimeId === "gemini" ||
-                chatPayload.runtimeId === "kilo" ||
-                chatPayload.runtimeId === "opencode"
-                    ? chatPayload.runtimeId
-                    : "codex",
+            runtimeId: parseAiRuntimeId(chatPayload.runtimeId),
             sessionId:
                 typeof chatPayload.sessionId === "string"
                     ? chatPayload.sessionId
@@ -498,14 +492,7 @@ function deserializeTabRow(row: WorkspaceTabRow): WorkspaceTab | null {
                 reviewPayload.projectId === null
                     ? reviewPayload.projectId
                     : null,
-            runtimeId:
-                reviewPayload.runtimeId === "claude" ||
-                reviewPayload.runtimeId === "codex" ||
-                reviewPayload.runtimeId === "gemini" ||
-                reviewPayload.runtimeId === "kilo" ||
-                reviewPayload.runtimeId === "opencode"
-                    ? reviewPayload.runtimeId
-                    : "codex",
+            runtimeId: parseAiRuntimeId(reviewPayload.runtimeId),
             sessionId:
                 typeof reviewPayload.sessionId === "string"
                     ? reviewPayload.sessionId
@@ -856,6 +843,17 @@ function parseNullableString(
     }
 
     return fallback;
+}
+
+function parseAiRuntimeId(value: unknown): AiRuntimeId {
+    return value === "claude" ||
+        value === "codex" ||
+        value === "gemini" ||
+        value === "grok" ||
+        value === "kilo" ||
+        value === "opencode"
+        ? value
+        : "codex";
 }
 
 function parseGitHubRepositoryRef(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -147,6 +147,7 @@ import {
     type GitUnstagePathsInput,
     type GitWorktreeListInput,
     type GitWorktreeSummary,
+    type GrokRuntimeSettingsInput,
     type KiloRuntimeSettingsInput,
     type ListProjectEntriesInput,
     type OpenCodeRuntimeSettingsInput,
@@ -1282,6 +1283,8 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.saveClaudeRuntimeSettings, settings),
     saveGeminiRuntimeSettings: (settings: GeminiRuntimeSettingsInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.saveGeminiRuntimeSettings, settings),
+    saveGrokRuntimeSettings: (settings: GrokRuntimeSettingsInput) =>
+        ipcRenderer.invoke(IPC_CHANNELS.saveGrokRuntimeSettings, settings),
     saveKiloRuntimeSettings: (settings: KiloRuntimeSettingsInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.saveKiloRuntimeSettings, settings),
     saveOpenCodeRuntimeSettings: (settings: OpenCodeRuntimeSettingsInput) =>

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -1075,7 +1075,7 @@ function mapProviderRuntimeStatuses(
                 status ? { ...status, runtimeId: providerId } : null,
             ];
         }),
-    ) as Partial<Record<AiProviderId, AiProviderRuntimeStatus | null>>;
+    );
 }
 
 function mapEnvironmentDiagnostics(

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -29,6 +29,7 @@ import {
     type AiProviderDiagnosticEntry,
     type AiProviderDiagnosticsState,
     type AiProviderId,
+    type AiProviderRuntimeStatus,
     type AiProviderRuntimeSettingsInput,
 } from "./components/settings";
 import {
@@ -57,6 +58,14 @@ import { useResolvedAppearance } from "./app/hooks/use-resolved-appearance";
 import { useSettingsStore } from "./app/store/settings-store";
 import { shortcutDefinitions, formatShortcut } from "./app/shortcuts/registry";
 
+const AI_PROVIDER_RUNTIME_IDS = [
+    "codex",
+    "claude",
+    "gemini",
+    "kilo",
+    "opencode",
+] as const satisfies readonly AiProviderId[];
+
 export function SettingsApp() {
     const runtimeProjectId = useMemo(() => {
         const params = new URLSearchParams(window.location.search);
@@ -80,6 +89,7 @@ export function SettingsApp() {
         claude: null,
         codex: null,
         gemini: null,
+        grok: null,
         kilo: null,
         opencode: null,
     });
@@ -160,6 +170,7 @@ export function SettingsApp() {
             claude,
             codex,
             gemini,
+            grok: null,
             kilo,
             opencode,
         });
@@ -901,7 +912,7 @@ export function SettingsApp() {
                     });
                 },
                 runtimeSettings: runtimeSettings ?? undefined,
-                runtimeStatuses,
+                runtimeStatuses: mapProviderRuntimeStatuses(runtimeStatuses),
             }}
             github={{
                 error: githubError,
@@ -1036,6 +1047,8 @@ function getRuntimeName(runtimeId: AiRuntimeId): string {
             return "Claude";
         case "gemini":
             return "Gemini";
+        case "grok":
+            return "Grok";
         case "kilo":
             return "Kilo";
         case "opencode":
@@ -1044,6 +1057,25 @@ function getRuntimeName(runtimeId: AiRuntimeId): string {
         default:
             return "Codex";
     }
+}
+
+function isAiProviderId(runtimeId: AiRuntimeId): runtimeId is AiProviderId {
+    return AI_PROVIDER_RUNTIME_IDS.includes(runtimeId as AiProviderId);
+}
+
+function mapProviderRuntimeStatuses(
+    statuses: Record<AiRuntimeId, AiRuntimeStatus | null>,
+): Partial<Record<AiProviderId, AiProviderRuntimeStatus | null>> {
+    return Object.fromEntries(
+        AI_PROVIDER_RUNTIME_IDS.map((providerId) => {
+            const status = statuses[providerId];
+
+            return [
+                providerId,
+                status ? { ...status, runtimeId: providerId } : null,
+            ];
+        }),
+    ) as Partial<Record<AiProviderId, AiProviderRuntimeStatus | null>>;
 }
 
 function mapEnvironmentDiagnostics(
@@ -1108,7 +1140,9 @@ function mapEnvironmentDiagnostics(
                     (runtime.authReady
                         ? "Runtime authentication is ready."
                         : "Runtime needs authentication."),
-                providerId: runtime.runtimeId,
+                providerId: isAiProviderId(runtime.runtimeId)
+                    ? runtime.runtimeId
+                    : undefined,
                 status:
                     runtime.state === "error"
                         ? "error"
@@ -1133,7 +1167,9 @@ function mapEnvironmentDiagnostics(
                 message: override.present
                     ? "Runtime path override is set."
                     : "Runtime path override is not set.",
-                providerId: override.runtimeId,
+                providerId: isAiProviderId(override.runtimeId)
+                    ? override.runtimeId
+                    : undefined,
                 status: override.present ? "ok" : "pending",
                 }),
             ),
@@ -1144,7 +1180,9 @@ function mapEnvironmentDiagnostics(
                 message: credential.present
                     ? "Environment credential is present."
                     : "Environment credential is not set.",
-                providerId: credential.runtimeId,
+                providerId: isAiProviderId(credential.runtimeId)
+                    ? credential.runtimeId
+                    : undefined,
                 status: credential.present ? "ok" : "pending",
                 }),
             ),

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -17,6 +17,7 @@ import type {
     AppEditorSettings,
     ChatFontFamily,
     GeminiRuntimeSettingsInput,
+    GrokRuntimeSettingsInput,
     GitHubAuthStatus,
     KiloRuntimeSettingsInput,
     OpenCodeRuntimeSettingsInput,
@@ -62,6 +63,7 @@ const AI_PROVIDER_RUNTIME_IDS = [
     "codex",
     "claude",
     "gemini",
+    "grok",
     "kilo",
     "opencode",
 ] as const satisfies readonly AiProviderId[];
@@ -155,12 +157,13 @@ export function SettingsApp() {
             return;
         }
 
-        const [settingsSnapshot, codex, claude, gemini, kilo, opencode] =
+        const [settingsSnapshot, codex, claude, gemini, grok, kilo, opencode] =
             await Promise.all([
                 window.comando.getSettingsSnapshot(),
                 window.comando.getAiRuntimeStatus("codex"),
                 window.comando.getAiRuntimeStatus("claude"),
                 window.comando.getAiRuntimeStatus("gemini"),
+                window.comando.getAiRuntimeStatus("grok"),
                 window.comando.getAiRuntimeStatus("kilo"),
                 window.comando.getAiRuntimeStatus("opencode"),
             ]);
@@ -170,7 +173,7 @@ export function SettingsApp() {
             claude,
             codex,
             gemini,
-            grok: null,
+            grok,
             kilo,
             opencode,
         });
@@ -562,6 +565,10 @@ export function SettingsApp() {
                 case "gemini":
                     return await window.comando.saveGeminiRuntimeSettings(
                         settings as GeminiRuntimeSettingsInput,
+                    );
+                case "grok":
+                    return await window.comando.saveGrokRuntimeSettings(
+                        settings as GrokRuntimeSettingsInput,
                     );
                 case "kilo":
                     return await window.comando.saveKiloRuntimeSettings(
@@ -1060,7 +1067,7 @@ function getRuntimeName(runtimeId: AiRuntimeId): string {
 }
 
 function isAiProviderId(runtimeId: AiRuntimeId): runtimeId is AiProviderId {
-    return AI_PROVIDER_RUNTIME_IDS.includes(runtimeId as AiProviderId);
+    return AI_PROVIDER_RUNTIME_IDS.includes(runtimeId);
 }
 
 function mapProviderRuntimeStatuses(

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -29,6 +29,8 @@ import type {
     ClaudeRuntimeSettingsInput,
     GeminiRuntimeSettings,
     GeminiRuntimeSettingsInput,
+    GrokRuntimeSettings,
+    GrokRuntimeSettingsInput,
     KiloRuntimeSettings,
     KiloRuntimeSettingsInput,
     OpenCodeRuntimeSettings,
@@ -155,6 +157,7 @@ interface AiStore {
     readonly codexBinaryPath: string;
     readonly codexSettings: CodexRuntimeSettings;
     readonly geminiSettings: GeminiRuntimeSettings;
+    readonly grokSettings: GrokRuntimeSettings;
     readonly kiloSettings: KiloRuntimeSettings;
     readonly opencodeSettings: OpenCodeRuntimeSettings;
     readonly runtimeCatalogById: Partial<Record<AiRuntimeId, AiRuntimeCatalog>>;
@@ -226,6 +229,9 @@ interface AiStore {
     saveGeminiRuntimeSettings: (
         settings: GeminiRuntimeSettingsInput,
     ) => Promise<AiRuntimeStatus>;
+    saveGrokRuntimeSettings: (
+        settings: GrokRuntimeSettingsInput,
+    ) => Promise<AiRuntimeStatus>;
     saveKiloRuntimeSettings: (
         settings: KiloRuntimeSettingsInput,
     ) => Promise<AiRuntimeStatus>;
@@ -281,6 +287,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
     codexBinaryPath: "",
     codexSettings: createEmptyCodexSettings(),
     geminiSettings: createEmptyGeminiSettings(),
+    grokSettings: createEmptyGrokSettings(),
     kiloSettings: createEmptyKiloSettings(),
     opencodeSettings: createEmptyOpenCodeSettings(),
     runtimeCatalogById: {},
@@ -971,6 +978,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
             codexBinaryPath: settings?.codex.binaryPath ?? "",
             codexSettings: settings?.codex ?? createEmptyCodexSettings(),
             geminiSettings: settings?.gemini ?? createEmptyGeminiSettings(),
+            grokSettings: settings?.grok ?? createEmptyGrokSettings(),
             kiloSettings: settings?.kilo ?? createEmptyKiloSettings(),
             opencodeSettings:
                 settings?.opencode ?? createEmptyOpenCodeSettings(),
@@ -1247,6 +1255,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
             claudeSettings: snapshot.ai?.claude ?? state.claudeSettings,
             codexSettings: snapshot.ai?.codex ?? state.codexSettings,
             geminiSettings: snapshot.ai?.gemini ?? state.geminiSettings,
+            grokSettings: snapshot.ai?.grok ?? state.grokSettings,
             kiloSettings: snapshot.ai?.kilo ?? state.kiloSettings,
             opencodeSettings:
                 snapshot.ai?.opencode ?? state.opencodeSettings,
@@ -1267,6 +1276,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
             claudeSettings: snapshot.ai?.claude ?? state.claudeSettings,
             codexSettings: snapshot.ai?.codex ?? state.codexSettings,
             geminiSettings: snapshot.ai?.gemini ?? state.geminiSettings,
+            grokSettings: snapshot.ai?.grok ?? state.grokSettings,
             kiloSettings: snapshot.ai?.kilo ?? state.kiloSettings,
             opencodeSettings:
                 snapshot.ai?.opencode ?? state.opencodeSettings,
@@ -1305,6 +1315,21 @@ export const useAiStore = create<AiStore>((set, get) => ({
             runtimeStatusById: {
                 ...state.runtimeStatusById,
                 gemini: status,
+            },
+        }));
+
+        return status;
+    },
+
+    saveGrokRuntimeSettings: async (settings) => {
+        const status = await getComandoApi().saveGrokRuntimeSettings(settings);
+        const snapshot = await getComandoApi().getSettingsSnapshot();
+
+        set((state) => ({
+            grokSettings: snapshot.ai?.grok ?? state.grokSettings,
+            runtimeStatusById: {
+                ...state.runtimeStatusById,
+                grok: status,
             },
         }));
 
@@ -1815,6 +1840,15 @@ function createEmptyGeminiSettings(): GeminiRuntimeSettings {
         googleCloudProject: null,
         hasGeminiApiKey: false,
         hasGoogleApiKey: false,
+    };
+}
+
+function createEmptyGrokSettings(): GrokRuntimeSettings {
+    return {
+        authInvalidatedAtMs: null,
+        authMethod: null,
+        binaryPath: null,
+        hasXaiApiKey: false,
     };
 }
 

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -3254,6 +3254,8 @@ function getRuntimeDisplayName(runtimeId: AiRuntimeId): string {
             return "Claude";
         case "gemini":
             return "Gemini";
+        case "grok":
+            return "Grok";
         case "kilo":
             return "Kilo";
         case "opencode":

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -74,7 +74,7 @@ function createWorkspaceFileTab(id: string, relativePath: string) {
 function createWorkspaceChatTab(
     id: string,
     sessionId: string,
-    runtimeId: "claude" | "codex" | "gemini" | "kilo" | "opencode",
+    runtimeId: "claude" | "codex" | "gemini" | "grok" | "kilo" | "opencode",
 ) {
     return {
         createdAt: "2026-04-14T00:00:00.000Z",
@@ -240,6 +240,25 @@ describe("workspace file opening", () => {
         });
         expect(state.lastFocusedRuntimeId).toBe("opencode");
         expect(state.lastQuickCreateAction).toBe("opencode");
+    });
+
+    it("creates Grok chat tabs with Grok titles", async () => {
+        await useWorkspaceStore
+            .getState()
+            .createChatTab("project-1", null, "grok");
+
+        const state = useWorkspaceStore.getState();
+        const chatTab = Object.values(state.tabsById).find(
+            (tab) => tab.kind === "chat" && tab.runtimeId === "grok",
+        );
+
+        expect(chatTab).toMatchObject({
+            kind: "chat",
+            runtimeId: "grok",
+            title: "Grok 1",
+        });
+        expect(state.lastFocusedRuntimeId).toBe("grok");
+        expect(state.lastQuickCreateAction).toBe("grok");
     });
 
     it("opens a file in the requested pane instead of the globally active pane", async () => {

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -83,6 +83,7 @@ export type WorkspaceQuickCreateAction =
     | "codex"
     | "gemini"
     | "git"
+    | "grok"
     | "history"
     | "kilo"
     | "opencode"
@@ -2988,6 +2989,8 @@ function getRuntimeDisplayName(runtimeId: AiRuntimeId): string {
             return "Claude";
         case "gemini":
             return "Gemini";
+        case "grok":
+            return "Grok";
         case "kilo":
             return "Kilo";
         case "opencode":

--- a/src/renderer/src/components/settings/AIProvidersSettings.test.tsx
+++ b/src/renderer/src/components/settings/AIProvidersSettings.test.tsx
@@ -42,6 +42,16 @@ const RUNTIME_STATUSES: AiProviderRuntimeStatusMap = {
         source: "settings",
         state: "ready",
     },
+    grok: {
+        authCredentialSourceLabel: "Using environment variable",
+        authMethod: "xai-api-key",
+        authReady: true,
+        checkedAt: "2026-05-19T12:00:00.000Z",
+        command: "grok --no-auto-update agent stdio",
+        runtimeId: "grok",
+        source: "env",
+        state: "ready",
+    },
     kilo: {
         authMethod: "kilo-api-key",
         authReady: false,
@@ -84,6 +94,11 @@ const RUNTIME_SETTINGS: AiProviderRuntimeSettingsMap = {
         hasGeminiApiKey: true,
         hasGoogleApiKey: true,
     },
+    grok: {
+        authMethod: "xai-api-key",
+        binaryPath: null,
+        hasXaiApiKey: true,
+    },
     kilo: {
         authMethod: "kilo-api-key",
         binaryPath: null,
@@ -108,6 +123,7 @@ describe("AIProvidersSettings", () => {
         expect(markup).toContain("Codex");
         expect(markup).toContain("Claude");
         expect(markup).toContain("Gemini");
+        expect(markup).toContain("Grok");
         expect(markup).toContain("Kilo");
         expect(markup).toContain("OpenCode");
         expect(markup).toContain("Anthropic API key");
@@ -116,6 +132,8 @@ describe("AIProvidersSettings", () => {
         expect(markup).not.toContain("Auth token");
         expect(markup).toContain("Gemini API key");
         expect(markup).toContain("Google Cloud project");
+        expect(markup).toContain("Grok login");
+        expect(markup).toContain("xAI API key");
         expect(markup).toContain("Kilo API key");
         expect(markup).toContain("OpenCode auth");
         expect(markup).toContain("project .env");
@@ -253,6 +271,45 @@ describe("AIProvidersSettings", () => {
         expect(markup).not.toContain("Claude login");
         expect(markup).toContain("Anthropic API key");
         expect(markup).toContain("Bedrock gateway");
+    });
+
+    it("filters Grok methods to the runtime-supported environment", () => {
+        const markup = renderToStaticMarkup(
+            <AIProvidersSettings
+                defaultExpandedProviderIds={["grok"]}
+                runtimeSettings={{
+                    grok: {
+                        authMethod: "grok-login",
+                        binaryPath: null,
+                        hasXaiApiKey: false,
+                    },
+                }}
+                runtimeStatuses={{
+                    grok: {
+                        authMethod: null,
+                        authMethods: [
+                            {
+                                description:
+                                    "Use an xAI API key stored only for Comando on this machine.",
+                                id: "xai-api-key",
+                                name: "xAI API key",
+                            },
+                        ],
+                        authReady: false,
+                        checkedAt: "2026-05-19T12:00:00.000Z",
+                        command: "grok --no-auto-update agent stdio",
+                        runtimeId: "grok",
+                        source: "path",
+                        state: "ready",
+                    },
+                }}
+            />,
+        );
+
+        expect(markup).toContain("xAI API key");
+        expect(markup).toContain("Optional XAI_API_KEY");
+        expect(markup).not.toContain("Grok login");
+        expect(markup).not.toContain("Run Grok login in a terminal");
     });
 
     it("does not render default API key fields before a method is selected or detected", () => {

--- a/src/renderer/src/components/settings/AIProvidersSettings.test.tsx
+++ b/src/renderer/src/components/settings/AIProvidersSettings.test.tsx
@@ -312,6 +312,73 @@ describe("AIProvidersSettings", () => {
         expect(markup).not.toContain("Run Grok login in a terminal");
     });
 
+    it("shows Grok-specific runtime messages before generic session notices", () => {
+        const markup = renderToStaticMarkup(
+            <AIProvidersSettings
+                defaultExpandedProviderIds={["grok"]}
+                runtimeSettings={{
+                    grok: {
+                        authMethod: "grok-login",
+                        binaryPath: null,
+                        hasXaiApiKey: false,
+                    },
+                }}
+                runtimeStatuses={{
+                    grok: {
+                        authCredentialSource: "external-runtime",
+                        authCredentialSourceLabel: "Using external Grok login",
+                        authMethod: "grok-login",
+                        authReady: true,
+                        authSessionMessage:
+                            "This affects new sessions. Active sessions may keep using credentials loaded at launch.",
+                        checkedAt: "2026-05-19T12:00:00.000Z",
+                        command: "grok --no-auto-update agent stdio",
+                        message:
+                            "Grok login is selected. Comando could not verify local Grok credentials.",
+                        runtimeId: "grok",
+                        source: "path",
+                        state: "ready",
+                    },
+                }}
+            />,
+        );
+
+        expect(markup).toContain(
+            "Grok login is selected. Comando could not verify local Grok credentials.",
+        );
+        expect(markup).not.toContain("This affects new sessions");
+    });
+
+    it("uses the effective Grok auth method in the provider summary", () => {
+        const markup = renderToStaticMarkup(
+            <AIProvidersSettings
+                runtimeSettings={{
+                    grok: {
+                        authMethod: "grok-login",
+                        binaryPath: null,
+                        hasXaiApiKey: false,
+                    },
+                }}
+                runtimeStatuses={{
+                    grok: {
+                        authCredentialSource: "environment",
+                        authCredentialSourceLabel: "Using environment variable",
+                        authMethod: "xai-api-key",
+                        authReady: true,
+                        checkedAt: "2026-05-19T12:00:00.000Z",
+                        command: "grok --no-auto-update agent stdio",
+                        runtimeId: "grok",
+                        source: "env",
+                        state: "ready",
+                    },
+                }}
+            />,
+        );
+
+        expect(markup).toContain("xAI API key / Using environment variable");
+        expect(markup).not.toContain("Grok login / Using environment variable");
+    });
+
     it("does not render default API key fields before a method is selected or detected", () => {
         const markup = renderToStaticMarkup(
             <AIProvidersSettings

--- a/src/renderer/src/components/settings/AIProvidersSettings.tsx
+++ b/src/renderer/src/components/settings/AIProvidersSettings.tsx
@@ -850,7 +850,10 @@ function ProviderCard({
     const provider = AI_PROVIDER_DEFINITIONS[providerId];
     const statusTone = getProviderStatusTone(status);
     const method = getProviderMethod(providerId, methodId);
-    const sourceLabel = buildProviderSourceLabel(status, method?.label);
+    const effectiveMethod = isMethodIdForProvider(providerId, status?.authMethod)
+        ? getProviderMethod(providerId, status.authMethod)
+        : method;
+    const sourceLabel = buildProviderSourceLabel(status, effectiveMethod?.label);
 
     return (
         <article style={PROVIDER_CARD_STYLE}>
@@ -2049,8 +2052,8 @@ function getRuntimeNotice(
     status: AiProviderRuntimeStatus | null | undefined,
 ): string | null {
     return (
-        status?.authSessionMessage ??
         status?.message ??
+        status?.authSessionMessage ??
         status?.authStorageMessage ??
         null
     );

--- a/src/renderer/src/components/settings/AIProvidersSettings.tsx
+++ b/src/renderer/src/components/settings/AIProvidersSettings.tsx
@@ -30,6 +30,7 @@ import {
     type ClaudeProviderAuthMethodId,
     type CodexProviderAuthMethodId,
     type GeminiProviderAuthMethodId,
+    type GrokProviderAuthMethodId,
     type KiloProviderAuthMethodId,
     type OpenCodeProviderAuthMethodId,
 } from "./aiProviderSettingsModel";
@@ -60,6 +61,7 @@ interface ProviderDrafts {
     readonly claude: ClaudeProviderDraft;
     readonly codex: CodexProviderDraft;
     readonly gemini: GeminiProviderDraft;
+    readonly grok: GrokProviderDraft;
     readonly kilo: KiloProviderDraft;
     readonly opencode: OpenCodeProviderDraft;
 }
@@ -88,6 +90,12 @@ interface GeminiProviderDraft {
     readonly googleApiKey: AiProviderSecretDraft;
     readonly googleCloudLocation: string;
     readonly googleCloudProject: string;
+}
+
+interface GrokProviderDraft {
+    readonly authMethod: GrokProviderAuthMethodId | null;
+    readonly binaryPath: string;
+    readonly xaiApiKey: AiProviderSecretDraft;
 }
 
 interface KiloProviderDraft {
@@ -291,6 +299,23 @@ export function AIProvidersSettings({
                 kilo: {
                     ...current.kilo,
                     kiloApiKey: createEmptySecretDraft(),
+                },
+            }));
+        });
+    };
+
+    const saveGrok = () => {
+        runProviderAction("grok", async () => {
+            await onSaveProviderSettings?.("grok", {
+                authMethod: drafts.grok.authMethod,
+                binaryPath: normalizeNullableText(drafts.grok.binaryPath),
+                xaiApiKey: buildSecretPatch(drafts.grok.xaiApiKey),
+            });
+            setDrafts((current) => ({
+                ...current,
+                grok: {
+                    ...current.grok,
+                    xaiApiKey: createEmptySecretDraft(),
                 },
             }));
         });
@@ -576,6 +601,81 @@ export function AIProvidersSettings({
                         ),
                         providerId: "gemini",
                         save: saveGemini,
+                    })}
+                </ProviderCard>
+
+                <ProviderCard
+                    error={errorByProviderId?.grok ?? localErrors.grok}
+                    expanded={expandedProviderIds.has("grok")}
+                    methodId={resolveMethodId(
+                        "grok",
+                        drafts.grok.authMethod,
+                        runtimeStatuses?.grok,
+                    )}
+                    providerId="grok"
+                    status={runtimeStatuses?.grok ?? null}
+                    onToggle={() => toggleExpanded("grok")}
+                >
+                    <CommonFields
+                        binaryPath={drafts.grok.binaryPath}
+                        binaryPathPlaceholder="Custom Grok runtime path, for example grok"
+                        notice={getRuntimeNotice(runtimeStatuses?.grok)}
+                        onBinaryPathChange={(binaryPath) =>
+                            setDrafts((current) => ({
+                                ...current,
+                                grok: { ...current.grok, binaryPath },
+                            }))
+                        }
+                    />
+                    <MethodPicker
+                        methods={getAvailableProviderMethods(
+                            "grok",
+                            runtimeStatuses?.grok,
+                        )}
+                        value={resolveMethodId(
+                            "grok",
+                            drafts.grok.authMethod,
+                            runtimeStatuses?.grok,
+                        )}
+                        onChange={(authMethod) =>
+                            setDrafts((current) => ({
+                                ...current,
+                                grok: { ...current.grok, authMethod },
+                            }))
+                        }
+                    />
+                    {resolveMethodId(
+                        "grok",
+                        drafts.grok.authMethod,
+                        runtimeStatuses?.grok,
+                    ) === "xai-api-key" ? (
+                        <SecretField
+                            draft={drafts.grok.xaiApiKey}
+                            label="xAI API key"
+                            placeholder="Optional XAI_API_KEY"
+                            stored={Boolean(runtimeSettings?.grok?.hasXaiApiKey)}
+                            onChange={(xaiApiKey) =>
+                                setDrafts((current) => ({
+                                    ...current,
+                                    grok: { ...current.grok, xaiApiKey },
+                                }))
+                            }
+                        />
+                    ) : (
+                        <InfoNote>
+                            Grok uses the local Grok CLI login state or
+                            XAI_API_KEY. Run Grok login in a terminal or save an
+                            xAI API key for this machine.
+                        </InfoNote>
+                    )}
+                    {renderActions({
+                        methodId: resolveMethodId(
+                            "grok",
+                            drafts.grok.authMethod,
+                            runtimeStatuses?.grok,
+                        ),
+                        providerId: "grok",
+                        save: saveGrok,
                     })}
                 </ProviderCard>
 
@@ -1789,6 +1889,7 @@ function createInitialDrafts(
     const claudeAuthMethod = settings?.claude?.authMethod;
     const codexAuthMethod = settings?.codex?.authMethod;
     const geminiAuthMethod = settings?.gemini?.authMethod;
+    const grokAuthMethod = settings?.grok?.authMethod;
     const kiloAuthMethod = settings?.kilo?.authMethod;
     const opencodeAuthMethod = settings?.opencode?.authMethod;
 
@@ -1821,6 +1922,13 @@ function createInitialDrafts(
             googleApiKey: createEmptySecretDraft(),
             googleCloudLocation: settings?.gemini?.googleCloudLocation ?? "",
             googleCloudProject: settings?.gemini?.googleCloudProject ?? "",
+        },
+        grok: {
+            authMethod: isMethodIdForProvider("grok", grokAuthMethod)
+                ? grokAuthMethod
+                : null,
+            binaryPath: settings?.grok?.binaryPath ?? "",
+            xaiApiKey: createEmptySecretDraft(),
         },
         kilo: {
             authMethod: isMethodIdForProvider("kilo", kiloAuthMethod)

--- a/src/renderer/src/components/settings/aiProviderSettingsModel.ts
+++ b/src/renderer/src/components/settings/aiProviderSettingsModel.ts
@@ -2,6 +2,7 @@ export const AI_PROVIDER_IDS = [
     "codex",
     "claude",
     "gemini",
+    "grok",
     "kilo",
     "opencode",
 ] as const;
@@ -23,6 +24,8 @@ export type ClaudeProviderAuthMethodId =
 
 export type GeminiProviderAuthMethodId = "login_with_google" | "use_gemini";
 
+export type GrokProviderAuthMethodId = "grok-login" | "xai-api-key";
+
 export type KiloProviderAuthMethodId = "kilo-login" | "kilo-api-key";
 
 export type OpenCodeProviderAuthMethodId = "opencode-login";
@@ -31,6 +34,7 @@ export interface AiProviderAuthMethodById {
     readonly codex: CodexProviderAuthMethodId;
     readonly claude: ClaudeProviderAuthMethodId;
     readonly gemini: GeminiProviderAuthMethodId;
+    readonly grok: GrokProviderAuthMethodId;
     readonly kilo: KiloProviderAuthMethodId;
     readonly opencode: OpenCodeProviderAuthMethodId;
 }
@@ -141,6 +145,19 @@ export interface GeminiProviderSettingsInput {
     readonly googleCloudProject: string | null;
 }
 
+export interface GrokProviderSettings {
+    readonly authInvalidatedAtMs?: number | null;
+    readonly authMethod?: GrokProviderAuthMethodId | null;
+    readonly binaryPath?: string | null;
+    readonly hasXaiApiKey?: boolean;
+}
+
+export interface GrokProviderSettingsInput {
+    readonly authMethod: GrokProviderAuthMethodId | null;
+    readonly binaryPath: string | null;
+    readonly xaiApiKey: AiProviderSecretPatch;
+}
+
 export interface KiloProviderSettings {
     readonly authInvalidatedAtMs?: number | null;
     readonly authMethod?: KiloProviderAuthMethodId | null;
@@ -169,6 +186,7 @@ export interface AiProviderRuntimeSettingsById {
     readonly codex: CodexProviderSettings;
     readonly claude: ClaudeProviderSettings;
     readonly gemini: GeminiProviderSettings;
+    readonly grok: GrokProviderSettings;
     readonly kilo: KiloProviderSettings;
     readonly opencode: OpenCodeProviderSettings;
 }
@@ -177,6 +195,7 @@ export interface AiProviderRuntimeSettingsInputById {
     readonly codex: CodexProviderSettingsInput;
     readonly claude: ClaudeProviderSettingsInput;
     readonly gemini: GeminiProviderSettingsInput;
+    readonly grok: GrokProviderSettingsInput;
     readonly kilo: KiloProviderSettingsInput;
     readonly opencode: OpenCodeProviderSettingsInput;
 }
@@ -321,6 +340,27 @@ export const AI_PROVIDER_DEFINITIONS = {
             },
         ],
         name: "Gemini",
+    },
+    grok: {
+        defaultMethodId: "grok-login",
+        description: "Grok Build runtime using local CLI login or an xAI API key.",
+        envVars: ["XAI_API_KEY"],
+        id: "grok",
+        methods: [
+            {
+                description: "Use the local Grok CLI login state.",
+                id: "grok-login",
+                label: "Grok login",
+                terminalAuth: true,
+            },
+            {
+                description: "Store an xAI API key in Comando secure storage.",
+                id: "xai-api-key",
+                label: "xAI API key",
+                terminalAuth: false,
+            },
+        ],
+        name: "Grok",
     },
     kilo: {
         defaultMethodId: "kilo-login",

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
@@ -204,6 +204,7 @@ describe("SidebarAgentsPanel new agent menu", () => {
                 "New Codex thread",
                 "New Claude thread",
                 "New Gemini thread",
+                "New Grok thread",
                 "New Kilo thread",
                 "New OpenCode thread",
                 "New Claude Code Terminal",
@@ -219,6 +220,11 @@ describe("SidebarAgentsPanel new agent menu", () => {
                 entry.type !== "separator" &&
                 entry.label === "New Claude Code Terminal",
         );
+        const grokEntry = entries.find(
+            (entry) =>
+                entry.type !== "separator" &&
+                entry.label === "New Grok thread",
+        );
 
         if (claudeEntry?.type === "separator" || !claudeEntry?.action) {
             throw new Error("Expected Claude thread entry.");
@@ -229,12 +235,17 @@ describe("SidebarAgentsPanel new agent menu", () => {
         ) {
             throw new Error("Expected Claude Code terminal entry.");
         }
+        if (grokEntry?.type === "separator" || !grokEntry?.action) {
+            throw new Error("Expected Grok thread entry.");
+        }
 
         claudeEntry.action();
         claudeCodeEntry.action();
+        grokEntry.action();
 
         expect(createAgent).toHaveBeenCalledWith("claude");
-        expect(createAgent).toHaveBeenCalledTimes(1);
+        expect(createAgent).toHaveBeenCalledWith("grok");
+        expect(createAgent).toHaveBeenCalledTimes(2);
         expect(openClaudeCodeTerminal).toHaveBeenCalledTimes(1);
     });
 

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -103,6 +103,7 @@ const SIDEBAR_AGENTS_NEW_RUNTIMES: readonly AiRuntimeId[] = [
     "codex",
     "claude",
     "gemini",
+    "grok",
     "kilo",
     "opencode",
 ];

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -3044,6 +3044,8 @@ function getRuntimeDisplayName(
             return "Claude";
         case "gemini":
             return "Gemini";
+        case "grok":
+            return "Grok";
         case "kilo":
             return "Kilo";
         case "opencode":

--- a/src/renderer/src/components/workspace/WorkspaceView.quick-create.test.ts
+++ b/src/renderer/src/components/workspace/WorkspaceView.quick-create.test.ts
@@ -21,6 +21,7 @@ describe("WorkspaceView quick create agents menu", () => {
                 "Claude",
                 "Claude Code",
                 "Gemini",
+                "Grok",
                 "Kilo",
                 "OpenCode",
             ]);
@@ -32,6 +33,9 @@ describe("WorkspaceView quick create agents menu", () => {
             (entry) =>
                 entry.type !== "separator" && entry.label === "Claude Code",
         );
+        const grokEntry = entries.find(
+            (entry) => entry.type !== "separator" && entry.label === "Grok",
+        );
 
         if (claudeEntry?.type === "separator" || !claudeEntry?.action) {
             throw new Error("Expected Claude entry.");
@@ -42,16 +46,25 @@ describe("WorkspaceView quick create agents menu", () => {
         ) {
             throw new Error("Expected Claude Code entry.");
         }
+        if (grokEntry?.type === "separator" || !grokEntry?.action) {
+            throw new Error("Expected Grok entry.");
+        }
 
         claudeEntry.action();
         claudeCodeEntry.action();
+        grokEntry.action();
 
         expect(createChatTab).toHaveBeenCalledWith(
             "project-1",
             "worktree-1",
             "claude",
         );
-        expect(createChatTab).toHaveBeenCalledTimes(1);
+        expect(createChatTab).toHaveBeenCalledWith(
+            "project-1",
+            "worktree-1",
+            "grok",
+        );
+        expect(createChatTab).toHaveBeenCalledTimes(2);
         expect(openClaudeCodeTerminal).toHaveBeenCalledTimes(1);
     });
 

--- a/src/renderer/src/components/workspace/WorkspaceView.quick-create.test.ts
+++ b/src/renderer/src/components/workspace/WorkspaceView.quick-create.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { buildWorkspaceAgentsQuickCreateEntries } from "./WorkspaceView";
+import {
+    buildWorkspaceAgentsQuickCreateEntries,
+    getQuickCreateButtonTitle,
+} from "./WorkspaceView";
 
 describe("WorkspaceView quick create agents menu", () => {
     it("includes Claude Code after Claude and keeps Claude as a runtime thread", () => {
@@ -87,5 +90,11 @@ describe("WorkspaceView quick create agents menu", () => {
             title:
                 "The claude command was not found in Comando's PATH. Your shell may still resolve it.",
         });
+    });
+
+    it("labels Grok as the last quick-create action", () => {
+        expect(getQuickCreateButtonTitle("grok", true)).toBe(
+            "Open last item: Grok chat",
+        );
     });
 });

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -551,6 +551,7 @@ export function buildWorkspaceAgentsQuickCreateEntries({
                     : CLAUDE_CODE_TERMINAL_DESCRIPTION,
         },
         createRuntimeEntry("Gemini", "gemini"),
+        createRuntimeEntry("Grok", "grok"),
         createRuntimeEntry("Kilo", "kilo"),
         createRuntimeEntry("OpenCode", "opencode"),
     ];
@@ -5866,6 +5867,25 @@ function ChatProviderIcon({ runtimeId }: { readonly runtimeId: AiRuntimeId }) {
                 <circle cx="8" cy="8" r="5.25" strokeWidth="1.1" />
                 <path d="M4.9 8h6.2M8 4.9v6.2" strokeWidth="1.1" />
                 <path d="M11.1 4.9 4.9 11.1" strokeWidth="0.9" />
+            </svg>
+        );
+    }
+
+    if (runtimeId === "grok") {
+        return (
+            <svg
+                className="shrink-0 opacity-55"
+                fill="none"
+                height={12}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                viewBox="0 0 16 16"
+                width={12}
+            >
+                <path d="M3.25 8a4.75 4.75 0 1 1 4.75 4.75" strokeWidth="1.1" />
+                <path d="M8 3.25v4.75h4.75" strokeWidth="1.1" />
+                <path d="M4.4 11.6 11.6 4.4" strokeWidth="1" />
             </svg>
         );
     }

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -1894,6 +1894,13 @@ function WorkspacePaneView({
                     "gemini",
                 );
                 return;
+            case "grok":
+                void createChatTab(
+                    defaultProjectId,
+                    defaultWorktreeId ?? null,
+                    "grok",
+                );
+                return;
             case "kilo":
                 void createChatTab(
                     defaultProjectId,
@@ -2900,7 +2907,7 @@ function QuickCreateMenu({
     );
 }
 
-function getQuickCreateButtonTitle(
+export function getQuickCreateButtonTitle(
     action: WorkspaceQuickCreateAction,
     hasProject: boolean,
 ) {
@@ -2909,6 +2916,8 @@ function getQuickCreateButtonTitle(
             return "Open last item: Claude chat";
         case "gemini":
             return "Open last item: Gemini chat";
+        case "grok":
+            return "Open last item: Grok chat";
         case "kilo":
             return "Open last item: Kilo chat";
         case "opencode":

--- a/src/renderer/src/components/workspace/chat-history/historyPresentation.test.ts
+++ b/src/renderer/src/components/workspace/chat-history/historyPresentation.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { getHistoryRuntimeLabel } from "./historyPresentation";
+
+describe("getHistoryRuntimeLabel", () => {
+    it("returns the Grok runtime label", () => {
+        expect(getHistoryRuntimeLabel("grok")).toBe("Grok");
+    });
+});

--- a/src/renderer/src/components/workspace/chat-history/historyPresentation.ts
+++ b/src/renderer/src/components/workspace/chat-history/historyPresentation.ts
@@ -10,6 +10,8 @@ export function getHistoryRuntimeLabel(runtimeId: AiRuntimeId): string {
             return "Claude";
         case "gemini":
             return "Gemini";
+        case "grok":
+            return "Grok";
         case "kilo":
             return "Kilo";
         case "opencode":

--- a/src/shared/chatTitle.test.ts
+++ b/src/shared/chatTitle.test.ts
@@ -18,6 +18,7 @@ describe("isDefaultChatTitle", () => {
     it("matches the runtime-generated defaults", () => {
         expect(isDefaultChatTitle("Claude 1")).toBe(true);
         expect(isDefaultChatTitle("Gemini 12")).toBe(true);
+        expect(isDefaultChatTitle("Grok 1")).toBe(true);
         expect(isDefaultChatTitle("Codex 3")).toBe(true);
         expect(isDefaultChatTitle("Kilo 4")).toBe(true);
         expect(isDefaultChatTitle("OpenCode 5")).toBe(true);

--- a/src/shared/chatTitle.ts
+++ b/src/shared/chatTitle.ts
@@ -3,7 +3,7 @@ export const CHAT_TITLE_HISTORY_MAX_CHARS = 70;
 export const CHAT_TITLE_STORED_MAX_CHARS = 100;
 
 export const DEFAULT_CHAT_TITLE_PATTERN =
-    /^(Claude|Gemini|Codex|Kilo|OpenCode|Agent) \d+$/;
+    /^(Claude|Gemini|Grok|Codex|Kilo|OpenCode|Agent) \d+$/;
 
 const PILL_OPEN = "\u200B\u00AB";
 const PILL_CLOSE = "\u00BB\u200B";

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -30,6 +30,7 @@ export const IPC_CHANNELS = {
     verifyCodexRuntimeSettings: "settings:verify-codex-runtime-settings",
     saveClaudeRuntimeSettings: "settings:save-claude-runtime-settings",
     saveGeminiRuntimeSettings: "settings:save-gemini-runtime-settings",
+    saveGrokRuntimeSettings: "settings:save-grok-runtime-settings",
     saveKiloRuntimeSettings: "settings:save-kilo-runtime-settings",
     saveOpenCodeRuntimeSettings: "settings:save-opencode-runtime-settings",
     getSystemTheme: "app:get-system-theme",
@@ -315,6 +316,7 @@ export type AiRuntimeId =
     | "claude"
     | "codex"
     | "gemini"
+    | "grok"
     | "kilo"
     | "opencode";
 
@@ -333,6 +335,8 @@ export type ClaudeAuthMethodId =
     | "gateway-bedrock";
 
 export type GeminiAuthMethodId = "login_with_google" | "use_gemini";
+
+export type GrokAuthMethodId = "grok-login" | "xai-api-key";
 
 export type KiloAuthMethodId = "kilo-login" | "kilo-api-key";
 
@@ -406,6 +410,19 @@ export interface GeminiRuntimeSettingsInput {
     readonly googleCloudProject: string | null;
 }
 
+export interface GrokRuntimeSettings {
+    readonly authInvalidatedAtMs: number | null;
+    readonly authMethod: GrokAuthMethodId | null;
+    readonly binaryPath: string | null;
+    readonly hasXaiApiKey: boolean;
+}
+
+export interface GrokRuntimeSettingsInput {
+    readonly authMethod: GrokAuthMethodId | null;
+    readonly binaryPath: string | null;
+    readonly xaiApiKey: SecretValuePatch;
+}
+
 export interface KiloRuntimeSettings {
     readonly authInvalidatedAtMs: number | null;
     readonly authMethod: KiloAuthMethodId | null;
@@ -434,6 +451,7 @@ export interface AiSettingsSnapshot {
     readonly claude: ClaudeRuntimeSettings;
     readonly codex: CodexRuntimeSettings;
     readonly gemini: GeminiRuntimeSettings;
+    readonly grok: GrokRuntimeSettings;
     readonly kilo: KiloRuntimeSettings;
     readonly opencode: OpenCodeRuntimeSettings;
 }
@@ -511,6 +529,7 @@ export interface AiRuntimePathOverrideDiagnostic {
         | "COMANDO_CLAUDE_ACP_BIN"
         | "COMANDO_CODEX_ACP_BIN"
         | "COMANDO_GEMINI_ACP_BIN"
+        | "COMANDO_GROK_ACP_BIN"
         | "COMANDO_KILO_ACP_BIN"
         | "COMANDO_OPENCODE_ACP_BIN";
     readonly pathOrCommand: string | null;
@@ -530,7 +549,8 @@ export interface AiCredentialEnvironmentDiagnostic {
         | "GOOGLE_API_KEY"
         | "KILO_API_KEY"
         | "OPENCODE_API_KEY"
-        | "OPENAI_API_KEY";
+        | "OPENAI_API_KEY"
+        | "XAI_API_KEY";
     readonly present: boolean;
     readonly runtimeId: AiRuntimeId;
 }
@@ -3016,6 +3036,9 @@ export interface ComandoApi {
     ) => Promise<AiRuntimeStatus>;
     saveGeminiRuntimeSettings: (
         settings: GeminiRuntimeSettingsInput,
+    ) => Promise<AiRuntimeStatus>;
+    saveGrokRuntimeSettings: (
+        settings: GrokRuntimeSettingsInput,
     ) => Promise<AiRuntimeStatus>;
     saveKiloRuntimeSettings: (
         settings: KiloRuntimeSettingsInput,


### PR DESCRIPTION
## Summary

- Adds Grok as an ACP-backed runtime, including provider setup, settings UI, diagnostics, auth handshake, runtime IPC, and docs.
- Hydrates Grok login state from ACP `cached_token` so existing CLI login is recognized after app restart or login completion.
- Preserves Grok chat tabs when restoring the workspace so sessions do not fall back to Codex.

## Root Cause

- Grok login could be present in the CLI runtime even when Comando could not detect a local auth directory, so the app needed to probe ACP initialization for `cached_token`.
- Workspace tab restore had a runtime whitelist that omitted `grok`, causing restored Grok tabs to parse as unknown and fall back to `codex`.

## Validation

- `pnpm exec vitest run src/main/ai/service.grok.test.ts src/main/ai/grok/setup.test.ts src/main/workspace/service.test.ts`
- `pnpm exec eslint src/main/workspace/service.ts src/main/workspace/service.test.ts`
- `pnpm run typecheck`
- `git diff --check`

Note: earlier full-repo lint still has pre-existing issues in `src/renderer/src/app/editor/monacoTextmate.test.ts` unrelated to this branch.