### PR TITLE
Fix chat queue drain ordering

### DIFF
--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -1258,6 +1258,203 @@ describe("ai-store queue", () => {
         });
     });
 
+    it("does not let a stale manual dispatch finally clear a newer queued dispatch", async () => {
+        const firstDispatch = createDeferred<void>();
+        const secondDispatch = createDeferred<void>();
+        const sendAiPrompt = vi
+            .fn()
+            .mockImplementationOnce(() => firstDispatch.promise)
+            .mockImplementationOnce(() => secondDispatch.promise)
+            .mockResolvedValue(undefined);
+
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    sendAiPrompt,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().registerSessionTab(TAB);
+        useAiStore.getState().applySessionSnapshot(createSnapshot());
+
+        const firstSendPromise = useAiStore
+            .getState()
+            .sendPrompt(TAB, "first");
+
+        await vi.waitFor(() => {
+            expect(sendAiPrompt).toHaveBeenCalledTimes(1);
+        });
+        expect(sendAiPrompt.mock.calls[0][0]).toMatchObject({
+            prompt: "first",
+        });
+
+        await useAiStore.getState().sendPrompt(TAB, "second");
+        await useAiStore.getState().sendPrompt(TAB, "third");
+        await useAiStore.getState().sendPrompt(TAB, "fourth");
+
+        expect(
+            useAiStore
+                .getState()
+                .sessions[TAB.sessionId]?.queue.map((item) => item.prompt),
+        ).toEqual(["second", "third", "fourth"]);
+
+        // The backend reports idle before the first IPC promise resolves, so
+        // the queue is allowed to dispatch the next prompt.
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+
+        await vi.waitFor(() => {
+            expect(sendAiPrompt).toHaveBeenCalledTimes(2);
+        });
+        expect(sendAiPrompt.mock.calls[1][0]).toMatchObject({
+            prompt: "second",
+        });
+
+        firstDispatch.resolve(undefined);
+        await firstSendPromise;
+        await Promise.resolve();
+
+        const sessionAfterStaleFinally =
+            useAiStore.getState().sessions[TAB.sessionId];
+        expect(sendAiPrompt).toHaveBeenCalledTimes(2);
+        expect(sessionAfterStaleFinally?.isDispatching).toBe(true);
+        expect(
+            sessionAfterStaleFinally?.queue.map((item) => item.prompt),
+        ).toEqual(["third", "fourth"]);
+
+        secondDispatch.resolve(undefined);
+        await vi.waitFor(() => {
+            expect(
+                useAiStore.getState().sessions[TAB.sessionId]?.isDispatching,
+            ).toBe(false);
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:02.000Z",
+            }),
+        );
+
+        await vi.waitFor(() => {
+            expect(sendAiPrompt).toHaveBeenCalledTimes(3);
+        });
+        expect(sendAiPrompt.mock.calls[2][0]).toMatchObject({
+            prompt: "third",
+        });
+        expect(
+            useAiStore
+                .getState()
+                .sessions[TAB.sessionId]?.queue.map((item) => item.prompt),
+        ).toEqual(["fourth"]);
+    });
+
+    it("drains several queued prompts in FIFO order on successive idle snapshots", async () => {
+        const sendAiPrompt = vi.fn().mockResolvedValue(undefined);
+
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    sendAiPrompt,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().registerSessionTab(TAB);
+        useAiStore
+            .getState()
+            .applySessionSnapshot(createSnapshot({ status: "streaming" }));
+
+        await useAiStore.getState().sendPrompt(TAB, "first");
+        await useAiStore.getState().sendPrompt(TAB, "second");
+        await useAiStore.getState().sendPrompt(TAB, "third");
+
+        for (const [index, prompt] of ["first", "second", "third"].entries()) {
+            useAiStore.getState().applySessionSnapshot(
+                createSnapshot({
+                    status: "idle",
+                    updatedAt: `2026-04-14T00:00:0${index + 1}.000Z`,
+                }),
+            );
+
+            await vi.waitFor(() => {
+                expect(sendAiPrompt).toHaveBeenCalledTimes(index + 1);
+            });
+            expect(sendAiPrompt.mock.calls[index][0]).toMatchObject({
+                prompt,
+            });
+            await vi.waitFor(() => {
+                expect(
+                    useAiStore.getState().sessions[TAB.sessionId]
+                    ?.isDispatching,
+                ).toBe(false);
+            });
+        }
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.queue,
+        ).toHaveLength(0);
+    });
+
+    it("restores a busy automatic dispatch to its original queued position", async () => {
+        const sendAiPrompt = vi
+            .fn()
+            .mockRejectedValueOnce(createIpcBusyError());
+
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    sendAiPrompt,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().registerSessionTab(TAB);
+        useAiStore
+            .getState()
+            .applySessionSnapshot(createSnapshot({ status: "streaming" }));
+
+        await useAiStore.getState().sendPrompt(TAB, "first");
+        await useAiStore.getState().sendPrompt(TAB, "second");
+        await useAiStore.getState().sendPrompt(TAB, "third");
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+
+        await vi.waitFor(() => {
+            expect(sendAiPrompt).toHaveBeenCalledTimes(1);
+        });
+        await vi.waitFor(() => {
+            const queuedSession = useAiStore.getState().sessions[TAB.sessionId];
+            expect(
+                queuedSession?.queue.map((item) => ({
+                    prompt: item.prompt,
+                    status: item.status,
+                })),
+            ).toEqual([
+                { prompt: "first", status: "queued" },
+                { prompt: "second", status: "queued" },
+                { prompt: "third", status: "queued" },
+            ]);
+            expect(queuedSession?.isDispatching).toBe(false);
+        });
+    });
+
     it("allows retrying a failed queued prompt with sendQueuedPromptNow", async () => {
         const sendAiPrompt = vi
             .fn()

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -1499,6 +1499,68 @@ describe("ai-store queue", () => {
         ).toHaveLength(0);
     });
 
+    it("completes an active queued dispatch when a new incoming snapshot reuses the same timestamp", async () => {
+        const firstDispatch = createDeferred<void>();
+        const sendAiPrompt = vi
+            .fn()
+            .mockImplementationOnce(() => firstDispatch.promise)
+            .mockResolvedValue(undefined);
+
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    sendAiPrompt,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().registerSessionTab(TAB);
+        useAiStore
+            .getState()
+            .applySessionSnapshot(createSnapshot({ status: "streaming" }));
+
+        await useAiStore.getState().sendPrompt(TAB, "first");
+        await useAiStore.getState().sendPrompt(TAB, "second");
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+
+        await vi.waitFor(() => {
+            expect(sendAiPrompt).toHaveBeenCalledTimes(1);
+        });
+        expect(sendAiPrompt.mock.calls[0][0]).toMatchObject({
+            prompt: "first",
+        });
+
+        // The backend can emit multiple snapshots within the same millisecond.
+        // The second incoming snapshot still proves something arrived after the
+        // queued prompt became active, even though updatedAt is unchanged.
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+
+        firstDispatch.resolve(undefined);
+
+        await vi.waitFor(() => {
+            expect(sendAiPrompt).toHaveBeenCalledTimes(2);
+        });
+        expect(sendAiPrompt.mock.calls[1][0]).toMatchObject({
+            prompt: "second",
+        });
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.queue,
+        ).toHaveLength(0);
+    });
+
     it("drains several queued prompts in FIFO order on successive idle snapshots", async () => {
         const sendAiPrompt = vi.fn().mockResolvedValue(undefined);
 

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -1432,6 +1432,73 @@ describe("ai-store queue", () => {
         });
     });
 
+    it("keeps the latest incoming snapshot marker when stale snapshots arrive during a queued dispatch", async () => {
+        const firstDispatch = createDeferred<void>();
+        const sendAiPrompt = vi
+            .fn()
+            .mockImplementationOnce(() => firstDispatch.promise)
+            .mockResolvedValue(undefined);
+
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    sendAiPrompt,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().registerSessionTab(TAB);
+        useAiStore
+            .getState()
+            .applySessionSnapshot(createSnapshot({ status: "streaming" }));
+
+        await useAiStore.getState().sendPrompt(TAB, "first");
+        await useAiStore.getState().sendPrompt(TAB, "second");
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+
+        await vi.waitFor(() => {
+            expect(sendAiPrompt).toHaveBeenCalledTimes(1);
+        });
+        expect(sendAiPrompt.mock.calls[0][0]).toMatchObject({
+            prompt: "first",
+        });
+
+        // The completion snapshot for the active queued prompt arrives before
+        // its IPC promise resolves, then an older snapshot arrives out of order.
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:02.000Z",
+            }),
+        );
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:00.500Z",
+            }),
+        );
+
+        firstDispatch.resolve(undefined);
+
+        await vi.waitFor(() => {
+            expect(sendAiPrompt).toHaveBeenCalledTimes(2);
+        });
+        expect(sendAiPrompt.mock.calls[1][0]).toMatchObject({
+            prompt: "second",
+        });
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.queue,
+        ).toHaveLength(0);
+    });
+
     it("drains several queued prompts in FIFO order on successive idle snapshots", async () => {
         const sendAiPrompt = vi.fn().mockResolvedValue(undefined);
 

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -1356,6 +1356,82 @@ describe("ai-store queue", () => {
         ).toEqual(["fourth"]);
     });
 
+    it("does not treat local snapshot mutations as queued dispatch completion", async () => {
+        const firstDispatch = createDeferred<void>();
+        const sendAiPrompt = vi
+            .fn()
+            .mockImplementationOnce(() => firstDispatch.promise)
+            .mockResolvedValue(undefined);
+        const setAiSessionModel = vi.fn().mockResolvedValue(undefined);
+
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    sendAiPrompt,
+                    setAiSessionModel,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().registerSessionTab(TAB);
+        useAiStore
+            .getState()
+            .applySessionSnapshot(createSnapshot({ status: "streaming" }));
+
+        await useAiStore.getState().sendPrompt(TAB, "first");
+        await useAiStore.getState().sendPrompt(TAB, "second");
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+
+        await vi.waitFor(() => {
+            expect(sendAiPrompt).toHaveBeenCalledTimes(1);
+        });
+        expect(sendAiPrompt.mock.calls[0][0]).toMatchObject({
+            prompt: "first",
+        });
+
+        await useAiStore.getState().setSessionModel({
+            modelId: "gpt-5",
+            sessionId: TAB.sessionId,
+        });
+
+        firstDispatch.resolve(undefined);
+
+        await vi.waitFor(() => {
+            expect(
+                useAiStore.getState().sessions[TAB.sessionId]?.isDispatching,
+            ).toBe(false);
+        });
+        expect(setAiSessionModel).toHaveBeenCalledTimes(1);
+        expect(sendAiPrompt).toHaveBeenCalledTimes(1);
+        expect(
+            useAiStore
+                .getState()
+                .sessions[TAB.sessionId]?.queue.map((item) => item.prompt),
+        ).toEqual(["second"]);
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:02.000Z",
+            }),
+        );
+
+        await vi.waitFor(() => {
+            expect(sendAiPrompt).toHaveBeenCalledTimes(2);
+        });
+        expect(sendAiPrompt.mock.calls[1][0]).toMatchObject({
+            prompt: "second",
+        });
+    });
+
     it("drains several queued prompts in FIFO order on successive idle snapshots", async () => {
         const sendAiPrompt = vi.fn().mockResolvedValue(undefined);
 

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -106,7 +106,7 @@ interface QueuedPromptPositionState {
 }
 
 interface ActiveQueuedPromptState {
-    readonly activatedAfterSnapshotUpdatedAt: string | null;
+    readonly activatedAfterIncomingSnapshotUpdatedAt: string | null;
     readonly position: QueuedPromptPositionState;
     readonly queuedPrompt: QueuedPrompt;
 }
@@ -124,6 +124,7 @@ interface AiSessionClientState {
     readonly hydrated: boolean;
     readonly isDispatching: boolean;
     readonly isHydrating: boolean;
+    readonly lastIncomingSnapshotUpdatedAt: string | null;
     readonly localError: string | null;
     readonly meta: RegisteredSessionMeta | null;
     readonly queue: readonly QueuedPrompt[];
@@ -529,6 +530,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         ),
                         hydrated: true,
                         isHydrating: false,
+                        lastIncomingSnapshotUpdatedAt: nextSnapshot.updatedAt,
                         localError: nextSnapshot.lastError,
                         meta: nextMeta,
                         snapshot: nextSnapshot,
@@ -630,6 +632,8 @@ export const useAiStore = create<AiStore>((set, get) => ({
                                 ),
                                 hydrated: true,
                                 isHydrating: false,
+                                lastIncomingSnapshotUpdatedAt:
+                                    incomingSnapshot.updatedAt,
                                 localError: nextSnapshot.lastError,
                                 meta: nextMeta,
                                 snapshot: nextSnapshot,
@@ -697,10 +701,12 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         ...session,
                         ...reconcileDispatchStateForIncomingSnapshot(
                             session,
-                            nextSnapshot,
+                            incomingSnapshot,
                         ),
                         hydrated: true,
                         isHydrating: false,
+                        lastIncomingSnapshotUpdatedAt:
+                            incomingSnapshot.updatedAt,
                         localError: nextSnapshot.lastError,
                         meta: nextMeta,
                         snapshot: nextSnapshot,
@@ -762,10 +768,12 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         ...session,
                         ...reconcileDispatchStateForIncomingSnapshot(
                             session,
-                            resolvedSnapshot,
+                            nextSnapshot,
                         ),
                         hydrated: true,
                         isHydrating: false,
+                        lastIncomingSnapshotUpdatedAt:
+                            nextSnapshot.updatedAt,
                         localError: resolvedSnapshot.lastError,
                         meta: nextMeta,
                         snapshot: resolvedSnapshot,
@@ -957,6 +965,10 @@ export const useAiStore = create<AiStore>((set, get) => ({
                                 createSessionState()),
                             hydrated: true,
                             isHydrating: false,
+                            lastIncomingSnapshotUpdatedAt: snapshot
+                                ? incomingSnapshot.updatedAt
+                                : (currentSession?.lastIncomingSnapshotUpdatedAt ??
+                                  null),
                             meta: buildSessionMeta(tab),
                             snapshot: nextSnapshot,
                             transcript: nextTranscript,
@@ -1806,6 +1818,7 @@ function createSessionState(
         hydrated: false,
         isDispatching: false,
         isHydrating: false,
+        lastIncomingSnapshotUpdatedAt: null,
         localError: null,
         meta: null,
         queue: [],
@@ -3044,8 +3057,8 @@ function activateQueuedPromptForDrain(
         }
 
         activeQueuedPrompt = {
-            activatedAfterSnapshotUpdatedAt:
-                session.snapshot?.updatedAt ?? null,
+            activatedAfterIncomingSnapshotUpdatedAt:
+                session.lastIncomingSnapshotUpdatedAt,
             position: createQueuedPromptPositionState(
                 session.queue,
                 queueIndex,
@@ -3124,8 +3137,8 @@ function completeActiveQueuedPromptIfSnapshotAdvanced(
             session.activeQueuedPrompt?.queuedPrompt.id !==
                 activeQueuedPrompt.queuedPrompt.id ||
             !session.snapshot ||
-            !isSnapshotNewerThanActiveQueuedPrompt(
-                session.snapshot,
+            !hasIncomingSnapshotAdvancedPastActiveQueuedPrompt(
+                session,
                 activeQueuedPrompt,
             )
         ) {
@@ -3469,7 +3482,7 @@ function reconcileDispatchStateForIncomingSnapshot(
 
     if (
         !session.activeDispatchToken &&
-        isSnapshotNewerThanActiveQueuedPrompt(
+        isIncomingSnapshotNewerThanActiveQueuedPrompt(
             snapshot,
             session.activeQueuedPrompt,
         )
@@ -3488,16 +3501,32 @@ function reconcileDispatchStateForIncomingSnapshot(
     };
 }
 
-function isSnapshotNewerThanActiveQueuedPrompt(
+function isIncomingSnapshotNewerThanActiveQueuedPrompt(
     snapshot: AiSessionSnapshot,
     activeQueuedPrompt: ActiveQueuedPromptState,
 ): boolean {
-    const activatedAfterSnapshotUpdatedAt =
-        activeQueuedPrompt.activatedAfterSnapshotUpdatedAt;
+    const activatedAfterIncomingSnapshotUpdatedAt =
+        activeQueuedPrompt.activatedAfterIncomingSnapshotUpdatedAt;
 
     return (
-        !activatedAfterSnapshotUpdatedAt ||
-        snapshot.updatedAt > activatedAfterSnapshotUpdatedAt
+        !activatedAfterIncomingSnapshotUpdatedAt ||
+        snapshot.updatedAt > activatedAfterIncomingSnapshotUpdatedAt
+    );
+}
+
+function hasIncomingSnapshotAdvancedPastActiveQueuedPrompt(
+    session: AiSessionClientState,
+    activeQueuedPrompt: ActiveQueuedPromptState,
+): boolean {
+    const activatedAfterIncomingSnapshotUpdatedAt =
+        activeQueuedPrompt.activatedAfterIncomingSnapshotUpdatedAt;
+    const lastIncomingSnapshotUpdatedAt = session.lastIncomingSnapshotUpdatedAt;
+
+    return Boolean(
+        lastIncomingSnapshotUpdatedAt &&
+            (!activatedAfterIncomingSnapshotUpdatedAt ||
+                lastIncomingSnapshotUpdatedAt >
+                    activatedAfterIncomingSnapshotUpdatedAt),
     );
 }
 

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -2517,13 +2517,7 @@ function isIncomingSnapshotFreshEnough(
     currentSnapshot: AiSessionSnapshot,
     incomingSnapshot: AiSessionSnapshot,
 ): boolean {
-    const currentMs = Date.parse(currentSnapshot.updatedAt);
-    const incomingMs = Date.parse(incomingSnapshot.updatedAt);
-    if (!Number.isFinite(currentMs) || !Number.isFinite(incomingMs)) {
-        return incomingSnapshot.updatedAt >= currentSnapshot.updatedAt;
-    }
-
-    return incomingMs >= currentMs;
+    return isUpdatedAtAtLeast(currentSnapshot.updatedAt, incomingSnapshot.updatedAt);
 }
 
 function getLatestIncomingSnapshotUpdatedAt(
@@ -2534,15 +2528,9 @@ function getLatestIncomingSnapshotUpdatedAt(
         return incomingUpdatedAt;
     }
 
-    const currentMs = Date.parse(currentUpdatedAt);
-    const incomingMs = Date.parse(incomingUpdatedAt);
-    if (!Number.isFinite(currentMs) || !Number.isFinite(incomingMs)) {
-        return incomingUpdatedAt >= currentUpdatedAt
-            ? incomingUpdatedAt
-            : currentUpdatedAt;
-    }
-
-    return incomingMs >= currentMs ? incomingUpdatedAt : currentUpdatedAt;
+    return isUpdatedAtAtLeast(currentUpdatedAt, incomingUpdatedAt)
+        ? incomingUpdatedAt
+        : currentUpdatedAt;
 }
 
 function resolveIncomingSnapshotProgress(
@@ -2562,10 +2550,7 @@ function resolveIncomingSnapshotProgress(
         session?.lastIncomingSnapshotUpdatedAt ?? null;
     const shouldCountIncoming =
         !lastIncomingSnapshotUpdatedAt ||
-        isIncomingUpdatedAtAtLeast(
-            lastIncomingSnapshotUpdatedAt,
-            incomingUpdatedAt,
-        );
+        isUpdatedAtAtLeast(lastIncomingSnapshotUpdatedAt, incomingUpdatedAt);
 
     return {
         incomingSnapshotVersion:
@@ -2578,7 +2563,7 @@ function resolveIncomingSnapshotProgress(
     };
 }
 
-function isIncomingUpdatedAtAtLeast(
+function isUpdatedAtAtLeast(
     currentUpdatedAt: string,
     incomingUpdatedAt: string,
 ): boolean {
@@ -2786,12 +2771,13 @@ async function drainQueueIfNeeded(
         return;
     }
 
-    const nextQueuedPrompt = session.queue.find(
-        (queuedPrompt) => queuedPrompt.status === "queued",
-    );
     const nextQueuedPromptIndex = session.queue.findIndex(
         (queuedPrompt) => queuedPrompt.status === "queued",
     );
+    const nextQueuedPrompt =
+        nextQueuedPromptIndex >= 0
+            ? session.queue[nextQueuedPromptIndex]
+            : null;
     if (!nextQueuedPrompt || nextQueuedPromptIndex < 0) {
         return;
     }

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -106,7 +106,7 @@ interface QueuedPromptPositionState {
 }
 
 interface ActiveQueuedPromptState {
-    readonly activatedAfterIncomingSnapshotUpdatedAt: string | null;
+    readonly activatedAfterIncomingSnapshotVersion: number;
     readonly position: QueuedPromptPositionState;
     readonly queuedPrompt: QueuedPrompt;
 }
@@ -122,6 +122,7 @@ interface AiSessionClientState {
     readonly editingQueuedPromptState: QueuedPromptEditState | null;
     readonly editingQueuedPrompt: QueuedPrompt | null;
     readonly hydrated: boolean;
+    readonly incomingSnapshotVersion: number;
     readonly isDispatching: boolean;
     readonly isHydrating: boolean;
     readonly lastIncomingSnapshotUpdatedAt: string | null;
@@ -529,12 +530,11 @@ export const useAiStore = create<AiStore>((set, get) => ({
                             nextSnapshot,
                         ),
                         hydrated: true,
+                        ...resolveIncomingSnapshotProgress(
+                            session,
+                            nextSnapshot.updatedAt,
+                        ),
                         isHydrating: false,
-                        lastIncomingSnapshotUpdatedAt:
-                            getLatestIncomingSnapshotUpdatedAt(
-                                session.lastIncomingSnapshotUpdatedAt,
-                                nextSnapshot.updatedAt,
-                            ),
                         localError: nextSnapshot.lastError,
                         meta: nextMeta,
                         snapshot: nextSnapshot,
@@ -635,12 +635,11 @@ export const useAiStore = create<AiStore>((set, get) => ({
                                     nextSnapshot,
                                 ),
                                 hydrated: true,
+                                ...resolveIncomingSnapshotProgress(
+                                    session,
+                                    incomingSnapshot.updatedAt,
+                                ),
                                 isHydrating: false,
-                                lastIncomingSnapshotUpdatedAt:
-                                    getLatestIncomingSnapshotUpdatedAt(
-                                        session.lastIncomingSnapshotUpdatedAt,
-                                        incomingSnapshot.updatedAt,
-                                    ),
                                 localError: nextSnapshot.lastError,
                                 meta: nextMeta,
                                 snapshot: nextSnapshot,
@@ -711,12 +710,11 @@ export const useAiStore = create<AiStore>((set, get) => ({
                             incomingSnapshot,
                         ),
                         hydrated: true,
+                        ...resolveIncomingSnapshotProgress(
+                            session,
+                            incomingSnapshot.updatedAt,
+                        ),
                         isHydrating: false,
-                        lastIncomingSnapshotUpdatedAt:
-                            getLatestIncomingSnapshotUpdatedAt(
-                                session.lastIncomingSnapshotUpdatedAt,
-                                incomingSnapshot.updatedAt,
-                            ),
                         localError: nextSnapshot.lastError,
                         meta: nextMeta,
                         snapshot: nextSnapshot,
@@ -781,12 +779,11 @@ export const useAiStore = create<AiStore>((set, get) => ({
                             nextSnapshot,
                         ),
                         hydrated: true,
+                        ...resolveIncomingSnapshotProgress(
+                            session,
+                            nextSnapshot.updatedAt,
+                        ),
                         isHydrating: false,
-                        lastIncomingSnapshotUpdatedAt:
-                            getLatestIncomingSnapshotUpdatedAt(
-                                session.lastIncomingSnapshotUpdatedAt,
-                                nextSnapshot.updatedAt,
-                            ),
                         localError: resolvedSnapshot.lastError,
                         meta: nextMeta,
                         snapshot: resolvedSnapshot,
@@ -977,15 +974,20 @@ export const useAiStore = create<AiStore>((set, get) => ({
                             ...(state.sessions[tab.sessionId] ??
                                 createSessionState()),
                             hydrated: true,
-                            isHydrating: false,
-                            lastIncomingSnapshotUpdatedAt: snapshot
-                                ? getLatestIncomingSnapshotUpdatedAt(
-                                      currentSession?.lastIncomingSnapshotUpdatedAt ??
-                                          null,
+                            ...(snapshot
+                                ? resolveIncomingSnapshotProgress(
+                                      currentSession,
                                       incomingSnapshot.updatedAt,
                                   )
-                                : (currentSession?.lastIncomingSnapshotUpdatedAt ??
-                                  null),
+                                : {
+                                      incomingSnapshotVersion:
+                                          currentSession?.incomingSnapshotVersion ??
+                                          0,
+                                      lastIncomingSnapshotUpdatedAt:
+                                          currentSession?.lastIncomingSnapshotUpdatedAt ??
+                                          null,
+                                  }),
+                            isHydrating: false,
                             meta: buildSessionMeta(tab),
                             snapshot: nextSnapshot,
                             transcript: nextTranscript,
@@ -1833,6 +1835,7 @@ function createSessionState(
         editingQueuedPromptState: null,
         editingQueuedPrompt: null,
         hydrated: false,
+        incomingSnapshotVersion: 0,
         isDispatching: false,
         isHydrating: false,
         lastIncomingSnapshotUpdatedAt: null,
@@ -2542,6 +2545,52 @@ function getLatestIncomingSnapshotUpdatedAt(
     return incomingMs >= currentMs ? incomingUpdatedAt : currentUpdatedAt;
 }
 
+function resolveIncomingSnapshotProgress(
+    session:
+        | Pick<
+              AiSessionClientState,
+              "incomingSnapshotVersion" | "lastIncomingSnapshotUpdatedAt"
+          >
+        | null
+        | undefined,
+    incomingUpdatedAt: string,
+): Pick<
+    AiSessionClientState,
+    "incomingSnapshotVersion" | "lastIncomingSnapshotUpdatedAt"
+> {
+    const lastIncomingSnapshotUpdatedAt =
+        session?.lastIncomingSnapshotUpdatedAt ?? null;
+    const shouldCountIncoming =
+        !lastIncomingSnapshotUpdatedAt ||
+        isIncomingUpdatedAtAtLeast(
+            lastIncomingSnapshotUpdatedAt,
+            incomingUpdatedAt,
+        );
+
+    return {
+        incomingSnapshotVersion:
+            (session?.incomingSnapshotVersion ?? 0) +
+            (shouldCountIncoming ? 1 : 0),
+        lastIncomingSnapshotUpdatedAt: getLatestIncomingSnapshotUpdatedAt(
+            lastIncomingSnapshotUpdatedAt,
+            incomingUpdatedAt,
+        ),
+    };
+}
+
+function isIncomingUpdatedAtAtLeast(
+    currentUpdatedAt: string,
+    incomingUpdatedAt: string,
+): boolean {
+    const currentMs = Date.parse(currentUpdatedAt);
+    const incomingMs = Date.parse(incomingUpdatedAt);
+    if (!Number.isFinite(currentMs) || !Number.isFinite(incomingMs)) {
+        return incomingUpdatedAt >= currentUpdatedAt;
+    }
+
+    return incomingMs >= currentMs;
+}
+
 function applyCatalogPatchToCatalog(
     catalog: AiRuntimeCatalog,
     changes: AiSessionPatch["changes"],
@@ -3093,8 +3142,8 @@ function activateQueuedPromptForDrain(
         }
 
         activeQueuedPrompt = {
-            activatedAfterIncomingSnapshotUpdatedAt:
-                session.lastIncomingSnapshotUpdatedAt,
+            activatedAfterIncomingSnapshotVersion:
+                session.incomingSnapshotVersion,
             position: createQueuedPromptPositionState(
                 session.queue,
                 queueIndex,
@@ -3173,7 +3222,7 @@ function completeActiveQueuedPromptIfSnapshotAdvanced(
             session.activeQueuedPrompt?.queuedPrompt.id !==
                 activeQueuedPrompt.queuedPrompt.id ||
             !session.snapshot ||
-            !hasIncomingSnapshotAdvancedPastActiveQueuedPrompt(
+            !hasIncomingSnapshotVersionAdvancedPastActiveQueuedPrompt(
                 session,
                 activeQueuedPrompt,
             )
@@ -3518,7 +3567,8 @@ function reconcileDispatchStateForIncomingSnapshot(
 
     if (
         !session.activeDispatchToken &&
-        isIncomingSnapshotNewerThanActiveQueuedPrompt(
+        doesIncomingSnapshotAdvancePastActiveQueuedPrompt(
+            session,
             snapshot,
             session.activeQueuedPrompt,
         )
@@ -3537,32 +3587,25 @@ function reconcileDispatchStateForIncomingSnapshot(
     };
 }
 
-function isIncomingSnapshotNewerThanActiveQueuedPrompt(
+function doesIncomingSnapshotAdvancePastActiveQueuedPrompt(
+    session: AiSessionClientState,
     snapshot: AiSessionSnapshot,
     activeQueuedPrompt: ActiveQueuedPromptState,
 ): boolean {
-    const activatedAfterIncomingSnapshotUpdatedAt =
-        activeQueuedPrompt.activatedAfterIncomingSnapshotUpdatedAt;
-
     return (
-        !activatedAfterIncomingSnapshotUpdatedAt ||
-        snapshot.updatedAt > activatedAfterIncomingSnapshotUpdatedAt
+        resolveIncomingSnapshotProgress(session, snapshot.updatedAt)
+            .incomingSnapshotVersion >
+        activeQueuedPrompt.activatedAfterIncomingSnapshotVersion
     );
 }
 
-function hasIncomingSnapshotAdvancedPastActiveQueuedPrompt(
+function hasIncomingSnapshotVersionAdvancedPastActiveQueuedPrompt(
     session: AiSessionClientState,
     activeQueuedPrompt: ActiveQueuedPromptState,
 ): boolean {
-    const activatedAfterIncomingSnapshotUpdatedAt =
-        activeQueuedPrompt.activatedAfterIncomingSnapshotUpdatedAt;
-    const lastIncomingSnapshotUpdatedAt = session.lastIncomingSnapshotUpdatedAt;
-
-    return Boolean(
-        lastIncomingSnapshotUpdatedAt &&
-            (!activatedAfterIncomingSnapshotUpdatedAt ||
-                lastIncomingSnapshotUpdatedAt >
-                    activatedAfterIncomingSnapshotUpdatedAt),
+    return (
+        session.incomingSnapshotVersion >
+        activeQueuedPrompt.activatedAfterIncomingSnapshotVersion
     );
 }
 

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -530,7 +530,11 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         ),
                         hydrated: true,
                         isHydrating: false,
-                        lastIncomingSnapshotUpdatedAt: nextSnapshot.updatedAt,
+                        lastIncomingSnapshotUpdatedAt:
+                            getLatestIncomingSnapshotUpdatedAt(
+                                session.lastIncomingSnapshotUpdatedAt,
+                                nextSnapshot.updatedAt,
+                            ),
                         localError: nextSnapshot.lastError,
                         meta: nextMeta,
                         snapshot: nextSnapshot,
@@ -633,7 +637,10 @@ export const useAiStore = create<AiStore>((set, get) => ({
                                 hydrated: true,
                                 isHydrating: false,
                                 lastIncomingSnapshotUpdatedAt:
-                                    incomingSnapshot.updatedAt,
+                                    getLatestIncomingSnapshotUpdatedAt(
+                                        session.lastIncomingSnapshotUpdatedAt,
+                                        incomingSnapshot.updatedAt,
+                                    ),
                                 localError: nextSnapshot.lastError,
                                 meta: nextMeta,
                                 snapshot: nextSnapshot,
@@ -706,7 +713,10 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         hydrated: true,
                         isHydrating: false,
                         lastIncomingSnapshotUpdatedAt:
-                            incomingSnapshot.updatedAt,
+                            getLatestIncomingSnapshotUpdatedAt(
+                                session.lastIncomingSnapshotUpdatedAt,
+                                incomingSnapshot.updatedAt,
+                            ),
                         localError: nextSnapshot.lastError,
                         meta: nextMeta,
                         snapshot: nextSnapshot,
@@ -773,7 +783,10 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         hydrated: true,
                         isHydrating: false,
                         lastIncomingSnapshotUpdatedAt:
-                            nextSnapshot.updatedAt,
+                            getLatestIncomingSnapshotUpdatedAt(
+                                session.lastIncomingSnapshotUpdatedAt,
+                                nextSnapshot.updatedAt,
+                            ),
                         localError: resolvedSnapshot.lastError,
                         meta: nextMeta,
                         snapshot: resolvedSnapshot,
@@ -966,7 +979,11 @@ export const useAiStore = create<AiStore>((set, get) => ({
                             hydrated: true,
                             isHydrating: false,
                             lastIncomingSnapshotUpdatedAt: snapshot
-                                ? incomingSnapshot.updatedAt
+                                ? getLatestIncomingSnapshotUpdatedAt(
+                                      currentSession?.lastIncomingSnapshotUpdatedAt ??
+                                          null,
+                                      incomingSnapshot.updatedAt,
+                                  )
                                 : (currentSession?.lastIncomingSnapshotUpdatedAt ??
                                   null),
                             meta: buildSessionMeta(tab),
@@ -2504,6 +2521,25 @@ function isIncomingSnapshotFreshEnough(
     }
 
     return incomingMs >= currentMs;
+}
+
+function getLatestIncomingSnapshotUpdatedAt(
+    currentUpdatedAt: string | null,
+    incomingUpdatedAt: string,
+): string {
+    if (!currentUpdatedAt) {
+        return incomingUpdatedAt;
+    }
+
+    const currentMs = Date.parse(currentUpdatedAt);
+    const incomingMs = Date.parse(incomingUpdatedAt);
+    if (!Number.isFinite(currentMs) || !Number.isFinite(incomingMs)) {
+        return incomingUpdatedAt >= currentUpdatedAt
+            ? incomingUpdatedAt
+            : currentUpdatedAt;
+    }
+
+    return incomingMs >= currentMs ? incomingUpdatedAt : currentUpdatedAt;
 }
 
 function applyCatalogPatchToCatalog(

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -99,7 +99,21 @@ interface QueuedPromptEditState {
     readonly queueIndex: number;
 }
 
+interface QueuedPromptPositionState {
+    readonly nextPromptId: string | null;
+    readonly previousPromptId: string | null;
+    readonly queueIndex: number;
+}
+
+interface ActiveQueuedPromptState {
+    readonly activatedAfterSnapshotUpdatedAt: string | null;
+    readonly position: QueuedPromptPositionState;
+    readonly queuedPrompt: QueuedPrompt;
+}
+
 interface AiSessionClientState {
+    readonly activeDispatchToken: string | null;
+    readonly activeQueuedPrompt: ActiveQueuedPromptState | null;
     readonly draftAttachments: readonly AiImageAttachment[];
     readonly draftComposerParts: readonly AiComposerDraftPart[];
     readonly draftFileContexts: readonly AiFileContextAttachment[];
@@ -282,6 +296,9 @@ interface AiStore {
 type SetAiState = typeof useAiStore.setState;
 type GetAiState = () => AiStore;
 
+const activeQueueDrainSessionIds = new Set<string>();
+const pendingQueueDrainSessionIds = new Set<string>();
+
 export const useAiStore = create<AiStore>((set, get) => ({
     claudeSettings: createEmptyClaudeSettings(),
     codexBinaryPath: "",
@@ -447,6 +464,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
                     ...state.sessions,
                     [sessionId]: {
                         ...session,
+                        activeQueuedPrompt: null,
                         editingQueuedPromptState: null,
                         editingQueuedPrompt: null,
                         queue: [],
@@ -505,8 +523,11 @@ export const useAiStore = create<AiStore>((set, get) => ({
                     ...state.sessions,
                     [event.sessionId]: {
                         ...session,
+                        ...reconcileDispatchStateForIncomingSnapshot(
+                            session,
+                            nextSnapshot,
+                        ),
                         hydrated: true,
-                        isDispatching: false,
                         isHydrating: false,
                         localError: nextSnapshot.lastError,
                         meta: nextMeta,
@@ -603,8 +624,11 @@ export const useAiStore = create<AiStore>((set, get) => ({
                             ...state.sessions,
                             [update.patch.sessionId]: {
                                 ...session,
+                                ...reconcileDispatchStateForIncomingSnapshot(
+                                    session,
+                                    nextSnapshot,
+                                ),
                                 hydrated: true,
-                                isDispatching: false,
                                 isHydrating: false,
                                 localError: nextSnapshot.lastError,
                                 meta: nextMeta,
@@ -671,8 +695,11 @@ export const useAiStore = create<AiStore>((set, get) => ({
                     ...state.sessions,
                     [update.patch.sessionId]: {
                         ...session,
+                        ...reconcileDispatchStateForIncomingSnapshot(
+                            session,
+                            nextSnapshot,
+                        ),
                         hydrated: true,
-                        isDispatching: false,
                         isHydrating: false,
                         localError: nextSnapshot.lastError,
                         meta: nextMeta,
@@ -733,8 +760,11 @@ export const useAiStore = create<AiStore>((set, get) => ({
                     ...state.sessions,
                     [snapshot.sessionId]: {
                         ...session,
+                        ...reconcileDispatchStateForIncomingSnapshot(
+                            session,
+                            resolvedSnapshot,
+                        ),
                         hydrated: true,
-                        isDispatching: false,
                         isHydrating: false,
                         localError: resolvedSnapshot.lastError,
                         meta: nextMeta,
@@ -1561,7 +1591,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
         }
 
         if (
-            latestSession.isDispatching ||
+            hasActiveLocalDispatch(latestSession) ||
             isBusySession(latestSession.snapshot)
         ) {
             try {
@@ -1682,7 +1712,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
             prompt: trimmedPrompt,
         });
         if (
-            session.isDispatching ||
+            hasActiveLocalDispatch(session) ||
             (session.snapshot ? isBusySession(session.snapshot) : false)
         ) {
             if (editingQueuedPrompt) {
@@ -1764,6 +1794,8 @@ function createSessionState(
     preferences?: SessionReviewPreferences | null,
 ): AiSessionClientState {
     return {
+        activeDispatchToken: null,
+        activeQueuedPrompt: null,
         draftAttachments: [],
         draftComposerParts: createEmptyComposerDraftParts(),
         draftFileContexts: [],
@@ -2523,6 +2555,8 @@ async function dispatchPrompt(
     attachments: readonly AiImageAttachment[],
     set: SetAiState,
 ): Promise<"deferred" | "sent"> {
+    const dispatchToken = crypto.randomUUID();
+
     set((state) => {
         const session = state.sessions[meta.sessionId] ?? createSessionState();
 
@@ -2531,6 +2565,7 @@ async function dispatchPrompt(
                 ...state.sessions,
                 [meta.sessionId]: {
                     ...session,
+                    activeDispatchToken: dispatchToken,
                     isDispatching: true,
                     localError: null,
                 },
@@ -2557,6 +2592,9 @@ async function dispatchPrompt(
             set((state) => {
                 const session =
                     state.sessions[meta.sessionId] ?? createSessionState();
+                if (session.activeDispatchToken !== dispatchToken) {
+                    return state;
+                }
 
                 return {
                     sessions: {
@@ -2582,12 +2620,16 @@ async function dispatchPrompt(
         set((state) => {
             const session =
                 state.sessions[meta.sessionId] ?? createSessionState();
+            if (session.activeDispatchToken !== dispatchToken) {
+                return state;
+            }
 
             return {
                 sessions: {
                     ...state.sessions,
                     [meta.sessionId]: {
                         ...session,
+                        activeDispatchToken: null,
                         isDispatching: false,
                         localError:
                             error instanceof Error
@@ -2602,12 +2644,16 @@ async function dispatchPrompt(
         set((state) => {
             const session =
                 state.sessions[meta.sessionId] ?? createSessionState();
+            if (session.activeDispatchToken !== dispatchToken) {
+                return state;
+            }
 
             return {
                 sessions: {
                     ...state.sessions,
                     [meta.sessionId]: {
                         ...session,
+                        activeDispatchToken: null,
                         isDispatching: false,
                     },
                 },
@@ -2623,10 +2669,15 @@ async function drainQueueIfNeeded(
     get: GetAiState,
     set: SetAiState,
 ): Promise<void> {
+    if (activeQueueDrainSessionIds.has(sessionId)) {
+        pendingQueueDrainSessionIds.add(sessionId);
+        return;
+    }
+
     const session = get().sessions[sessionId];
     if (
         !session ||
-        session.isDispatching ||
+        hasActiveLocalDispatch(session) ||
         !session.meta ||
         !session.snapshot ||
         session.queue.length === 0 ||
@@ -2647,23 +2698,33 @@ async function drainQueueIfNeeded(
         return;
     }
 
-    removeQueuedPromptById(sessionId, nextQueuedPrompt.id, set);
+    const activeQueuedPrompt = activateQueuedPromptForDrain(
+        sessionId,
+        nextQueuedPrompt.id,
+        set,
+    );
+    if (!activeQueuedPrompt) {
+        return;
+    }
 
+    activeQueueDrainSessionIds.add(sessionId);
+    let shouldDrainAfterUnlock = false;
     try {
         const result = await dispatchPrompt(
             {
                 additionalRoots: collectExternalComposerRoots(
-                    nextQueuedPrompt.composerPartsSnapshot,
+                    activeQueuedPrompt.queuedPrompt.composerPartsSnapshot,
                 ),
-                composerParts: nextQueuedPrompt.composerPartsSnapshot,
+                composerParts:
+                    activeQueuedPrompt.queuedPrompt.composerPartsSnapshot,
                 projectId: session.meta.projectId,
                 runtimeId: session.meta.runtimeId,
                 sessionId,
                 title: session.meta.title,
                 worktreeId: session.meta.worktreeId,
             },
-            nextQueuedPrompt.prompt,
-            nextQueuedPrompt.attachments,
+            activeQueuedPrompt.queuedPrompt.prompt,
+            activeQueuedPrompt.queuedPrompt.attachments,
             set,
         );
 
@@ -2672,30 +2733,38 @@ async function drainQueueIfNeeded(
             // next queued item here — it would race the "starting" patch and
             // get rejected as busy. The patch pipeline (applySessionPatch /
             // applySessionSnapshot) calls drainQueueIfNeeded whenever the
-            // session transitions back to idle, which is the only moment the
-            // next prompt can be dispatched safely.
+            // session transitions back to idle. If that idle snapshot already
+            // arrived while IPC was still resolving, reconcile it after this
+            // drain lock is released.
+            shouldDrainAfterUnlock =
+                completeActiveQueuedPromptIfSnapshotAdvanced(
+                    sessionId,
+                    activeQueuedPrompt,
+                    get,
+                    set,
+                );
             return;
         }
 
-        insertQueuedPromptAtIndex(
+        restoreActiveQueuedPrompt(
             sessionId,
-            {
-                ...nextQueuedPrompt,
-                status: "queued",
-            },
-            nextQueuedPromptIndex,
+            activeQueuedPrompt,
+            "queued",
             set,
         );
     } catch {
-        insertQueuedPromptAtIndex(
+        restoreActiveQueuedPrompt(
             sessionId,
-            {
-                ...nextQueuedPrompt,
-                status: "failed",
-            },
-            nextQueuedPromptIndex,
+            activeQueuedPrompt,
+            "failed",
             set,
         );
+    } finally {
+        activeQueueDrainSessionIds.delete(sessionId);
+        const hasPendingDrain = pendingQueueDrainSessionIds.delete(sessionId);
+        if (shouldDrainAfterUnlock || hasPendingDrain) {
+            await drainQueueIfNeeded(sessionId, get, set);
+        }
     }
 }
 
@@ -2727,11 +2796,13 @@ function createQueuedPromptEditState(input: {
     readonly queueIndex: number;
     readonly session: AiSessionClientState;
 }): QueuedPromptEditState {
-    const normalizedQueueIndex =
-        input.queueIndex < 0 ? input.queue.length : input.queueIndex;
+    const position = createQueuedPromptPositionState(
+        input.queue,
+        input.queueIndex,
+    );
 
     return {
-        nextPromptId: input.queue[normalizedQueueIndex + 1]?.id ?? null,
+        ...position,
         previousComposerParts: cloneComposerDraftParts(
             input.currentComposerParts,
         ),
@@ -2741,9 +2812,20 @@ function createQueuedPromptEditState(input: {
         previousDraftFileContexts: cloneDraftFileContexts(
             input.session.draftFileContexts,
         ),
+    };
+}
+
+function createQueuedPromptPositionState(
+    queue: readonly QueuedPrompt[],
+    queueIndex: number,
+): QueuedPromptPositionState {
+    const normalizedQueueIndex = queueIndex < 0 ? queue.length : queueIndex;
+
+    return {
+        nextPromptId: queue[normalizedQueueIndex + 1]?.id ?? null,
         previousPromptId:
             normalizedQueueIndex > 0
-                ? (input.queue[normalizedQueueIndex - 1]?.id ?? null)
+                ? (queue[normalizedQueueIndex - 1]?.id ?? null)
                 : null,
         queueIndex: normalizedQueueIndex,
     };
@@ -2754,16 +2836,24 @@ function insertQueuedPromptAtEditPosition(
     queuedPrompt: QueuedPrompt,
     editState: QueuedPromptEditState | null,
 ): QueuedPrompt[] {
+    return insertQueuedPromptAtPosition(queue, queuedPrompt, editState);
+}
+
+function insertQueuedPromptAtPosition(
+    queue: readonly QueuedPrompt[],
+    queuedPrompt: QueuedPrompt,
+    position: QueuedPromptPositionState | null,
+): QueuedPrompt[] {
     const remainingQueue = queue.filter(
         (candidate) => candidate.id !== queuedPrompt.id,
     );
-    if (!editState) {
+    if (!position) {
         return [queuedPrompt, ...remainingQueue];
     }
 
-    if (editState.nextPromptId) {
+    if (position.nextPromptId) {
         const nextIndex = remainingQueue.findIndex(
-            (candidate) => candidate.id === editState.nextPromptId,
+            (candidate) => candidate.id === position.nextPromptId,
         );
         if (nextIndex >= 0) {
             return [
@@ -2774,9 +2864,9 @@ function insertQueuedPromptAtEditPosition(
         }
     }
 
-    if (editState.previousPromptId) {
+    if (position.previousPromptId) {
         const previousIndex = remainingQueue.findIndex(
-            (candidate) => candidate.id === editState.previousPromptId,
+            (candidate) => candidate.id === position.previousPromptId,
         );
         if (previousIndex >= 0) {
             const insertionIndex = previousIndex + 1;
@@ -2789,7 +2879,7 @@ function insertQueuedPromptAtEditPosition(
     }
 
     const insertionIndex = Math.min(
-        Math.max(editState.queueIndex, 0),
+        Math.max(position.queueIndex, 0),
         remainingQueue.length,
     );
 
@@ -2930,6 +3020,136 @@ function insertQueuedPromptAtIndex(
             },
         };
     });
+}
+
+function activateQueuedPromptForDrain(
+    sessionId: string,
+    promptId: string,
+    set: SetAiState,
+): ActiveQueuedPromptState | null {
+    let activeQueuedPrompt: ActiveQueuedPromptState | null = null;
+
+    set((state) => {
+        const session = state.sessions[sessionId];
+        if (!session || session.activeQueuedPrompt) {
+            return state;
+        }
+
+        const queueIndex = session.queue.findIndex(
+            (candidate) => candidate.id === promptId,
+        );
+        const queuedPrompt = session.queue[queueIndex];
+        if (!queuedPrompt || queuedPrompt.status !== "queued") {
+            return state;
+        }
+
+        activeQueuedPrompt = {
+            activatedAfterSnapshotUpdatedAt:
+                session.snapshot?.updatedAt ?? null,
+            position: createQueuedPromptPositionState(
+                session.queue,
+                queueIndex,
+            ),
+            queuedPrompt: {
+                ...queuedPrompt,
+                status: "sending",
+            },
+        };
+
+        return {
+            sessions: {
+                ...state.sessions,
+                [sessionId]: {
+                    ...session,
+                    activeQueuedPrompt,
+                    queue: session.queue.filter(
+                        (candidate) => candidate.id !== promptId,
+                    ),
+                },
+            },
+        };
+    });
+
+    return activeQueuedPrompt;
+}
+
+function restoreActiveQueuedPrompt(
+    sessionId: string,
+    activeQueuedPrompt: ActiveQueuedPromptState,
+    status: QueuedPrompt["status"],
+    set: SetAiState,
+): void {
+    set((state) => {
+        const session = state.sessions[sessionId];
+        if (
+            !session ||
+            session.activeQueuedPrompt?.queuedPrompt.id !==
+                activeQueuedPrompt.queuedPrompt.id
+        ) {
+            return state;
+        }
+
+        return {
+            sessions: {
+                ...state.sessions,
+                [sessionId]: {
+                    ...session,
+                    activeQueuedPrompt: null,
+                    queue: insertQueuedPromptAtPosition(
+                        session.queue,
+                        {
+                            ...activeQueuedPrompt.queuedPrompt,
+                            status,
+                        },
+                        activeQueuedPrompt.position,
+                    ),
+                },
+            },
+        };
+    });
+}
+
+function completeActiveQueuedPromptIfSnapshotAdvanced(
+    sessionId: string,
+    activeQueuedPrompt: ActiveQueuedPromptState,
+    get: GetAiState,
+    set: SetAiState,
+): boolean {
+    let shouldDrainAfterUnlock = false;
+
+    set((state) => {
+        const session = state.sessions[sessionId];
+        if (
+            !session ||
+            session.activeQueuedPrompt?.queuedPrompt.id !==
+                activeQueuedPrompt.queuedPrompt.id ||
+            !session.snapshot ||
+            !isSnapshotNewerThanActiveQueuedPrompt(
+                session.snapshot,
+                activeQueuedPrompt,
+            )
+        ) {
+            return state;
+        }
+
+        shouldDrainAfterUnlock =
+            session.queue.some((queuedPrompt) => queuedPrompt.status === "queued") &&
+            !session.queuePaused &&
+            !isBusySession(session.snapshot) &&
+            !isClosedSubagentSession(session.snapshot);
+
+        return {
+            sessions: {
+                ...state.sessions,
+                [sessionId]: {
+                    ...session,
+                    activeQueuedPrompt: null,
+                },
+            },
+        };
+    });
+
+    return shouldDrainAfterUnlock && Boolean(get().sessions[sessionId]);
 }
 
 function clearEditingQueuedPromptState(
@@ -3225,6 +3445,59 @@ function isBusySession(snapshot: AiSessionSnapshot): boolean {
         snapshot.status === "streaming" ||
         snapshot.status === "waiting_permission" ||
         snapshot.status === "waiting_user_input"
+    );
+}
+
+function hasActiveLocalDispatch(session: AiSessionClientState): boolean {
+    return Boolean(session.isDispatching || session.activeQueuedPrompt);
+}
+
+function reconcileDispatchStateForIncomingSnapshot(
+    session: AiSessionClientState,
+    snapshot: AiSessionSnapshot,
+): Pick<
+    AiSessionClientState,
+    "activeDispatchToken" | "activeQueuedPrompt" | "isDispatching"
+> {
+    if (!session.activeQueuedPrompt) {
+        return {
+            activeDispatchToken: null,
+            activeQueuedPrompt: null,
+            isDispatching: false,
+        };
+    }
+
+    if (
+        !session.activeDispatchToken &&
+        isSnapshotNewerThanActiveQueuedPrompt(
+            snapshot,
+            session.activeQueuedPrompt,
+        )
+    ) {
+        return {
+            activeDispatchToken: null,
+            activeQueuedPrompt: null,
+            isDispatching: false,
+        };
+    }
+
+    return {
+        activeDispatchToken: session.activeDispatchToken,
+        activeQueuedPrompt: session.activeQueuedPrompt,
+        isDispatching: session.isDispatching,
+    };
+}
+
+function isSnapshotNewerThanActiveQueuedPrompt(
+    snapshot: AiSessionSnapshot,
+    activeQueuedPrompt: ActiveQueuedPromptState,
+): boolean {
+    const activatedAfterSnapshotUpdatedAt =
+        activeQueuedPrompt.activatedAfterSnapshotUpdatedAt;
+
+    return (
+        !activatedAfterSnapshotUpdatedAt ||
+        snapshot.updatedAt > activatedAfterSnapshotUpdatedAt
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes queued chat dispatch ordering under rapid multi-message sends and out-of-order session snapshots.

The queue flow now keeps dispatch ownership explicit with per-session drain locking, dispatch tokens, and active queued prompt state that can be restored to its original queue position on busy or failure responses. It also keeps the incoming snapshot marker monotonic so a stale snapshot cannot hide a newer idle snapshot while a queued dispatch IPC call is still resolving.

## User impact

Queued chat messages should send in FIFO order, one at a time, without later messages jumping ahead or the queue getting stuck when snapshots and IPC completions arrive in a tricky order.

## Validation

- `pnpm exec vitest run src/renderer/src/app/store/ai-store.test.ts`
- `pnpm exec tsc --noEmit -p tsconfig.web.json`
- `git diff --check`
