### PR TITLE
Virtualize live chat timeline history

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Contributions are welcome. Before opening a PR:
 1. Files with pending agent review changes cannot be edited. This is intentional: the review flow prioritizes accuracy and reliability over allowing concurrent edits.
 2. The Pending review tab may show approximate diffs for some agent edits. Comando tracks pending changes from agent tool-call diffs and reconciles snippet-based edits when possible, but ambiguous snippets can still produce incomplete review data.
 3. Scroll restoration is not accurate when switching from inline review to the editable file view.
+4. Resizing panes can cause unwanted scroll movement in agent threads because the chat timeline is virtualized. This is an intentional trade-off to prioritize chat performance in extremely long conversations.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
         "eslint": "^10.4.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.6.0",
+        "jsdom": "^29.1.1",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       globals:
         specifier: ^17.6.0
         version: 17.6.0
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -188,7 +191,7 @@ importers:
         version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 4.1.7(@types/node@25.9.1)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1))
 
 packages:
 
@@ -199,6 +202,21 @@ packages:
     resolution: {integrity: sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -277,6 +295,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
 
@@ -330,6 +352,42 @@ packages:
 
   '@codemirror/view@6.41.0':
     resolution: {integrity: sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.1':
+    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5':
+    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
@@ -734,6 +792,15 @@ packages:
   '@eslint/plugin-kit@0.7.1':
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1368,6 +1435,9 @@ packages:
     resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -1510,8 +1580,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1521,6 +1599,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1634,6 +1715,10 @@ packages:
   enhanced-resolve@5.22.0:
     resolution: {integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -1920,6 +2005,10 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -1981,6 +2070,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   isbinaryfile@4.0.10:
     resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
     engines: {node: '>= 8.0.0'}
@@ -2015,6 +2107,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2146,6 +2247,10 @@ packages:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2168,6 +2273,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2303,6 +2411,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2406,6 +2517,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
     engines: {node: '>=12', npm: '>=6'}
@@ -2446,6 +2561,10 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2558,6 +2677,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
@@ -2604,12 +2726,27 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.2:
+    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
+
+  tldts@7.4.2:
+    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
+    hasBin: true
+
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
@@ -2780,6 +2917,22 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2811,9 +2964,16 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2878,6 +3038,26 @@ snapshots:
   '@agentclientprotocol/sdk@0.22.1(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2985,6 +3165,10 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@codemirror/autocomplete@6.20.1':
     dependencies:
@@ -3117,6 +3301,30 @@ snapshots:
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@develar/schema-utils@2.6.5':
     dependencies:
@@ -3420,6 +3628,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -4070,6 +4280,10 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -4235,11 +4449,25 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -4417,6 +4645,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -4795,6 +5025,12 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   http-cache-semantics@4.2.0: {}
 
   http-proxy-agent@7.0.2:
@@ -4851,6 +5087,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-potential-custom-element-name@1.0.1: {}
+
   isbinaryfile@4.0.10: {}
 
   isbinaryfile@5.0.7: {}
@@ -4874,6 +5112,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -4970,6 +5234,8 @@ snapshots:
 
   lowercase-keys@2.0.0: {}
 
+  lru-cache@11.5.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -4990,6 +5256,8 @@ snapshots:
     optional: true
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   mime-db@1.52.0: {}
 
@@ -5116,6 +5384,10 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -5218,6 +5490,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resedit@1.7.2:
     dependencies:
       pe-library: 0.4.1
@@ -5274,6 +5548,10 @@ snapshots:
       truncate-utf8-bytes: 1.0.2
 
   sax@1.6.0: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -5381,6 +5659,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
@@ -5435,11 +5715,25 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.4.2: {}
+
+  tldts@7.4.2:
+    dependencies:
+      tldts-core: 7.4.2
+
   tmp-promise@3.0.3:
     dependencies:
       tmp: 0.2.5
 
   tmp@0.2.5: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.2
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   truncate-utf8-bytes@1.0.2:
     dependencies:
@@ -5482,8 +5776,7 @@ snapshots:
 
   undici@6.25.0: {}
 
-  undici@7.25.0:
-    optional: true
+  undici@7.25.0: {}
 
   universalify@0.1.2: {}
 
@@ -5523,7 +5816,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)):
+  vitest@4.1.7(@types/node@25.9.1)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1))
@@ -5547,6 +5840,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
 
@@ -5555,6 +5849,22 @@ snapshots:
   vscode-textmate@9.3.2: {}
 
   w3c-keyname@2.2.8: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -5583,7 +5893,11 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  xml-name-validator@5.0.0: {}
+
   xmlbuilder@15.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -310,6 +310,7 @@ export function App() {
     const leftWidth = useShellStore((state) => state.leftWidth);
     const nudgePanel = useShellStore((state) => state.nudgePanel);
     const resizePanel = useShellStore((state) => state.resizePanel);
+    const setResizingPanel = useShellStore((state) => state.setResizingPanel);
     const setLeftCollapsed = useShellStore((state) => state.setLeftCollapsed);
     const setSidebarView = useShellStore((state) => state.setSidebarView);
     const sidebarView = useShellStore((state) => state.sidebarView);
@@ -976,6 +977,13 @@ export function App() {
             return;
         }
 
+        // Mark the splitter drag as active for the whole gesture. The chat
+        // timeline reads this to freeze its virtualized layout while dragging,
+        // so the scroll stays put instead of jittering on every reflow. Every
+        // drag-end path (pointerup/cancel/blur/hidden) clears dragState, which
+        // runs this cleanup and lifts the freeze.
+        setResizingPanel(true);
+
         const previousCursor = document.body.style.cursor;
         const previousUserSelect = document.body.style.userSelect;
 
@@ -994,6 +1002,7 @@ export function App() {
         document.addEventListener("visibilitychange", handleVisibilityChange);
 
         return () => {
+            setResizingPanel(false);
             document.body.style.cursor = previousCursor;
             document.body.style.userSelect = previousUserSelect;
             window.removeEventListener("pointermove", handlePointerMove);
@@ -1005,7 +1014,7 @@ export function App() {
                 handleVisibilityChange,
             );
         };
-    }, [dragState]);
+    }, [dragState, setResizingPanel]);
 
     const cancelSidebarOverlayClose = useCallback(() => {
         setSidebarOverlayClosing(false);

--- a/src/renderer/src/app/store/shell-store.ts
+++ b/src/renderer/src/app/store/shell-store.ts
@@ -18,6 +18,7 @@ type SidebarView = "files" | "git" | "agents" | "issues" | "pull_requests";
 
 interface ShellStore extends ShellLayoutDimensions {
     readonly activeSurface: ShellSurface;
+    readonly isResizingPanel: boolean;
     readonly leftCollapsed: boolean;
     readonly sidebarView: SidebarView;
     readonly viewportWidth: number;
@@ -25,6 +26,7 @@ interface ShellStore extends ShellLayoutDimensions {
     hydrate: (snapshot: PersistedShellState | null) => void;
     resizePanel: (side: ShellPanelSide, nextWidth: number) => void;
     nudgePanel: (side: ShellPanelSide, delta: number) => void;
+    setResizingPanel: (resizing: boolean) => void;
     setLeftCollapsed: (collapsed: boolean) => void;
     setSidebarView: (view: SidebarView) => void;
     toggleLeftCollapsed: () => void;
@@ -63,6 +65,7 @@ function normalizeSidebarView(
 
 export const useShellStore = create<ShellStore>((set) => ({
     activeSurface: "workspace",
+    isResizingPanel: false,
     leftCollapsed: false,
     leftWidth: initialLayout.leftWidth,
     sidebarView: "files",
@@ -96,6 +99,7 @@ export const useShellStore = create<ShellStore>((set) => ({
         set((state) =>
             nudgeShellPanel(state, side, delta, state.viewportWidth),
         ),
+    setResizingPanel: (resizing) => set({ isResizingPanel: resizing }),
     setLeftCollapsed: (collapsed) => set({ leftCollapsed: collapsed }),
     setSidebarView: (view) => set({ sidebarView: view }),
     toggleLeftCollapsed: () =>

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
@@ -1,0 +1,285 @@
+/** @vitest-environment jsdom */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MeasuredVirtualList } from "./MeasuredVirtualList";
+
+// Integration coverage for the scroll-anchor compensation (mechanism B in the
+// resize hardening): when a row ABOVE the viewport re-measures to a new height,
+// the list must nudge scrollTop by the delta so the visible content stays put.
+// The pure math is unit-tested elsewhere; this drives the real component under
+// react-dom so the effect ordering, ResizeObserver wiring, and the actual
+// scrollTop mutation are exercised end to end.
+
+const ITEM_HEIGHT = 20;
+const VIEWPORT_HEIGHT = 100;
+
+// jsdom has no layout engine and no ResizeObserver, so we drive measurements by
+// hand: a fake observer records the elements the list observes and lets a test
+// fire a contentRect height for any of them — exactly the channel the list uses
+// for the virtualized measurement path.
+interface FakeResizeEntry {
+    readonly target: Element;
+    readonly contentRect: { readonly height: number };
+}
+
+const observers: FakeResizeObserver[] = [];
+
+class FakeResizeObserver {
+    private readonly callback: (entries: FakeResizeEntry[]) => void;
+    readonly elements = new Set<Element>();
+
+    constructor(callback: (entries: FakeResizeEntry[]) => void) {
+        this.callback = callback;
+        observers.push(this);
+    }
+
+    observe(element: Element) {
+        this.elements.add(element);
+    }
+
+    unobserve(element: Element) {
+        this.elements.delete(element);
+    }
+
+    disconnect() {
+        this.elements.clear();
+        const index = observers.indexOf(this);
+        if (index >= 0) {
+            observers.splice(index, 1);
+        }
+    }
+
+    fire(element: Element, height: number) {
+        if (this.elements.has(element)) {
+            this.callback([{ target: element, contentRect: { height } }]);
+        }
+    }
+}
+
+// A real browser keeps an element's measured height and its ResizeObserver
+// report in sync. The list re-measures via getBoundingClientRect on every
+// render (its ref callback is a fresh closure each time), so the stub MUST
+// reflect the latest "resized" height — otherwise a constant stub would revert
+// a just-reported resize on the next render. This map is the single source of
+// truth for both channels.
+const heightByElement = new WeakMap<Element, number>();
+
+function fireRowResize(element: Element, height: number) {
+    heightByElement.set(element, height);
+    for (const observer of observers) {
+        observer.fire(element, height);
+    }
+}
+
+interface Item {
+    readonly id: string;
+}
+
+function createItems(count: number): Item[] {
+    return Array.from({ length: count }, (_, index) => ({
+        id: `row-${index}`,
+    }));
+}
+
+interface MountedList {
+    readonly scrollContainer: HTMLElement;
+    readonly mountNode: HTMLElement;
+    readonly root: Root;
+}
+
+function mountList({
+    items,
+    overscan,
+    preserveScrollAnchorOnMeasure,
+}: {
+    readonly items: readonly Item[];
+    readonly overscan: number;
+    readonly preserveScrollAnchorOnMeasure: boolean;
+}): MountedList {
+    const scrollContainer = document.createElement("div");
+    Object.defineProperty(scrollContainer, "clientHeight", {
+        configurable: true,
+        get: () => VIEWPORT_HEIGHT,
+    });
+    scrollContainer.scrollTop = 0;
+    document.body.appendChild(scrollContainer);
+
+    const mountNode = document.createElement("div");
+    scrollContainer.appendChild(mountNode);
+
+    const root = createRoot(mountNode);
+    const scrollContainerRef = { current: scrollContainer };
+
+    act(() => {
+        root.render(
+            <MeasuredVirtualList
+                defaultViewportHeight={VIEWPORT_HEIGHT}
+                estimateSize={() => ITEM_HEIGHT}
+                getItemKey={(item) => item.id}
+                items={items}
+                overscan={overscan}
+                preserveScrollAnchorOnMeasure={preserveScrollAnchorOnMeasure}
+                scrollContainerRef={scrollContainerRef}
+                scrollMarginTop={0}
+                renderItem={({ index, item }) => (
+                    <div data-idx={index}>{item.id}</div>
+                )}
+            />,
+        );
+    });
+
+    return { scrollContainer, mountNode, root };
+}
+
+function scrollTo(list: MountedList, scrollTop: number) {
+    act(() => {
+        list.scrollContainer.scrollTop = scrollTop;
+        list.scrollContainer.dispatchEvent(new Event("scroll"));
+    });
+}
+
+function renderedIndexes(mountNode: HTMLElement): number[] {
+    return [...mountNode.querySelectorAll("[data-idx]")]
+        .map((element) => Number(element.getAttribute("data-idx")))
+        .sort((left, right) => left - right);
+}
+
+// The element the list observes is the absolute-positioned wrapper, i.e. the
+// parent of the row content we render.
+function rowWrapper(mountNode: HTMLElement, index: number): Element {
+    const content = mountNode.querySelector(`[data-idx="${index}"]`);
+    if (!content?.parentElement) {
+        throw new Error(`row ${index} is not rendered`);
+    }
+    return content.parentElement;
+}
+
+beforeEach(() => {
+    (
+        globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    (
+        globalThis as unknown as { ResizeObserver: typeof FakeResizeObserver }
+    ).ResizeObserver = FakeResizeObserver;
+
+    // jsdom has no layout, so getBoundingClientRect() reports 0 — but the list
+    // measures each row's height that way on attach (setMeasuredElement). Back
+    // it with heightByElement so the initial layout matches a real render and a
+    // fired resize stays reflected on subsequent re-measures.
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+        function getBoundingClientRect(this: Element): DOMRect {
+            const height = heightByElement.get(this) ?? ITEM_HEIGHT;
+            return {
+                height,
+                width: 0,
+                top: 0,
+                left: 0,
+                bottom: height,
+                right: 0,
+                x: 0,
+                y: 0,
+                toJSON: () => ({}),
+            };
+        },
+    );
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    observers.length = 0;
+    document.body.innerHTML = "";
+});
+
+describe("MeasuredVirtualList scroll anchoring (integration)", () => {
+    it("nudges scrollTop when a row above the viewport grows", () => {
+        const list = mountList({
+            items: createItems(60),
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+        });
+
+        // Scroll into the middle so there are rows rendered ABOVE the viewport
+        // (the overscan band) whose re-measure should compensate.
+        scrollTo(list, 300);
+
+        const rendered = renderedIndexes(list.mountNode);
+        const aboveIndex = rendered[0]; // overscan start, strictly above the top
+        // Guard the premise: the fired row must really sit above the viewport.
+        expect(aboveIndex).toBeLessThan(300 / ITEM_HEIGHT);
+
+        act(() => {
+            fireRowResize(rowWrapper(list.mountNode, aboveIndex), 60);
+        });
+
+        // The row grew from its estimate (20) to 60 → +40, so scrollTop must
+        // move from 300 to 340 to keep the same content under the viewport.
+        expect(list.scrollContainer.scrollTop).toBe(300 + (60 - ITEM_HEIGHT));
+
+        list.root.unmount();
+    });
+
+    it("shrinks scrollTop when a row above the viewport gets smaller", () => {
+        const list = mountList({
+            items: createItems(60),
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+        });
+
+        scrollTo(list, 300);
+
+        const aboveIndex = renderedIndexes(list.mountNode)[0];
+
+        act(() => {
+            fireRowResize(rowWrapper(list.mountNode, aboveIndex), 8);
+        });
+
+        // 20 → 8 is -12, so scrollTop drops from 300 to 288.
+        expect(list.scrollContainer.scrollTop).toBe(300 + (8 - ITEM_HEIGHT));
+
+        list.root.unmount();
+    });
+
+    it("does not move scrollTop when a row inside the viewport re-measures", () => {
+        const list = mountList({
+            items: createItems(60),
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+        });
+
+        scrollTo(list, 300);
+
+        const rendered = renderedIndexes(list.mountNode);
+        const belowIndex = rendered[rendered.length - 1]; // overscan end, in/after view
+
+        act(() => {
+            fireRowResize(rowWrapper(list.mountNode, belowIndex), 120);
+        });
+
+        // A row at or below the top anchor must not shift the viewport.
+        expect(list.scrollContainer.scrollTop).toBe(300);
+
+        list.root.unmount();
+    });
+
+    it("leaves scrollTop untouched when preserveScrollAnchorOnMeasure is off", () => {
+        const list = mountList({
+            items: createItems(60),
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: false,
+        });
+
+        scrollTo(list, 300);
+
+        const aboveIndex = renderedIndexes(list.mountNode)[0];
+
+        act(() => {
+            fireRowResize(rowWrapper(list.mountNode, aboveIndex), 60);
+        });
+
+        expect(list.scrollContainer.scrollTop).toBe(300);
+
+        list.root.unmount();
+    });
+});

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
@@ -1,26 +1,36 @@
 /** @vitest-environment jsdom */
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+    type MockInstance,
+} from "vitest";
 
 import { MeasuredVirtualList } from "./MeasuredVirtualList";
 
-// Integration coverage for the scroll-anchor compensation (mechanism B in the
-// resize hardening): when a row ABOVE the viewport re-measures to a new height,
-// the list must nudge scrollTop by the delta so the visible content stays put.
-// The pure math is unit-tested elsewhere; this drives the real component under
-// react-dom so the effect ordering, ResizeObserver wiring, and the actual
-// scrollTop mutation are exercised end to end.
+// Integration coverage for the virtualized measurement path under react-dom:
+// the scroll-anchor compensation (a row above the viewport re-measures → scroll
+// stays put), that a row attaches/measures exactly once instead of on every
+// render, that the ResizeObserver's border-box size is the one used, and that a
+// measurement-key churn on a reused node re-routes to the new key. The pure math
+// is unit-tested elsewhere; this exercises the real effect ordering, the
+// ResizeObserver wiring, and the actual scrollTop / layout mutations.
 
 const ITEM_HEIGHT = 20;
 const VIEWPORT_HEIGHT = 100;
 
 // jsdom has no layout engine and no ResizeObserver, so we drive measurements by
 // hand: a fake observer records the elements the list observes and lets a test
-// fire a contentRect height for any of them — exactly the channel the list uses
-// for the virtualized measurement path.
+// fire a size for any of them. The list reads the border-box size (with a
+// content-box fallback), so an entry carries both.
 interface FakeResizeEntry {
     readonly target: Element;
+    readonly borderBoxSize: readonly { readonly blockSize: number }[];
     readonly contentRect: { readonly height: number };
 }
 
@@ -35,6 +45,8 @@ class FakeResizeObserver {
         observers.push(this);
     }
 
+    // The list observes with { box: "border-box" }; the fake ignores the option
+    // (extra call args are harmless at runtime), so it takes only the element.
     observe(element: Element) {
         this.elements.add(element);
     }
@@ -51,25 +63,34 @@ class FakeResizeObserver {
         }
     }
 
-    fire(element: Element, height: number) {
+    fire(element: Element, borderBoxHeight: number, contentHeight: number) {
         if (this.elements.has(element)) {
-            this.callback([{ target: element, contentRect: { height } }]);
+            this.callback([
+                {
+                    target: element,
+                    borderBoxSize: [{ blockSize: borderBoxHeight }],
+                    contentRect: { height: contentHeight },
+                },
+            ]);
         }
     }
 }
 
-// A real browser keeps an element's measured height and its ResizeObserver
-// report in sync. The list re-measures via getBoundingClientRect on every
-// render (its ref callback is a fresh closure each time), so the stub MUST
-// reflect the latest "resized" height — otherwise a constant stub would revert
-// a just-reported resize on the next render. This map is the single source of
-// truth for both channels.
+// A real browser keeps an element's measured height (getBoundingClientRect, used
+// once on attach) and its ResizeObserver report in sync. The stub backs
+// getBoundingClientRect off this map so a fired resize stays reflected if the row
+// is ever re-measured; fireRowResize updates it alongside firing the observer.
 const heightByElement = new WeakMap<Element, number>();
 
-function fireRowResize(element: Element, height: number) {
+function fireRowResize(
+    element: Element,
+    height: number,
+    options?: { readonly contentHeight?: number },
+) {
     heightByElement.set(element, height);
+    const contentHeight = options?.contentHeight ?? height;
     for (const observer of observers) {
-        observer.fire(element, height);
+        observer.fire(element, height, contentHeight);
     }
 }
 
@@ -83,21 +104,25 @@ function createItems(count: number): Item[] {
     }));
 }
 
+interface MountConfig {
+    readonly items: readonly Item[];
+    readonly overscan: number;
+    readonly preserveScrollAnchorOnMeasure: boolean;
+    readonly getItemMeasurementKey?: (item: Item, index: number) => string;
+    readonly getItemIdentityKey?: (item: Item, index: number) => string;
+}
+
 interface MountedList {
     readonly scrollContainer: HTMLElement;
     readonly mountNode: HTMLElement;
     readonly root: Root;
+    readonly rerender: (next?: {
+        readonly items?: readonly Item[];
+        readonly getItemMeasurementKey?: (item: Item, index: number) => string;
+    }) => void;
 }
 
-function mountList({
-    items,
-    overscan,
-    preserveScrollAnchorOnMeasure,
-}: {
-    readonly items: readonly Item[];
-    readonly overscan: number;
-    readonly preserveScrollAnchorOnMeasure: boolean;
-}): MountedList {
+function mountList(config: MountConfig): MountedList {
     const scrollContainer = document.createElement("div");
     Object.defineProperty(scrollContainer, "clientHeight", {
         configurable: true,
@@ -112,25 +137,44 @@ function mountList({
     const root = createRoot(mountNode);
     const scrollContainerRef = { current: scrollContainer };
 
+    let currentItems = config.items;
+    let currentMeasurementKey = config.getItemMeasurementKey;
+
+    const element = () => (
+        <MeasuredVirtualList
+            defaultViewportHeight={VIEWPORT_HEIGHT}
+            estimateSize={() => ITEM_HEIGHT}
+            getItemIdentityKey={config.getItemIdentityKey}
+            getItemKey={(item) => item.id}
+            getItemMeasurementKey={currentMeasurementKey}
+            items={currentItems}
+            overscan={config.overscan}
+            preserveScrollAnchorOnMeasure={config.preserveScrollAnchorOnMeasure}
+            scrollContainerRef={scrollContainerRef}
+            scrollMarginTop={0}
+            renderItem={({ index, item }) => (
+                <div data-idx={index}>{item.id}</div>
+            )}
+        />
+    );
+
     act(() => {
-        root.render(
-            <MeasuredVirtualList
-                defaultViewportHeight={VIEWPORT_HEIGHT}
-                estimateSize={() => ITEM_HEIGHT}
-                getItemKey={(item) => item.id}
-                items={items}
-                overscan={overscan}
-                preserveScrollAnchorOnMeasure={preserveScrollAnchorOnMeasure}
-                scrollContainerRef={scrollContainerRef}
-                scrollMarginTop={0}
-                renderItem={({ index, item }) => (
-                    <div data-idx={index}>{item.id}</div>
-                )}
-            />,
-        );
+        root.render(element());
     });
 
-    return { scrollContainer, mountNode, root };
+    const rerender: MountedList["rerender"] = (next) => {
+        if (next?.items) {
+            currentItems = next.items;
+        }
+        if (next?.getItemMeasurementKey) {
+            currentMeasurementKey = next.getItemMeasurementKey;
+        }
+        act(() => {
+            root.render(element());
+        });
+    };
+
+    return { scrollContainer, mountNode, root, rerender };
 }
 
 function scrollTo(list: MountedList, scrollTop: number) {
@@ -156,6 +200,25 @@ function rowWrapper(mountNode: HTMLElement, index: number): Element {
     return content.parentElement;
 }
 
+function totalHeightPx(list: MountedList): string | undefined {
+    const listRoot = list.mountNode.firstElementChild as HTMLElement | null;
+    return listRoot?.style.height;
+}
+
+// Spy captured each test so call counts can be read without referencing the
+// (unbound) prototype method.
+let getBoundingClientRectSpy: MockInstance<() => DOMRect>;
+
+// Number of getBoundingClientRect calls made against row wrappers (they carry a
+// data-list-key). Equal to the number of attach measurements the list has done.
+function rowMeasureCount(): number {
+    return getBoundingClientRectSpy.mock.contexts.filter(
+        (context) =>
+            context instanceof HTMLElement &&
+            context.dataset.listKey !== undefined,
+    ).length;
+}
+
 beforeEach(() => {
     (
         globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
@@ -165,11 +228,14 @@ beforeEach(() => {
     ).ResizeObserver = FakeResizeObserver;
 
     // jsdom has no layout, so getBoundingClientRect() reports 0 — but the list
-    // measures each row's height that way on attach (setMeasuredElement). Back
-    // it with heightByElement so the initial layout matches a real render and a
-    // fired resize stays reflected on subsequent re-measures.
-    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
-        function getBoundingClientRect(this: Element): DOMRect {
+    // measures each row's height that way on attach. Back it with heightByElement
+    // so the initial layout matches a real render and a fired resize stays
+    // reflected if the row is re-measured.
+    getBoundingClientRectSpy = vi
+        .spyOn(Element.prototype, "getBoundingClientRect")
+        .mockImplementation(function getBoundingClientRect(
+            this: Element,
+        ): DOMRect {
             const height = heightByElement.get(this) ?? ITEM_HEIGHT;
             return {
                 height,
@@ -182,8 +248,7 @@ beforeEach(() => {
                 y: 0,
                 toJSON: () => ({}),
             };
-        },
-    );
+        });
 });
 
 afterEach(() => {
@@ -279,6 +344,91 @@ describe("MeasuredVirtualList scroll anchoring (integration)", () => {
         });
 
         expect(list.scrollContainer.scrollTop).toBe(300);
+
+        list.root.unmount();
+    });
+});
+
+describe("MeasuredVirtualList measurement wiring (integration)", () => {
+    it("measures each row once on attach, not on every render", () => {
+        const list = mountList({
+            items: createItems(60),
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+        });
+
+        scrollTo(list, 300);
+        const afterScroll = rowMeasureCount();
+        expect(afterScroll).toBeGreaterThan(0); // rows attached and measured
+
+        // Re-render with no row changes. The row ref is stable, so React must not
+        // detach/reattach it, and no row is re-measured. An inline-closure ref
+        // (the pre-fix behavior) would re-measure every visible row per render.
+        list.rerender();
+        list.rerender();
+
+        expect(rowMeasureCount()).toBe(afterScroll);
+
+        list.root.unmount();
+    });
+
+    it("uses the ResizeObserver border-box size, not the content-box rect", () => {
+        const list = mountList({
+            items: createItems(60),
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+        });
+
+        scrollTo(list, 300);
+        const aboveIndex = renderedIndexes(list.mountNode)[0];
+
+        // Border-box 60 but a divergent content-box 999. The list must use the
+        // border-box value so it matches its getBoundingClientRect channel.
+        act(() => {
+            fireRowResize(rowWrapper(list.mountNode, aboveIndex), 60, {
+                contentHeight: 999,
+            });
+        });
+
+        // Compensation uses 60 (border-box): 300 + (60 - 20) = 340. A content-box
+        // read would have moved it to 300 + (999 - 20).
+        expect(list.scrollContainer.scrollTop).toBe(340);
+
+        list.root.unmount();
+    });
+
+    it("re-routes measurements to the new key when a reused row's measurement key churns", () => {
+        const list = mountList({
+            items: createItems(60),
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+            getItemMeasurementKey: (item) => `${item.id}:v1`,
+            // Width-invariant identity, stable across the churn, so the row keeps
+            // its measured height via carry-over instead of snapping to estimate.
+            getItemIdentityKey: (item) => item.id,
+        });
+
+        scrollTo(list, 300);
+        const aboveIndex = renderedIndexes(list.mountNode)[0];
+
+        act(() => {
+            fireRowResize(rowWrapper(list.mountNode, aboveIndex), 60);
+        });
+        // One row measured 20 → 60 grows the total by 40 (60 rows × 20 = 1200).
+        expect(totalHeightPx(list)).toBe("1240px");
+
+        // Churn every row's measurement key while reusing the same DOM nodes.
+        list.rerender({ getItemMeasurementKey: (item) => `${item.id}:v2` });
+        // Carry-over keeps the row at 60 across the churn.
+        expect(totalHeightPx(list)).toBe("1240px");
+
+        // A resize after the churn must land on the new key (:v2). If the
+        // observer were still keyed to :v1, this 80 would be dropped and the
+        // total would stay 1240.
+        act(() => {
+            fireRowResize(rowWrapper(list.mountNode, aboveIndex), 80);
+        });
+        expect(totalHeightPx(list)).toBe("1260px");
 
         list.root.unmount();
     });

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
@@ -110,6 +110,7 @@ interface MountConfig {
     readonly preserveScrollAnchorOnMeasure: boolean;
     readonly getItemMeasurementKey?: (item: Item, index: number) => string;
     readonly getItemIdentityKey?: (item: Item, index: number) => string;
+    readonly shouldPreserveScrollAnchorOnMeasure?: () => boolean;
 }
 
 interface MountedList {
@@ -150,6 +151,9 @@ function mountList(config: MountConfig): MountedList {
             items={currentItems}
             overscan={config.overscan}
             preserveScrollAnchorOnMeasure={config.preserveScrollAnchorOnMeasure}
+            shouldPreserveScrollAnchorOnMeasure={
+                config.shouldPreserveScrollAnchorOnMeasure
+            }
             scrollContainerRef={scrollContainerRef}
             scrollMarginTop={0}
             renderItem={({ index, item }) => (
@@ -333,6 +337,27 @@ describe("MeasuredVirtualList scroll anchoring (integration)", () => {
             items: createItems(60),
             overscan: 10,
             preserveScrollAnchorOnMeasure: false,
+        });
+
+        scrollTo(list, 300);
+
+        const aboveIndex = renderedIndexes(list.mountNode)[0];
+
+        act(() => {
+            fireRowResize(rowWrapper(list.mountNode, aboveIndex), 60);
+        });
+
+        expect(list.scrollContainer.scrollTop).toBe(300);
+
+        list.root.unmount();
+    });
+
+    it("leaves scrollTop untouched when the live preserve predicate is off", () => {
+        const list = mountList({
+            items: createItems(60),
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+            shouldPreserveScrollAnchorOnMeasure: () => false,
         });
 
         scrollTo(list, 300);

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx
@@ -6,6 +6,7 @@ import {
     calculateMeasuredVirtualRange,
     calculateMeasuredVirtualScrollTop,
     MeasuredVirtualList,
+    pruneMeasuredSizesToKeys,
 } from "./MeasuredVirtualList";
 
 const ITEM_HEIGHT = 20;
@@ -205,5 +206,57 @@ describe("MeasuredVirtualList", () => {
         expect(markup).toContain("Item 0");
         expect(markup).toContain("Item 4");
         expect(markup.match(/data-row-index=/g)).toHaveLength(5);
+    });
+});
+
+describe("pruneMeasuredSizesToKeys", () => {
+    it("drops entries whose keys are no longer valid", () => {
+        const sizes = new Map([
+            ["a", 10],
+            ["b", 20],
+            ["c", 30],
+        ]);
+
+        const result = pruneMeasuredSizesToKeys(sizes, new Set(["a", "c"]));
+
+        expect([...result.entries()]).toEqual([
+            ["a", 10],
+            ["c", 30],
+        ]);
+    });
+
+    it("returns the same reference when nothing is stale", () => {
+        const sizes = new Map([
+            ["a", 10],
+            ["b", 20],
+        ]);
+
+        // Lets the caller skip the state update when there is nothing to prune.
+        expect(pruneMeasuredSizesToKeys(sizes, new Set(["a", "b", "c"]))).toBe(
+            sizes,
+        );
+    });
+
+    it("never mutates the input map", () => {
+        const sizes = new Map([
+            ["a", 10],
+            ["b", 20],
+        ]);
+
+        pruneMeasuredSizesToKeys(sizes, new Set(["a"]));
+
+        expect([...sizes.entries()]).toEqual([
+            ["a", 10],
+            ["b", 20],
+        ]);
+    });
+
+    it("returns a fresh empty map when no key survives", () => {
+        const sizes = new Map([["a", 10]]);
+
+        const result = pruneMeasuredSizesToKeys(sizes, new Set());
+
+        expect(result.size).toBe(0);
+        expect(result).not.toBe(sizes);
     });
 });

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx
@@ -262,6 +262,39 @@ describe("resolvePreviousMeasuredSize", () => {
         ).toBe(90 - ITEM_HEIGHT);
     });
 
+    it("prefers the last identity measurement over the estimate after a width re-key", () => {
+        // The resize case: the row's measurement key churned (new width bucket),
+        // so previousMeasuredSize is undefined, but the layout is showing the
+        // row at its last real measurement carried over by identity. That height
+        // — not the heuristic estimate — must be the compensation baseline.
+        const { itemIndex, previousKnownSize } = resolvePreviousMeasuredSize({
+            estimateSize,
+            fallbackSize: 90,
+            itemIndexByMeasurementKey: indexByKey,
+            items,
+            key: "key-4",
+            previousMeasuredSize: undefined,
+            previousIdentitySize: 130,
+        });
+
+        expect(itemIndex).toBe(4);
+        expect(previousKnownSize).toBe(130);
+
+        // The compensation is computed against the carried-over height, so a row
+        // above the viewport that re-measures from 130 to 96 nudges the scroll by
+        // the real delta rather than a spurious estimate-vs-measurement jump.
+        expect(
+            calculateMeasuredVirtualScrollAnchorAdjustment({
+                itemIndex,
+                nextSize: 96,
+                preserveScrollAnchorOnMeasure: true,
+                previousSize: previousKnownSize,
+                virtualizationEnabled: true,
+                visibleStartIndex: 6,
+            }),
+        ).toBe(96 - 130);
+    });
+
     it("degrades to the fallback size when the key is absent from the index map", () => {
         // A stale index map (the bug this guards against) makes the lookup miss:
         // itemIndex = -1 and previousKnownSize collapses onto the measurement, so

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx
@@ -7,6 +7,7 @@ import {
     calculateMeasuredVirtualScrollTop,
     MeasuredVirtualList,
     pruneMeasuredSizesToKeys,
+    resolvePreviousMeasuredSize,
 } from "./MeasuredVirtualList";
 
 const ITEM_HEIGHT = 20;
@@ -206,6 +207,88 @@ describe("MeasuredVirtualList", () => {
         expect(markup).toContain("Item 0");
         expect(markup).toContain("Item 4");
         expect(markup.match(/data-row-index=/g)).toHaveLength(5);
+    });
+});
+
+describe("resolvePreviousMeasuredSize", () => {
+    const items = createItems(10);
+    const estimateSize = () => ITEM_HEIGHT;
+    const indexByKey = new Map(
+        items.map((_, index) => [`key-${index}`, index]),
+    );
+
+    it("uses the existing measured size when the key was already measured", () => {
+        const { itemIndex, previousKnownSize } = resolvePreviousMeasuredSize({
+            estimateSize,
+            fallbackSize: 80,
+            itemIndexByMeasurementKey: indexByKey,
+            items,
+            key: "key-3",
+            previousMeasuredSize: 52,
+        });
+
+        expect(itemIndex).toBe(3);
+        expect(previousKnownSize).toBe(52);
+    });
+
+    it("falls back to the row estimate for a freshly-keyed row the layout has not measured", () => {
+        // This is the re-key case (expansion/font/resize): the new key is in the
+        // current index map but not yet in measuredSizes, so the layout is
+        // showing the row at its estimate. The estimate must be the baseline so
+        // the caller computes a real anchor delta against the new measurement.
+        const { itemIndex, previousKnownSize } = resolvePreviousMeasuredSize({
+            estimateSize,
+            fallbackSize: 90,
+            itemIndexByMeasurementKey: indexByKey,
+            items,
+            key: "key-4",
+            previousMeasuredSize: undefined,
+        });
+
+        expect(itemIndex).toBe(4);
+        expect(previousKnownSize).toBe(ITEM_HEIGHT);
+
+        // The resolved values feed a non-zero compensation for a row above the
+        // viewport — exactly what a stale index map (itemIndex = -1) would drop.
+        expect(
+            calculateMeasuredVirtualScrollAnchorAdjustment({
+                itemIndex,
+                nextSize: 90,
+                preserveScrollAnchorOnMeasure: true,
+                previousSize: previousKnownSize,
+                virtualizationEnabled: true,
+                visibleStartIndex: 6,
+            }),
+        ).toBe(90 - ITEM_HEIGHT);
+    });
+
+    it("degrades to the fallback size when the key is absent from the index map", () => {
+        // A stale index map (the bug this guards against) makes the lookup miss:
+        // itemIndex = -1 and previousKnownSize collapses onto the measurement, so
+        // the anchor adjustment below is silently zeroed for the above-viewport
+        // row that actually changed height.
+        const { itemIndex, previousKnownSize } = resolvePreviousMeasuredSize({
+            estimateSize,
+            fallbackSize: 90,
+            itemIndexByMeasurementKey: indexByKey,
+            items,
+            key: "key-unknown",
+            previousMeasuredSize: undefined,
+        });
+
+        expect(itemIndex).toBe(-1);
+        expect(previousKnownSize).toBe(90);
+
+        expect(
+            calculateMeasuredVirtualScrollAnchorAdjustment({
+                itemIndex,
+                nextSize: 90,
+                preserveScrollAnchorOnMeasure: true,
+                previousSize: previousKnownSize,
+                virtualizationEnabled: true,
+                visibleStartIndex: 6,
+            }),
+        ).toBe(0);
     });
 });
 

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
+    calculateMeasuredVirtualScrollAnchorAdjustment,
     calculateMeasuredVirtualRange,
     calculateMeasuredVirtualScrollTop,
     MeasuredVirtualList,
@@ -139,6 +140,52 @@ describe("MeasuredVirtualList", () => {
             visibleEndIndex: 9,
             visibleStartIndex: 0,
         });
+    });
+
+    it("calculates scroll anchoring adjustments only for measured rows above the viewport", () => {
+        expect(
+            calculateMeasuredVirtualScrollAnchorAdjustment({
+                itemIndex: 3,
+                nextSize: 52,
+                preserveScrollAnchorOnMeasure: true,
+                previousSize: 20,
+                virtualizationEnabled: true,
+                visibleStartIndex: 5,
+            }),
+        ).toBe(32);
+
+        expect(
+            calculateMeasuredVirtualScrollAnchorAdjustment({
+                itemIndex: 3,
+                nextSize: 12,
+                preserveScrollAnchorOnMeasure: true,
+                previousSize: 20,
+                virtualizationEnabled: true,
+                visibleStartIndex: 5,
+            }),
+        ).toBe(-8);
+
+        expect(
+            calculateMeasuredVirtualScrollAnchorAdjustment({
+                itemIndex: 5,
+                nextSize: 52,
+                preserveScrollAnchorOnMeasure: true,
+                previousSize: 20,
+                virtualizationEnabled: true,
+                visibleStartIndex: 5,
+            }),
+        ).toBe(0);
+
+        expect(
+            calculateMeasuredVirtualScrollAnchorAdjustment({
+                itemIndex: 3,
+                nextSize: 52,
+                preserveScrollAnchorOnMeasure: false,
+                previousSize: 20,
+                virtualizationEnabled: true,
+                visibleStartIndex: 5,
+            }),
+        ).toBe(0);
     });
 
     it("renders every item during server rendering", () => {

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -379,6 +379,20 @@ export function MeasuredVirtualList<T>({
     }, [itemMeasurementKeys]);
     const virtualizationEnabled = enabled && isBrowser;
 
+    // Keep the latest values in refs so updateMeasuredSize — and therefore the
+    // ResizeObserver effect that depends on it — stay referentially stable as
+    // items change. The observer must keep observing the same nodes during
+    // streaming; recreating it on every reconciliation would re-measure every
+    // visible row needlessly.
+    const itemsRef = useRef(items);
+    const estimateSizeRef = useRef(estimateSize);
+    const itemIndexByMeasurementKeyRef = useRef(itemIndexByMeasurementKey);
+    useEffect(() => {
+        itemsRef.current = items;
+        estimateSizeRef.current = estimateSize;
+        itemIndexByMeasurementKeyRef.current = itemIndexByMeasurementKey;
+    });
+
     const updateMeasuredSize = useCallback((key: string, nextSize: number) => {
         const normalizedSize = normalizeMeasuredVirtualSize(nextSize);
         const currentSizes = measuredSizesRef.current;
@@ -388,11 +402,12 @@ export function MeasuredVirtualList<T>({
             return;
         }
 
-        const itemIndex = itemIndexByMeasurementKey.get(key) ?? -1;
+        const currentItems = itemsRef.current;
+        const itemIndex = itemIndexByMeasurementKeyRef.current.get(key) ?? -1;
         const previousKnownSize =
             previousMeasuredSize ??
-            (itemIndex >= 0 && itemIndex < items.length
-                ? estimateSize(items[itemIndex], itemIndex)
+            (itemIndex >= 0 && itemIndex < currentItems.length
+                ? estimateSizeRef.current(currentItems[itemIndex], itemIndex)
                 : normalizedSize);
         const range = layoutRangeRef.current;
         const anchorAdjustment = calculateMeasuredVirtualScrollAnchorAdjustment(
@@ -414,13 +429,7 @@ export function MeasuredVirtualList<T>({
         nextSizes.set(key, normalizedSize);
         measuredSizesRef.current = nextSizes;
         setMeasuredSizes(nextSizes);
-    }, [
-        estimateSize,
-        itemIndexByMeasurementKey,
-        items,
-        preserveScrollAnchorOnMeasure,
-        virtualizationEnabled,
-    ]);
+    }, [preserveScrollAnchorOnMeasure, virtualizationEnabled]);
 
     useEffect(() => {
         if (!virtualizationEnabled || typeof ResizeObserver === "undefined") {

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -267,6 +267,35 @@ export function calculateMeasuredVirtualScrollTop({
     return clamp(nextScrollTop, 0, maxScrollTop);
 }
 
+/**
+ * Drops measured sizes whose keys are no longer valid, keeping the cache
+ * bounded to the current rows. Measurement keys are derived from row content
+ * and layout, so they churn over a long-lived session (resize, expansion
+ * toggles, review-state changes); without pruning the map grows without bound
+ * and each measurement clone gets progressively more expensive. Returns the
+ * SAME map reference when nothing is stale, so the caller can skip the state
+ * update; never mutates the input.
+ */
+export function pruneMeasuredSizesToKeys(
+    sizes: Map<string, number>,
+    validKeys: ReadonlySet<string>,
+): Map<string, number> {
+    let pruned: Map<string, number> | null = null;
+
+    for (const key of sizes.keys()) {
+        if (validKeys.has(key)) {
+            continue;
+        }
+
+        if (!pruned) {
+            pruned = new Map(sizes);
+        }
+        pruned.delete(key);
+    }
+
+    return pruned ?? sizes;
+}
+
 export function calculateMeasuredVirtualScrollAnchorAdjustment({
     itemIndex,
     nextSize,
@@ -435,27 +464,12 @@ export function MeasuredVirtualList<T>({
         }
 
         // Prune superseded measurements so the cache stays bounded to the
-        // current rows. Measurement keys are derived from row content and
-        // layout, so they churn over a long-lived session (resize, expansion
-        // toggles, review-state changes). Without pruning, the map grows
-        // without bound and each measurement clone gets progressively more
-        // expensive. Keys for current rows always live in validKeys, so only
-        // stale revisions — never an in-use measurement — get dropped.
+        // current rows. Keys for current rows always live in validKeys, so
+        // only stale revisions — never an in-use measurement — get dropped.
         const currentSizes = measuredSizesRef.current;
-        let prunedSizes: Map<string, number> | null = null;
+        const prunedSizes = pruneMeasuredSizesToKeys(currentSizes, validKeys);
 
-        for (const key of currentSizes.keys()) {
-            if (validKeys.has(key)) {
-                continue;
-            }
-
-            if (!prunedSizes) {
-                prunedSizes = new Map(currentSizes);
-            }
-            prunedSizes.delete(key);
-        }
-
-        if (prunedSizes) {
+        if (prunedSizes !== currentSizes) {
             measuredSizesRef.current = prunedSizes;
             setMeasuredSizes(prunedSizes);
         }

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -59,6 +59,7 @@ export interface MeasuredVirtualListProps<T> {
     readonly onRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onReady?: (handle: MeasuredVirtualListHandle | null) => void;
     readonly preserveScrollAnchorOnMeasure?: boolean;
+    readonly shouldPreserveScrollAnchorOnMeasure?: () => boolean;
     readonly renderItem: (params: {
         readonly index: number;
         readonly isVisible: boolean;
@@ -394,6 +395,7 @@ export function MeasuredVirtualList<T>({
     onRangeChange,
     onReady,
     preserveScrollAnchorOnMeasure = false,
+    shouldPreserveScrollAnchorOnMeasure,
     renderItem,
 }: MeasuredVirtualListProps<T>) {
     const isBrowser = typeof window !== "undefined";
@@ -419,6 +421,11 @@ export function MeasuredVirtualList<T>({
     const pendingScrollAnchorAdjustmentRef = useRef(0);
     const resizeObserverRef = useRef<ResizeObserver | null>(null);
     const previousRangeRef = useRef<MeasuredVirtualRange | null>(null);
+    const shouldPreserveScrollAnchorOnMeasureRef = useRef(
+        shouldPreserveScrollAnchorOnMeasure,
+    );
+    shouldPreserveScrollAnchorOnMeasureRef.current =
+        shouldPreserveScrollAnchorOnMeasure;
     const itemKeys = useMemo(
         () => items.map((item, index) => getItemKey(item, index)),
         [getItemKey, items],
@@ -494,6 +501,13 @@ export function MeasuredVirtualList<T>({
     itemIdentityKeysRef.current = itemIdentityKeys;
     measurementKeyByListKeyRef.current = measurementKeyByListKey;
 
+    const shouldPreserveScrollAnchorOnMeasureNow = useCallback(() => {
+        return (
+            preserveScrollAnchorOnMeasure &&
+            (shouldPreserveScrollAnchorOnMeasureRef.current?.() ?? true)
+        );
+    }, [preserveScrollAnchorOnMeasure]);
+
     const updateMeasuredSize = useCallback((key: string, nextSize: number) => {
         const normalizedSize = normalizeMeasuredVirtualSize(nextSize);
         const currentSizes = measuredSizesRef.current;
@@ -529,7 +543,8 @@ export function MeasuredVirtualList<T>({
             {
                 itemIndex,
                 nextSize: normalizedSize,
-                preserveScrollAnchorOnMeasure,
+                preserveScrollAnchorOnMeasure:
+                    shouldPreserveScrollAnchorOnMeasureNow(),
                 previousSize: previousKnownSize,
                 virtualizationEnabled,
                 visibleStartIndex: range?.visibleStartIndex ?? 0,
@@ -551,7 +566,7 @@ export function MeasuredVirtualList<T>({
         nextSizes.set(key, normalizedSize);
         measuredSizesRef.current = nextSizes;
         setMeasuredSizes(nextSizes);
-    }, [preserveScrollAnchorOnMeasure, virtualizationEnabled]);
+    }, [shouldPreserveScrollAnchorOnMeasureNow, virtualizationEnabled]);
 
     useEffect(() => {
         if (!virtualizationEnabled || typeof ResizeObserver === "undefined") {
@@ -807,6 +822,11 @@ export function MeasuredVirtualList<T>({
             return;
         }
 
+        if (!shouldPreserveScrollAnchorOnMeasureNow()) {
+            pendingScrollAnchorAdjustmentRef.current = 0;
+            return;
+        }
+
         const adjustment = pendingScrollAnchorAdjustmentRef.current;
         pendingScrollAnchorAdjustmentRef.current = 0;
 
@@ -823,6 +843,7 @@ export function MeasuredVirtualList<T>({
     }, [
         measuredSizes,
         preserveScrollAnchorOnMeasure,
+        shouldPreserveScrollAnchorOnMeasureNow,
         scrollContainerRef,
         virtualizationEnabled,
     ]);

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -408,8 +408,13 @@ export function MeasuredVirtualList<T>({
             ? defaultViewportHeight
             : Number.POSITIVE_INFINITY,
     }));
-    const elementByKeyRef = useRef(new Map<string, HTMLDivElement>());
-    const keyByElementRef = useRef(new WeakMap<Element, string>());
+    // Element bookkeeping is keyed by the STABLE list key (getItemKey), not the
+    // volatile measurement key: the wrapper's React key is the list key, so its
+    // DOM node is reused across measurement-key churn (resize, content edits).
+    // The live measurement key is resolved from the list key at measure time
+    // (measurementKeyByListKey), which lets the row ref attach exactly once.
+    const elementByListKeyRef = useRef(new Map<string, HTMLDivElement>());
+    const listKeyByElementRef = useRef(new WeakMap<Element, string>());
     const layoutRangeRef = useRef<MeasuredVirtualRange | null>(null);
     const pendingScrollAnchorAdjustmentRef = useRef(0);
     const resizeObserverRef = useRef<ResizeObserver | null>(null);
@@ -445,6 +450,18 @@ export function MeasuredVirtualList<T>({
             ),
         [getItemIdentityKey, itemMeasurementKeys, items],
     );
+    // Live list-key -> measurement-key map. The row ref is keyed by the stable
+    // list key, so a measurement must resolve the row's CURRENT measurement key
+    // here (it changes on resize/content edits while the DOM node is reused).
+    const measurementKeyByListKey = useMemo(() => {
+        const next = new Map<string, string>();
+
+        itemKeys.forEach((listKey, index) => {
+            next.set(listKey, itemMeasurementKeys[index]);
+        });
+
+        return next;
+    }, [itemKeys, itemMeasurementKeys]);
     // Last measured height per width-invariant identity. Mutated in place (like
     // the element maps below) and read during layout to bridge a row's height
     // across a measurement-key churn; pruned to the live identities alongside
@@ -470,10 +487,12 @@ export function MeasuredVirtualList<T>({
     const estimateSizeRef = useRef(estimateSize);
     const itemIndexByMeasurementKeyRef = useRef(itemIndexByMeasurementKey);
     const itemIdentityKeysRef = useRef(itemIdentityKeys);
+    const measurementKeyByListKeyRef = useRef(measurementKeyByListKey);
     itemsRef.current = items;
     estimateSizeRef.current = estimateSize;
     itemIndexByMeasurementKeyRef.current = itemIndexByMeasurementKey;
     itemIdentityKeysRef.current = itemIdentityKeys;
+    measurementKeyByListKeyRef.current = measurementKeyByListKey;
 
     const updateMeasuredSize = useCallback((key: string, nextSize: number) => {
         const normalizedSize = normalizeMeasuredVirtualSize(nextSize);
@@ -541,20 +560,34 @@ export function MeasuredVirtualList<T>({
 
         const observer = new ResizeObserver((entries) => {
             for (const entry of entries) {
-                const key = keyByElementRef.current.get(entry.target);
-                if (!key) {
+                const listKey = listKeyByElementRef.current.get(entry.target);
+                if (listKey === undefined) {
                     continue;
                 }
 
-                updateMeasuredSize(key, entry.contentRect.height);
+                // Resolve the row's CURRENT measurement key from its stable list
+                // key, so a measurement-key churn on a reused node is reported
+                // under the new key without re-attaching the ref.
+                const measurementKey =
+                    measurementKeyByListKeyRef.current.get(listKey);
+                if (measurementKey === undefined) {
+                    continue;
+                }
+
+                // Border-box to match the synchronous getBoundingClientRect
+                // measurement on attach, so the two channels can never disagree
+                // by the wrapper's padding/border.
+                const height =
+                    entry.borderBoxSize?.[0]?.blockSize ??
+                    entry.contentRect.height;
+                updateMeasuredSize(measurementKey, height);
             }
         });
 
         resizeObserverRef.current = observer;
 
-        for (const [key, element] of elementByKeyRef.current.entries()) {
-            keyByElementRef.current.set(element, key);
-            observer.observe(element);
+        for (const element of elementByListKeyRef.current.values()) {
+            observer.observe(element, { box: "border-box" });
         }
 
         return () => {
@@ -564,22 +597,29 @@ export function MeasuredVirtualList<T>({
     }, [updateMeasuredSize, virtualizationEnabled]);
 
     useEffect(() => {
-        const validKeys = new Set(itemMeasurementKeys);
+        // Drop elements for rows that no longer exist. Elements are keyed by the
+        // stable list key, so validate against itemKeys (not measurement keys).
+        const validListKeys = new Set(itemKeys);
 
-        for (const [key, element] of elementByKeyRef.current.entries()) {
-            if (validKeys.has(key)) {
+        for (const [listKey, element] of elementByListKeyRef.current.entries()) {
+            if (validListKeys.has(listKey)) {
                 continue;
             }
 
             resizeObserverRef.current?.unobserve(element);
-            elementByKeyRef.current.delete(key);
+            elementByListKeyRef.current.delete(listKey);
         }
 
         // Prune superseded measurements so the cache stays bounded to the
-        // current rows. Keys for current rows always live in validKeys, so
-        // only stale revisions — never an in-use measurement — get dropped.
+        // current rows. measuredSizes is keyed by measurement key (which churns
+        // more often than the list key), so validate it against those; keys for
+        // current rows always survive, only stale revisions get dropped.
+        const validMeasurementKeys = new Set(itemMeasurementKeys);
         const currentSizes = measuredSizesRef.current;
-        const prunedSizes = pruneMeasuredSizesToKeys(currentSizes, validKeys);
+        const prunedSizes = pruneMeasuredSizesToKeys(
+            currentSizes,
+            validMeasurementKeys,
+        );
 
         if (prunedSizes !== currentSizes) {
             measuredSizesRef.current = prunedSizes;
@@ -597,7 +637,7 @@ export function MeasuredVirtualList<T>({
                 measuredByIdentity.delete(identityKey);
             }
         }
-    }, [itemIdentityKeys, itemMeasurementKeys]);
+    }, [itemIdentityKeys, itemKeys, itemMeasurementKeys]);
 
     useEffect(() => {
         if (!virtualizationEnabled) {
@@ -829,27 +869,43 @@ export function MeasuredVirtualList<T>({
         [layout.virtualItems, resolveItemSize],
     );
 
-    const setMeasuredElement = useCallback(
-        (key: string, node: HTMLDivElement | null) => {
-            const previousElement = elementByKeyRef.current.get(key);
-
-            if (previousElement === node) {
-                return;
-            }
-
-            if (previousElement) {
-                resizeObserverRef.current?.unobserve(previousElement);
-                elementByKeyRef.current.delete(key);
-            }
-
+    // Stable ref for a measured row, keyed off the wrapper's data-list-key. Its
+    // identity only changes when updateMeasuredSize does (rarely), so React
+    // attaches it ONCE per row and runs the returned cleanup on unmount — rather
+    // than re-running an inline closure (and forcing a synchronous reflow) on
+    // every render. The ResizeObserver tracks every size change after attach, so
+    // the single getBoundingClientRect here is just the immediate first paint;
+    // a measurement-key churn on a reused node is handled by the observer.
+    const registerMeasuredElement = useCallback(
+        (node: HTMLDivElement | null) => {
             if (!node) {
                 return;
             }
 
-            elementByKeyRef.current.set(key, node);
-            keyByElementRef.current.set(node, key);
-            updateMeasuredSize(key, node.getBoundingClientRect().height);
-            resizeObserverRef.current?.observe(node);
+            const listKey = node.dataset.listKey;
+            if (listKey === undefined) {
+                return;
+            }
+
+            elementByListKeyRef.current.set(listKey, node);
+            listKeyByElementRef.current.set(node, listKey);
+
+            const measurementKey =
+                measurementKeyByListKeyRef.current.get(listKey);
+            if (measurementKey !== undefined) {
+                updateMeasuredSize(
+                    measurementKey,
+                    node.getBoundingClientRect().height,
+                );
+            }
+            resizeObserverRef.current?.observe(node, { box: "border-box" });
+
+            return () => {
+                resizeObserverRef.current?.unobserve(node);
+                if (elementByListKeyRef.current.get(listKey) === node) {
+                    elementByListKeyRef.current.delete(listKey);
+                }
+            };
         },
         [updateMeasuredSize],
     );
@@ -997,9 +1053,8 @@ export function MeasuredVirtualList<T>({
             {layout.virtualItems.map((virtualItem) => (
                 <div
                     key={virtualItem.key}
-                    ref={(node) => {
-                        setMeasuredElement(virtualItem.measurementKey, node);
-                    }}
+                    data-list-key={virtualItem.key}
+                    ref={registerMeasuredElement}
                     style={{
                         left: 0,
                         position: "absolute",

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -1,6 +1,7 @@
 import {
     useCallback,
     useEffect,
+    useLayoutEffect,
     useMemo,
     useRef,
     useState,
@@ -40,6 +41,7 @@ export interface MeasuredVirtualListProps<T> {
     readonly getItemMeasurementKey?: (item: T, index: number) => string;
     readonly onRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onReady?: (handle: MeasuredVirtualListHandle | null) => void;
+    readonly preserveScrollAnchorOnMeasure?: boolean;
     readonly renderItem: (params: {
         readonly index: number;
         readonly isVisible: boolean;
@@ -84,8 +86,25 @@ interface CalculateMeasuredVirtualScrollTopOptions {
     readonly viewportHeight: number;
 }
 
+interface CalculateMeasuredVirtualScrollAnchorAdjustmentOptions {
+    readonly itemIndex: number;
+    readonly nextSize: number;
+    readonly preserveScrollAnchorOnMeasure: boolean;
+    readonly previousSize: number;
+    readonly virtualizationEnabled: boolean;
+    readonly visibleStartIndex: number;
+}
+
 function clamp(value: number, min: number, max: number): number {
     return Math.min(Math.max(value, min), max);
+}
+
+function normalizeMeasuredVirtualSize(value: number): number {
+    if (!Number.isFinite(value)) {
+        return 1;
+    }
+
+    return Math.max(1, Math.ceil(value));
 }
 
 function areRangesEqual(
@@ -238,6 +257,32 @@ export function calculateMeasuredVirtualScrollTop({
     return clamp(nextScrollTop, 0, maxScrollTop);
 }
 
+export function calculateMeasuredVirtualScrollAnchorAdjustment({
+    itemIndex,
+    nextSize,
+    preserveScrollAnchorOnMeasure,
+    previousSize,
+    virtualizationEnabled,
+    visibleStartIndex,
+}: CalculateMeasuredVirtualScrollAnchorAdjustmentOptions): number {
+    if (
+        !preserveScrollAnchorOnMeasure ||
+        !virtualizationEnabled ||
+        itemIndex < 0 ||
+        itemIndex >= visibleStartIndex
+    ) {
+        return 0;
+    }
+
+    const delta = nextSize - previousSize;
+
+    if (!Number.isFinite(delta)) {
+        return 0;
+    }
+
+    return delta;
+}
+
 export function MeasuredVirtualList<T>({
     items,
     enabled = true,
@@ -250,6 +295,7 @@ export function MeasuredVirtualList<T>({
     getItemMeasurementKey,
     onRangeChange,
     onReady,
+    preserveScrollAnchorOnMeasure = false,
     renderItem,
 }: MeasuredVirtualListProps<T>) {
     const isBrowser = typeof window !== "undefined";
@@ -257,6 +303,7 @@ export function MeasuredVirtualList<T>({
     const [measuredSizes, setMeasuredSizes] = useState<Map<string, number>>(
         () => new Map(),
     );
+    const measuredSizesRef = useRef(measuredSizes);
     const [scrollState, setScrollState] = useState(() => ({
         scrollTop: 0,
         viewportHeight: isBrowser
@@ -265,6 +312,8 @@ export function MeasuredVirtualList<T>({
     }));
     const elementByKeyRef = useRef(new Map<string, HTMLDivElement>());
     const keyByElementRef = useRef(new WeakMap<Element, string>());
+    const layoutRangeRef = useRef<MeasuredVirtualRange | null>(null);
+    const pendingScrollAnchorAdjustmentRef = useRef(0);
     const resizeObserverRef = useRef<ResizeObserver | null>(null);
     const previousRangeRef = useRef<MeasuredVirtualRange | null>(null);
     const itemKeys = useMemo(
@@ -280,22 +329,59 @@ export function MeasuredVirtualList<T>({
             ),
         [getItemMeasurementKey, itemKeys, items],
     );
+    const itemIndexByMeasurementKey = useMemo(() => {
+        const next = new Map<string, number>();
+
+        itemMeasurementKeys.forEach((key, index) => {
+            next.set(key, index);
+        });
+
+        return next;
+    }, [itemMeasurementKeys]);
     const virtualizationEnabled = enabled && isBrowser;
 
     const updateMeasuredSize = useCallback((key: string, nextSize: number) => {
-        const normalizedSize = Math.max(1, Math.ceil(nextSize));
-        setMeasuredSizes((current) => {
-            const previousSize = current.get(key);
+        const normalizedSize = normalizeMeasuredVirtualSize(nextSize);
+        const currentSizes = measuredSizesRef.current;
+        const previousMeasuredSize = currentSizes.get(key);
 
-            if (previousSize === normalizedSize) {
-                return current;
-            }
+        if (previousMeasuredSize === normalizedSize) {
+            return;
+        }
 
-            const next = new Map(current);
-            next.set(key, normalizedSize);
-            return next;
-        });
-    }, []);
+        const itemIndex = itemIndexByMeasurementKey.get(key) ?? -1;
+        const previousKnownSize =
+            previousMeasuredSize ??
+            (itemIndex >= 0 && itemIndex < items.length
+                ? estimateSize(items[itemIndex], itemIndex)
+                : normalizedSize);
+        const range = layoutRangeRef.current;
+        const anchorAdjustment = calculateMeasuredVirtualScrollAnchorAdjustment(
+            {
+                itemIndex,
+                nextSize: normalizedSize,
+                preserveScrollAnchorOnMeasure,
+                previousSize: previousKnownSize,
+                virtualizationEnabled,
+                visibleStartIndex: range?.visibleStartIndex ?? 0,
+            },
+        );
+
+        if (anchorAdjustment !== 0) {
+            pendingScrollAnchorAdjustmentRef.current += anchorAdjustment;
+        }
+
+        const nextSizes = new Map(currentSizes);
+        nextSizes.set(key, normalizedSize);
+        measuredSizesRef.current = nextSizes;
+        setMeasuredSizes(nextSizes);
+    }, [
+        estimateSize,
+        itemIndexByMeasurementKey,
+        items,
+        preserveScrollAnchorOnMeasure,
+        virtualizationEnabled,
+    ]);
 
     useEffect(() => {
         if (!virtualizationEnabled || typeof ResizeObserver === "undefined") {
@@ -471,6 +557,34 @@ export function MeasuredVirtualList<T>({
         overscan,
         scrollState.scrollTop,
         scrollState.viewportHeight,
+        virtualizationEnabled,
+    ]);
+
+    layoutRangeRef.current = layout.range;
+
+    useLayoutEffect(() => {
+        if (!preserveScrollAnchorOnMeasure || !virtualizationEnabled) {
+            pendingScrollAnchorAdjustmentRef.current = 0;
+            return;
+        }
+
+        const adjustment = pendingScrollAnchorAdjustmentRef.current;
+        pendingScrollAnchorAdjustmentRef.current = 0;
+
+        if (adjustment === 0) {
+            return;
+        }
+
+        const container = scrollContainerRef.current;
+        if (!container) {
+            return;
+        }
+
+        container.scrollTop = Math.max(0, container.scrollTop + adjustment);
+    }, [
+        measuredSizes,
+        preserveScrollAnchorOnMeasure,
+        scrollContainerRef,
         virtualizationEnabled,
     ]);
 

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -433,6 +433,32 @@ export function MeasuredVirtualList<T>({
             resizeObserverRef.current?.unobserve(element);
             elementByKeyRef.current.delete(key);
         }
+
+        // Prune superseded measurements so the cache stays bounded to the
+        // current rows. Measurement keys are derived from row content and
+        // layout, so they churn over a long-lived session (resize, expansion
+        // toggles, review-state changes). Without pruning, the map grows
+        // without bound and each measurement clone gets progressively more
+        // expensive. Keys for current rows always live in validKeys, so only
+        // stale revisions — never an in-use measurement — get dropped.
+        const currentSizes = measuredSizesRef.current;
+        let prunedSizes: Map<string, number> | null = null;
+
+        for (const key of currentSizes.keys()) {
+            if (validKeys.has(key)) {
+                continue;
+            }
+
+            if (!prunedSizes) {
+                prunedSizes = new Map(currentSizes);
+            }
+            prunedSizes.delete(key);
+        }
+
+        if (prunedSizes) {
+            measuredSizesRef.current = prunedSizes;
+            setMeasuredSizes(prunedSizes);
+        }
     }, [itemMeasurementKeys]);
 
     useEffect(() => {

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -49,6 +49,13 @@ export interface MeasuredVirtualListProps<T> {
     readonly estimateSize: (item: T, index: number) => number;
     readonly getItemKey: (item: T, index: number) => string;
     readonly getItemMeasurementKey?: (item: T, index: number) => string;
+    /**
+     * Width-invariant identity for a row revision. When a row's measurement key
+     * churns (e.g. a resize re-buckets the width) the list reuses the row's last
+     * measured height under this key as the estimate, instead of snapping back
+     * to estimateSize. Defaults to the measurement key (no carry-over).
+     */
+    readonly getItemIdentityKey?: (item: T, index: number) => string;
     readonly onRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onReady?: (handle: MeasuredVirtualListHandle | null) => void;
     readonly preserveScrollAnchorOnMeasure?: boolean;
@@ -303,6 +310,10 @@ interface ResolvePreviousMeasuredSizeOptions<T> {
     readonly items: readonly T[];
     readonly key: string;
     readonly previousMeasuredSize: number | undefined;
+    // Last measured height for this row's width-invariant identity, if any. It
+    // is what the layout is currently assuming after a measurement-key churn,
+    // so it must take precedence over the estimate as the compensation baseline.
+    readonly previousIdentitySize?: number | undefined;
 }
 
 /**
@@ -327,6 +338,7 @@ export function resolvePreviousMeasuredSize<T>({
     items,
     key,
     previousMeasuredSize,
+    previousIdentitySize,
 }: ResolvePreviousMeasuredSizeOptions<T>): {
     readonly itemIndex: number;
     readonly previousKnownSize: number;
@@ -334,6 +346,7 @@ export function resolvePreviousMeasuredSize<T>({
     const itemIndex = itemIndexByMeasurementKey.get(key) ?? -1;
     const previousKnownSize =
         previousMeasuredSize ??
+        previousIdentitySize ??
         (itemIndex >= 0 && itemIndex < items.length
             ? estimateSize(items[itemIndex], itemIndex)
             : fallbackSize);
@@ -377,6 +390,7 @@ export function MeasuredVirtualList<T>({
     estimateSize,
     getItemKey,
     getItemMeasurementKey,
+    getItemIdentityKey,
     onRangeChange,
     onReady,
     preserveScrollAnchorOnMeasure = false,
@@ -422,6 +436,20 @@ export function MeasuredVirtualList<T>({
 
         return next;
     }, [itemMeasurementKeys]);
+    const itemIdentityKeys = useMemo(
+        () =>
+            items.map((item, index) =>
+                getItemIdentityKey
+                    ? getItemIdentityKey(item, index)
+                    : itemMeasurementKeys[index],
+            ),
+        [getItemIdentityKey, itemMeasurementKeys, items],
+    );
+    // Last measured height per width-invariant identity. Mutated in place (like
+    // the element maps below) and read during layout to bridge a row's height
+    // across a measurement-key churn; pruned to the live identities alongside
+    // measuredSizes so it stays bounded.
+    const measuredByIdentityRef = useRef(new Map<string, number>());
     const virtualizationEnabled = enabled && isBrowser;
 
     // Keep the latest values in refs so updateMeasuredSize — and therefore the
@@ -441,9 +469,11 @@ export function MeasuredVirtualList<T>({
     const itemsRef = useRef(items);
     const estimateSizeRef = useRef(estimateSize);
     const itemIndexByMeasurementKeyRef = useRef(itemIndexByMeasurementKey);
+    const itemIdentityKeysRef = useRef(itemIdentityKeys);
     itemsRef.current = items;
     estimateSizeRef.current = estimateSize;
     itemIndexByMeasurementKeyRef.current = itemIndexByMeasurementKey;
+    itemIdentityKeysRef.current = itemIdentityKeys;
 
     const updateMeasuredSize = useCallback((key: string, nextSize: number) => {
         const normalizedSize = normalizeMeasuredVirtualSize(nextSize);
@@ -454,6 +484,18 @@ export function MeasuredVirtualList<T>({
             return;
         }
 
+        const measuredByIdentity = measuredByIdentityRef.current;
+        const itemIndexForKey =
+            itemIndexByMeasurementKeyRef.current.get(key) ?? -1;
+        const identityKey =
+            itemIndexForKey >= 0
+                ? itemIdentityKeysRef.current[itemIndexForKey]
+                : undefined;
+        const previousIdentitySize =
+            identityKey !== undefined
+                ? measuredByIdentity.get(identityKey)
+                : undefined;
+
         const { itemIndex, previousKnownSize } = resolvePreviousMeasuredSize({
             estimateSize: estimateSizeRef.current,
             fallbackSize: normalizedSize,
@@ -461,6 +503,7 @@ export function MeasuredVirtualList<T>({
             items: itemsRef.current,
             key,
             previousMeasuredSize,
+            previousIdentitySize,
         });
         const range = layoutRangeRef.current;
         const anchorAdjustment = calculateMeasuredVirtualScrollAnchorAdjustment(
@@ -476,6 +519,13 @@ export function MeasuredVirtualList<T>({
 
         if (anchorAdjustment !== 0) {
             pendingScrollAnchorAdjustmentRef.current += anchorAdjustment;
+        }
+
+        // Record the height under the row's identity so a later measurement-key
+        // churn (e.g. a resize re-buckets the width) can reuse it as the
+        // estimate instead of snapping back to estimateSize.
+        if (identityKey !== undefined) {
+            measuredByIdentity.set(identityKey, normalizedSize);
         }
 
         const nextSizes = new Map(currentSizes);
@@ -535,7 +585,19 @@ export function MeasuredVirtualList<T>({
             measuredSizesRef.current = prunedSizes;
             setMeasuredSizes(prunedSizes);
         }
-    }, [itemMeasurementKeys]);
+
+        // Keep the identity-keyed estimate cache bounded the same way. Rows
+        // still present (even if scrolled out of view) keep their identity in
+        // validIdentityKeys; only removed rows get dropped. It is a pure
+        // estimate cache mutated in place, so no re-render is needed.
+        const validIdentityKeys = new Set(itemIdentityKeys);
+        const measuredByIdentity = measuredByIdentityRef.current;
+        for (const identityKey of measuredByIdentity.keys()) {
+            if (!validIdentityKeys.has(identityKey)) {
+                measuredByIdentity.delete(identityKey);
+            }
+        }
+    }, [itemIdentityKeys, itemMeasurementKeys]);
 
     useEffect(() => {
         if (!virtualizationEnabled) {
@@ -586,11 +648,37 @@ export function MeasuredVirtualList<T>({
         };
     }, [scrollContainerRef, virtualizationEnabled]);
 
+    // Resolve a row's height: an exact measurement wins; otherwise the row's
+    // last measurement under its width-invariant identity (so a resize doesn't
+    // snap it back to the estimate); the heuristic estimate is the final
+    // fallback for a never-measured row.
+    const resolveItemSize = useCallback(
+        (index: number): number => {
+            const measured = measuredSizes.get(itemMeasurementKeys[index]);
+            if (measured !== undefined) {
+                return measured;
+            }
+
+            const byIdentity = measuredByIdentityRef.current.get(
+                itemIdentityKeys[index],
+            );
+            if (byIdentity !== undefined) {
+                return byIdentity;
+            }
+
+            return estimateSize(items[index], index);
+        },
+        [
+            estimateSize,
+            itemIdentityKeys,
+            itemMeasurementKeys,
+            items,
+            measuredSizes,
+        ],
+    );
+
     const layout = useMemo((): LayoutSnapshot<T> => {
-        const sizes = items.map((item, index) => {
-            const key = itemMeasurementKeys[index];
-            return measuredSizes.get(key) ?? estimateSize(item, index);
-        });
+        const sizes = items.map((_item, index) => resolveItemSize(index));
         const offsets = new Array<number>(items.length);
         let totalSize = 0;
 
@@ -660,13 +748,12 @@ export function MeasuredVirtualList<T>({
             virtualItems,
         };
     }, [
-        estimateSize,
         itemMeasurementKeys,
         itemKeys,
         items,
-        measuredSizes,
         normalizedScrollMarginTop,
         overscan,
+        resolveItemSize,
         scrollState.scrollTop,
         scrollState.viewportHeight,
         virtualizationEnabled,
@@ -724,19 +811,11 @@ export function MeasuredVirtualList<T>({
 
             let total = 0;
             for (let cursor = 0; cursor < index; cursor += 1) {
-                total +=
-                    measuredSizes.get(itemMeasurementKeys[cursor]) ??
-                    estimateSize(items[cursor], cursor);
+                total += resolveItemSize(cursor);
             }
             return total;
         },
-        [
-            estimateSize,
-            itemMeasurementKeys,
-            items,
-            layout.virtualItems,
-            measuredSizes,
-        ],
+        [layout.virtualItems, resolveItemSize],
     );
 
     const getItemSize = useCallback(
@@ -745,19 +824,9 @@ export function MeasuredVirtualList<T>({
                 layout.virtualItems.find((item) => item.index === index) ??
                 null;
 
-            return (
-                targetItem?.size ??
-                measuredSizes.get(itemMeasurementKeys[index]) ??
-                estimateSize(items[index], index)
-            );
+            return targetItem?.size ?? resolveItemSize(index);
         },
-        [
-            estimateSize,
-            itemMeasurementKeys,
-            items,
-            layout.virtualItems,
-            measuredSizes,
-        ],
+        [layout.virtualItems, resolveItemSize],
     );
 
     const setMeasuredElement = useCallback(

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -296,6 +296,51 @@ export function pruneMeasuredSizesToKeys(
     return pruned ?? sizes;
 }
 
+interface ResolvePreviousMeasuredSizeOptions<T> {
+    readonly estimateSize: (item: T, index: number) => number;
+    readonly fallbackSize: number;
+    readonly itemIndexByMeasurementKey: ReadonlyMap<string, number>;
+    readonly items: readonly T[];
+    readonly key: string;
+    readonly previousMeasuredSize: number | undefined;
+}
+
+/**
+ * Resolves the row index for a measurement key and the size the layout is
+ * currently assuming for it, so a fresh measurement can be compared against the
+ * right baseline for scroll-anchor compensation.
+ *
+ * The index map MUST reflect the same render that produced the measured node.
+ * A measurement key changes whenever a row could render at a new height (resize,
+ * expansion toggle, content reconciliation); when it does, the new key has no
+ * entry in measuredSizes yet, so the layout is showing the row at its ESTIMATE.
+ * Returning that estimate as previousKnownSize lets updateMeasuredSize compute a
+ * real delta. If the index map lagged a render behind, the lookup would miss
+ * (itemIndex = -1) and fall back to the measured size — a zero delta — which
+ * silently drops the compensation and lets an above-viewport row shift the
+ * total height without adjusting scrollTop.
+ */
+export function resolvePreviousMeasuredSize<T>({
+    estimateSize,
+    fallbackSize,
+    itemIndexByMeasurementKey,
+    items,
+    key,
+    previousMeasuredSize,
+}: ResolvePreviousMeasuredSizeOptions<T>): {
+    readonly itemIndex: number;
+    readonly previousKnownSize: number;
+} {
+    const itemIndex = itemIndexByMeasurementKey.get(key) ?? -1;
+    const previousKnownSize =
+        previousMeasuredSize ??
+        (itemIndex >= 0 && itemIndex < items.length
+            ? estimateSize(items[itemIndex], itemIndex)
+            : fallbackSize);
+
+    return { itemIndex, previousKnownSize };
+}
+
 export function calculateMeasuredVirtualScrollAnchorAdjustment({
     itemIndex,
     nextSize,
@@ -384,14 +429,21 @@ export function MeasuredVirtualList<T>({
     // items change. The observer must keep observing the same nodes during
     // streaming; recreating it on every reconciliation would re-measure every
     // visible row needlessly.
+    //
+    // These are assigned during render (not in an effect) on purpose: a ref
+    // callback measures a freshly-keyed node during the commit phase, BEFORE
+    // passive effects run. If the index map lagged behind in an effect, that
+    // first measurement would look the new measurementKey up against the
+    // previous render's map, get -1, and skip the scroll-anchor compensation —
+    // letting an above-viewport row change the total height without adjusting
+    // scrollTop (a visible jump on expansion/font re-keys). Mirrors the
+    // layoutRangeRef assignment below.
     const itemsRef = useRef(items);
     const estimateSizeRef = useRef(estimateSize);
     const itemIndexByMeasurementKeyRef = useRef(itemIndexByMeasurementKey);
-    useEffect(() => {
-        itemsRef.current = items;
-        estimateSizeRef.current = estimateSize;
-        itemIndexByMeasurementKeyRef.current = itemIndexByMeasurementKey;
-    });
+    itemsRef.current = items;
+    estimateSizeRef.current = estimateSize;
+    itemIndexByMeasurementKeyRef.current = itemIndexByMeasurementKey;
 
     const updateMeasuredSize = useCallback((key: string, nextSize: number) => {
         const normalizedSize = normalizeMeasuredVirtualSize(nextSize);
@@ -402,13 +454,14 @@ export function MeasuredVirtualList<T>({
             return;
         }
 
-        const currentItems = itemsRef.current;
-        const itemIndex = itemIndexByMeasurementKeyRef.current.get(key) ?? -1;
-        const previousKnownSize =
-            previousMeasuredSize ??
-            (itemIndex >= 0 && itemIndex < currentItems.length
-                ? estimateSizeRef.current(currentItems[itemIndex], itemIndex)
-                : normalizedSize);
+        const { itemIndex, previousKnownSize } = resolvePreviousMeasuredSize({
+            estimateSize: estimateSizeRef.current,
+            fallbackSize: normalizedSize,
+            itemIndexByMeasurementKey: itemIndexByMeasurementKeyRef.current,
+            items: itemsRef.current,
+            key,
+            previousMeasuredSize,
+        });
         const range = layoutRangeRef.current;
         const anchorAdjustment = calculateMeasuredVirtualScrollAnchorAdjustment(
             {

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -37,6 +37,7 @@ export interface MeasuredVirtualListProps<T> {
     readonly scrollContainerRef: RefObject<HTMLElement | null>;
     readonly estimateSize: (item: T, index: number) => number;
     readonly getItemKey: (item: T, index: number) => string;
+    readonly getItemMeasurementKey?: (item: T, index: number) => string;
     readonly onRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onReady?: (handle: MeasuredVirtualListHandle | null) => void;
     readonly renderItem: (params: {
@@ -51,6 +52,7 @@ interface MeasuredVirtualItem<T> {
     readonly isVisible: boolean;
     readonly item: T;
     readonly key: string;
+    readonly measurementKey: string;
     readonly size: number;
     readonly start: number;
 }
@@ -245,6 +247,7 @@ export function MeasuredVirtualList<T>({
     scrollContainerRef,
     estimateSize,
     getItemKey,
+    getItemMeasurementKey,
     onRangeChange,
     onReady,
     renderItem,
@@ -267,6 +270,15 @@ export function MeasuredVirtualList<T>({
     const itemKeys = useMemo(
         () => items.map((item, index) => getItemKey(item, index)),
         [getItemKey, items],
+    );
+    const itemMeasurementKeys = useMemo(
+        () =>
+            items.map((item, index) =>
+                getItemMeasurementKey
+                    ? getItemMeasurementKey(item, index)
+                    : itemKeys[index],
+            ),
+        [getItemMeasurementKey, itemKeys, items],
     );
     const virtualizationEnabled = enabled && isBrowser;
 
@@ -315,7 +327,7 @@ export function MeasuredVirtualList<T>({
     }, [updateMeasuredSize, virtualizationEnabled]);
 
     useEffect(() => {
-        const validKeys = new Set(itemKeys);
+        const validKeys = new Set(itemMeasurementKeys);
 
         for (const [key, element] of elementByKeyRef.current.entries()) {
             if (validKeys.has(key)) {
@@ -325,7 +337,7 @@ export function MeasuredVirtualList<T>({
             resizeObserverRef.current?.unobserve(element);
             elementByKeyRef.current.delete(key);
         }
-    }, [itemKeys]);
+    }, [itemMeasurementKeys]);
 
     useEffect(() => {
         if (!virtualizationEnabled) {
@@ -378,7 +390,7 @@ export function MeasuredVirtualList<T>({
 
     const layout = useMemo((): LayoutSnapshot<T> => {
         const sizes = items.map((item, index) => {
-            const key = itemKeys[index];
+            const key = itemMeasurementKeys[index];
             return measuredSizes.get(key) ?? estimateSize(item, index);
         });
         const offsets = new Array<number>(items.length);
@@ -417,6 +429,7 @@ export function MeasuredVirtualList<T>({
                     isVisible: true,
                     item,
                     key: itemKeys[index],
+                    measurementKey: itemMeasurementKeys[index],
                     size: sizes[index],
                     start: offsets[index],
                 })),
@@ -437,6 +450,7 @@ export function MeasuredVirtualList<T>({
                     index <= range.visibleEndIndex,
                 item: items[index],
                 key: itemKeys[index],
+                measurementKey: itemMeasurementKeys[index],
                 size: sizes[index],
                 start: offsets[index],
             });
@@ -449,6 +463,7 @@ export function MeasuredVirtualList<T>({
         };
     }, [
         estimateSize,
+        itemMeasurementKeys,
         itemKeys,
         items,
         measuredSizes,
@@ -521,14 +536,14 @@ export function MeasuredVirtualList<T>({
                       let total = 0;
                       for (let cursor = 0; cursor < index; cursor += 1) {
                           total +=
-                              measuredSizes.get(itemKeys[cursor]) ??
+                              measuredSizes.get(itemMeasurementKeys[cursor]) ??
                               estimateSize(items[cursor], cursor);
                       }
                       return total;
                   })();
             const itemSize =
                 targetItem?.size ??
-                measuredSizes.get(itemKeys[index]) ??
+                measuredSizes.get(itemMeasurementKeys[index]) ??
                 estimateSize(items[index], index);
             container.scrollTop = calculateMeasuredVirtualScrollTop({
                 align,
@@ -542,7 +557,7 @@ export function MeasuredVirtualList<T>({
         },
         [
             estimateSize,
-            itemKeys,
+            itemMeasurementKeys,
             items,
             layout,
             measuredSizes,
@@ -575,7 +590,7 @@ export function MeasuredVirtualList<T>({
                             }
 
                             updateMeasuredSize(
-                                itemKeys[index],
+                                itemMeasurementKeys[index],
                                 node.getBoundingClientRect().height,
                             );
                         }}
@@ -600,7 +615,7 @@ export function MeasuredVirtualList<T>({
                 <div
                     key={virtualItem.key}
                     ref={(node) => {
-                        setMeasuredElement(virtualItem.key, node);
+                        setMeasuredElement(virtualItem.measurementKey, node);
                     }}
                     style={{
                         left: 0,

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -19,13 +19,23 @@ export interface MeasuredVirtualRange {
     readonly visibleEndIndex: number;
 }
 
+export interface MeasuredVirtualViewportAnchor {
+    readonly index: number;
+    readonly key: string;
+    readonly offset: number;
+}
+
 export interface MeasuredVirtualListHandle {
+    readonly captureViewportAnchor?: () => MeasuredVirtualViewportAnchor | null;
     readonly scrollToIndex: (
         index: number,
         options?: {
             readonly align?: "center" | "end" | "start";
             readonly offset?: number;
         },
+    ) => void;
+    readonly scrollToViewportAnchor?: (
+        anchor: MeasuredVirtualViewportAnchor,
     ) => void;
 }
 
@@ -600,6 +610,54 @@ export function MeasuredVirtualList<T>({
         onRangeChange(layout.range);
     }, [layout.range, onRangeChange]);
 
+    const getItemStart = useCallback(
+        (index: number): number => {
+            const targetItem =
+                layout.virtualItems.find((item) => item.index === index) ??
+                null;
+
+            if (targetItem) {
+                return targetItem.start;
+            }
+
+            let total = 0;
+            for (let cursor = 0; cursor < index; cursor += 1) {
+                total +=
+                    measuredSizes.get(itemMeasurementKeys[cursor]) ??
+                    estimateSize(items[cursor], cursor);
+            }
+            return total;
+        },
+        [
+            estimateSize,
+            itemMeasurementKeys,
+            items,
+            layout.virtualItems,
+            measuredSizes,
+        ],
+    );
+
+    const getItemSize = useCallback(
+        (index: number): number => {
+            const targetItem =
+                layout.virtualItems.find((item) => item.index === index) ??
+                null;
+
+            return (
+                targetItem?.size ??
+                measuredSizes.get(itemMeasurementKeys[index]) ??
+                estimateSize(items[index], index)
+            );
+        },
+        [
+            estimateSize,
+            itemMeasurementKeys,
+            items,
+            layout.virtualItems,
+            measuredSizes,
+        ],
+    );
+
     const setMeasuredElement = useCallback(
         (key: string, node: HTMLDivElement | null) => {
             const previousElement = elementByKeyRef.current.get(key);
@@ -641,28 +699,10 @@ export function MeasuredVirtualList<T>({
 
             const align = options?.align ?? "start";
             const offset = options?.offset ?? 0;
-            const targetItem =
-                layout.virtualItems.find((item) => item.index === index) ??
-                null;
-            const itemStart = targetItem
-                ? targetItem.start
-                : (() => {
-                      let total = 0;
-                      for (let cursor = 0; cursor < index; cursor += 1) {
-                          total +=
-                              measuredSizes.get(itemMeasurementKeys[cursor]) ??
-                              estimateSize(items[cursor], cursor);
-                      }
-                      return total;
-                  })();
-            const itemSize =
-                targetItem?.size ??
-                measuredSizes.get(itemMeasurementKeys[index]) ??
-                estimateSize(items[index], index);
             container.scrollTop = calculateMeasuredVirtualScrollTop({
                 align,
-                itemSize,
-                itemStart,
+                itemSize: getItemSize(index),
+                itemStart: getItemStart(index),
                 offset,
                 scrollMarginTop: normalizedScrollMarginTop,
                 totalSize: layout.totalSize,
@@ -670,23 +710,81 @@ export function MeasuredVirtualList<T>({
             });
         },
         [
-            estimateSize,
-            itemMeasurementKeys,
+            getItemSize,
+            getItemStart,
             items,
-            layout,
-            measuredSizes,
+            layout.totalSize,
             normalizedScrollMarginTop,
             scrollContainerRef,
         ],
     );
 
+    const captureViewportAnchor = useCallback(():
+        | MeasuredVirtualViewportAnchor
+        | null => {
+        const container = scrollContainerRef.current;
+
+        if (!container || items.length === 0) {
+            return null;
+        }
+
+        const index = clamp(
+            layout.range.visibleStartIndex,
+            0,
+            items.length - 1,
+        );
+        const effectiveScrollTop = Math.max(
+            0,
+            container.scrollTop - normalizedScrollMarginTop,
+        );
+        const itemStart = getItemStart(index);
+
+        return {
+            index,
+            key: itemKeys[index],
+            offset: Math.max(0, Math.round(effectiveScrollTop - itemStart)),
+        };
+    }, [
+        getItemStart,
+        itemKeys,
+        items.length,
+        layout.range.visibleStartIndex,
+        normalizedScrollMarginTop,
+        scrollContainerRef,
+    ]);
+
+    const scrollToViewportAnchor = useCallback(
+        (anchor: MeasuredVirtualViewportAnchor) => {
+            const keyedIndex = itemKeys.indexOf(anchor.key);
+            const index =
+                keyedIndex >= 0
+                    ? keyedIndex
+                    : clamp(anchor.index, 0, items.length - 1);
+
+            scrollToIndex(index, {
+                align: "start",
+                offset: anchor.offset,
+            });
+        },
+        [itemKeys, items.length, scrollToIndex],
+    );
+
     useEffect(() => {
-        onReady?.({ scrollToIndex });
+        onReady?.({
+            captureViewportAnchor,
+            scrollToIndex,
+            scrollToViewportAnchor,
+        });
 
         return () => {
             onReady?.(null);
         };
-    }, [onReady, scrollToIndex]);
+    }, [
+        captureViewportAnchor,
+        onReady,
+        scrollToIndex,
+        scrollToViewportAnchor,
+    ]);
 
     if (items.length === 0) {
         return null;

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -47,10 +47,7 @@ import type {
     RuntimeWorkspaceChatTab,
     RuntimeWorkspaceFileReviewContext,
 } from "@renderer/app/workspace/tree";
-import type {
-    MeasuredVirtualListHandle,
-    MeasuredVirtualRange,
-} from "@renderer/components/virtual/MeasuredVirtualList";
+import type { MeasuredVirtualRange } from "@renderer/components/virtual/MeasuredVirtualList";
 
 import { AIChatAgentControls } from "./AIChatAgentControls";
 import { LanguageIcon } from "./LanguageIcon";
@@ -251,8 +248,6 @@ export const ChatTabView = memo(function ChatTabView({
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const scrollRef = useRef<HTMLDivElement | null>(null);
     const timelineContentRef = useRef<HTMLDivElement | null>(null);
-    const timelineVirtualListHandleRef =
-        useRef<MeasuredVirtualListHandle | null>(null);
     const shouldAutoFollowRef = useRef(true);
     const pendingScrollFrameRef = useRef<number | null>(null);
     const restoreScrollFrameRef = useRef<number | null>(null);
@@ -784,13 +779,6 @@ export const ChatTabView = memo(function ChatTabView({
             scrollToBottom();
         });
     }, [scrollToBottom]);
-
-    const handleTimelineVirtualListReady = useCallback(
-        (handle: MeasuredVirtualListHandle | null) => {
-            timelineVirtualListHandleRef.current = handle;
-        },
-        [],
-    );
 
     const handleTimelineVirtualRangeChange = useCallback(() => {
         if (shouldAutoFollowRef.current) {
@@ -1545,7 +1533,6 @@ export const ChatTabView = memo(function ChatTabView({
                     onOpenSession={openAiSessionById}
                     onRevealFileReference={handleRevealResolvedFileReference}
                     onScroll={handleScroll}
-                    onVirtualListReady={handleTimelineVirtualListReady}
                     onVirtualRangeChange={handleTimelineVirtualRangeChange}
                     onVirtualResizeAutoFollow={
                         handleTimelineVirtualResizeAutoFollow
@@ -2002,7 +1989,6 @@ const ChatTimeline = memo(function ChatTimeline({
     onOpenSession,
     onRevealFileReference,
     onScroll,
-    onVirtualListReady,
     onVirtualRangeChange,
     onVirtualResizeAutoFollow,
     projectId,
@@ -2041,9 +2027,6 @@ const ChatTimeline = memo(function ChatTimeline({
         reference: ResolvedProjectFileReference,
     ) => void;
     readonly onScroll: () => void;
-    readonly onVirtualListReady?: (
-        handle: MeasuredVirtualListHandle | null,
-    ) => void;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onVirtualResizeAutoFollow?: () => void;
     readonly projectId: string | null;
@@ -2092,7 +2075,6 @@ const ChatTimeline = memo(function ChatTimeline({
                     onOpenResolvedFileReference={onOpenResolvedFileReference}
                     onOpenSession={onOpenSession}
                     onRevealFileReference={onRevealFileReference}
-                    onVirtualListReady={onVirtualListReady}
                     onVirtualRangeChange={onVirtualRangeChange}
                     onVirtualResizeAutoFollow={onVirtualResizeAutoFollow}
                     projectId={projectId}
@@ -2145,7 +2127,6 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
     onOpenResolvedFileReference,
     onOpenSession,
     onRevealFileReference,
-    onVirtualListReady,
     onVirtualRangeChange,
     onVirtualResizeAutoFollow,
     projectId,
@@ -2179,9 +2160,6 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
     readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
     readonly onRevealFileReference?: (
         reference: ResolvedProjectFileReference,
-    ) => void;
-    readonly onVirtualListReady?: (
-        handle: MeasuredVirtualListHandle | null,
     ) => void;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onVirtualResizeAutoFollow?: () => void;
@@ -2247,7 +2225,6 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
             latestStreamingEditedFileToolRowId={
                 latestStreamingEditedFileToolRowId
             }
-            onVirtualListReady={onVirtualListReady}
             onVirtualRangeChange={onVirtualRangeChange}
             onVirtualResizeAutoFollow={onVirtualResizeAutoFollow}
             renderRow={renderRow}
@@ -2450,9 +2427,6 @@ function areChatTimelinePropsEqual(
             reference: ResolvedProjectFileReference,
         ) => void;
         readonly onScroll: () => void;
-        readonly onVirtualListReady?: (
-            handle: MeasuredVirtualListHandle | null,
-        ) => void;
         readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
         readonly onVirtualResizeAutoFollow?: () => void;
         readonly projectId: string | null;
@@ -2490,9 +2464,6 @@ function areChatTimelinePropsEqual(
             reference: ResolvedProjectFileReference,
         ) => void;
         readonly onScroll: () => void;
-        readonly onVirtualListReady?: (
-            handle: MeasuredVirtualListHandle | null,
-        ) => void;
         readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
         readonly onVirtualResizeAutoFollow?: () => void;
         readonly projectId: string | null;
@@ -2521,7 +2492,6 @@ function areChatTimelinePropsEqual(
         previous.onOpenSession === next.onOpenSession &&
         previous.onRevealFileReference === next.onRevealFileReference &&
         previous.onScroll === next.onScroll &&
-        previous.onVirtualListReady === next.onVirtualListReady &&
         previous.onVirtualRangeChange === next.onVirtualRangeChange &&
         previous.onVirtualResizeAutoFollow === next.onVirtualResizeAutoFollow &&
         previous.projectId === next.projectId &&
@@ -2557,9 +2527,6 @@ function areChatTimelineHistoryPropsEqual(
         readonly onRevealFileReference?: (
             reference: ResolvedProjectFileReference,
         ) => void;
-        readonly onVirtualListReady?: (
-            handle: MeasuredVirtualListHandle | null,
-        ) => void;
         readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
         readonly onVirtualResizeAutoFollow?: () => void;
         readonly projectId: string | null;
@@ -2593,9 +2560,6 @@ function areChatTimelineHistoryPropsEqual(
         readonly onRevealFileReference?: (
             reference: ResolvedProjectFileReference,
         ) => void;
-        readonly onVirtualListReady?: (
-            handle: MeasuredVirtualListHandle | null,
-        ) => void;
         readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
         readonly onVirtualResizeAutoFollow?: () => void;
         readonly projectId: string | null;
@@ -2620,7 +2584,6 @@ function areChatTimelineHistoryPropsEqual(
             next.onOpenResolvedFileReference &&
         previous.onOpenSession === next.onOpenSession &&
         previous.onRevealFileReference === next.onRevealFileReference &&
-        previous.onVirtualListReady === next.onVirtualListReady &&
         previous.onVirtualRangeChange === next.onVirtualRangeChange &&
         previous.onVirtualResizeAutoFollow === next.onVirtualResizeAutoFollow &&
         previous.projectId === next.projectId &&

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -54,6 +54,7 @@ import { LanguageIcon } from "./LanguageIcon";
 import { AIChatComposer } from "./chat/AIChatComposer";
 import { AIChatContextUsageBar } from "./chat/AIChatContextUsageBar";
 import { ChatTimelineHistoryRows } from "./chat/ChatTimelineHistoryRows";
+import { ToolExpansionStoreProvider } from "./chat/toolExpansionStore";
 import { ChatMessageRow } from "./chat/ChatMessageRow";
 import { CHAT_PILL_VARIANTS } from "./chat/chatPillPalette";
 import {
@@ -2056,63 +2057,67 @@ const ChatTimeline = memo(function ChatTimeline({
     });
 
     return (
-        <div
-            ref={scrollRef}
-            className="chat-scroll min-h-0 min-w-0 flex-1 overflow-y-auto px-3 py-3"
-            onScroll={onScroll}
-        >
+        <ToolExpansionStoreProvider>
             <div
-                ref={timelineContentRef}
-                className="min-w-0 space-y-2"
-                style={{ fontFamily: chatFontFamily }}
+                ref={scrollRef}
+                className="chat-scroll min-h-0 min-w-0 flex-1 overflow-y-auto px-3 py-3"
+                onScroll={onScroll}
             >
-                <ChatTimelineHistory
-                    canRenderRawFileReference={canRenderRawFileReference}
-                    chatFontFamily={chatFontFamily}
-                    chatFontSize={chatFontSize}
-                    historyRows={historyRows}
-                    onAddFileReferenceToChat={onAddFileReferenceToChat}
-                    onOpenFile={onOpenFile}
-                    onOpenImage={onOpenImage}
-                    onOpenResolvedFileReference={onOpenResolvedFileReference}
-                    onOpenSession={onOpenSession}
-                    onRevealFileReference={onRevealFileReference}
-                    onVirtualRangeChange={onVirtualRangeChange}
-                    onVirtualResizeAutoFollow={onVirtualResizeAutoFollow}
-                    projectId={projectId}
-                    resolveFileReference={resolveFileReference}
-                    latestStreamingEditedFileToolRowId={
-                        latestStreamingEditedFileToolRowId
-                    }
-                    scrollRef={scrollRef}
-                    shouldPreserveVirtualResizeAnchor={
-                        shouldPreserveVirtualResizeAnchor
-                    }
-                    toolCardExpansionMode={toolCardExpansionMode}
-                    worktreeId={worktreeId}
-                />
-                <ChatTimelineLiveTail
-                    canRenderRawFileReference={canRenderRawFileReference}
-                    chatFontFamily={chatFontFamily}
-                    chatFontSize={chatFontSize}
-                    onAddFileReferenceToChat={onAddFileReferenceToChat}
-                    onOpenFile={onOpenFile}
-                    onOpenImage={onOpenImage}
-                    onOpenResolvedFileReference={onOpenResolvedFileReference}
-                    onOpenSession={onOpenSession}
-                    onRevealFileReference={onRevealFileReference}
-                    projectId={projectId}
-                    resolveFileReference={resolveFileReference}
-                    row={liveTailRow}
-                    latestStreamingEditedFileToolRowId={
-                        latestStreamingEditedFileToolRowId
-                    }
-                    toolCardExpansionMode={toolCardExpansionMode}
-                    worktreeId={worktreeId}
-                />
-                {isStreaming ? <StreamingIndicator elapsed={elapsed} /> : null}
+                <div
+                    ref={timelineContentRef}
+                    className="min-w-0 space-y-2"
+                    style={{ fontFamily: chatFontFamily }}
+                >
+                    <ChatTimelineHistory
+                        canRenderRawFileReference={canRenderRawFileReference}
+                        chatFontFamily={chatFontFamily}
+                        chatFontSize={chatFontSize}
+                        historyRows={historyRows}
+                        onAddFileReferenceToChat={onAddFileReferenceToChat}
+                        onOpenFile={onOpenFile}
+                        onOpenImage={onOpenImage}
+                        onOpenResolvedFileReference={onOpenResolvedFileReference}
+                        onOpenSession={onOpenSession}
+                        onRevealFileReference={onRevealFileReference}
+                        onVirtualRangeChange={onVirtualRangeChange}
+                        onVirtualResizeAutoFollow={onVirtualResizeAutoFollow}
+                        projectId={projectId}
+                        resolveFileReference={resolveFileReference}
+                        latestStreamingEditedFileToolRowId={
+                            latestStreamingEditedFileToolRowId
+                        }
+                        scrollRef={scrollRef}
+                        shouldPreserveVirtualResizeAnchor={
+                            shouldPreserveVirtualResizeAnchor
+                        }
+                        toolCardExpansionMode={toolCardExpansionMode}
+                        worktreeId={worktreeId}
+                    />
+                    <ChatTimelineLiveTail
+                        canRenderRawFileReference={canRenderRawFileReference}
+                        chatFontFamily={chatFontFamily}
+                        chatFontSize={chatFontSize}
+                        onAddFileReferenceToChat={onAddFileReferenceToChat}
+                        onOpenFile={onOpenFile}
+                        onOpenImage={onOpenImage}
+                        onOpenResolvedFileReference={onOpenResolvedFileReference}
+                        onOpenSession={onOpenSession}
+                        onRevealFileReference={onRevealFileReference}
+                        projectId={projectId}
+                        resolveFileReference={resolveFileReference}
+                        row={liveTailRow}
+                        latestStreamingEditedFileToolRowId={
+                            latestStreamingEditedFileToolRowId
+                        }
+                        toolCardExpansionMode={toolCardExpansionMode}
+                        worktreeId={worktreeId}
+                    />
+                    {isStreaming ? (
+                        <StreamingIndicator elapsed={elapsed} />
+                    ) : null}
+                </div>
             </div>
-        </div>
+        </ToolExpansionStoreProvider>
     );
 });
 

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -47,11 +47,16 @@ import type {
     RuntimeWorkspaceChatTab,
     RuntimeWorkspaceFileReviewContext,
 } from "@renderer/app/workspace/tree";
+import type {
+    MeasuredVirtualListHandle,
+    MeasuredVirtualRange,
+} from "@renderer/components/virtual/MeasuredVirtualList";
 
 import { AIChatAgentControls } from "./AIChatAgentControls";
 import { LanguageIcon } from "./LanguageIcon";
 import { AIChatComposer } from "./chat/AIChatComposer";
 import { AIChatContextUsageBar } from "./chat/AIChatContextUsageBar";
+import { ChatTimelineHistoryRows } from "./chat/ChatTimelineHistoryRows";
 import { ChatMessageRow } from "./chat/ChatMessageRow";
 import { CHAT_PILL_VARIANTS } from "./chat/chatPillPalette";
 import {
@@ -246,6 +251,8 @@ export const ChatTabView = memo(function ChatTabView({
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const scrollRef = useRef<HTMLDivElement | null>(null);
     const timelineContentRef = useRef<HTMLDivElement | null>(null);
+    const timelineVirtualListHandleRef =
+        useRef<MeasuredVirtualListHandle | null>(null);
     const shouldAutoFollowRef = useRef(true);
     const pendingScrollFrameRef = useRef<number | null>(null);
     const restoreScrollFrameRef = useRef<number | null>(null);
@@ -777,6 +784,19 @@ export const ChatTabView = memo(function ChatTabView({
             scrollToBottom();
         });
     }, [scrollToBottom]);
+
+    const handleTimelineVirtualListReady = useCallback(
+        (handle: MeasuredVirtualListHandle | null) => {
+            timelineVirtualListHandleRef.current = handle;
+        },
+        [],
+    );
+
+    const handleTimelineVirtualRangeChange = useCallback(() => {
+        if (shouldAutoFollowRef.current) {
+            scheduleScrollToBottom();
+        }
+    }, [scheduleScrollToBottom]);
 
     const persistCurrentViewState = useCallback(
         (overrides?: {
@@ -1517,6 +1537,8 @@ export const ChatTabView = memo(function ChatTabView({
                     onOpenSession={openAiSessionById}
                     onRevealFileReference={handleRevealResolvedFileReference}
                     onScroll={handleScroll}
+                    onVirtualListReady={handleTimelineVirtualListReady}
+                    onVirtualRangeChange={handleTimelineVirtualRangeChange}
                     projectId={tab.projectId}
                     resolveFileReference={resolveChatFileReference}
                     scrollRef={scrollRef}
@@ -1966,6 +1988,8 @@ const ChatTimeline = memo(function ChatTimeline({
     onOpenSession,
     onRevealFileReference,
     onScroll,
+    onVirtualListReady,
+    onVirtualRangeChange,
     projectId,
     resolveFileReference,
     scrollRef,
@@ -2001,6 +2025,10 @@ const ChatTimeline = memo(function ChatTimeline({
         reference: ResolvedProjectFileReference,
     ) => void;
     readonly onScroll: () => void;
+    readonly onVirtualListReady?: (
+        handle: MeasuredVirtualListHandle | null,
+    ) => void;
+    readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly projectId: string | null;
     readonly resolveFileReference: (
         reference: string,
@@ -2046,11 +2074,14 @@ const ChatTimeline = memo(function ChatTimeline({
                     onOpenResolvedFileReference={onOpenResolvedFileReference}
                     onOpenSession={onOpenSession}
                     onRevealFileReference={onRevealFileReference}
+                    onVirtualListReady={onVirtualListReady}
+                    onVirtualRangeChange={onVirtualRangeChange}
                     projectId={projectId}
                     resolveFileReference={resolveFileReference}
                     latestStreamingEditedFileToolRowId={
                         latestStreamingEditedFileToolRowId
                     }
+                    scrollRef={scrollRef}
                     toolCardExpansionMode={toolCardExpansionMode}
                     worktreeId={worktreeId}
                 />
@@ -2092,9 +2123,12 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
     onOpenResolvedFileReference,
     onOpenSession,
     onRevealFileReference,
+    onVirtualListReady,
+    onVirtualRangeChange,
     projectId,
     resolveFileReference,
     latestStreamingEditedFileToolRowId,
+    scrollRef,
     toolCardExpansionMode,
     worktreeId,
 }: {
@@ -2122,36 +2156,78 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
     readonly onRevealFileReference?: (
         reference: ResolvedProjectFileReference,
     ) => void;
+    readonly onVirtualListReady?: (
+        handle: MeasuredVirtualListHandle | null,
+    ) => void;
+    readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly projectId: string | null;
     readonly resolveFileReference: (
         reference: string,
     ) => ResolvedProjectFileReference | null;
     readonly latestStreamingEditedFileToolRowId: string | null;
+    readonly scrollRef: RefObject<HTMLDivElement | null>;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
 }) {
-    return historyRows.map((row) => (
-        <ChatTimelineRowView
-            canRenderRawFileReference={canRenderRawFileReference}
+    const renderRow = useCallback(
+        ({
+            isLatestStreamingTool,
+            row,
+        }: {
+            readonly isLatestStreamingTool: boolean;
+            readonly row: ChatTimelineRow;
+        }) => (
+            <ChatTimelineRowView
+                canRenderRawFileReference={canRenderRawFileReference}
+                chatFontFamily={chatFontFamily}
+                chatFontSize={chatFontSize}
+                key={row.id}
+                onAddFileReferenceToChat={onAddFileReferenceToChat}
+                onOpenFile={onOpenFile}
+                onOpenImage={onOpenImage}
+                onOpenResolvedFileReference={onOpenResolvedFileReference}
+                onOpenSession={onOpenSession}
+                onRevealFileReference={onRevealFileReference}
+                projectId={projectId}
+                resolveFileReference={resolveFileReference}
+                row={row}
+                isLatestStreamingTool={isLatestStreamingTool}
+                toolCardExpansionMode={toolCardExpansionMode}
+                worktreeId={worktreeId}
+            />
+        ),
+        [
+            canRenderRawFileReference,
+            chatFontFamily,
+            chatFontSize,
+            onAddFileReferenceToChat,
+            onOpenFile,
+            onOpenImage,
+            onOpenResolvedFileReference,
+            onOpenSession,
+            onRevealFileReference,
+            projectId,
+            resolveFileReference,
+            toolCardExpansionMode,
+            worktreeId,
+        ],
+    );
+
+    return (
+        <ChatTimelineHistoryRows
             chatFontFamily={chatFontFamily}
             chatFontSize={chatFontSize}
-            key={row.id}
-            onAddFileReferenceToChat={onAddFileReferenceToChat}
-            onOpenFile={onOpenFile}
-            onOpenImage={onOpenImage}
-            onOpenResolvedFileReference={onOpenResolvedFileReference}
-            onOpenSession={onOpenSession}
-            onRevealFileReference={onRevealFileReference}
-            projectId={projectId}
-            resolveFileReference={resolveFileReference}
-            row={row}
-            isLatestStreamingTool={
-                row.id === latestStreamingEditedFileToolRowId
+            historyRows={historyRows}
+            latestStreamingEditedFileToolRowId={
+                latestStreamingEditedFileToolRowId
             }
+            onVirtualListReady={onVirtualListReady}
+            onVirtualRangeChange={onVirtualRangeChange}
+            renderRow={renderRow}
+            scrollRef={scrollRef}
             toolCardExpansionMode={toolCardExpansionMode}
-            worktreeId={worktreeId}
         />
-    ));
+    );
 }, areChatTimelineHistoryPropsEqual);
 
 ChatTimelineHistory.displayName = "ChatTimelineHistory";
@@ -2344,6 +2420,10 @@ function areChatTimelinePropsEqual(
             reference: ResolvedProjectFileReference,
         ) => void;
         readonly onScroll: () => void;
+        readonly onVirtualListReady?: (
+            handle: MeasuredVirtualListHandle | null,
+        ) => void;
+        readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
         readonly projectId: string | null;
         readonly resolveFileReference: (
             reference: string,
@@ -2378,6 +2458,10 @@ function areChatTimelinePropsEqual(
             reference: ResolvedProjectFileReference,
         ) => void;
         readonly onScroll: () => void;
+        readonly onVirtualListReady?: (
+            handle: MeasuredVirtualListHandle | null,
+        ) => void;
+        readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
         readonly projectId: string | null;
         readonly resolveFileReference: (
             reference: string,
@@ -2402,6 +2486,9 @@ function areChatTimelinePropsEqual(
             next.onOpenResolvedFileReference &&
         previous.onOpenSession === next.onOpenSession &&
         previous.onRevealFileReference === next.onRevealFileReference &&
+        previous.onScroll === next.onScroll &&
+        previous.onVirtualListReady === next.onVirtualListReady &&
+        previous.onVirtualRangeChange === next.onVirtualRangeChange &&
         previous.projectId === next.projectId &&
         previous.resolveFileReference === next.resolveFileReference &&
         previous.scrollRef === next.scrollRef &&
@@ -2433,11 +2520,16 @@ function areChatTimelineHistoryPropsEqual(
         readonly onRevealFileReference?: (
             reference: ResolvedProjectFileReference,
         ) => void;
+        readonly onVirtualListReady?: (
+            handle: MeasuredVirtualListHandle | null,
+        ) => void;
+        readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
         readonly projectId: string | null;
         readonly resolveFileReference: (
             reference: string,
         ) => ResolvedProjectFileReference | null;
         readonly latestStreamingEditedFileToolRowId: string | null;
+        readonly scrollRef: RefObject<HTMLDivElement | null>;
         readonly toolCardExpansionMode: AiToolCardExpansionMode;
         readonly worktreeId: string | null;
     }>,
@@ -2462,11 +2554,16 @@ function areChatTimelineHistoryPropsEqual(
         readonly onRevealFileReference?: (
             reference: ResolvedProjectFileReference,
         ) => void;
+        readonly onVirtualListReady?: (
+            handle: MeasuredVirtualListHandle | null,
+        ) => void;
+        readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
         readonly projectId: string | null;
         readonly resolveFileReference: (
             reference: string,
         ) => ResolvedProjectFileReference | null;
         readonly latestStreamingEditedFileToolRowId: string | null;
+        readonly scrollRef: RefObject<HTMLDivElement | null>;
         readonly toolCardExpansionMode: AiToolCardExpansionMode;
         readonly worktreeId: string | null;
     }>,
@@ -2482,10 +2579,13 @@ function areChatTimelineHistoryPropsEqual(
             next.onOpenResolvedFileReference &&
         previous.onOpenSession === next.onOpenSession &&
         previous.onRevealFileReference === next.onRevealFileReference &&
+        previous.onVirtualListReady === next.onVirtualListReady &&
+        previous.onVirtualRangeChange === next.onVirtualRangeChange &&
         previous.projectId === next.projectId &&
         previous.resolveFileReference === next.resolveFileReference &&
         previous.latestStreamingEditedFileToolRowId ===
             next.latestStreamingEditedFileToolRowId &&
+        previous.scrollRef === next.scrollRef &&
         previous.toolCardExpansionMode === next.toolCardExpansionMode &&
         previous.worktreeId === next.worktreeId
     );

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -2243,23 +2243,7 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
 
 ChatTimelineHistory.displayName = "ChatTimelineHistory";
 
-const ChatTimelineLiveTail = memo(function ChatTimelineLiveTail({
-    canRenderRawFileReference,
-    chatFontFamily,
-    chatFontSize,
-    onAddFileReferenceToChat,
-    onOpenFile,
-    onOpenImage,
-    onOpenResolvedFileReference,
-    onOpenSession,
-    onRevealFileReference,
-    projectId,
-    resolveFileReference,
-    row,
-    latestStreamingEditedFileToolRowId,
-    toolCardExpansionMode,
-    worktreeId,
-}: {
+type ChatTimelineLiveTailProps = {
     readonly canRenderRawFileReference?: (
         rawReference: string,
         reference: ResolvedProjectFileReference,
@@ -2291,7 +2275,25 @@ const ChatTimelineLiveTail = memo(function ChatTimelineLiveTail({
     readonly latestStreamingEditedFileToolRowId: string | null;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
-}) {
+};
+
+const ChatTimelineLiveTail = memo(function ChatTimelineLiveTail({
+    canRenderRawFileReference,
+    chatFontFamily,
+    chatFontSize,
+    onAddFileReferenceToChat,
+    onOpenFile,
+    onOpenImage,
+    onOpenResolvedFileReference,
+    onOpenSession,
+    onRevealFileReference,
+    projectId,
+    resolveFileReference,
+    row,
+    latestStreamingEditedFileToolRowId,
+    toolCardExpansionMode,
+    worktreeId,
+}: ChatTimelineLiveTailProps) {
     if (!row) {
         return null;
     }
@@ -2322,23 +2324,7 @@ const ChatTimelineLiveTail = memo(function ChatTimelineLiveTail({
 
 ChatTimelineLiveTail.displayName = "ChatTimelineLiveTail";
 
-const ChatTimelineRowView = memo(function ChatTimelineRowView({
-    canRenderRawFileReference,
-    chatFontFamily,
-    chatFontSize,
-    onAddFileReferenceToChat,
-    onOpenFile,
-    onOpenImage,
-    onOpenResolvedFileReference,
-    onOpenSession,
-    onRevealFileReference,
-    projectId,
-    resolveFileReference,
-    row,
-    isLatestStreamingTool,
-    toolCardExpansionMode,
-    worktreeId,
-}: {
+type ChatTimelineRowViewProps = {
     readonly canRenderRawFileReference?: (
         rawReference: string,
         reference: ResolvedProjectFileReference,
@@ -2370,7 +2356,25 @@ const ChatTimelineRowView = memo(function ChatTimelineRowView({
     readonly isLatestStreamingTool: boolean;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
-}) {
+};
+
+const ChatTimelineRowView = memo(function ChatTimelineRowView({
+    canRenderRawFileReference,
+    chatFontFamily,
+    chatFontSize,
+    onAddFileReferenceToChat,
+    onOpenFile,
+    onOpenImage,
+    onOpenResolvedFileReference,
+    onOpenSession,
+    onRevealFileReference,
+    projectId,
+    resolveFileReference,
+    row,
+    isLatestStreamingTool,
+    toolCardExpansionMode,
+    worktreeId,
+}: ChatTimelineRowViewProps) {
     if (row.kind === "message") {
         return (
             <ChatMessageRow
@@ -2499,162 +2503,69 @@ function areChatTimelineHistoryPropsEqual(
     );
 }
 
+const CHAT_TIMELINE_LIVE_TAIL_EQUALITY_PLAN: PropEqualityPlan<ChatTimelineLiveTailProps> =
+    {
+        // Intentionally not compared — treated as a stable callback. TODO:
+        // confirm this is deliberate and not a latent stale-UI bug (pending
+        // review item).
+        canRenderRawFileReference: false,
+        chatFontFamily: true,
+        chatFontSize: true,
+        latestStreamingEditedFileToolRowId: true,
+        onAddFileReferenceToChat: true,
+        onOpenFile: true,
+        onOpenImage: true,
+        onOpenResolvedFileReference: true,
+        onOpenSession: true,
+        onRevealFileReference: true,
+        projectId: true,
+        resolveFileReference: true,
+        row: true,
+        toolCardExpansionMode: true,
+        worktreeId: true,
+    };
+
 function areChatTimelineLiveTailPropsEqual(
-    previous: Readonly<{
-        readonly chatFontFamily?: string;
-        readonly chatFontSize?: number;
-        readonly onAddFileReferenceToChat?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenFile: (
-            projectId: string,
-            relativePath: string,
-            worktreeId?: string | null,
-            reviewContext?: RuntimeWorkspaceFileReviewContext | null,
-        ) => Promise<void>;
-        readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
-        readonly onOpenResolvedFileReference: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
-        readonly onRevealFileReference?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly projectId: string | null;
-        readonly resolveFileReference: (
-            reference: string,
-        ) => ResolvedProjectFileReference | null;
-        readonly row: ChatTimelineRow | null;
-        readonly latestStreamingEditedFileToolRowId: string | null;
-        readonly toolCardExpansionMode: AiToolCardExpansionMode;
-        readonly worktreeId: string | null;
-    }>,
-    next: Readonly<{
-        readonly chatFontFamily?: string;
-        readonly chatFontSize?: number;
-        readonly onAddFileReferenceToChat?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenFile: (
-            projectId: string,
-            relativePath: string,
-            worktreeId?: string | null,
-            reviewContext?: RuntimeWorkspaceFileReviewContext | null,
-        ) => Promise<void>;
-        readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
-        readonly onOpenResolvedFileReference: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
-        readonly onRevealFileReference?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly projectId: string | null;
-        readonly resolveFileReference: (
-            reference: string,
-        ) => ResolvedProjectFileReference | null;
-        readonly row: ChatTimelineRow | null;
-        readonly latestStreamingEditedFileToolRowId: string | null;
-        readonly toolCardExpansionMode: AiToolCardExpansionMode;
-        readonly worktreeId: string | null;
-    }>,
-) {
-    return (
-        previous.chatFontFamily === next.chatFontFamily &&
-        previous.chatFontSize === next.chatFontSize &&
-        previous.onAddFileReferenceToChat === next.onAddFileReferenceToChat &&
-        previous.onOpenFile === next.onOpenFile &&
-        previous.onOpenImage === next.onOpenImage &&
-        previous.onOpenResolvedFileReference ===
-            next.onOpenResolvedFileReference &&
-        previous.onOpenSession === next.onOpenSession &&
-        previous.onRevealFileReference === next.onRevealFileReference &&
-        previous.projectId === next.projectId &&
-        previous.resolveFileReference === next.resolveFileReference &&
-        previous.row === next.row &&
-        previous.latestStreamingEditedFileToolRowId ===
-            next.latestStreamingEditedFileToolRowId &&
-        previous.toolCardExpansionMode === next.toolCardExpansionMode &&
-        previous.worktreeId === next.worktreeId
+    previous: Readonly<ChatTimelineLiveTailProps>,
+    next: Readonly<ChatTimelineLiveTailProps>,
+): boolean {
+    return arePropsEqualByPlan(
+        previous,
+        next,
+        CHAT_TIMELINE_LIVE_TAIL_EQUALITY_PLAN,
     );
 }
 
+const CHAT_TIMELINE_ROW_VIEW_EQUALITY_PLAN: PropEqualityPlan<ChatTimelineRowViewProps> =
+    {
+        // Intentionally not compared — treated as a stable callback. TODO:
+        // confirm this is deliberate and not a latent stale-UI bug (pending
+        // review item).
+        canRenderRawFileReference: false,
+        chatFontFamily: true,
+        chatFontSize: true,
+        isLatestStreamingTool: true,
+        onAddFileReferenceToChat: true,
+        onOpenFile: true,
+        onOpenImage: true,
+        onOpenResolvedFileReference: true,
+        onOpenSession: true,
+        onRevealFileReference: true,
+        projectId: true,
+        resolveFileReference: true,
+        row: true,
+        toolCardExpansionMode: true,
+        worktreeId: true,
+    };
+
 function areChatTimelineRowViewPropsEqual(
-    previous: Readonly<{
-        readonly chatFontFamily?: string;
-        readonly chatFontSize?: number;
-        readonly onAddFileReferenceToChat?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenFile: (
-            projectId: string,
-            relativePath: string,
-            worktreeId?: string | null,
-            reviewContext?: RuntimeWorkspaceFileReviewContext | null,
-        ) => Promise<void>;
-        readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
-        readonly onOpenResolvedFileReference: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
-        readonly onRevealFileReference?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly projectId: string | null;
-        readonly resolveFileReference: (
-            reference: string,
-        ) => ResolvedProjectFileReference | null;
-        readonly row: ChatTimelineRow;
-        readonly isLatestStreamingTool: boolean;
-        readonly toolCardExpansionMode: AiToolCardExpansionMode;
-        readonly worktreeId: string | null;
-    }>,
-    next: Readonly<{
-        readonly chatFontFamily?: string;
-        readonly chatFontSize?: number;
-        readonly onAddFileReferenceToChat?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenFile: (
-            projectId: string,
-            relativePath: string,
-            worktreeId?: string | null,
-            reviewContext?: RuntimeWorkspaceFileReviewContext | null,
-        ) => Promise<void>;
-        readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
-        readonly onOpenResolvedFileReference: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
-        readonly onRevealFileReference?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly projectId: string | null;
-        readonly resolveFileReference: (
-            reference: string,
-        ) => ResolvedProjectFileReference | null;
-        readonly row: ChatTimelineRow;
-        readonly isLatestStreamingTool: boolean;
-        readonly toolCardExpansionMode: AiToolCardExpansionMode;
-        readonly worktreeId: string | null;
-    }>,
-) {
-    return (
-        previous.chatFontFamily === next.chatFontFamily &&
-        previous.chatFontSize === next.chatFontSize &&
-        previous.onAddFileReferenceToChat === next.onAddFileReferenceToChat &&
-        previous.onOpenFile === next.onOpenFile &&
-        previous.onOpenImage === next.onOpenImage &&
-        previous.onOpenResolvedFileReference ===
-            next.onOpenResolvedFileReference &&
-        previous.onOpenSession === next.onOpenSession &&
-        previous.onRevealFileReference === next.onRevealFileReference &&
-        previous.projectId === next.projectId &&
-        previous.resolveFileReference === next.resolveFileReference &&
-        previous.row === next.row &&
-        previous.isLatestStreamingTool === next.isLatestStreamingTool &&
-        previous.toolCardExpansionMode === next.toolCardExpansionMode &&
-        previous.worktreeId === next.worktreeId
+    previous: Readonly<ChatTimelineRowViewProps>,
+    next: Readonly<ChatTimelineRowViewProps>,
+): boolean {
+    return arePropsEqualByPlan(
+        previous,
+        next,
+        CHAT_TIMELINE_ROW_VIEW_EQUALITY_PLAN,
     );
 }
 

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -1695,7 +1695,7 @@ export const ChatTabView = memo(function ChatTabView({
             </div>
         </div>
     );
-}, areChatTabViewPropsEqual);
+});
 
 ChatTabView.displayName = "ChatTabView";
 
@@ -2566,19 +2566,6 @@ function areChatTimelineRowViewPropsEqual(
         previous,
         next,
         CHAT_TIMELINE_ROW_VIEW_EQUALITY_PLAN,
-    );
-}
-
-function areChatTabViewPropsEqual(
-    previous: Readonly<ChatTabViewProps>,
-    next: Readonly<ChatTabViewProps>,
-) {
-    return (
-        previous.onDraftChange === next.onDraftChange &&
-        previous.onOpenFile === next.onOpenFile &&
-        previous.onOpenImage === next.onOpenImage &&
-        previous.onOpenReview === next.onOpenReview &&
-        previous.tab === next.tab
     );
 }
 

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -1974,31 +1974,7 @@ function getLatestEditedFileToolRowId(
     return null;
 }
 
-const ChatTimeline = memo(function ChatTimeline({
-    canRenderRawFileReference,
-    chatFontFamily,
-    chatFontSize,
-    elapsed,
-    historyRows,
-    isStreaming,
-    liveTailRow,
-    onAddFileReferenceToChat,
-    onOpenFile,
-    onOpenImage,
-    onOpenResolvedFileReference,
-    onOpenSession,
-    onRevealFileReference,
-    onScroll,
-    onVirtualRangeChange,
-    onVirtualResizeAutoFollow,
-    projectId,
-    resolveFileReference,
-    scrollRef,
-    shouldPreserveVirtualResizeAnchor,
-    timelineContentRef,
-    toolCardExpansionMode,
-    worktreeId,
-}: {
+type ChatTimelineProps = {
     readonly canRenderRawFileReference?: (
         rawReference: string,
         reference: ResolvedProjectFileReference,
@@ -2038,7 +2014,33 @@ const ChatTimeline = memo(function ChatTimeline({
     readonly timelineContentRef: RefObject<HTMLDivElement | null>;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
-}) {
+};
+
+const ChatTimeline = memo(function ChatTimeline({
+    canRenderRawFileReference,
+    chatFontFamily,
+    chatFontSize,
+    elapsed,
+    historyRows,
+    isStreaming,
+    liveTailRow,
+    onAddFileReferenceToChat,
+    onOpenFile,
+    onOpenImage,
+    onOpenResolvedFileReference,
+    onOpenSession,
+    onRevealFileReference,
+    onScroll,
+    onVirtualRangeChange,
+    onVirtualResizeAutoFollow,
+    projectId,
+    resolveFileReference,
+    scrollRef,
+    shouldPreserveVirtualResizeAnchor,
+    timelineContentRef,
+    toolCardExpansionMode,
+    worktreeId,
+}: ChatTimelineProps) {
     const latestStreamingEditedFileToolRowId = useMemo(
         () =>
             isStreaming
@@ -2116,27 +2118,7 @@ const ChatTimeline = memo(function ChatTimeline({
 
 ChatTimeline.displayName = "ChatTimeline";
 
-const ChatTimelineHistory = memo(function ChatTimelineHistory({
-    canRenderRawFileReference,
-    chatFontFamily,
-    chatFontSize,
-    historyRows,
-    onAddFileReferenceToChat,
-    onOpenFile,
-    onOpenImage,
-    onOpenResolvedFileReference,
-    onOpenSession,
-    onRevealFileReference,
-    onVirtualRangeChange,
-    onVirtualResizeAutoFollow,
-    projectId,
-    resolveFileReference,
-    latestStreamingEditedFileToolRowId,
-    scrollRef,
-    shouldPreserveVirtualResizeAnchor,
-    toolCardExpansionMode,
-    worktreeId,
-}: {
+type ChatTimelineHistoryProps = {
     readonly canRenderRawFileReference?: (
         rawReference: string,
         reference: ResolvedProjectFileReference,
@@ -2172,7 +2154,29 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
-}) {
+};
+
+const ChatTimelineHistory = memo(function ChatTimelineHistory({
+    canRenderRawFileReference,
+    chatFontFamily,
+    chatFontSize,
+    historyRows,
+    onAddFileReferenceToChat,
+    onOpenFile,
+    onOpenImage,
+    onOpenResolvedFileReference,
+    onOpenSession,
+    onRevealFileReference,
+    onVirtualRangeChange,
+    onVirtualResizeAutoFollow,
+    projectId,
+    resolveFileReference,
+    latestStreamingEditedFileToolRowId,
+    scrollRef,
+    shouldPreserveVirtualResizeAnchor,
+    toolCardExpansionMode,
+    worktreeId,
+}: ChatTimelineHistoryProps) {
     const renderRow = useCallback(
         ({
             isLatestStreamingTool,
@@ -2401,200 +2405,97 @@ const ChatTimelineRowView = memo(function ChatTimelineRowView({
 
 ChatTimelineRowView.displayName = "ChatTimelineRowView";
 
-function areChatTimelinePropsEqual(
-    previous: Readonly<{
-        readonly chatFontFamily?: string;
-        readonly chatFontSize?: number;
-        readonly elapsed: string;
-        readonly historyRows: readonly ChatTimelineRow[];
-        readonly isStreaming: boolean;
-        readonly liveTailRow: ChatTimelineRow | null;
-        readonly onAddFileReferenceToChat?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenFile: (
-            projectId: string,
-            relativePath: string,
-            worktreeId?: string | null,
-            reviewContext?: RuntimeWorkspaceFileReviewContext | null,
-        ) => Promise<void>;
-        readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
-        readonly onOpenResolvedFileReference: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
-        readonly onRevealFileReference?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onScroll: () => void;
-        readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
-        readonly onVirtualResizeAutoFollow?: () => void;
-        readonly projectId: string | null;
-        readonly resolveFileReference: (
-            reference: string,
-        ) => ResolvedProjectFileReference | null;
-        readonly scrollRef: RefObject<HTMLDivElement | null>;
-        readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
-        readonly timelineContentRef: RefObject<HTMLDivElement | null>;
-        readonly toolCardExpansionMode: AiToolCardExpansionMode;
-        readonly worktreeId: string | null;
-    }>,
-    next: Readonly<{
-        readonly chatFontFamily?: string;
-        readonly chatFontSize?: number;
-        readonly elapsed: string;
-        readonly historyRows: readonly ChatTimelineRow[];
-        readonly isStreaming: boolean;
-        readonly liveTailRow: ChatTimelineRow | null;
-        readonly onAddFileReferenceToChat?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenFile: (
-            projectId: string,
-            relativePath: string,
-            worktreeId?: string | null,
-            reviewContext?: RuntimeWorkspaceFileReviewContext | null,
-        ) => Promise<void>;
-        readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
-        readonly onOpenResolvedFileReference: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
-        readonly onRevealFileReference?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onScroll: () => void;
-        readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
-        readonly onVirtualResizeAutoFollow?: () => void;
-        readonly projectId: string | null;
-        readonly resolveFileReference: (
-            reference: string,
-        ) => ResolvedProjectFileReference | null;
-        readonly scrollRef: RefObject<HTMLDivElement | null>;
-        readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
-        readonly timelineContentRef: RefObject<HTMLDivElement | null>;
-        readonly toolCardExpansionMode: AiToolCardExpansionMode;
-        readonly worktreeId: string | null;
-    }>,
-) {
-    return (
-        previous.chatFontFamily === next.chatFontFamily &&
-        previous.chatFontSize === next.chatFontSize &&
-        previous.elapsed === next.elapsed &&
-        previous.historyRows === next.historyRows &&
-        previous.isStreaming === next.isStreaming &&
-        previous.liveTailRow === next.liveTailRow &&
-        previous.onAddFileReferenceToChat === next.onAddFileReferenceToChat &&
-        previous.onOpenFile === next.onOpenFile &&
-        previous.onOpenImage === next.onOpenImage &&
-        previous.onOpenResolvedFileReference ===
-            next.onOpenResolvedFileReference &&
-        previous.onOpenSession === next.onOpenSession &&
-        previous.onRevealFileReference === next.onRevealFileReference &&
-        previous.onScroll === next.onScroll &&
-        previous.onVirtualRangeChange === next.onVirtualRangeChange &&
-        previous.onVirtualResizeAutoFollow === next.onVirtualResizeAutoFollow &&
-        previous.projectId === next.projectId &&
-        previous.resolveFileReference === next.resolveFileReference &&
-        previous.scrollRef === next.scrollRef &&
-        previous.shouldPreserveVirtualResizeAnchor ===
-            next.shouldPreserveVirtualResizeAnchor &&
-        previous.timelineContentRef === next.timelineContentRef &&
-        previous.toolCardExpansionMode === next.toolCardExpansionMode &&
-        previous.worktreeId === next.worktreeId
-    );
+type PropEqualityPlan<P> = Readonly<Record<keyof P, boolean>>;
+
+// Memo equality driven by an explicit, exhaustive plan. Because the plan is
+// keyed by `keyof Props`, adding a prop to a memoized component forces a
+// compile-time decision on whether to compare it — a prop can no longer
+// silently fall out of the check (the failure mode that left `onScroll`
+// uncompared until it was caught in review). Props mapped to `true` are
+// compared by identity; `false` opts a prop out intentionally.
+function arePropsEqualByPlan<P extends object>(
+    previous: Readonly<P>,
+    next: Readonly<P>,
+    plan: PropEqualityPlan<P>,
+): boolean {
+    for (const key of Object.keys(plan) as (keyof P)[]) {
+        if (plan[key] && !Object.is(previous[key], next[key])) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
+const CHAT_TIMELINE_EQUALITY_PLAN: PropEqualityPlan<ChatTimelineProps> = {
+    // Intentionally not compared — treated as a stable callback. TODO: confirm
+    // this is deliberate and not a latent stale-UI bug (pending review item).
+    canRenderRawFileReference: false,
+    chatFontFamily: true,
+    chatFontSize: true,
+    elapsed: true,
+    historyRows: true,
+    isStreaming: true,
+    liveTailRow: true,
+    onAddFileReferenceToChat: true,
+    onOpenFile: true,
+    onOpenImage: true,
+    onOpenResolvedFileReference: true,
+    onOpenSession: true,
+    onRevealFileReference: true,
+    onScroll: true,
+    onVirtualRangeChange: true,
+    onVirtualResizeAutoFollow: true,
+    projectId: true,
+    resolveFileReference: true,
+    scrollRef: true,
+    shouldPreserveVirtualResizeAnchor: true,
+    timelineContentRef: true,
+    toolCardExpansionMode: true,
+    worktreeId: true,
+};
+
+function areChatTimelinePropsEqual(
+    previous: Readonly<ChatTimelineProps>,
+    next: Readonly<ChatTimelineProps>,
+): boolean {
+    return arePropsEqualByPlan(previous, next, CHAT_TIMELINE_EQUALITY_PLAN);
+}
+
+const CHAT_TIMELINE_HISTORY_EQUALITY_PLAN: PropEqualityPlan<ChatTimelineHistoryProps> =
+    {
+        // Intentionally not compared — treated as a stable callback. TODO:
+        // confirm this is deliberate and not a latent stale-UI bug (pending
+        // review item).
+        canRenderRawFileReference: false,
+        chatFontFamily: true,
+        chatFontSize: true,
+        historyRows: true,
+        latestStreamingEditedFileToolRowId: true,
+        onAddFileReferenceToChat: true,
+        onOpenFile: true,
+        onOpenImage: true,
+        onOpenResolvedFileReference: true,
+        onOpenSession: true,
+        onRevealFileReference: true,
+        onVirtualRangeChange: true,
+        onVirtualResizeAutoFollow: true,
+        projectId: true,
+        resolveFileReference: true,
+        scrollRef: true,
+        shouldPreserveVirtualResizeAnchor: true,
+        toolCardExpansionMode: true,
+        worktreeId: true,
+    };
+
 function areChatTimelineHistoryPropsEqual(
-    previous: Readonly<{
-        readonly chatFontFamily?: string;
-        readonly chatFontSize?: number;
-        readonly historyRows: readonly ChatTimelineRow[];
-        readonly onAddFileReferenceToChat?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenFile: (
-            projectId: string,
-            relativePath: string,
-            worktreeId?: string | null,
-            reviewContext?: RuntimeWorkspaceFileReviewContext | null,
-        ) => Promise<void>;
-        readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
-        readonly onOpenResolvedFileReference: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
-        readonly onRevealFileReference?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
-        readonly onVirtualResizeAutoFollow?: () => void;
-        readonly projectId: string | null;
-        readonly resolveFileReference: (
-            reference: string,
-        ) => ResolvedProjectFileReference | null;
-        readonly latestStreamingEditedFileToolRowId: string | null;
-        readonly scrollRef: RefObject<HTMLDivElement | null>;
-        readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
-        readonly toolCardExpansionMode: AiToolCardExpansionMode;
-        readonly worktreeId: string | null;
-    }>,
-    next: Readonly<{
-        readonly chatFontFamily?: string;
-        readonly chatFontSize?: number;
-        readonly historyRows: readonly ChatTimelineRow[];
-        readonly onAddFileReferenceToChat?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenFile: (
-            projectId: string,
-            relativePath: string,
-            worktreeId?: string | null,
-            reviewContext?: RuntimeWorkspaceFileReviewContext | null,
-        ) => Promise<void>;
-        readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
-        readonly onOpenResolvedFileReference: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
-        readonly onRevealFileReference?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
-        readonly onVirtualResizeAutoFollow?: () => void;
-        readonly projectId: string | null;
-        readonly resolveFileReference: (
-            reference: string,
-        ) => ResolvedProjectFileReference | null;
-        readonly latestStreamingEditedFileToolRowId: string | null;
-        readonly scrollRef: RefObject<HTMLDivElement | null>;
-        readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
-        readonly toolCardExpansionMode: AiToolCardExpansionMode;
-        readonly worktreeId: string | null;
-    }>,
-) {
-    return (
-        previous.chatFontFamily === next.chatFontFamily &&
-        previous.chatFontSize === next.chatFontSize &&
-        previous.historyRows === next.historyRows &&
-        previous.onAddFileReferenceToChat === next.onAddFileReferenceToChat &&
-        previous.onOpenFile === next.onOpenFile &&
-        previous.onOpenImage === next.onOpenImage &&
-        previous.onOpenResolvedFileReference ===
-            next.onOpenResolvedFileReference &&
-        previous.onOpenSession === next.onOpenSession &&
-        previous.onRevealFileReference === next.onRevealFileReference &&
-        previous.onVirtualRangeChange === next.onVirtualRangeChange &&
-        previous.onVirtualResizeAutoFollow === next.onVirtualResizeAutoFollow &&
-        previous.projectId === next.projectId &&
-        previous.resolveFileReference === next.resolveFileReference &&
-        previous.latestStreamingEditedFileToolRowId ===
-            next.latestStreamingEditedFileToolRowId &&
-        previous.scrollRef === next.scrollRef &&
-        previous.shouldPreserveVirtualResizeAnchor ===
-            next.shouldPreserveVirtualResizeAnchor &&
-        previous.toolCardExpansionMode === next.toolCardExpansionMode &&
-        previous.worktreeId === next.worktreeId
+    previous: Readonly<ChatTimelineHistoryProps>,
+    next: Readonly<ChatTimelineHistoryProps>,
+): boolean {
+    return arePropsEqualByPlan(
+        previous,
+        next,
+        CHAT_TIMELINE_HISTORY_EQUALITY_PLAN,
     );
 }
 

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -132,6 +132,7 @@ const FALLBACK_COMMANDS: readonly AiAvailableCommand[] = [
 ];
 
 const NEAR_BOTTOM_THRESHOLD = 80;
+const RESIZE_BOTTOM_SETTLE_FRAMES = 2;
 const SCROLL_PERSIST_DELAY_MS = 80;
 const EMPTY_DRAFT_ATTACHMENTS: readonly AiImageAttachment[] = [];
 const EMPTY_COMPOSER_PARTS: readonly AIComposerPart[] =
@@ -252,6 +253,9 @@ export const ChatTabView = memo(function ChatTabView({
     const shouldAutoFollowRef = useRef(true);
     const pendingScrollFrameRef = useRef<number | null>(null);
     const restoreScrollFrameRef = useRef<number | null>(null);
+    const resizeBottomSettleFrameRef = useRef<number | null>(null);
+    const resizeBottomLockRef = useRef(false);
+    const resizeStartedNearBottomRef = useRef(false);
     const scrollPersistTimerRef = useRef<number | null>(null);
     const pendingPersistedScrollTopRef = useRef<number | null>(null);
     const pendingPersistedNearBottomRef = useRef<boolean | null>(null);
@@ -792,7 +796,7 @@ export const ChatTabView = memo(function ChatTabView({
     }, [scheduleScrollToBottom]);
 
     const shouldPreserveTimelineVirtualResizeAnchor = useCallback(() => {
-        return !shouldAutoFollowRef.current;
+        return !resizeBottomLockRef.current && !shouldAutoFollowRef.current;
     }, []);
 
     const persistCurrentViewState = useCallback(
@@ -880,6 +884,72 @@ export const ChatTabView = memo(function ChatTabView({
         [persistCurrentViewState],
     );
 
+    // When a splitter drag starts at the bottom, bottom-follow is the user's
+    // intent. Keep that intent alive while virtual rows re-measure at the
+    // released width, then settle to the final bottom over a couple of frames.
+    const settleResizeScrollToBottom = useCallback(() => {
+        if (resizeBottomSettleFrameRef.current !== null) {
+            window.cancelAnimationFrame(resizeBottomSettleFrameRef.current);
+            resizeBottomSettleFrameRef.current = null;
+        }
+
+        shouldAutoFollowRef.current = true;
+        scrollToBottom();
+
+        const runSettleFrame = (remainingFrames: number) => {
+            resizeBottomSettleFrameRef.current = window.requestAnimationFrame(
+                () => {
+                    resizeBottomSettleFrameRef.current = null;
+                    shouldAutoFollowRef.current = true;
+                    scrollToBottom();
+
+                    if (remainingFrames > 1) {
+                        runSettleFrame(remainingFrames - 1);
+                        return;
+                    }
+
+                    const scrollEl = scrollRef.current;
+                    if (scrollEl) {
+                        scheduleScrollPersist(scrollEl.scrollTop, true);
+                    }
+                    resizeBottomLockRef.current = false;
+                    resizeStartedNearBottomRef.current = false;
+                },
+            );
+        };
+
+        runSettleFrame(RESIZE_BOTTOM_SETTLE_FRAMES);
+    }, [scheduleScrollPersist, scrollToBottom]);
+
+    const handleTimelineVirtualResizeStart = useCallback(() => {
+        if (resizeBottomSettleFrameRef.current !== null) {
+            window.cancelAnimationFrame(resizeBottomSettleFrameRef.current);
+            resizeBottomSettleFrameRef.current = null;
+        }
+
+        const scrollEl = scrollRef.current;
+        const startedNearBottom =
+            shouldAutoFollowRef.current ||
+            (scrollEl ? isNearBottom(scrollEl) : false);
+
+        resizeStartedNearBottomRef.current = startedNearBottom;
+        resizeBottomLockRef.current = startedNearBottom;
+
+        if (startedNearBottom) {
+            shouldAutoFollowRef.current = true;
+        }
+    }, [isNearBottom]);
+
+    const handleTimelineVirtualResizeEnd = useCallback(() => {
+        if (resizeStartedNearBottomRef.current) {
+            settleResizeScrollToBottom();
+            return;
+        }
+
+        resizeBottomLockRef.current = false;
+        resizeStartedNearBottomRef.current = false;
+    }, [settleResizeScrollToBottom]);
+
     useEffect(() => {
         return () => {
             if (pendingScrollFrameRef.current !== null) {
@@ -890,6 +960,14 @@ export const ChatTabView = memo(function ChatTabView({
                 window.cancelAnimationFrame(restoreScrollFrameRef.current);
                 restoreScrollFrameRef.current = null;
             }
+            if (resizeBottomSettleFrameRef.current !== null) {
+                window.cancelAnimationFrame(
+                    resizeBottomSettleFrameRef.current,
+                );
+                resizeBottomSettleFrameRef.current = null;
+            }
+            resizeBottomLockRef.current = false;
+            resizeStartedNearBottomRef.current = false;
             flushScheduledScrollPersist();
         };
     }, [flushScheduledScrollPersist]);
@@ -986,6 +1064,15 @@ export const ChatTabView = memo(function ChatTabView({
     const handleScroll = useCallback(() => {
         const el = scrollRef.current;
         if (!el) return;
+
+        // Ignore programmatic scroll/layout churn while the resize bottom lock
+        // is active; otherwise a transient virtual scrollHeight can disable
+        // auto-follow even though the user started the resize at the bottom.
+        if (resizeBottomLockRef.current) {
+            shouldAutoFollowRef.current = true;
+            return;
+        }
+
         const nextIsNearBottom = isNearBottom(el);
         shouldAutoFollowRef.current = nextIsNearBottom;
         scheduleScrollPersist(el.scrollTop, nextIsNearBottom);
@@ -1535,9 +1622,11 @@ export const ChatTabView = memo(function ChatTabView({
                     onRevealFileReference={handleRevealResolvedFileReference}
                     onScroll={handleScroll}
                     onVirtualRangeChange={handleTimelineVirtualRangeChange}
+                    onVirtualResizeEnd={handleTimelineVirtualResizeEnd}
                     onVirtualResizeAutoFollow={
                         handleTimelineVirtualResizeAutoFollow
                     }
+                    onVirtualResizeStart={handleTimelineVirtualResizeStart}
                     projectId={tab.projectId}
                     resolveFileReference={resolveChatFileReference}
                     scrollRef={scrollRef}
@@ -2005,7 +2094,9 @@ type ChatTimelineProps = {
     ) => void;
     readonly onScroll: () => void;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
+    readonly onVirtualResizeEnd?: () => void;
     readonly onVirtualResizeAutoFollow?: () => void;
+    readonly onVirtualResizeStart?: () => void;
     readonly projectId: string | null;
     readonly resolveFileReference: (
         reference: string,
@@ -2033,7 +2124,9 @@ const ChatTimeline = memo(function ChatTimeline({
     onRevealFileReference,
     onScroll,
     onVirtualRangeChange,
+    onVirtualResizeEnd,
     onVirtualResizeAutoFollow,
+    onVirtualResizeStart,
     projectId,
     resolveFileReference,
     scrollRef,
@@ -2080,7 +2173,9 @@ const ChatTimeline = memo(function ChatTimeline({
                         onOpenSession={onOpenSession}
                         onRevealFileReference={onRevealFileReference}
                         onVirtualRangeChange={onVirtualRangeChange}
+                        onVirtualResizeEnd={onVirtualResizeEnd}
                         onVirtualResizeAutoFollow={onVirtualResizeAutoFollow}
+                        onVirtualResizeStart={onVirtualResizeStart}
                         projectId={projectId}
                         resolveFileReference={resolveFileReference}
                         latestStreamingEditedFileToolRowId={
@@ -2149,7 +2244,9 @@ type ChatTimelineHistoryProps = {
         reference: ResolvedProjectFileReference,
     ) => void;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
+    readonly onVirtualResizeEnd?: () => void;
     readonly onVirtualResizeAutoFollow?: () => void;
+    readonly onVirtualResizeStart?: () => void;
     readonly projectId: string | null;
     readonly resolveFileReference: (
         reference: string,
@@ -2173,7 +2270,9 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
     onOpenSession,
     onRevealFileReference,
     onVirtualRangeChange,
+    onVirtualResizeEnd,
     onVirtualResizeAutoFollow,
+    onVirtualResizeStart,
     projectId,
     resolveFileReference,
     latestStreamingEditedFileToolRowId,
@@ -2237,7 +2336,9 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
                 latestStreamingEditedFileToolRowId
             }
             onVirtualRangeChange={onVirtualRangeChange}
+            onVirtualResizeEnd={onVirtualResizeEnd}
             onVirtualResizeAutoFollow={onVirtualResizeAutoFollow}
+            onVirtualResizeStart={onVirtualResizeStart}
             renderRow={renderRow}
             scrollRef={scrollRef}
             shouldPreserveVirtualResizeAnchor={

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -2190,11 +2190,13 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
             readonly isLatestStreamingTool: boolean;
             readonly row: ChatTimelineRow;
         }) => (
+            // The list `key` is owned by each call site (the virtual list keys
+            // its row wrapper; the non-virtual path keys via Fragment), so this
+            // renderer only describes a row's content.
             <ChatTimelineRowView
                 canRenderRawFileReference={canRenderRawFileReference}
                 chatFontFamily={chatFontFamily}
                 chatFontSize={chatFontSize}
-                key={row.id}
                 onAddFileReferenceToChat={onAddFileReferenceToChat}
                 onOpenFile={onOpenFile}
                 onOpenImage={onOpenImage}

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -8,6 +8,7 @@ import {
     useState,
     type ReactNode,
     type RefObject,
+    type WheelEvent,
 } from "react";
 
 import type {
@@ -774,16 +775,32 @@ export const ChatTabView = memo(function ChatTabView({
         if (el) el.scrollTop = el.scrollHeight;
     }, []);
 
-    const scheduleScrollToBottom = useCallback(() => {
-        if (pendingScrollFrameRef.current !== null) {
-            window.cancelAnimationFrame(pendingScrollFrameRef.current);
+    const cancelPendingScrollToBottom = useCallback(() => {
+        if (pendingScrollFrameRef.current === null) {
+            return;
         }
+
+        window.cancelAnimationFrame(pendingScrollFrameRef.current);
+        pendingScrollFrameRef.current = null;
+    }, []);
+
+    const cancelResizeBottomSettle = useCallback(() => {
+        if (resizeBottomSettleFrameRef.current === null) {
+            return;
+        }
+
+        window.cancelAnimationFrame(resizeBottomSettleFrameRef.current);
+        resizeBottomSettleFrameRef.current = null;
+    }, []);
+
+    const scheduleScrollToBottom = useCallback(() => {
+        cancelPendingScrollToBottom();
 
         pendingScrollFrameRef.current = window.requestAnimationFrame(() => {
             pendingScrollFrameRef.current = null;
             scrollToBottom();
         });
-    }, [scrollToBottom]);
+    }, [cancelPendingScrollToBottom, scrollToBottom]);
 
     const handleTimelineVirtualRangeChange = useCallback(() => {
         if (shouldAutoFollowRef.current) {
@@ -797,6 +814,10 @@ export const ChatTabView = memo(function ChatTabView({
 
     const shouldPreserveTimelineVirtualResizeAnchor = useCallback(() => {
         return !resizeBottomLockRef.current && !shouldAutoFollowRef.current;
+    }, []);
+
+    const shouldPreserveTimelineVirtualMeasureAnchor = useCallback(() => {
+        return !resizeBottomLockRef.current;
     }, []);
 
     const persistCurrentViewState = useCallback(
@@ -888,10 +909,7 @@ export const ChatTabView = memo(function ChatTabView({
     // intent. Keep that intent alive while virtual rows re-measure at the
     // released width, then settle to the final bottom over a couple of frames.
     const settleResizeScrollToBottom = useCallback(() => {
-        if (resizeBottomSettleFrameRef.current !== null) {
-            window.cancelAnimationFrame(resizeBottomSettleFrameRef.current);
-            resizeBottomSettleFrameRef.current = null;
-        }
+        cancelResizeBottomSettle();
 
         shouldAutoFollowRef.current = true;
         scrollToBottom();
@@ -919,13 +937,10 @@ export const ChatTabView = memo(function ChatTabView({
         };
 
         runSettleFrame(RESIZE_BOTTOM_SETTLE_FRAMES);
-    }, [scheduleScrollPersist, scrollToBottom]);
+    }, [cancelResizeBottomSettle, scheduleScrollPersist, scrollToBottom]);
 
     const handleTimelineVirtualResizeStart = useCallback(() => {
-        if (resizeBottomSettleFrameRef.current !== null) {
-            window.cancelAnimationFrame(resizeBottomSettleFrameRef.current);
-            resizeBottomSettleFrameRef.current = null;
-        }
+        cancelResizeBottomSettle();
 
         const scrollEl = scrollRef.current;
         const startedNearBottom =
@@ -938,7 +953,7 @@ export const ChatTabView = memo(function ChatTabView({
         if (startedNearBottom) {
             shouldAutoFollowRef.current = true;
         }
-    }, [isNearBottom]);
+    }, [cancelResizeBottomSettle, isNearBottom]);
 
     const handleTimelineVirtualResizeEnd = useCallback(() => {
         if (resizeStartedNearBottomRef.current) {
@@ -950,27 +965,38 @@ export const ChatTabView = memo(function ChatTabView({
         resizeStartedNearBottomRef.current = false;
     }, [settleResizeScrollToBottom]);
 
+    const handleTimelineWheelCapture = useCallback(
+        (event: WheelEvent<HTMLDivElement>) => {
+            if (event.deltaY >= 0 || !shouldAutoFollowRef.current) {
+                return;
+            }
+
+            cancelPendingScrollToBottom();
+            cancelResizeBottomSettle();
+            shouldAutoFollowRef.current = false;
+            resizeBottomLockRef.current = false;
+            resizeStartedNearBottomRef.current = false;
+        },
+        [cancelPendingScrollToBottom, cancelResizeBottomSettle],
+    );
+
     useEffect(() => {
         return () => {
-            if (pendingScrollFrameRef.current !== null) {
-                window.cancelAnimationFrame(pendingScrollFrameRef.current);
-                pendingScrollFrameRef.current = null;
-            }
+            cancelPendingScrollToBottom();
             if (restoreScrollFrameRef.current !== null) {
                 window.cancelAnimationFrame(restoreScrollFrameRef.current);
                 restoreScrollFrameRef.current = null;
             }
-            if (resizeBottomSettleFrameRef.current !== null) {
-                window.cancelAnimationFrame(
-                    resizeBottomSettleFrameRef.current,
-                );
-                resizeBottomSettleFrameRef.current = null;
-            }
+            cancelResizeBottomSettle();
             resizeBottomLockRef.current = false;
             resizeStartedNearBottomRef.current = false;
             flushScheduledScrollPersist();
         };
-    }, [flushScheduledScrollPersist]);
+    }, [
+        cancelPendingScrollToBottom,
+        cancelResizeBottomSettle,
+        flushScheduledScrollPersist,
+    ]);
 
     useLayoutEffect(() => {
         const scrollEl = scrollRef.current;
@@ -1621,6 +1647,7 @@ export const ChatTabView = memo(function ChatTabView({
                     onOpenSession={openAiSessionById}
                     onRevealFileReference={handleRevealResolvedFileReference}
                     onScroll={handleScroll}
+                    onWheelCapture={handleTimelineWheelCapture}
                     onVirtualRangeChange={handleTimelineVirtualRangeChange}
                     onVirtualResizeEnd={handleTimelineVirtualResizeEnd}
                     onVirtualResizeAutoFollow={
@@ -1630,6 +1657,9 @@ export const ChatTabView = memo(function ChatTabView({
                     projectId={tab.projectId}
                     resolveFileReference={resolveChatFileReference}
                     scrollRef={scrollRef}
+                    shouldPreserveVirtualMeasureAnchor={
+                        shouldPreserveTimelineVirtualMeasureAnchor
+                    }
                     shouldPreserveVirtualResizeAnchor={
                         shouldPreserveTimelineVirtualResizeAnchor
                     }
@@ -2093,6 +2123,7 @@ type ChatTimelineProps = {
         reference: ResolvedProjectFileReference,
     ) => void;
     readonly onScroll: () => void;
+    readonly onWheelCapture?: (event: WheelEvent<HTMLDivElement>) => void;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onVirtualResizeEnd?: () => void;
     readonly onVirtualResizeAutoFollow?: () => void;
@@ -2102,6 +2133,7 @@ type ChatTimelineProps = {
         reference: string,
     ) => ResolvedProjectFileReference | null;
     readonly scrollRef: RefObject<HTMLDivElement | null>;
+    readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
     readonly timelineContentRef: RefObject<HTMLDivElement | null>;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
@@ -2123,6 +2155,7 @@ const ChatTimeline = memo(function ChatTimeline({
     onOpenSession,
     onRevealFileReference,
     onScroll,
+    onWheelCapture,
     onVirtualRangeChange,
     onVirtualResizeEnd,
     onVirtualResizeAutoFollow,
@@ -2130,6 +2163,7 @@ const ChatTimeline = memo(function ChatTimeline({
     projectId,
     resolveFileReference,
     scrollRef,
+    shouldPreserveVirtualMeasureAnchor,
     shouldPreserveVirtualResizeAnchor,
     timelineContentRef,
     toolCardExpansionMode,
@@ -2155,6 +2189,7 @@ const ChatTimeline = memo(function ChatTimeline({
                 ref={scrollRef}
                 className="chat-scroll min-h-0 min-w-0 flex-1 overflow-y-auto px-3 py-3"
                 onScroll={onScroll}
+                onWheelCapture={onWheelCapture}
             >
                 <div
                     ref={timelineContentRef}
@@ -2182,6 +2217,9 @@ const ChatTimeline = memo(function ChatTimeline({
                             latestStreamingEditedFileToolRowId
                         }
                         scrollRef={scrollRef}
+                        shouldPreserveVirtualMeasureAnchor={
+                            shouldPreserveVirtualMeasureAnchor
+                        }
                         shouldPreserveVirtualResizeAnchor={
                             shouldPreserveVirtualResizeAnchor
                         }
@@ -2253,6 +2291,7 @@ type ChatTimelineHistoryProps = {
     ) => ResolvedProjectFileReference | null;
     readonly latestStreamingEditedFileToolRowId: string | null;
     readonly scrollRef: RefObject<HTMLDivElement | null>;
+    readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
@@ -2277,6 +2316,7 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
     resolveFileReference,
     latestStreamingEditedFileToolRowId,
     scrollRef,
+    shouldPreserveVirtualMeasureAnchor,
     shouldPreserveVirtualResizeAnchor,
     toolCardExpansionMode,
     worktreeId,
@@ -2341,6 +2381,9 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
             onVirtualResizeStart={onVirtualResizeStart}
             renderRow={renderRow}
             scrollRef={scrollRef}
+            shouldPreserveVirtualMeasureAnchor={
+                shouldPreserveVirtualMeasureAnchor
+            }
             shouldPreserveVirtualResizeAnchor={
                 shouldPreserveVirtualResizeAnchor
             }

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -2114,7 +2114,7 @@ const ChatTimeline = memo(function ChatTimeline({
             </div>
         </div>
     );
-}, areChatTimelinePropsEqual);
+});
 
 ChatTimeline.displayName = "ChatTimeline";
 
@@ -2239,7 +2239,7 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
             toolCardExpansionMode={toolCardExpansionMode}
         />
     );
-}, areChatTimelineHistoryPropsEqual);
+});
 
 ChatTimelineHistory.displayName = "ChatTimelineHistory";
 
@@ -2320,7 +2320,7 @@ const ChatTimelineLiveTail = memo(function ChatTimelineLiveTail({
             worktreeId={worktreeId}
         />
     );
-}, areChatTimelineLiveTailPropsEqual);
+});
 
 ChatTimelineLiveTail.displayName = "ChatTimelineLiveTail";
 
@@ -2405,169 +2405,9 @@ const ChatTimelineRowView = memo(function ChatTimelineRowView({
             worktreeId={worktreeId}
         />
     );
-}, areChatTimelineRowViewPropsEqual);
+});
 
 ChatTimelineRowView.displayName = "ChatTimelineRowView";
-
-type PropEqualityPlan<P> = Readonly<Record<keyof P, boolean>>;
-
-// Memo equality driven by an explicit, exhaustive plan. Because the plan is
-// keyed by `keyof Props`, adding a prop to a memoized component forces a
-// compile-time decision on whether to compare it — a prop can no longer
-// silently fall out of the check (the failure mode that left `onScroll`
-// uncompared until it was caught in review). Props mapped to `true` are
-// compared by identity; `false` opts a prop out intentionally.
-function arePropsEqualByPlan<P extends object>(
-    previous: Readonly<P>,
-    next: Readonly<P>,
-    plan: PropEqualityPlan<P>,
-): boolean {
-    for (const key of Object.keys(plan) as (keyof P)[]) {
-        if (plan[key] && !Object.is(previous[key], next[key])) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-const CHAT_TIMELINE_EQUALITY_PLAN: PropEqualityPlan<ChatTimelineProps> = {
-    // Intentionally not compared — treated as a stable callback. TODO: confirm
-    // this is deliberate and not a latent stale-UI bug (pending review item).
-    canRenderRawFileReference: false,
-    chatFontFamily: true,
-    chatFontSize: true,
-    elapsed: true,
-    historyRows: true,
-    isStreaming: true,
-    liveTailRow: true,
-    onAddFileReferenceToChat: true,
-    onOpenFile: true,
-    onOpenImage: true,
-    onOpenResolvedFileReference: true,
-    onOpenSession: true,
-    onRevealFileReference: true,
-    onScroll: true,
-    onVirtualRangeChange: true,
-    onVirtualResizeAutoFollow: true,
-    projectId: true,
-    resolveFileReference: true,
-    scrollRef: true,
-    shouldPreserveVirtualResizeAnchor: true,
-    timelineContentRef: true,
-    toolCardExpansionMode: true,
-    worktreeId: true,
-};
-
-function areChatTimelinePropsEqual(
-    previous: Readonly<ChatTimelineProps>,
-    next: Readonly<ChatTimelineProps>,
-): boolean {
-    return arePropsEqualByPlan(previous, next, CHAT_TIMELINE_EQUALITY_PLAN);
-}
-
-const CHAT_TIMELINE_HISTORY_EQUALITY_PLAN: PropEqualityPlan<ChatTimelineHistoryProps> =
-    {
-        // Intentionally not compared — treated as a stable callback. TODO:
-        // confirm this is deliberate and not a latent stale-UI bug (pending
-        // review item).
-        canRenderRawFileReference: false,
-        chatFontFamily: true,
-        chatFontSize: true,
-        historyRows: true,
-        latestStreamingEditedFileToolRowId: true,
-        onAddFileReferenceToChat: true,
-        onOpenFile: true,
-        onOpenImage: true,
-        onOpenResolvedFileReference: true,
-        onOpenSession: true,
-        onRevealFileReference: true,
-        onVirtualRangeChange: true,
-        onVirtualResizeAutoFollow: true,
-        projectId: true,
-        resolveFileReference: true,
-        scrollRef: true,
-        shouldPreserveVirtualResizeAnchor: true,
-        toolCardExpansionMode: true,
-        worktreeId: true,
-    };
-
-function areChatTimelineHistoryPropsEqual(
-    previous: Readonly<ChatTimelineHistoryProps>,
-    next: Readonly<ChatTimelineHistoryProps>,
-): boolean {
-    return arePropsEqualByPlan(
-        previous,
-        next,
-        CHAT_TIMELINE_HISTORY_EQUALITY_PLAN,
-    );
-}
-
-const CHAT_TIMELINE_LIVE_TAIL_EQUALITY_PLAN: PropEqualityPlan<ChatTimelineLiveTailProps> =
-    {
-        // Intentionally not compared — treated as a stable callback. TODO:
-        // confirm this is deliberate and not a latent stale-UI bug (pending
-        // review item).
-        canRenderRawFileReference: false,
-        chatFontFamily: true,
-        chatFontSize: true,
-        latestStreamingEditedFileToolRowId: true,
-        onAddFileReferenceToChat: true,
-        onOpenFile: true,
-        onOpenImage: true,
-        onOpenResolvedFileReference: true,
-        onOpenSession: true,
-        onRevealFileReference: true,
-        projectId: true,
-        resolveFileReference: true,
-        row: true,
-        toolCardExpansionMode: true,
-        worktreeId: true,
-    };
-
-function areChatTimelineLiveTailPropsEqual(
-    previous: Readonly<ChatTimelineLiveTailProps>,
-    next: Readonly<ChatTimelineLiveTailProps>,
-): boolean {
-    return arePropsEqualByPlan(
-        previous,
-        next,
-        CHAT_TIMELINE_LIVE_TAIL_EQUALITY_PLAN,
-    );
-}
-
-const CHAT_TIMELINE_ROW_VIEW_EQUALITY_PLAN: PropEqualityPlan<ChatTimelineRowViewProps> =
-    {
-        // Intentionally not compared — treated as a stable callback. TODO:
-        // confirm this is deliberate and not a latent stale-UI bug (pending
-        // review item).
-        canRenderRawFileReference: false,
-        chatFontFamily: true,
-        chatFontSize: true,
-        isLatestStreamingTool: true,
-        onAddFileReferenceToChat: true,
-        onOpenFile: true,
-        onOpenImage: true,
-        onOpenResolvedFileReference: true,
-        onOpenSession: true,
-        onRevealFileReference: true,
-        projectId: true,
-        resolveFileReference: true,
-        row: true,
-        toolCardExpansionMode: true,
-        worktreeId: true,
-    };
-
-function areChatTimelineRowViewPropsEqual(
-    previous: Readonly<ChatTimelineRowViewProps>,
-    next: Readonly<ChatTimelineRowViewProps>,
-): boolean {
-    return arePropsEqualByPlan(
-        previous,
-        next,
-        CHAT_TIMELINE_ROW_VIEW_EQUALITY_PLAN,
-    );
-}
 
 function UserInputRequestCard({
     onRespond,

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -798,6 +798,14 @@ export const ChatTabView = memo(function ChatTabView({
         }
     }, [scheduleScrollToBottom]);
 
+    const handleTimelineVirtualResizeAutoFollow = useCallback(() => {
+        scheduleScrollToBottom();
+    }, [scheduleScrollToBottom]);
+
+    const shouldPreserveTimelineVirtualResizeAnchor = useCallback(() => {
+        return !shouldAutoFollowRef.current;
+    }, []);
+
     const persistCurrentViewState = useCallback(
         (overrides?: {
             readonly isNearBottom?: boolean;
@@ -1539,9 +1547,15 @@ export const ChatTabView = memo(function ChatTabView({
                     onScroll={handleScroll}
                     onVirtualListReady={handleTimelineVirtualListReady}
                     onVirtualRangeChange={handleTimelineVirtualRangeChange}
+                    onVirtualResizeAutoFollow={
+                        handleTimelineVirtualResizeAutoFollow
+                    }
                     projectId={tab.projectId}
                     resolveFileReference={resolveChatFileReference}
                     scrollRef={scrollRef}
+                    shouldPreserveVirtualResizeAnchor={
+                        shouldPreserveTimelineVirtualResizeAnchor
+                    }
                     timelineContentRef={timelineContentRef}
                     worktreeId={tab.worktreeId ?? null}
                 />
@@ -1990,9 +2004,11 @@ const ChatTimeline = memo(function ChatTimeline({
     onScroll,
     onVirtualListReady,
     onVirtualRangeChange,
+    onVirtualResizeAutoFollow,
     projectId,
     resolveFileReference,
     scrollRef,
+    shouldPreserveVirtualResizeAnchor,
     timelineContentRef,
     toolCardExpansionMode,
     worktreeId,
@@ -2029,11 +2045,13 @@ const ChatTimeline = memo(function ChatTimeline({
         handle: MeasuredVirtualListHandle | null,
     ) => void;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
+    readonly onVirtualResizeAutoFollow?: () => void;
     readonly projectId: string | null;
     readonly resolveFileReference: (
         reference: string,
     ) => ResolvedProjectFileReference | null;
     readonly scrollRef: RefObject<HTMLDivElement | null>;
+    readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
     readonly timelineContentRef: RefObject<HTMLDivElement | null>;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
@@ -2076,12 +2094,16 @@ const ChatTimeline = memo(function ChatTimeline({
                     onRevealFileReference={onRevealFileReference}
                     onVirtualListReady={onVirtualListReady}
                     onVirtualRangeChange={onVirtualRangeChange}
+                    onVirtualResizeAutoFollow={onVirtualResizeAutoFollow}
                     projectId={projectId}
                     resolveFileReference={resolveFileReference}
                     latestStreamingEditedFileToolRowId={
                         latestStreamingEditedFileToolRowId
                     }
                     scrollRef={scrollRef}
+                    shouldPreserveVirtualResizeAnchor={
+                        shouldPreserveVirtualResizeAnchor
+                    }
                     toolCardExpansionMode={toolCardExpansionMode}
                     worktreeId={worktreeId}
                 />
@@ -2125,10 +2147,12 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
     onRevealFileReference,
     onVirtualListReady,
     onVirtualRangeChange,
+    onVirtualResizeAutoFollow,
     projectId,
     resolveFileReference,
     latestStreamingEditedFileToolRowId,
     scrollRef,
+    shouldPreserveVirtualResizeAnchor,
     toolCardExpansionMode,
     worktreeId,
 }: {
@@ -2160,12 +2184,14 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
         handle: MeasuredVirtualListHandle | null,
     ) => void;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
+    readonly onVirtualResizeAutoFollow?: () => void;
     readonly projectId: string | null;
     readonly resolveFileReference: (
         reference: string,
     ) => ResolvedProjectFileReference | null;
     readonly latestStreamingEditedFileToolRowId: string | null;
     readonly scrollRef: RefObject<HTMLDivElement | null>;
+    readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
 }) {
@@ -2223,8 +2249,12 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
             }
             onVirtualListReady={onVirtualListReady}
             onVirtualRangeChange={onVirtualRangeChange}
+            onVirtualResizeAutoFollow={onVirtualResizeAutoFollow}
             renderRow={renderRow}
             scrollRef={scrollRef}
+            shouldPreserveVirtualResizeAnchor={
+                shouldPreserveVirtualResizeAnchor
+            }
             toolCardExpansionMode={toolCardExpansionMode}
         />
     );
@@ -2424,11 +2454,13 @@ function areChatTimelinePropsEqual(
             handle: MeasuredVirtualListHandle | null,
         ) => void;
         readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
+        readonly onVirtualResizeAutoFollow?: () => void;
         readonly projectId: string | null;
         readonly resolveFileReference: (
             reference: string,
         ) => ResolvedProjectFileReference | null;
         readonly scrollRef: RefObject<HTMLDivElement | null>;
+        readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
         readonly timelineContentRef: RefObject<HTMLDivElement | null>;
         readonly toolCardExpansionMode: AiToolCardExpansionMode;
         readonly worktreeId: string | null;
@@ -2462,11 +2494,13 @@ function areChatTimelinePropsEqual(
             handle: MeasuredVirtualListHandle | null,
         ) => void;
         readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
+        readonly onVirtualResizeAutoFollow?: () => void;
         readonly projectId: string | null;
         readonly resolveFileReference: (
             reference: string,
         ) => ResolvedProjectFileReference | null;
         readonly scrollRef: RefObject<HTMLDivElement | null>;
+        readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
         readonly timelineContentRef: RefObject<HTMLDivElement | null>;
         readonly toolCardExpansionMode: AiToolCardExpansionMode;
         readonly worktreeId: string | null;
@@ -2489,9 +2523,12 @@ function areChatTimelinePropsEqual(
         previous.onScroll === next.onScroll &&
         previous.onVirtualListReady === next.onVirtualListReady &&
         previous.onVirtualRangeChange === next.onVirtualRangeChange &&
+        previous.onVirtualResizeAutoFollow === next.onVirtualResizeAutoFollow &&
         previous.projectId === next.projectId &&
         previous.resolveFileReference === next.resolveFileReference &&
         previous.scrollRef === next.scrollRef &&
+        previous.shouldPreserveVirtualResizeAnchor ===
+            next.shouldPreserveVirtualResizeAnchor &&
         previous.timelineContentRef === next.timelineContentRef &&
         previous.toolCardExpansionMode === next.toolCardExpansionMode &&
         previous.worktreeId === next.worktreeId
@@ -2524,12 +2561,14 @@ function areChatTimelineHistoryPropsEqual(
             handle: MeasuredVirtualListHandle | null,
         ) => void;
         readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
+        readonly onVirtualResizeAutoFollow?: () => void;
         readonly projectId: string | null;
         readonly resolveFileReference: (
             reference: string,
         ) => ResolvedProjectFileReference | null;
         readonly latestStreamingEditedFileToolRowId: string | null;
         readonly scrollRef: RefObject<HTMLDivElement | null>;
+        readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
         readonly toolCardExpansionMode: AiToolCardExpansionMode;
         readonly worktreeId: string | null;
     }>,
@@ -2558,12 +2597,14 @@ function areChatTimelineHistoryPropsEqual(
             handle: MeasuredVirtualListHandle | null,
         ) => void;
         readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
+        readonly onVirtualResizeAutoFollow?: () => void;
         readonly projectId: string | null;
         readonly resolveFileReference: (
             reference: string,
         ) => ResolvedProjectFileReference | null;
         readonly latestStreamingEditedFileToolRowId: string | null;
         readonly scrollRef: RefObject<HTMLDivElement | null>;
+        readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
         readonly toolCardExpansionMode: AiToolCardExpansionMode;
         readonly worktreeId: string | null;
     }>,
@@ -2581,11 +2622,14 @@ function areChatTimelineHistoryPropsEqual(
         previous.onRevealFileReference === next.onRevealFileReference &&
         previous.onVirtualListReady === next.onVirtualListReady &&
         previous.onVirtualRangeChange === next.onVirtualRangeChange &&
+        previous.onVirtualResizeAutoFollow === next.onVirtualResizeAutoFollow &&
         previous.projectId === next.projectId &&
         previous.resolveFileReference === next.resolveFileReference &&
         previous.latestStreamingEditedFileToolRowId ===
             next.latestStreamingEditedFileToolRowId &&
         previous.scrollRef === next.scrollRef &&
+        previous.shouldPreserveVirtualResizeAnchor ===
+            next.shouldPreserveVirtualResizeAnchor &&
         previous.toolCardExpansionMode === next.toolCardExpansionMode &&
         previous.worktreeId === next.worktreeId
     );

--- a/src/renderer/src/components/workspace/chat/ChangeReviewPanel.tsx
+++ b/src/renderer/src/components/workspace/chat/ChangeReviewPanel.tsx
@@ -1,10 +1,4 @@
-import {
-    memo,
-    useCallback,
-    useMemo,
-    useState,
-    type CSSProperties,
-} from "react";
+import { memo, useCallback, useMemo, type CSSProperties } from "react";
 
 import type { AiToolActivity, AiTrackedFile } from "@shared/ipc";
 import type { RuntimeWorkspaceFileReviewContext } from "@renderer/app/workspace/tree";
@@ -20,6 +14,7 @@ import {
     type ChangeReviewItem,
 } from "./toolActivityReviewModel";
 import { ResizableDiffContainer } from "./ResizableDiffContainer";
+import { usePersistentToolExpansion } from "./toolExpansionStore";
 import { FileTypeIcon } from "@renderer/components/icons/FileTypeIcon";
 
 const TOOL_ACTION_BUTTON_STYLE: CSSProperties = {
@@ -206,18 +201,18 @@ function ChangeReviewFileCard({
     readonly item: ChangeReviewItem;
     readonly onOpen: (() => void) | null;
 }) {
+    // Persist expansion (and the diff height below) in the timeline scroller so
+    // it survives this card unmounting when its virtualized row scrolls out of
+    // view. The reset key still encodes the expansion mode, so switching modes
+    // re-hydrates to the mode's default exactly as before.
     const resetKey = `${activity.id}:${item.key}:${
         defaultExpanded ? "open" : "closed"
     }:${forceExpanded ? "forced" : "free"}`;
-    const [expansionState, setExpansionState] = useState({
-        expanded: defaultExpanded,
+    const [expanded, setExpanded] = usePersistentToolExpansion(
         resetKey,
-    });
-    const currentExpanded =
-        expansionState.resetKey === resetKey
-            ? expansionState.expanded
-            : defaultExpanded;
-    const resolvedExpanded = forceExpanded ? true : currentExpanded;
+        defaultExpanded,
+    );
+    const resolvedExpanded = forceExpanded ? true : expanded;
     const accent = getPanelAccent(activity);
     const actionLabel = getActivityActionLabel(activity.kind);
     const summaryLabel = `${actionLabel} ${getFileNameFromPath(item.path)}`;
@@ -253,17 +248,7 @@ function ChangeReviewFileCard({
                             return;
                         }
 
-                        setExpansionState((current) => {
-                            const expanded =
-                                current.resetKey === resetKey
-                                    ? current.expanded
-                                    : defaultExpanded;
-
-                            return {
-                                expanded: !expanded,
-                                resetKey,
-                            };
-                        });
+                        setExpanded((previous) => !previous);
                     }}
                     style={{
                         alignItems: "center",
@@ -373,7 +358,10 @@ function ChangeReviewFileCard({
             </div>
 
             {resolvedExpanded ? (
-                <ResizableDiffContainer accent={accent}>
+                <ResizableDiffContainer
+                    accent={accent}
+                    persistKey={`${activity.id}:${item.key}:diff-height`}
+                >
                     <EditedFileDiffPreview
                         compactLineNumbers
                         diff={item.diff}

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -15,6 +15,7 @@ interface MeasuredVirtualListMockSnapshot {
     readonly hasOnReady: boolean;
     readonly itemCount: number;
     readonly overscan?: number;
+    readonly preserveScrollAnchorOnMeasure?: boolean;
     readonly scrollMarginTop?: number;
 }
 
@@ -39,6 +40,7 @@ vi.mock("@renderer/components/virtual/MeasuredVirtualList", async () => {
             onRangeChange,
             onReady,
             overscan,
+            preserveScrollAnchorOnMeasure,
             renderItem,
             scrollMarginTop,
         }: {
@@ -52,6 +54,7 @@ vi.mock("@renderer/components/virtual/MeasuredVirtualList", async () => {
             readonly onRangeChange?: () => void;
             readonly onReady?: () => void;
             readonly overscan?: number;
+            readonly preserveScrollAnchorOnMeasure?: boolean;
             readonly renderItem: (params: {
                 readonly index: number;
                 readonly isVisible: boolean;
@@ -71,6 +74,7 @@ vi.mock("@renderer/components/virtual/MeasuredVirtualList", async () => {
                 hasOnReady: typeof onReady === "function",
                 itemCount: items.length,
                 overscan,
+                preserveScrollAnchorOnMeasure,
                 scrollMarginTop,
             });
 
@@ -179,6 +183,7 @@ describe("ChatTimelineHistoryRows", () => {
                 hasOnReady: true,
                 itemCount: CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
                 overscan: 10,
+                preserveScrollAnchorOnMeasure: true,
                 scrollMarginTop: 0,
             }),
         );

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -1,0 +1,194 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AiSessionSnapshot } from "@shared/ipc";
+
+import type { ChatTimelineRow } from "./chatTimelineModel";
+import { CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD } from "./chatTimelineVirtualization";
+
+interface MeasuredVirtualListMockSnapshot {
+    readonly firstEstimate: number | null;
+    readonly firstKey: string | null;
+    readonly firstMeasurementKey: string | null;
+    readonly hasOnRangeChange: boolean;
+    readonly hasOnReady: boolean;
+    readonly itemCount: number;
+    readonly overscan?: number;
+    readonly scrollMarginTop?: number;
+}
+
+type MeasuredVirtualListMock = (
+    snapshot: MeasuredVirtualListMockSnapshot,
+) => void;
+
+const measuredVirtualListMock = vi.hoisted(() =>
+    vi.fn<MeasuredVirtualListMock>(),
+);
+
+vi.mock("@renderer/components/virtual/MeasuredVirtualList", async () => {
+    const { createElement } =
+        await vi.importActual<typeof import("react")>("react");
+
+    return {
+        MeasuredVirtualList: <T,>({
+            estimateSize,
+            getItemMeasurementKey,
+            getItemKey,
+            items,
+            onRangeChange,
+            onReady,
+            overscan,
+            renderItem,
+            scrollMarginTop,
+        }: {
+            readonly estimateSize: (item: T, index: number) => number;
+            readonly getItemMeasurementKey?: (
+                item: T,
+                index: number,
+            ) => string;
+            readonly getItemKey: (item: T, index: number) => string;
+            readonly items: readonly T[];
+            readonly onRangeChange?: () => void;
+            readonly onReady?: () => void;
+            readonly overscan?: number;
+            readonly renderItem: (params: {
+                readonly index: number;
+                readonly isVisible: boolean;
+                readonly item: T;
+            }) => ReactNode;
+            readonly scrollMarginTop?: number;
+        }) => {
+            measuredVirtualListMock({
+                firstEstimate:
+                    items.length > 0 ? estimateSize(items[0], 0) : null,
+                firstKey: items.length > 0 ? getItemKey(items[0], 0) : null,
+                firstMeasurementKey:
+                    items.length > 0 && getItemMeasurementKey
+                        ? getItemMeasurementKey(items[0], 0)
+                        : null,
+                hasOnRangeChange: typeof onRangeChange === "function",
+                hasOnReady: typeof onReady === "function",
+                itemCount: items.length,
+                overscan,
+                scrollMarginTop,
+            });
+
+            const indexes =
+                items.length > 1 ? [0, items.length - 1] : [0];
+
+            return createElement(
+                "div",
+                { "data-testid": "mock-measured-virtual-list" },
+                indexes.map((index) =>
+                    createElement(
+                        "div",
+                        { key: getItemKey(items[index], index) },
+                        renderItem({
+                            index,
+                            isVisible: true,
+                            item: items[index],
+                        }),
+                    ),
+                ),
+            );
+        },
+    };
+});
+
+import { ChatTimelineHistoryRows } from "./ChatTimelineHistoryRows";
+
+function createMessage(
+    overrides: Partial<AiSessionSnapshot["messages"][number]> = {},
+): AiSessionSnapshot["messages"][number] {
+    return {
+        attachments: [],
+        content: "hello",
+        createdAt: "2026-04-14T00:00:00.000Z",
+        id: "message-1",
+        kind: "assistant",
+        status: "completed",
+        ...overrides,
+    };
+}
+
+function createRows(count: number): ChatTimelineRow[] {
+    return Array.from({ length: count }, (_, index) => {
+        const message = createMessage({
+            id: `message-${index}`,
+        });
+
+        return {
+            id: `message:${message.id}`,
+            kind: "message",
+            message,
+        };
+    });
+}
+
+function renderHistoryRows(historyRows: readonly ChatTimelineRow[]) {
+    return renderToStaticMarkup(
+        <ChatTimelineHistoryRows
+            historyRows={historyRows}
+            latestStreamingEditedFileToolRowId={null}
+            onVirtualListReady={() => {}}
+            onVirtualRangeChange={() => {}}
+            renderRow={({ isLatestStreamingTool, row }) => (
+                <div
+                    data-latest-streaming-tool={
+                        isLatestStreamingTool ? "true" : "false"
+                    }
+                    data-row-id={row.id}
+                    key={row.id}
+                >
+                    {row.id}
+                </div>
+            )}
+            scrollRef={{ current: null }}
+            toolCardExpansionMode="collapsed"
+        />,
+    );
+}
+
+describe("ChatTimelineHistoryRows", () => {
+    beforeEach(() => {
+        measuredVirtualListMock.mockClear();
+    });
+
+    it("keeps the non-virtualized path below the threshold", () => {
+        const rows = createRows(CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD - 1);
+        const markup = renderHistoryRows(rows);
+
+        expect(measuredVirtualListMock).not.toHaveBeenCalled();
+        expect(markup).toContain("message:message-0");
+        expect(markup).toContain(
+            `message:message-${CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD - 2}`,
+        );
+    });
+
+    it("passes all history rows to MeasuredVirtualList at the threshold", () => {
+        const rows = createRows(CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD);
+        const markup = renderHistoryRows(rows);
+        const firstCall = measuredVirtualListMock.mock.calls[0]?.[0];
+
+        expect(measuredVirtualListMock).toHaveBeenCalledTimes(1);
+        expect(measuredVirtualListMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                firstKey: "message:message-0",
+                hasOnRangeChange: true,
+                hasOnReady: true,
+                itemCount: CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
+                overscan: 10,
+                scrollMarginTop: 0,
+            }),
+        );
+        expect(firstCall?.firstEstimate).toBeGreaterThan(0);
+        expect(firstCall?.firstMeasurementKey).toContain("message:message-0");
+        expect(markup).toContain("mock-measured-virtual-list");
+        expect(markup).toContain("message:message-0");
+        expect(markup).toContain(
+            `message:message-${CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD - 1}`,
+        );
+        expect(markup.match(/padding-bottom:8px/g)).toHaveLength(1);
+    });
+});

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -135,7 +135,6 @@ function renderHistoryRows(historyRows: readonly ChatTimelineRow[]) {
         <ChatTimelineHistoryRows
             historyRows={historyRows}
             latestStreamingEditedFileToolRowId={null}
-            onVirtualListReady={() => {}}
             onVirtualRangeChange={() => {}}
             renderRow={({ isLatestStreamingTool, row }) => (
                 <div

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -1,4 +1,5 @@
 import {
+    Fragment,
     memo,
     useCallback,
     useEffect,
@@ -290,13 +291,16 @@ export const ChatTimelineHistoryRows = memo(
         if (!shouldVirtualize) {
             return (
                 <>
-                    {historyRows.map((row) =>
-                        renderRow({
-                            isLatestStreamingTool:
-                                row.id === latestStreamingEditedFileToolRowId,
-                            row,
-                        }),
-                    )}
+                    {historyRows.map((row) => (
+                        <Fragment key={row.id}>
+                            {renderRow({
+                                isLatestStreamingTool:
+                                    row.id ===
+                                    latestStreamingEditedFileToolRowId,
+                                row,
+                            })}
+                        </Fragment>
+                    ))}
                 </>
             );
         }

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 
 import type { AiToolCardExpansionMode } from "@shared/ipc";
+import { useShellStore } from "@renderer/app/store/shell-store";
 import {
     MeasuredVirtualList,
     type MeasuredVirtualListHandle,
@@ -71,6 +72,17 @@ export const ChatTimelineHistoryRows = memo(
         );
         const [scrollMarginTop, setScrollMarginTop] = useState(0);
         const [scrollContainerWidth, setScrollContainerWidth] = useState(0);
+        // While the pane splitter is being dragged we freeze the timeline: the
+        // content keeps its pre-drag width (so rows don't reflow) and all metric
+        // updates are skipped, then we re-sync once on release. frozenContentWidth
+        // is the pinned width (null = not frozen); the ref mirrors it for the
+        // synchronous early-return inside syncLayoutMetrics.
+        const isResizingPanel = useShellStore((state) => state.isResizingPanel);
+        const [frozenContentWidth, setFrozenContentWidth] = useState<
+            number | null
+        >(null);
+        const isFreezeActiveRef = useRef(false);
+        isFreezeActiveRef.current = frozenContentWidth !== null;
         const shouldVirtualize = shouldVirtualizeChatTimeline(
             historyRows.length,
         );
@@ -107,6 +119,13 @@ export const ChatTimelineHistoryRows = memo(
         }, [restorePendingResizeAnchor]);
 
         const syncLayoutMetrics = useCallback(() => {
+            // Frozen during an active splitter drag: skip every metric/anchor
+            // update so the scroll stays put. The single re-sync happens when the
+            // freeze lifts (see the freeze effects below).
+            if (isFreezeActiveRef.current) {
+                return;
+            }
+
             const historyElement = historyRef.current;
             const scrollContainer = scrollRef.current;
             const nextScrollContainerWidth = scrollContainer?.clientWidth ?? 0;
@@ -205,6 +224,33 @@ export const ChatTimelineHistoryRows = memo(
                 }
             };
         }, []);
+
+        // Engage/lift the freeze as the splitter drag starts/ends. Captured
+        // before the first width change lands (pointerdown precedes pointermove),
+        // so the pinned width matches the pre-drag layout exactly.
+        useLayoutEffect(() => {
+            if (!shouldVirtualize) {
+                return;
+            }
+
+            if (isResizingPanel) {
+                const width =
+                    historyRef.current?.getBoundingClientRect().width ?? 0;
+                setFrozenContentWidth(width > 0 ? width : null);
+            } else {
+                setFrozenContentWidth(null);
+            }
+        }, [isResizingPanel, shouldVirtualize]);
+
+        // Once the freeze lifts the DOM holds the real width again, so adopt it
+        // and re-anchor exactly once — instead of on every drag frame.
+        useLayoutEffect(() => {
+            if (!shouldVirtualize || frozenContentWidth !== null) {
+                return;
+            }
+
+            syncLayoutMetrics();
+        }, [frozenContentWidth, shouldVirtualize, syncLayoutMetrics]);
 
         const estimateSize = useCallback(
             (row: ChatTimelineRow, index: number) =>
@@ -334,7 +380,18 @@ export const ChatTimelineHistoryRows = memo(
         }
 
         return (
-            <div ref={historyRef} className="relative w-full">
+            <div
+                ref={historyRef}
+                className="relative w-full"
+                // Pin the content width while dragging the splitter so rows keep
+                // their pre-drag layout (no reflow); clip any overhang instead of
+                // letting it spill. Released to fluid width on drag end.
+                style={
+                    frozenContentWidth !== null
+                        ? { width: frozenContentWidth, overflowX: "clip" }
+                        : undefined
+                }
+            >
                 <MeasuredVirtualList
                     defaultViewportHeight={
                         CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -24,6 +24,7 @@ import {
     CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN,
     calculateChatTimelineVirtualScrollMarginTop,
     estimateChatTimelineRowHeight,
+    getChatTimelineRowIdentityKey,
     getChatTimelineRowMeasurementKey,
     getChatTimelineRowKey,
     getChatTimelineVirtualMeasurementWidth,
@@ -251,6 +252,33 @@ export const ChatTimelineHistoryRows = memo(
             ],
         );
 
+        // Width-invariant identity (the row's measurement key minus the width
+        // bucket), so a resize reuses each row's last measured height instead of
+        // collapsing the timeline back to estimates.
+        const getItemIdentityKey = useCallback(
+            (row: ChatTimelineRow, index: number) =>
+                getChatTimelineRowIdentityKey(row, {
+                    chatFontFamily,
+                    chatFontSize,
+                    gapPx: getChatTimelineVirtualRowGapPx({
+                        index,
+                        rowCount: historyRows.length,
+                    }),
+                    isLatestStreamingTool:
+                        row.id === latestStreamingEditedFileToolRowId,
+                    toolCardExpansionMode,
+                    width: scrollContainerWidth,
+                }),
+            [
+                chatFontFamily,
+                chatFontSize,
+                historyRows.length,
+                latestStreamingEditedFileToolRowId,
+                scrollContainerWidth,
+                toolCardExpansionMode,
+            ],
+        );
+
         const renderVirtualItem = useCallback(
             ({
                 index,
@@ -313,6 +341,7 @@ export const ChatTimelineHistoryRows = memo(
                     }
                     estimateSize={estimateSize}
                     getItemKey={getChatTimelineRowKey}
+                    getItemIdentityKey={getItemIdentityKey}
                     getItemMeasurementKey={getItemMeasurementKey}
                     items={historyRows}
                     onRangeChange={onVirtualRangeChange}

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -1,0 +1,232 @@
+import {
+    memo,
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useRef,
+    useState,
+    type ReactNode,
+    type RefObject,
+} from "react";
+
+import type { AiToolCardExpansionMode } from "@shared/ipc";
+import {
+    MeasuredVirtualList,
+    type MeasuredVirtualListHandle,
+    type MeasuredVirtualRange,
+} from "@renderer/components/virtual/MeasuredVirtualList";
+
+import type { ChatTimelineRow } from "./chatTimelineModel";
+import {
+    CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT,
+    CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN,
+    calculateChatTimelineVirtualScrollMarginTop,
+    estimateChatTimelineRowHeight,
+    getChatTimelineRowMeasurementKey,
+    getChatTimelineRowKey,
+    getChatTimelineVirtualRowGapPx,
+    shouldVirtualizeChatTimeline,
+} from "./chatTimelineVirtualization";
+
+interface ChatTimelineHistoryRowsProps {
+    readonly chatFontFamily?: string;
+    readonly chatFontSize?: number;
+    readonly historyRows: readonly ChatTimelineRow[];
+    readonly latestStreamingEditedFileToolRowId: string | null;
+    readonly onVirtualListReady?: (
+        handle: MeasuredVirtualListHandle | null,
+    ) => void;
+    readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
+    readonly renderRow: (params: {
+        readonly isLatestStreamingTool: boolean;
+        readonly row: ChatTimelineRow;
+    }) => ReactNode;
+    readonly scrollRef: RefObject<HTMLElement | null>;
+    readonly toolCardExpansionMode: AiToolCardExpansionMode;
+}
+
+export const ChatTimelineHistoryRows = memo(
+    function ChatTimelineHistoryRows({
+        chatFontFamily,
+        chatFontSize,
+        historyRows,
+        latestStreamingEditedFileToolRowId,
+        onVirtualListReady,
+        onVirtualRangeChange,
+        renderRow,
+        scrollRef,
+        toolCardExpansionMode,
+    }: ChatTimelineHistoryRowsProps) {
+        const historyRef = useRef<HTMLDivElement | null>(null);
+        const [scrollMarginTop, setScrollMarginTop] = useState(0);
+        const [scrollContainerWidth, setScrollContainerWidth] = useState(0);
+        const shouldVirtualize = shouldVirtualizeChatTimeline(
+            historyRows.length,
+        );
+
+        const syncLayoutMetrics = useCallback(() => {
+            const historyElement = historyRef.current;
+            const scrollContainer = scrollRef.current;
+
+            setScrollMarginTop(
+                calculateChatTimelineVirtualScrollMarginTop({
+                    historyElement,
+                    scrollContainer,
+                }),
+            );
+            setScrollContainerWidth(scrollContainer?.clientWidth ?? 0);
+        }, [scrollRef]);
+
+        useLayoutEffect(() => {
+            if (!shouldVirtualize) {
+                return;
+            }
+
+            syncLayoutMetrics();
+        }, [historyRows.length, shouldVirtualize, syncLayoutMetrics]);
+
+        useEffect(() => {
+            if (!shouldVirtualize || typeof ResizeObserver === "undefined") {
+                return;
+            }
+
+            const historyElement = historyRef.current;
+            const scrollContainer = scrollRef.current;
+            if (!historyElement || !scrollContainer) {
+                return;
+            }
+
+            syncLayoutMetrics();
+
+            const observer = new ResizeObserver(() => {
+                syncLayoutMetrics();
+            });
+
+            observer.observe(historyElement);
+            observer.observe(scrollContainer);
+            window.addEventListener("resize", syncLayoutMetrics);
+
+            return () => {
+                observer.disconnect();
+                window.removeEventListener("resize", syncLayoutMetrics);
+            };
+        }, [scrollRef, shouldVirtualize, syncLayoutMetrics]);
+
+        const estimateSize = useCallback(
+            (row: ChatTimelineRow, index: number) =>
+                estimateChatTimelineRowHeight(row, {
+                    chatFontSize,
+                    gapPx: getChatTimelineVirtualRowGapPx({
+                        index,
+                        rowCount: historyRows.length,
+                    }),
+                    isLatestStreamingTool:
+                        row.id === latestStreamingEditedFileToolRowId,
+                    toolCardExpansionMode,
+                }),
+            [
+                chatFontSize,
+                historyRows.length,
+                latestStreamingEditedFileToolRowId,
+                toolCardExpansionMode,
+            ],
+        );
+
+        const getItemMeasurementKey = useCallback(
+            (row: ChatTimelineRow, index: number) =>
+                getChatTimelineRowMeasurementKey(row, {
+                    chatFontFamily,
+                    chatFontSize,
+                    gapPx: getChatTimelineVirtualRowGapPx({
+                        index,
+                        rowCount: historyRows.length,
+                    }),
+                    isLatestStreamingTool:
+                        row.id === latestStreamingEditedFileToolRowId,
+                    toolCardExpansionMode,
+                    width: scrollContainerWidth,
+                }),
+            [
+                chatFontFamily,
+                chatFontSize,
+                historyRows.length,
+                latestStreamingEditedFileToolRowId,
+                scrollContainerWidth,
+                toolCardExpansionMode,
+            ],
+        );
+
+        const renderVirtualItem = useCallback(
+            ({
+                index,
+                item,
+            }: {
+                readonly index: number;
+                readonly isVisible: boolean;
+                readonly item: ChatTimelineRow;
+            }) => {
+                const gapPx = getChatTimelineVirtualRowGapPx({
+                    index,
+                    rowCount: historyRows.length,
+                });
+
+                return (
+                    <div
+                        style={
+                            gapPx > 0
+                                ? { paddingBottom: `${gapPx}px` }
+                                : undefined
+                        }
+                    >
+                        {renderRow({
+                            isLatestStreamingTool:
+                                item.id === latestStreamingEditedFileToolRowId,
+                            row: item,
+                        })}
+                    </div>
+                );
+            },
+            [
+                historyRows.length,
+                latestStreamingEditedFileToolRowId,
+                renderRow,
+            ],
+        );
+
+        if (!shouldVirtualize) {
+            return (
+                <>
+                    {historyRows.map((row) =>
+                        renderRow({
+                            isLatestStreamingTool:
+                                row.id === latestStreamingEditedFileToolRowId,
+                            row,
+                        }),
+                    )}
+                </>
+            );
+        }
+
+        return (
+            <div ref={historyRef} className="relative w-full">
+                <MeasuredVirtualList
+                    defaultViewportHeight={
+                        CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT
+                    }
+                    estimateSize={estimateSize}
+                    getItemKey={getChatTimelineRowKey}
+                    getItemMeasurementKey={getItemMeasurementKey}
+                    items={historyRows}
+                    onRangeChange={onVirtualRangeChange}
+                    onReady={onVirtualListReady}
+                    overscan={CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN}
+                    scrollContainerRef={scrollRef}
+                    scrollMarginTop={scrollMarginTop}
+                    renderItem={renderVirtualItem}
+                />
+            </div>
+        );
+    },
+);
+
+ChatTimelineHistoryRows.displayName = "ChatTimelineHistoryRows";

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -31,6 +31,7 @@ import {
     getChatTimelineVirtualMeasurementWidth,
     getChatTimelineVirtualRowGapPx,
     shouldVirtualizeChatTimeline,
+    type ChatTimelineRowMeasurementContext,
 } from "./chatTimelineVirtualization";
 
 interface ChatTimelineHistoryRowsProps {
@@ -252,77 +253,67 @@ export const ChatTimelineHistoryRows = memo(
             syncLayoutMetrics();
         }, [frozenContentWidth, shouldVirtualize, syncLayoutMetrics]);
 
-        const estimateSize = useCallback(
-            (row: ChatTimelineRow, index: number) =>
-                estimateChatTimelineRowHeight(row, {
-                    chatFontSize,
-                    gapPx: getChatTimelineVirtualRowGapPx({
-                        index,
-                        rowCount: historyRows.length,
-                    }),
-                    isLatestStreamingTool:
-                        row.id === latestStreamingEditedFileToolRowId,
-                    toolCardExpansionMode,
-                    width: scrollContainerWidth,
+        // The gap below a row depends only on its position in the list, so it is
+        // resolved once here and shared by the row context and the rendered
+        // wrapper — keeping it off buildRowContext's dependency churn so the row
+        // renderer stays as stable as historyRows.length.
+        const resolveRowGapPx = useCallback(
+            (index: number) =>
+                getChatTimelineVirtualRowGapPx({
+                    index,
+                    rowCount: historyRows.length,
                 }),
-            [
+            [historyRows.length],
+        );
+
+        // The estimate, the measurement key and the width-invariant identity key
+        // all derive from the same per-row layout inputs and must stay in
+        // lockstep — a divergence would key a fresh measurement against the wrong
+        // estimate. Build that context once. ChatTimelineRowMeasurementContext
+        // extends the estimate context, so one object satisfies all three; the
+        // identity key simply ignores the width bucket it carries.
+        const buildRowContext = useCallback(
+            (
+                row: ChatTimelineRow,
+                index: number,
+            ): ChatTimelineRowMeasurementContext => ({
+                chatFontFamily,
                 chatFontSize,
-                historyRows.length,
+                gapPx: resolveRowGapPx(index),
+                isLatestStreamingTool:
+                    row.id === latestStreamingEditedFileToolRowId,
+                toolCardExpansionMode,
+                width: scrollContainerWidth,
+            }),
+            [
+                chatFontFamily,
+                chatFontSize,
                 latestStreamingEditedFileToolRowId,
+                resolveRowGapPx,
                 scrollContainerWidth,
                 toolCardExpansionMode,
             ],
+        );
+
+        const estimateSize = useCallback(
+            (row: ChatTimelineRow, index: number) =>
+                estimateChatTimelineRowHeight(row, buildRowContext(row, index)),
+            [buildRowContext],
         );
 
         const getItemMeasurementKey = useCallback(
             (row: ChatTimelineRow, index: number) =>
-                getChatTimelineRowMeasurementKey(row, {
-                    chatFontFamily,
-                    chatFontSize,
-                    gapPx: getChatTimelineVirtualRowGapPx({
-                        index,
-                        rowCount: historyRows.length,
-                    }),
-                    isLatestStreamingTool:
-                        row.id === latestStreamingEditedFileToolRowId,
-                    toolCardExpansionMode,
-                    width: scrollContainerWidth,
-                }),
-            [
-                chatFontFamily,
-                chatFontSize,
-                historyRows.length,
-                latestStreamingEditedFileToolRowId,
-                scrollContainerWidth,
-                toolCardExpansionMode,
-            ],
+                getChatTimelineRowMeasurementKey(
+                    row,
+                    buildRowContext(row, index),
+                ),
+            [buildRowContext],
         );
 
-        // Width-invariant identity (the row's measurement key minus the width
-        // bucket), so a resize reuses each row's last measured height instead of
-        // collapsing the timeline back to estimates.
         const getItemIdentityKey = useCallback(
             (row: ChatTimelineRow, index: number) =>
-                getChatTimelineRowIdentityKey(row, {
-                    chatFontFamily,
-                    chatFontSize,
-                    gapPx: getChatTimelineVirtualRowGapPx({
-                        index,
-                        rowCount: historyRows.length,
-                    }),
-                    isLatestStreamingTool:
-                        row.id === latestStreamingEditedFileToolRowId,
-                    toolCardExpansionMode,
-                    width: scrollContainerWidth,
-                }),
-            [
-                chatFontFamily,
-                chatFontSize,
-                historyRows.length,
-                latestStreamingEditedFileToolRowId,
-                scrollContainerWidth,
-                toolCardExpansionMode,
-            ],
+                getChatTimelineRowIdentityKey(row, buildRowContext(row, index)),
+            [buildRowContext],
         );
 
         const renderVirtualItem = useCallback(
@@ -334,10 +325,7 @@ export const ChatTimelineHistoryRows = memo(
                 readonly isVisible: boolean;
                 readonly item: ChatTimelineRow;
             }) => {
-                const gapPx = getChatTimelineVirtualRowGapPx({
-                    index,
-                    rowCount: historyRows.length,
-                });
+                const gapPx = resolveRowGapPx(index);
 
                 return (
                     <div
@@ -356,9 +344,9 @@ export const ChatTimelineHistoryRows = memo(
                 );
             },
             [
-                historyRows.length,
                 latestStreamingEditedFileToolRowId,
                 renderRow,
+                resolveRowGapPx,
             ],
         );
 

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -35,9 +35,6 @@ interface ChatTimelineHistoryRowsProps {
     readonly chatFontSize?: number;
     readonly historyRows: readonly ChatTimelineRow[];
     readonly latestStreamingEditedFileToolRowId: string | null;
-    readonly onVirtualListReady?: (
-        handle: MeasuredVirtualListHandle | null,
-    ) => void;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onVirtualResizeAutoFollow?: () => void;
     readonly renderRow: (params: {
@@ -55,7 +52,6 @@ export const ChatTimelineHistoryRows = memo(
         chatFontSize,
         historyRows,
         latestStreamingEditedFileToolRowId,
-        onVirtualListReady,
         onVirtualRangeChange,
         onVirtualResizeAutoFollow,
         renderRow,
@@ -154,9 +150,8 @@ export const ChatTimelineHistoryRows = memo(
         const handleVirtualListReady = useCallback(
             (handle: MeasuredVirtualListHandle | null) => {
                 virtualListHandleRef.current = handle;
-                onVirtualListReady?.(handle);
             },
-            [onVirtualListReady],
+            [],
         );
 
         useLayoutEffect(() => {

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -40,7 +40,9 @@ interface ChatTimelineHistoryRowsProps {
     readonly historyRows: readonly ChatTimelineRow[];
     readonly latestStreamingEditedFileToolRowId: string | null;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
+    readonly onVirtualResizeEnd?: () => void;
     readonly onVirtualResizeAutoFollow?: () => void;
+    readonly onVirtualResizeStart?: () => void;
     readonly renderRow: (params: {
         readonly isLatestStreamingTool: boolean;
         readonly row: ChatTimelineRow;
@@ -57,7 +59,9 @@ export const ChatTimelineHistoryRows = memo(
         historyRows,
         latestStreamingEditedFileToolRowId,
         onVirtualRangeChange,
+        onVirtualResizeEnd,
         onVirtualResizeAutoFollow,
+        onVirtualResizeStart,
         renderRow,
         scrollRef,
         shouldPreserveVirtualResizeAnchor,
@@ -67,10 +71,12 @@ export const ChatTimelineHistoryRows = memo(
         const pendingResizeAnchorFrameRef = useRef<number | null>(null);
         const pendingResizeAnchorRef =
             useRef<MeasuredVirtualViewportAnchor | null>(null);
+        const pendingVirtualResizeEndRef = useRef(false);
         const previousScrollContainerWidthRef = useRef<number | null>(null);
         const virtualListHandleRef = useRef<MeasuredVirtualListHandle | null>(
             null,
         );
+        const virtualResizeActiveRef = useRef(false);
         const [scrollMarginTop, setScrollMarginTop] = useState(0);
         const [scrollContainerWidth, setScrollContainerWidth] = useState(0);
         // While the pane splitter is being dragged we freeze the timeline: the
@@ -231,17 +237,37 @@ export const ChatTimelineHistoryRows = memo(
         // so the pinned width matches the pre-drag layout exactly.
         useLayoutEffect(() => {
             if (!shouldVirtualize) {
+                if (virtualResizeActiveRef.current) {
+                    virtualResizeActiveRef.current = false;
+                    pendingVirtualResizeEndRef.current = false;
+                    onVirtualResizeEnd?.();
+                }
                 return;
             }
 
             if (isResizingPanel) {
+                if (!virtualResizeActiveRef.current) {
+                    virtualResizeActiveRef.current = true;
+                    pendingVirtualResizeEndRef.current = false;
+                    onVirtualResizeStart?.();
+                }
+
                 const width =
                     historyRef.current?.getBoundingClientRect().width ?? 0;
                 setFrozenContentWidth(width > 0 ? width : null);
             } else {
+                if (virtualResizeActiveRef.current) {
+                    pendingVirtualResizeEndRef.current = true;
+                }
+
                 setFrozenContentWidth(null);
             }
-        }, [isResizingPanel, shouldVirtualize]);
+        }, [
+            isResizingPanel,
+            onVirtualResizeEnd,
+            onVirtualResizeStart,
+            shouldVirtualize,
+        ]);
 
         // Once the freeze lifts the DOM holds the real width again, so adopt it
         // and re-anchor exactly once — instead of on every drag frame.
@@ -251,7 +277,18 @@ export const ChatTimelineHistoryRows = memo(
             }
 
             syncLayoutMetrics();
-        }, [frozenContentWidth, shouldVirtualize, syncLayoutMetrics]);
+
+            if (pendingVirtualResizeEndRef.current) {
+                pendingVirtualResizeEndRef.current = false;
+                virtualResizeActiveRef.current = false;
+                onVirtualResizeEnd?.();
+            }
+        }, [
+            frozenContentWidth,
+            onVirtualResizeEnd,
+            shouldVirtualize,
+            syncLayoutMetrics,
+        ]);
 
         // The gap below a row depends only on its position in the list, so it is
         // resolved once here and shared by the row context and the rendered
@@ -393,6 +430,9 @@ export const ChatTimelineHistoryRows = memo(
                     onReady={handleVirtualListReady}
                     overscan={CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN}
                     preserveScrollAnchorOnMeasure
+                    shouldPreserveScrollAnchorOnMeasure={
+                        shouldPreserveVirtualResizeAnchor
+                    }
                     scrollContainerRef={scrollRef}
                     scrollMarginTop={scrollMarginTop}
                     renderItem={renderVirtualItem}

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -48,6 +48,7 @@ interface ChatTimelineHistoryRowsProps {
         readonly row: ChatTimelineRow;
     }) => ReactNode;
     readonly scrollRef: RefObject<HTMLElement | null>;
+    readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
 }
@@ -64,6 +65,7 @@ export const ChatTimelineHistoryRows = memo(
         onVirtualResizeStart,
         renderRow,
         scrollRef,
+        shouldPreserveVirtualMeasureAnchor,
         shouldPreserveVirtualResizeAnchor,
         toolCardExpansionMode,
     }: ChatTimelineHistoryRowsProps) {
@@ -431,7 +433,7 @@ export const ChatTimelineHistoryRows = memo(
                     overscan={CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN}
                     preserveScrollAnchorOnMeasure
                     shouldPreserveScrollAnchorOnMeasure={
-                        shouldPreserveVirtualResizeAnchor
+                        shouldPreserveVirtualMeasureAnchor
                     }
                     scrollContainerRef={scrollRef}
                     scrollMarginTop={scrollMarginTop}

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -123,11 +123,13 @@ export const ChatTimelineHistoryRows = memo(
                     isLatestStreamingTool:
                         row.id === latestStreamingEditedFileToolRowId,
                     toolCardExpansionMode,
+                    width: scrollContainerWidth,
                 }),
             [
                 chatFontSize,
                 historyRows.length,
                 latestStreamingEditedFileToolRowId,
+                scrollContainerWidth,
                 toolCardExpansionMode,
             ],
         );
@@ -220,6 +222,7 @@ export const ChatTimelineHistoryRows = memo(
                     onRangeChange={onVirtualRangeChange}
                     onReady={onVirtualListReady}
                     overscan={CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN}
+                    preserveScrollAnchorOnMeasure
                     scrollContainerRef={scrollRef}
                     scrollMarginTop={scrollMarginTop}
                     renderItem={renderVirtualItem}

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -14,6 +14,7 @@ import {
     MeasuredVirtualList,
     type MeasuredVirtualListHandle,
     type MeasuredVirtualRange,
+    type MeasuredVirtualViewportAnchor,
 } from "@renderer/components/virtual/MeasuredVirtualList";
 
 import type { ChatTimelineRow } from "./chatTimelineModel";
@@ -24,6 +25,7 @@ import {
     estimateChatTimelineRowHeight,
     getChatTimelineRowMeasurementKey,
     getChatTimelineRowKey,
+    getChatTimelineVirtualMeasurementWidth,
     getChatTimelineVirtualRowGapPx,
     shouldVirtualizeChatTimeline,
 } from "./chatTimelineVirtualization";
@@ -37,11 +39,13 @@ interface ChatTimelineHistoryRowsProps {
         handle: MeasuredVirtualListHandle | null,
     ) => void;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
+    readonly onVirtualResizeAutoFollow?: () => void;
     readonly renderRow: (params: {
         readonly isLatestStreamingTool: boolean;
         readonly row: ChatTimelineRow;
     }) => ReactNode;
     readonly scrollRef: RefObject<HTMLElement | null>;
+    readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
 }
 
@@ -53,20 +57,80 @@ export const ChatTimelineHistoryRows = memo(
         latestStreamingEditedFileToolRowId,
         onVirtualListReady,
         onVirtualRangeChange,
+        onVirtualResizeAutoFollow,
         renderRow,
         scrollRef,
+        shouldPreserveVirtualResizeAnchor,
         toolCardExpansionMode,
     }: ChatTimelineHistoryRowsProps) {
         const historyRef = useRef<HTMLDivElement | null>(null);
+        const pendingResizeAnchorFrameRef = useRef<number | null>(null);
+        const pendingResizeAnchorRef =
+            useRef<MeasuredVirtualViewportAnchor | null>(null);
+        const previousScrollContainerWidthRef = useRef<number | null>(null);
+        const virtualListHandleRef = useRef<MeasuredVirtualListHandle | null>(
+            null,
+        );
         const [scrollMarginTop, setScrollMarginTop] = useState(0);
         const [scrollContainerWidth, setScrollContainerWidth] = useState(0);
         const shouldVirtualize = shouldVirtualizeChatTimeline(
             historyRows.length,
         );
 
+        const restorePendingResizeAnchor = useCallback(() => {
+            const anchor = pendingResizeAnchorRef.current;
+            pendingResizeAnchorRef.current = null;
+
+            if (!anchor) {
+                return;
+            }
+
+            virtualListHandleRef.current?.scrollToViewportAnchor?.(anchor);
+        }, []);
+
+        const scheduleResizeAnchorRestore = useCallback(() => {
+            if (typeof window === "undefined") {
+                restorePendingResizeAnchor();
+                return;
+            }
+
+            if (pendingResizeAnchorFrameRef.current !== null) {
+                window.cancelAnimationFrame(
+                    pendingResizeAnchorFrameRef.current,
+                );
+            }
+
+            pendingResizeAnchorFrameRef.current = window.requestAnimationFrame(
+                () => {
+                    pendingResizeAnchorFrameRef.current = null;
+                    restorePendingResizeAnchor();
+                },
+            );
+        }, [restorePendingResizeAnchor]);
+
         const syncLayoutMetrics = useCallback(() => {
             const historyElement = historyRef.current;
             const scrollContainer = scrollRef.current;
+            const nextScrollContainerWidth = scrollContainer?.clientWidth ?? 0;
+            const previousScrollContainerWidth =
+                previousScrollContainerWidthRef.current;
+            previousScrollContainerWidthRef.current = nextScrollContainerWidth;
+
+            if (
+                shouldVirtualize &&
+                previousScrollContainerWidth !== null &&
+                previousScrollContainerWidth !== nextScrollContainerWidth
+            ) {
+                if (shouldPreserveVirtualResizeAnchor?.() ?? true) {
+                    pendingResizeAnchorRef.current =
+                        virtualListHandleRef.current?.captureViewportAnchor?.() ??
+                        null;
+                    scheduleResizeAnchorRestore();
+                } else {
+                    pendingResizeAnchorRef.current = null;
+                    onVirtualResizeAutoFollow?.();
+                }
+            }
 
             setScrollMarginTop(
                 calculateChatTimelineVirtualScrollMarginTop({
@@ -74,8 +138,26 @@ export const ChatTimelineHistoryRows = memo(
                     scrollContainer,
                 }),
             );
-            setScrollContainerWidth(scrollContainer?.clientWidth ?? 0);
-        }, [scrollRef]);
+            setScrollContainerWidth(
+                getChatTimelineVirtualMeasurementWidth(
+                    nextScrollContainerWidth,
+                ),
+            );
+        }, [
+            onVirtualResizeAutoFollow,
+            scheduleResizeAnchorRestore,
+            scrollRef,
+            shouldPreserveVirtualResizeAnchor,
+            shouldVirtualize,
+        ]);
+
+        const handleVirtualListReady = useCallback(
+            (handle: MeasuredVirtualListHandle | null) => {
+                virtualListHandleRef.current = handle;
+                onVirtualListReady?.(handle);
+            },
+            [onVirtualListReady],
+        );
 
         useLayoutEffect(() => {
             if (!shouldVirtualize) {
@@ -111,6 +193,21 @@ export const ChatTimelineHistoryRows = memo(
                 window.removeEventListener("resize", syncLayoutMetrics);
             };
         }, [scrollRef, shouldVirtualize, syncLayoutMetrics]);
+
+        useLayoutEffect(() => {
+            restorePendingResizeAnchor();
+        }, [restorePendingResizeAnchor, scrollContainerWidth]);
+
+        useEffect(() => {
+            return () => {
+                if (pendingResizeAnchorFrameRef.current !== null) {
+                    window.cancelAnimationFrame(
+                        pendingResizeAnchorFrameRef.current,
+                    );
+                    pendingResizeAnchorFrameRef.current = null;
+                }
+            };
+        }, []);
 
         const estimateSize = useCallback(
             (row: ChatTimelineRow, index: number) =>
@@ -220,7 +317,7 @@ export const ChatTimelineHistoryRows = memo(
                     getItemMeasurementKey={getItemMeasurementKey}
                     items={historyRows}
                     onRangeChange={onVirtualRangeChange}
-                    onReady={onVirtualListReady}
+                    onReady={handleVirtualListReady}
                     overscan={CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN}
                     preserveScrollAnchorOnMeasure
                     scrollContainerRef={scrollRef}

--- a/src/renderer/src/components/workspace/chat/ResizableDiffContainer.tsx
+++ b/src/renderer/src/components/workspace/chat/ResizableDiffContainer.tsx
@@ -63,7 +63,7 @@ export function ResizableDiffContainer({
             const delta = event.clientY - startYRef.current;
             setHeight(Math.max(minHeight, startHeightRef.current + delta));
         },
-        [minHeight],
+        [minHeight, setHeight],
     );
 
     const handlePointerUp = useCallback(() => {

--- a/src/renderer/src/components/workspace/chat/ResizableDiffContainer.tsx
+++ b/src/renderer/src/components/workspace/chat/ResizableDiffContainer.tsx
@@ -1,10 +1,12 @@
 import {
     useCallback,
+    useId,
     useRef,
-    useState,
     type PointerEvent as ReactPointerEvent,
     type ReactNode,
 } from "react";
+
+import { usePersistentToolState } from "./toolExpansionStore";
 
 const DEFAULT_DIFF_HEIGHT = 200;
 const MIN_DIFF_HEIGHT = 80;
@@ -14,6 +16,13 @@ export interface ResizableDiffContainerProps {
     readonly children: ReactNode;
     readonly defaultHeight?: number;
     readonly minHeight?: number;
+    /**
+     * Stable key under which the dragged height is persisted in the surrounding
+     * ToolExpansionStoreProvider, so it survives the diff card unmounting when
+     * its virtualized timeline row scrolls out of view. When omitted the height
+     * is per-instance and resets on unmount.
+     */
+    readonly persistKey?: string;
 }
 
 export function ResizableDiffContainer({
@@ -21,8 +30,15 @@ export function ResizableDiffContainer({
     children,
     defaultHeight = DEFAULT_DIFF_HEIGHT,
     minHeight = MIN_DIFF_HEIGHT,
+    persistKey,
 }: ResizableDiffContainerProps) {
-    const [height, setHeight] = useState(defaultHeight);
+    // Fall back to a per-instance id when no persist key is given, so the hook
+    // is always called with a stable, collision-free key.
+    const fallbackKey = useId();
+    const [height, setHeight] = usePersistentToolState<number>(
+        persistKey ?? fallbackKey,
+        defaultHeight,
+    );
     const draggingRef = useRef(false);
     const startHeightRef = useRef(defaultHeight);
     const startYRef = useRef(0);

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo } from "react";
 
 import type {
     AiToolCardExpansionMode,
@@ -19,6 +19,7 @@ import {
     type ResolvedProjectFileReference,
 } from "../projectFileReferences";
 import { ChangeReviewPanel } from "./ChangeReviewPanel";
+import { usePersistentToolExpansion } from "./toolExpansionStore";
 
 /* ─── Tool icon SVGs ─── */
 
@@ -486,33 +487,19 @@ function useSyncedToolExpansion({
     readonly forceExpanded: boolean;
     readonly resetKey: string;
 }) {
-    const [expansionState, setExpansionState] = useState({
-        expanded: defaultExpanded,
+    const [expanded, setExpanded] = usePersistentToolExpansion(
         resetKey,
-    });
-    const currentExpanded =
-        expansionState.resetKey === resetKey
-            ? expansionState.expanded
-            : defaultExpanded;
+        defaultExpanded,
+    );
 
     return {
-        expanded: forceExpanded ? true : currentExpanded,
+        expanded: forceExpanded ? true : expanded,
         toggleExpanded: () => {
             if (forceExpanded) {
                 return;
             }
 
-            setExpansionState((current) => {
-                const expanded =
-                    current.resetKey === resetKey
-                        ? current.expanded
-                        : defaultExpanded;
-
-                return {
-                    expanded: !expanded,
-                    resetKey,
-                };
-            });
+            setExpanded((previous) => !previous);
         },
     };
 }
@@ -917,7 +904,8 @@ function TerminalToolMessage({
         !!command && !isCommandDuplicatedByTitle(activity.title, command);
     const hasTerminalOutput = !!activity.terminalOutput;
     const hasDetail = shouldShowCommand || hasTerminalOutput;
-    const [expanded, setExpanded] = useState(
+    const [expanded, setExpanded] = usePersistentToolExpansion(
+        `${activity.id}:terminal`,
         (isFailed || hasNonZeroExit) && hasTerminalOutput,
     );
 
@@ -1069,7 +1057,10 @@ function GenericToolMessage({
     ) => ResolvedProjectFileReference | null;
 }) {
     const isFailed = activity.status === "failed";
-    const [expanded, setExpanded] = useState(isFailed);
+    const [expanded, setExpanded] = usePersistentToolExpansion(
+        `${activity.id}:generic`,
+        isFailed,
+    );
     const isInProgress = activity.status === "in_progress";
     const isCompleted = activity.status === "completed";
     const rawInputJson = activity.rawInputJson;

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
@@ -19,6 +19,11 @@ import {
     type ResolvedProjectFileReference,
 } from "../projectFileReferences";
 import { ChangeReviewPanel } from "./ChangeReviewPanel";
+import {
+    isFileToolActivity,
+    isTerminalToolActivity,
+    isTurnStartedActivity,
+} from "./toolActivityKinds";
 import { usePersistentToolExpansion } from "./toolExpansionStore";
 
 /* ─── Tool icon SVGs ─── */
@@ -138,19 +143,6 @@ function Chevron({ expanded }: { readonly expanded: boolean }) {
 
 /* ─── Helpers ─── */
 
-const FILE_TOOL_KINDS = new Set([
-    "create",
-    "delete",
-    "edit",
-    "move",
-    "read",
-    "remove",
-    "rename",
-    "search",
-    "update",
-    "write",
-]);
-
 const EDITED_FILE_TOOL_KINDS = new Set([
     "create",
     "delete",
@@ -185,17 +177,6 @@ function getToolIcon(kind: string) {
     return <DefaultIcon />;
 }
 
-function isFileToolActivity(
-    activity: AiToolActivity,
-    trackedFiles: readonly AiTrackedFile[],
-): boolean {
-    if (trackedFiles.length > 0) return true;
-    if (FILE_TOOL_KINDS.has(activity.kind.toLowerCase())) return true;
-    if (activity.locations.length > 0) return true;
-    if (activity.diffs.length > 0) return true;
-    return false;
-}
-
 export function isEditedFileToolActivity(
     activity: AiToolActivity,
     trackedFiles: readonly AiTrackedFile[],
@@ -203,13 +184,6 @@ export function isEditedFileToolActivity(
     if (trackedFiles.length > 0) return true;
     if (activity.diffs.length > 0) return true;
     return EDITED_FILE_TOOL_KINDS.has(activity.kind.toLowerCase());
-}
-
-function isTurnStartedActivity(activity: AiToolActivity): boolean {
-    return (
-        activity.id.startsWith("codex-acp:status:turn:") ||
-        activity.id.startsWith("comando:status:turn:")
-    );
 }
 
 function summarizeDiff(oldText: string | null, newText: string | null): string {
@@ -848,12 +822,6 @@ function FileToolMessage({
 }
 
 /* ─── Terminal tool message (card style for bash/shell/execute) ─── */
-
-const TERMINAL_TOOL_KINDS = new Set(["bash", "shell", "execute"]);
-
-function isTerminalToolActivity(activity: AiToolActivity): boolean {
-    return TERMINAL_TOOL_KINDS.has(activity.kind.toLowerCase());
-}
 
 function parseJsonValue(raw: string): unknown {
     return JSON.parse(raw) as unknown;

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -10,6 +10,7 @@ import {
     estimateChatTimelineRowHeight,
     getChatTimelineRowMeasurementKey,
     getChatTimelineRowKey,
+    getChatTimelineVirtualMeasurementWidth,
     getChatTimelineVirtualRowGapPx,
     shouldVirtualizeChatTimeline,
 } from "./chatTimelineVirtualization";
@@ -323,9 +324,19 @@ describe("chatTimelineVirtualization", () => {
                 gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
                 isLatestStreamingTool: false,
                 toolCardExpansionMode: "collapsed",
-                width: 641,
+                width: 672,
             }),
         ).not.toBe(base);
+        expect(
+            getChatTimelineRowMeasurementKey(row, {
+                chatFontFamily: "Inter",
+                chatFontSize: 13,
+                gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+                isLatestStreamingTool: false,
+                toolCardExpansionMode: "collapsed",
+                width: 641,
+            }),
+        ).toBe(base);
         expect(
             getChatTimelineRowMeasurementKey(
                 createMessageRow({ content: "hello, changed" }),
@@ -339,5 +350,13 @@ describe("chatTimelineVirtualization", () => {
                 },
             ),
         ).not.toBe(base);
+    });
+
+    it("buckets virtual measurement widths to reduce resize churn", () => {
+        expect(getChatTimelineVirtualMeasurementWidth(0)).toBe(0);
+        expect(getChatTimelineVirtualMeasurementWidth(Number.NaN)).toBe(0);
+        expect(getChatTimelineVirtualMeasurementWidth(640)).toBe(648);
+        expect(getChatTimelineVirtualMeasurementWidth(641)).toBe(648);
+        expect(getChatTimelineVirtualMeasurementWidth(672)).toBe(672);
     });
 });

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -233,6 +233,29 @@ describe("chatTimelineVirtualization", () => {
         expect(expandedToolHeight).toBeGreaterThan(collapsedToolHeight);
     });
 
+    it("uses the available width when estimating message wrapping", () => {
+        const longMessage = createMessageRow({
+            content: "A measured timeline should keep long text stable. ".repeat(
+                24,
+            ),
+        });
+
+        const narrowHeight = estimateChatTimelineRowHeight(longMessage, {
+            chatFontSize: 13,
+            gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+            toolCardExpansionMode: "collapsed",
+            width: 320,
+        });
+        const wideHeight = estimateChatTimelineRowHeight(longMessage, {
+            chatFontSize: 13,
+            gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+            toolCardExpansionMode: "collapsed",
+            width: 960,
+        });
+
+        expect(narrowHeight).toBeGreaterThan(wideHeight);
+    });
+
     it("calculates scroll margin from the history offset inside the scroller", () => {
         const scrollContainer = {
             getBoundingClientRect: () => ({ top: 20 }) as DOMRect,

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -11,10 +11,12 @@ import {
     CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
     calculateChatTimelineVirtualScrollMarginTop,
     estimateChatTimelineRowHeight,
+    getChatTimelineRowIdentityKey,
     getChatTimelineRowMeasurementKey,
     getChatTimelineRowKey,
     getChatTimelineVirtualMeasurementWidth,
     getChatTimelineVirtualRowGapPx,
+    isWidthSensitiveChatTimelineRow,
     shouldVirtualizeChatTimeline,
 } from "./chatTimelineVirtualization";
 
@@ -353,6 +355,88 @@ describe("chatTimelineVirtualization", () => {
                 },
             ),
         ).not.toBe(base);
+    });
+
+    it("keys tool rows independent of width but messages by width bucket", () => {
+        const baseContext = {
+            chatFontFamily: "Inter",
+            chatFontSize: 13,
+            gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+            isLatestStreamingTool: false,
+            toolCardExpansionMode: "collapsed" as const,
+        };
+        const toolRow = createToolRow();
+        const messageRow = createMessageRow({ content: "hello" });
+
+        expect(isWidthSensitiveChatTimelineRow(toolRow)).toBe(false);
+        expect(isWidthSensitiveChatTimelineRow(messageRow)).toBe(true);
+
+        // A tool card lays out at a width-invariant height, so crossing a width
+        // bucket must NOT churn its measurement key — that is what kept the whole
+        // cache from collapsing to estimates mid-resize.
+        expect(
+            getChatTimelineRowMeasurementKey(toolRow, {
+                ...baseContext,
+                width: 640,
+            }),
+        ).toBe(
+            getChatTimelineRowMeasurementKey(toolRow, {
+                ...baseContext,
+                width: 960,
+            }),
+        );
+
+        // A message reflows with width, so a bucket change still invalidates it.
+        expect(
+            getChatTimelineRowMeasurementKey(messageRow, {
+                ...baseContext,
+                width: 640,
+            }),
+        ).not.toBe(
+            getChatTimelineRowMeasurementKey(messageRow, {
+                ...baseContext,
+                width: 960,
+            }),
+        );
+    });
+
+    it("keeps the identity key stable across width changes for one revision", () => {
+        const baseContext = {
+            chatFontFamily: "Inter",
+            chatFontSize: 13,
+            gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+            isLatestStreamingTool: false,
+            toolCardExpansionMode: "collapsed" as const,
+        };
+        const messageRow = createMessageRow({ content: "hello" });
+
+        // The identity key carries a measured height over a resize, so it must
+        // ignore the width even for a width-sensitive row...
+        expect(
+            getChatTimelineRowIdentityKey(messageRow, {
+                ...baseContext,
+                width: 640,
+            }),
+        ).toBe(
+            getChatTimelineRowIdentityKey(messageRow, {
+                ...baseContext,
+                width: 960,
+            }),
+        );
+
+        // ...but still react to a real layout change like the expansion mode.
+        expect(
+            getChatTimelineRowIdentityKey(messageRow, {
+                ...baseContext,
+                toolCardExpansionMode: "expanded",
+                width: 640,
+            }),
+        ).not.toBe(
+            getChatTimelineRowIdentityKey(messageRow, {
+                ...baseContext,
+                width: 640,
+            }),
+        );
     });
 
     it("buckets virtual measurement widths to reduce resize churn", () => {

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { AiSessionSnapshot, AiToolActivity, AiTrackedFile } from "@shared/ipc";
 
-import type { ChatTimelineRow } from "./chatTimelineModel";
+import {
+    reconcileChatTimelineModel,
+    type ChatTimelineRow,
+} from "./chatTimelineModel";
 import {
     CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
     CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
@@ -360,7 +363,7 @@ describe("chatTimelineVirtualization", () => {
         expect(getChatTimelineVirtualMeasurementWidth(672)).toBe(672);
     });
 
-    it("caches the content signature by row identity", () => {
+    it("keys measurement by row identity, not by content", () => {
         const context = {
             chatFontFamily: "Inter",
             chatFontSize: 13,
@@ -376,19 +379,62 @@ describe("chatTimelineVirtualization", () => {
 
         const initialKey = getChatTimelineRowMeasurementKey(row, context);
 
-        // Mutating the same row reference in place must NOT change the key:
-        // the content signature is cached by identity. Production rows are
-        // immutable (the timeline model swaps references on change), so this
-        // pins the exact invariant the cache relies on — same reference means
-        // byte-identical content.
+        // The key is derived from the row's identity, so mutating the same
+        // reference in place must NOT change it. Production rows are immutable
+        // (the model swaps references on change), and the same reference is
+        // never re-rendered, so its height cannot change either.
         (row.message as { content: string }).content = "mutated in place";
         expect(getChatTimelineRowMeasurementKey(row, context)).toBe(initialKey);
 
-        // A fresh row object recomputes the signature, so changed content is
-        // still reflected once the model allocates a new reference.
+        // A fresh row object is a new identity, so its measurement is keyed
+        // separately — changed content is reflected once the model allocates a
+        // new reference.
         const replacedRow = createMessageRow({ content: "mutated in place" });
         expect(getChatTimelineRowMeasurementKey(replacedRow, context)).not.toBe(
             initialKey,
+        );
+    });
+
+    it("invalidates the measurement key exactly when the model reconciles a new row reference", () => {
+        const context = {
+            chatFontFamily: "Inter",
+            chatFontSize: 13,
+            gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+            isLatestStreamingTool: false,
+            toolCardExpansionMode: "collapsed" as const,
+            width: 640,
+        };
+        const reconcile = (summary: string, updatedAt: string) =>
+            (previous: Parameters<typeof reconcileChatTimelineModel>[0]) =>
+                reconcileChatTimelineModel(previous, {
+                    messages: [],
+                    status: "idle",
+                    toolActivity: [
+                        createActivity({ id: "tool-1", summary, updatedAt }),
+                    ],
+                    trackedFiles: [],
+                });
+
+        const model1 = reconcile("first", "2026-04-14T00:00:00.000Z")(null);
+        const row1 = model1.historyRows[0];
+        const key1 = row1 && getChatTimelineRowMeasurementKey(row1, context);
+
+        // A real content change (the model sees a new updatedAt) allocates a
+        // fresh row reference, so the measurement key must change.
+        const model2 = reconcile("second", "2026-04-14T00:00:05.000Z")(model1);
+        const row2 = model2.historyRows[0];
+        expect(row2).not.toBe(row1);
+        expect(row2 && getChatTimelineRowMeasurementKey(row2, context)).not.toBe(
+            key1,
+        );
+
+        // An identical snapshot reuses the same reference, so the key is reused
+        // and the measured height is kept.
+        const model3 = reconcile("second", "2026-04-14T00:00:05.000Z")(model2);
+        const row3 = model3.historyRows[0];
+        expect(row3).toBe(row2);
+        expect(row3 && getChatTimelineRowMeasurementKey(row3, context)).toBe(
+            row2 && getChatTimelineRowMeasurementKey(row2, context),
         );
     });
 });

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from "vitest";
+
+import type { AiSessionSnapshot, AiToolActivity, AiTrackedFile } from "@shared/ipc";
+
+import type { ChatTimelineRow } from "./chatTimelineModel";
+import {
+    CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
+    CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+    calculateChatTimelineVirtualScrollMarginTop,
+    estimateChatTimelineRowHeight,
+    getChatTimelineRowKey,
+    getChatTimelineVirtualMeasurementKey,
+    getChatTimelineVirtualRowGapPx,
+    shouldVirtualizeChatTimeline,
+} from "./chatTimelineVirtualization";
+
+function createMessage(
+    overrides: Partial<AiSessionSnapshot["messages"][number]> = {},
+): AiSessionSnapshot["messages"][number] {
+    return {
+        attachments: [],
+        content: "hello",
+        createdAt: "2026-04-14T00:00:00.000Z",
+        id: "message-1",
+        kind: "assistant",
+        status: "completed",
+        ...overrides,
+    };
+}
+
+function createActivity(
+    overrides: Partial<AiToolActivity> = {},
+): AiToolActivity {
+    return {
+        createdAt: "2026-04-14T00:00:00.000Z",
+        diffs: [],
+        exitCode: null,
+        id: "tool-1",
+        kind: "edit",
+        locations: [],
+        rawInputJson: null,
+        rawOutputJson: null,
+        sessionId: "session-1",
+        status: "completed",
+        summary: null,
+        terminalOutput: null,
+        title: "Edit file",
+        updatedAt: "2026-04-14T00:00:00.000Z",
+        ...overrides,
+    };
+}
+
+function createTrackedFile(
+    overrides: Partial<AiTrackedFile> = {},
+): AiTrackedFile {
+    return {
+        hunks: [],
+        identityKey: "tracked-1",
+        isText: true,
+        kind: "update",
+        newText: "next",
+        oldText: "prev",
+        path: "src/app.ts",
+        previousPath: null,
+        reviewState: "pending",
+        reversible: true,
+        sessionId: "session-1",
+        toolCallId: "tool-1",
+        updatedAt: "2026-04-14T00:00:00.000Z",
+        ...overrides,
+    };
+}
+
+function createMessageRow(
+    overrides: Partial<AiSessionSnapshot["messages"][number]> = {},
+): ChatTimelineRow {
+    const message = createMessage(overrides);
+    return {
+        id: `message:${message.id}`,
+        kind: "message",
+        message,
+    };
+}
+
+function createToolRow({
+    activity,
+    trackedFiles = [],
+}: {
+    readonly activity?: AiToolActivity;
+    readonly trackedFiles?: readonly AiTrackedFile[];
+} = {}): ChatTimelineRow {
+    const nextActivity = activity ?? createActivity();
+    return {
+        id: `tool:${nextActivity.id}`,
+        kind: "tool",
+        reviewEntry: {
+            activity: nextActivity,
+            hasPendingTrackedFiles: trackedFiles.some(
+                (trackedFile) => trackedFile.reviewState === "pending",
+            ),
+            pendingTrackedFiles: trackedFiles.filter(
+                (trackedFile) => trackedFile.reviewState === "pending",
+            ),
+            trackedFiles,
+        },
+    };
+}
+
+function createElementRect(top: number): HTMLElement {
+    return {
+        getBoundingClientRect: () => ({ top }) as DOMRect,
+    } as HTMLElement;
+}
+
+describe("chatTimelineVirtualization", () => {
+    it("uses a high threshold and respects the escape hatch", () => {
+        expect(
+            shouldVirtualizeChatTimeline(
+                CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD - 1,
+            ),
+        ).toBe(false);
+        expect(
+            shouldVirtualizeChatTimeline(CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD),
+        ).toBe(true);
+        expect(
+            shouldVirtualizeChatTimeline(
+                CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
+                { enabled: false },
+            ),
+        ).toBe(false);
+        expect(
+            shouldVirtualizeChatTimeline(20, {
+                enabled: true,
+                threshold: 20,
+            }),
+        ).toBe(true);
+    });
+
+    it("preserves row ids as virtual keys", () => {
+        const row = createMessageRow({ id: "message-42" });
+
+        expect(getChatTimelineRowKey(row, 0)).toBe("message:message-42");
+    });
+
+    it("calculates measured row gaps without duplicating the parent gap", () => {
+        expect(
+            getChatTimelineVirtualRowGapPx({
+                hasFollowingTimelineContent: false,
+                index: 0,
+                rowCount: 2,
+            }),
+        ).toBe(CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX);
+        expect(
+            getChatTimelineVirtualRowGapPx({
+                hasFollowingTimelineContent: false,
+                index: 1,
+                rowCount: 2,
+            }),
+        ).toBe(0);
+        expect(
+            getChatTimelineVirtualRowGapPx({
+                hasFollowingTimelineContent: true,
+                index: 1,
+                rowCount: 2,
+            }),
+        ).toBe(0);
+    });
+
+    it("returns positive estimates and accounts for content, gap, and expansion mode", () => {
+        const shortMessage = createMessageRow({ content: "short" });
+        const richMessage = createMessageRow({
+            attachments: [
+                {
+                    dataBase64: "",
+                    id: "image-1",
+                    mimeType: "image/png",
+                    name: "image.png",
+                    sizeBytes: 1200,
+                },
+            ],
+            content: [
+                "Here is code:",
+                "```ts",
+                "const answer = 42;",
+                "```",
+                "and a lot more prose ".repeat(40),
+            ].join("\n"),
+        });
+        const collapsedTool = createToolRow({
+            activity: createActivity({
+                diffs: [
+                    {
+                        hunks: [],
+                        isText: true,
+                        kind: "update",
+                        newText: "next",
+                        oldText: "prev",
+                        path: "src/app.ts",
+                        previousPath: null,
+                        reversible: true,
+                    },
+                ],
+                summary: "Updated src/app.ts",
+            }),
+            trackedFiles: [createTrackedFile()],
+        });
+
+        const messageHeight = estimateChatTimelineRowHeight(shortMessage, {
+            gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+            toolCardExpansionMode: "collapsed",
+        });
+        const richMessageHeight = estimateChatTimelineRowHeight(richMessage, {
+            gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+            toolCardExpansionMode: "collapsed",
+        });
+        const collapsedToolHeight = estimateChatTimelineRowHeight(
+            collapsedTool,
+            {
+                gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+                toolCardExpansionMode: "collapsed",
+            },
+        );
+        const expandedToolHeight = estimateChatTimelineRowHeight(
+            collapsedTool,
+            {
+                gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+                toolCardExpansionMode: "expanded",
+            },
+        );
+
+        expect(messageHeight).toBeGreaterThan(CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX);
+        expect(richMessageHeight).toBeGreaterThan(messageHeight);
+        expect(collapsedToolHeight).toBeGreaterThan(
+            CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+        );
+        expect(expandedToolHeight).toBeGreaterThan(collapsedToolHeight);
+    });
+
+    it("calculates scroll margin from the history offset inside the scroller", () => {
+        const scrollContainer = {
+            getBoundingClientRect: () => ({ top: 20 }) as DOMRect,
+            scrollTop: 75,
+        } as HTMLElement;
+
+        expect(
+            calculateChatTimelineVirtualScrollMarginTop({
+                historyElement: createElementRect(45),
+                scrollContainer,
+            }),
+        ).toBe(100);
+        expect(
+            calculateChatTimelineVirtualScrollMarginTop({
+                historyElement: createElementRect(5),
+                scrollContainer: {
+                    ...scrollContainer,
+                    scrollTop: 0,
+                } as HTMLElement,
+            }),
+        ).toBe(0);
+        expect(
+            calculateChatTimelineVirtualScrollMarginTop({
+                historyElement: null,
+                scrollContainer,
+            }),
+        ).toBe(0);
+    });
+
+    it("changes the measurement key when layout-affecting inputs change", () => {
+        const base = getChatTimelineVirtualMeasurementKey({
+            chatFontFamily: "Inter",
+            chatFontSize: 13,
+            hasFollowingTimelineContent: false,
+            latestStreamingEditedFileToolRowId: null,
+            toolCardExpansionMode: "collapsed",
+            width: 640,
+        });
+
+        expect(
+            getChatTimelineVirtualMeasurementKey({
+                chatFontFamily: "Inter",
+                chatFontSize: 14,
+                hasFollowingTimelineContent: false,
+                latestStreamingEditedFileToolRowId: null,
+                toolCardExpansionMode: "collapsed",
+                width: 640,
+            }),
+        ).not.toBe(base);
+        expect(
+            getChatTimelineVirtualMeasurementKey({
+                chatFontFamily: "Inter",
+                chatFontSize: 13,
+                hasFollowingTimelineContent: false,
+                latestStreamingEditedFileToolRowId: null,
+                toolCardExpansionMode: "expanded",
+                width: 640,
+            }),
+        ).not.toBe(base);
+        expect(
+            getChatTimelineVirtualMeasurementKey({
+                chatFontFamily: "Inter",
+                chatFontSize: 13,
+                hasFollowingTimelineContent: false,
+                latestStreamingEditedFileToolRowId: null,
+                toolCardExpansionMode: "collapsed",
+                width: 641,
+            }),
+        ).not.toBe(base);
+    });
+});

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -359,4 +359,36 @@ describe("chatTimelineVirtualization", () => {
         expect(getChatTimelineVirtualMeasurementWidth(641)).toBe(648);
         expect(getChatTimelineVirtualMeasurementWidth(672)).toBe(672);
     });
+
+    it("caches the content signature by row identity", () => {
+        const context = {
+            chatFontFamily: "Inter",
+            chatFontSize: 13,
+            gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+            isLatestStreamingTool: false,
+            toolCardExpansionMode: "collapsed" as const,
+            width: 640,
+        };
+        const row = createMessageRow({ content: "original" });
+        if (row.kind !== "message") {
+            throw new Error("expected a message row");
+        }
+
+        const initialKey = getChatTimelineRowMeasurementKey(row, context);
+
+        // Mutating the same row reference in place must NOT change the key:
+        // the content signature is cached by identity. Production rows are
+        // immutable (the timeline model swaps references on change), so this
+        // pins the exact invariant the cache relies on — same reference means
+        // byte-identical content.
+        (row.message as { content: string }).content = "mutated in place";
+        expect(getChatTimelineRowMeasurementKey(row, context)).toBe(initialKey);
+
+        // A fresh row object recomputes the signature, so changed content is
+        // still reflected once the model allocates a new reference.
+        const replacedRow = createMessageRow({ content: "mutated in place" });
+        expect(getChatTimelineRowMeasurementKey(replacedRow, context)).not.toBe(
+            initialKey,
+        );
+    });
 });

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -8,8 +8,8 @@ import {
     CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
     calculateChatTimelineVirtualScrollMarginTop,
     estimateChatTimelineRowHeight,
+    getChatTimelineRowMeasurementKey,
     getChatTimelineRowKey,
-    getChatTimelineVirtualMeasurementKey,
     getChatTimelineVirtualRowGapPx,
     shouldVirtualizeChatTimeline,
 } from "./chatTimelineVirtualization";
@@ -139,27 +139,24 @@ describe("chatTimelineVirtualization", () => {
     it("preserves row ids as virtual keys", () => {
         const row = createMessageRow({ id: "message-42" });
 
-        expect(getChatTimelineRowKey(row, 0)).toBe("message:message-42");
+        expect(getChatTimelineRowKey(row)).toBe("message:message-42");
     });
 
     it("calculates measured row gaps without duplicating the parent gap", () => {
         expect(
             getChatTimelineVirtualRowGapPx({
-                hasFollowingTimelineContent: false,
                 index: 0,
                 rowCount: 2,
             }),
         ).toBe(CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX);
         expect(
             getChatTimelineVirtualRowGapPx({
-                hasFollowingTimelineContent: false,
                 index: 1,
                 rowCount: 2,
             }),
         ).toBe(0);
         expect(
             getChatTimelineVirtualRowGapPx({
-                hasFollowingTimelineContent: true,
                 index: 1,
                 rowCount: 2,
             }),
@@ -254,7 +251,7 @@ describe("chatTimelineVirtualization", () => {
                 scrollContainer: {
                     ...scrollContainer,
                     scrollTop: 0,
-                } as HTMLElement,
+                },
             }),
         ).toBe(0);
         expect(
@@ -265,45 +262,59 @@ describe("chatTimelineVirtualization", () => {
         ).toBe(0);
     });
 
-    it("changes the measurement key when layout-affecting inputs change", () => {
-        const base = getChatTimelineVirtualMeasurementKey({
+    it("changes row measurement keys when layout or row content changes", () => {
+        const row = createMessageRow({ content: "hello" });
+        const base = getChatTimelineRowMeasurementKey(row, {
             chatFontFamily: "Inter",
             chatFontSize: 13,
-            hasFollowingTimelineContent: false,
-            latestStreamingEditedFileToolRowId: null,
+            gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+            isLatestStreamingTool: false,
             toolCardExpansionMode: "collapsed",
             width: 640,
         });
 
         expect(
-            getChatTimelineVirtualMeasurementKey({
+            getChatTimelineRowMeasurementKey(row, {
                 chatFontFamily: "Inter",
                 chatFontSize: 14,
-                hasFollowingTimelineContent: false,
-                latestStreamingEditedFileToolRowId: null,
+                gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+                isLatestStreamingTool: false,
                 toolCardExpansionMode: "collapsed",
                 width: 640,
             }),
         ).not.toBe(base);
         expect(
-            getChatTimelineVirtualMeasurementKey({
+            getChatTimelineRowMeasurementKey(row, {
                 chatFontFamily: "Inter",
                 chatFontSize: 13,
-                hasFollowingTimelineContent: false,
-                latestStreamingEditedFileToolRowId: null,
+                gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+                isLatestStreamingTool: false,
                 toolCardExpansionMode: "expanded",
                 width: 640,
             }),
         ).not.toBe(base);
         expect(
-            getChatTimelineVirtualMeasurementKey({
+            getChatTimelineRowMeasurementKey(row, {
                 chatFontFamily: "Inter",
                 chatFontSize: 13,
-                hasFollowingTimelineContent: false,
-                latestStreamingEditedFileToolRowId: null,
+                gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+                isLatestStreamingTool: false,
                 toolCardExpansionMode: "collapsed",
                 width: 641,
             }),
+        ).not.toBe(base);
+        expect(
+            getChatTimelineRowMeasurementKey(
+                createMessageRow({ content: "hello, changed" }),
+                {
+                    chatFontFamily: "Inter",
+                    chatFontSize: 13,
+                    gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+                    isLatestStreamingTool: false,
+                    toolCardExpansionMode: "collapsed",
+                    width: 640,
+                },
+            ),
         ).not.toBe(base);
     });
 });

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -64,30 +64,38 @@ export function getChatTimelineRowMeasurementKey(
         measurementWidth,
     ].join(":");
 
-    return `${row.id}:${layoutSignature}:${getCachedRowContentMeasurementSignature(
-        row,
-    )}`;
+    return `${row.id}:${layoutSignature}:${getRowMeasurementToken(row)}`;
 }
 
-// The content signature hashes the full text of every row, so recomputing it
-// on each measurement key rebuild dominates resize/font changes (where only
-// the layout signature actually changes). Cache it by row identity: the
-// timeline model reconciles rows immutably (createRowById reuses the same
-// reference when content is unchanged and allocates a fresh object when it
-// changes), so "same reference" means "byte-identical content" — the cached
-// signature is always valid for that reference. A WeakMap keeps it bounded:
-// rows dropped from the timeline are collected automatically.
-const rowContentSignatureCache = new WeakMap<ChatTimelineRow, string>();
+// The measurement key must change exactly when a row could render at a new
+// height. The timeline model reconciles rows immutably: createRowById reuses
+// the same ChatTimelineRow reference while the row is equivalent and allocates
+// a fresh one as soon as any compared field changes. An unchanged reference is
+// never re-rendered, so its height cannot change either — which makes row
+// IDENTITY a sufficient and exact trigger.
+//
+// Keying off identity (rather than a content hash) avoids a hidden coupling:
+// a hash would have to mirror exactly which fields the model's equivalence
+// checks compare, and could go stale if the model reused a reference whose
+// content the hash inspected but the equivalence ignored. It also skips
+// hashing every row's text on each rebuild.
+//
+// Each distinct reference gets a stable token; a fresh reference (the model
+// decided the row changed) gets a new one, invalidating the cached
+// measurement. The WeakMap keeps it bounded — dropped rows are collected.
+let nextRowMeasurementToken = 0;
+const rowMeasurementTokens = new WeakMap<ChatTimelineRow, number>();
 
-function getCachedRowContentMeasurementSignature(row: ChatTimelineRow): string {
-    const cached = rowContentSignatureCache.get(row);
-    if (cached !== undefined) {
-        return cached;
+function getRowMeasurementToken(row: ChatTimelineRow): number {
+    const existing = rowMeasurementTokens.get(row);
+    if (existing !== undefined) {
+        return existing;
     }
 
-    const signature = getRowContentMeasurementSignature(row);
-    rowContentSignatureCache.set(row, signature);
-    return signature;
+    const token = nextRowMeasurementToken;
+    nextRowMeasurementToken += 1;
+    rowMeasurementTokens.set(row, token);
+    return token;
 }
 
 export function getChatTimelineVirtualMeasurementWidth(width: number): number {
@@ -309,76 +317,4 @@ function isFileToolLike(
         normalizedKind === "update" ||
         normalizedKind === "write"
     );
-}
-
-function getRowContentMeasurementSignature(row: ChatTimelineRow): string {
-    if (row.kind === "message") {
-        const message = row.message;
-
-        return [
-            "message",
-            message.status,
-            message.kind,
-            hashString(message.content),
-            message.attachments
-                .map(
-                    (attachment) =>
-                        `${attachment.id}:${attachment.mimeType}:${attachment.sizeBytes ?? "unknown"}`,
-                )
-                .join(","),
-            message.generatedImage
-                ? [
-                      message.generatedImage.status,
-                      message.generatedImage.path ?? "",
-                      hashString(message.generatedImage.result ?? ""),
-                      hashString(message.generatedImage.revisedPrompt ?? ""),
-                      hashString(message.generatedImage.title ?? ""),
-                  ].join("/")
-                : "none",
-        ].join(":");
-    }
-
-    const activity = row.reviewEntry.activity;
-    return [
-        "tool",
-        activity.status,
-        activity.updatedAt,
-        activity.kind,
-        activity.exitCode ?? "none",
-        hashString(activity.title),
-        hashString(activity.summary ?? ""),
-        hashString(activity.terminalOutput ?? ""),
-        hashString(activity.rawInputJson ?? ""),
-        hashString(activity.rawOutputJson ?? ""),
-        activity.locations
-            .map(
-                (location) =>
-                    `${location.path}:${location.line ?? ""}:${location.endLine ?? ""}`,
-            )
-            .join(","),
-        activity.diffs
-            .map(
-                (diff) =>
-                    `${diff.kind}:${diff.path}:${diff.previousPath ?? ""}:${hashString(
-                        diff.oldText ?? "",
-                    )}:${hashString(diff.newText ?? "")}:${diff.hunks.length}`,
-            )
-            .join(","),
-        row.reviewEntry.trackedFiles
-            .map(
-                (trackedFile) =>
-                    `${trackedFile.identityKey}:${trackedFile.updatedAt}:${trackedFile.reviewState}`,
-            )
-            .join(","),
-    ].join(":");
-}
-
-function hashString(value: string): string {
-    let hash = 0;
-
-    for (let index = 0; index < value.length; index += 1) {
-        hash = (hash * 31 + value.charCodeAt(index)) | 0;
-    }
-
-    return `${value.length}:${Math.abs(hash)}`;
 }

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -20,6 +20,12 @@ export interface ChatTimelineRowEstimateContext {
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
 }
 
+export interface ChatTimelineRowMeasurementContext
+    extends ChatTimelineRowEstimateContext {
+    readonly chatFontFamily?: string;
+    readonly width: number;
+}
+
 export interface ChatTimelineVirtualScrollMarginOptions {
     readonly historyElement: HTMLElement | null;
     readonly scrollContainer: HTMLElement | null;
@@ -36,11 +42,26 @@ export function shouldVirtualizeChatTimeline(
     return enabled && rowCount >= threshold;
 }
 
-export function getChatTimelineRowKey(
-    row: ChatTimelineRow,
-    _index: number,
-): string {
+export function getChatTimelineRowKey(row: ChatTimelineRow): string {
     return row.id;
+}
+
+export function getChatTimelineRowMeasurementKey(
+    row: ChatTimelineRow,
+    context: ChatTimelineRowMeasurementContext,
+): string {
+    const layoutSignature = [
+        context.chatFontFamily ?? "default",
+        context.chatFontSize ?? "default",
+        context.gapPx ?? 0,
+        context.isLatestStreamingTool ? "latest" : "history",
+        context.toolCardExpansionMode,
+        Math.max(0, Math.round(context.width)),
+    ].join(":");
+
+    return `${row.id}:${layoutSignature}:${getRowContentMeasurementSignature(
+        row,
+    )}`;
 }
 
 export function calculateChatTimelineVirtualScrollMarginTop({
@@ -59,36 +80,10 @@ export function calculateChatTimelineVirtualScrollMarginTop({
     return Math.max(0, marginTop);
 }
 
-export function getChatTimelineVirtualMeasurementKey({
-    chatFontFamily,
-    chatFontSize,
-    hasFollowingTimelineContent,
-    latestStreamingEditedFileToolRowId,
-    toolCardExpansionMode,
-    width,
-}: {
-    readonly chatFontFamily?: string;
-    readonly chatFontSize?: number;
-    readonly hasFollowingTimelineContent: boolean;
-    readonly latestStreamingEditedFileToolRowId: string | null;
-    readonly toolCardExpansionMode: AiToolCardExpansionMode;
-    readonly width: number;
-}): string {
-    return [
-        chatFontFamily ?? "default",
-        chatFontSize ?? "default",
-        hasFollowingTimelineContent ? "tail" : "end",
-        latestStreamingEditedFileToolRowId ?? "none",
-        toolCardExpansionMode,
-        Math.max(0, Math.round(width)),
-    ].join(":");
-}
-
 export function getChatTimelineVirtualRowGapPx({
     index,
     rowCount,
 }: {
-    readonly hasFollowingTimelineContent: boolean;
     readonly index: number;
     readonly rowCount: number;
 }): number {
@@ -255,4 +250,76 @@ function isFileToolLike(
         normalizedKind === "update" ||
         normalizedKind === "write"
     );
+}
+
+function getRowContentMeasurementSignature(row: ChatTimelineRow): string {
+    if (row.kind === "message") {
+        const message = row.message;
+
+        return [
+            "message",
+            message.status,
+            message.kind,
+            hashString(message.content),
+            message.attachments
+                .map(
+                    (attachment) =>
+                        `${attachment.id}:${attachment.mimeType}:${attachment.sizeBytes ?? "unknown"}`,
+                )
+                .join(","),
+            message.generatedImage
+                ? [
+                      message.generatedImage.status,
+                      message.generatedImage.path ?? "",
+                      hashString(message.generatedImage.result ?? ""),
+                      hashString(message.generatedImage.revisedPrompt ?? ""),
+                      hashString(message.generatedImage.title ?? ""),
+                  ].join("/")
+                : "none",
+        ].join(":");
+    }
+
+    const activity = row.reviewEntry.activity;
+    return [
+        "tool",
+        activity.status,
+        activity.updatedAt,
+        activity.kind,
+        activity.exitCode ?? "none",
+        hashString(activity.title),
+        hashString(activity.summary ?? ""),
+        hashString(activity.terminalOutput ?? ""),
+        hashString(activity.rawInputJson ?? ""),
+        hashString(activity.rawOutputJson ?? ""),
+        activity.locations
+            .map(
+                (location) =>
+                    `${location.path}:${location.line ?? ""}:${location.endLine ?? ""}`,
+            )
+            .join(","),
+        activity.diffs
+            .map(
+                (diff) =>
+                    `${diff.kind}:${diff.path}:${diff.previousPath ?? ""}:${hashString(
+                        diff.oldText ?? "",
+                    )}:${hashString(diff.newText ?? "")}:${diff.hunks.length}`,
+            )
+            .join(","),
+        row.reviewEntry.trackedFiles
+            .map(
+                (trackedFile) =>
+                    `${trackedFile.identityKey}:${trackedFile.updatedAt}:${trackedFile.reviewState}`,
+            )
+            .join(","),
+    ].join(":");
+}
+
+function hashString(value: string): string {
+    let hash = 0;
+
+    for (let index = 0; index < value.length; index += 1) {
+        hash = (hash * 31 + value.charCodeAt(index)) | 0;
+    }
+
+    return `${value.length}:${Math.abs(hash)}`;
 }

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -139,6 +139,19 @@ export function getChatTimelineVirtualRowGapPx({
     return 0;
 }
 
+// Estimates a row's pixel height BEFORE it is rendered, so the virtual list can
+// size its scrollbar and place off-screen rows. These are deliberately rough
+// guesses: once a row scrolls into view its real height is measured and the
+// layout self-corrects, so a wrong estimate only causes a brief scroll wobble,
+// never incorrect output.
+//
+// The magic numbers below (base heights, per-detail increments, expansion
+// caps) are hand-tuned to approximate the real layout of `ChatMessageRow` and
+// `ToolActivityItem`/`ChangeReviewPanel`. They are NOT derived from those
+// components, so they can silently drift: if you change a tool card's or
+// message row's heights/padding/expanded layout, revisit the matching branch
+// here. The symptom of staleness is subtle — scroll jitter while flinging
+// through a long history — so it is worth updating in the same change.
 export function estimateChatTimelineRowHeight(
     row: ChatTimelineRow,
     context: ChatTimelineRowEstimateContext,

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -18,6 +18,7 @@ export interface ChatTimelineRowEstimateContext {
     readonly gapPx?: number;
     readonly isLatestStreamingTool?: boolean;
     readonly toolCardExpansionMode: AiToolCardExpansionMode;
+    readonly width?: number;
 }
 
 export interface ChatTimelineRowMeasurementContext
@@ -102,8 +103,7 @@ export function estimateChatTimelineRowHeight(
 
     if (row.kind === "message") {
         return Math.ceil(
-            estimateMessageRowHeight(row.message, context.chatFontSize) +
-                gapPx,
+            estimateMessageRowHeight(row.message, context) + gapPx,
         );
     }
 
@@ -112,11 +112,15 @@ export function estimateChatTimelineRowHeight(
 
 function estimateMessageRowHeight(
     message: Extract<ChatTimelineRow, { readonly kind: "message" }>["message"],
-    chatFontSize: number | undefined,
+    context: ChatTimelineRowEstimateContext,
 ): number {
+    const chatFontSize = context.chatFontSize;
     const fontScale = getFontScale(chatFontSize);
     const content = message.content ?? "";
-    const estimatedLines = estimateTextLines(content, 96);
+    const estimatedLines = estimateTextLines(
+        content,
+        estimateCharactersPerLine(context.width, chatFontSize),
+    );
     const contentHeight = Math.min(340, estimatedLines * 18 * fontScale);
     const codeBlockCount = countCodeBlocks(content);
     const attachmentHeight = message.attachments.length * 48;
@@ -134,6 +138,25 @@ function estimateMessageRowHeight(
         Math.min(260, codeBlockCount * 92) +
         attachmentHeight +
         imageHeight
+    );
+}
+
+function estimateCharactersPerLine(
+    width: number | undefined,
+    chatFontSize: number | undefined,
+): number {
+    if (!width || !Number.isFinite(width) || width <= 0) {
+        return 96;
+    }
+
+    const safeFontSize =
+        chatFontSize && Number.isFinite(chatFontSize) ? chatFontSize : 13;
+    const contentWidth = Math.max(160, width - 72);
+    const averageCharacterWidth = Math.max(6, safeFontSize * 0.56);
+
+    return Math.max(
+        24,
+        Math.min(140, Math.floor(contentWidth / averageCharacterWidth)),
     );
 }
 

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -7,6 +7,7 @@ export const CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD = 200;
 export const CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN = 10;
 export const CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT = 720;
 export const CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX = 8;
+export const CHAT_TIMELINE_VIRTUAL_WIDTH_BUCKET_PX = 24;
 
 interface ShouldVirtualizeChatTimelineOptions {
     readonly enabled?: boolean;
@@ -51,18 +52,32 @@ export function getChatTimelineRowMeasurementKey(
     row: ChatTimelineRow,
     context: ChatTimelineRowMeasurementContext,
 ): string {
+    const measurementWidth = getChatTimelineVirtualMeasurementWidth(
+        context.width,
+    );
     const layoutSignature = [
         context.chatFontFamily ?? "default",
         context.chatFontSize ?? "default",
         context.gapPx ?? 0,
         context.isLatestStreamingTool ? "latest" : "history",
         context.toolCardExpansionMode,
-        Math.max(0, Math.round(context.width)),
+        measurementWidth,
     ].join(":");
 
     return `${row.id}:${layoutSignature}:${getRowContentMeasurementSignature(
         row,
     )}`;
+}
+
+export function getChatTimelineVirtualMeasurementWidth(width: number): number {
+    if (!Number.isFinite(width) || width <= 0) {
+        return 0;
+    }
+
+    return (
+        Math.round(width / CHAT_TIMELINE_VIRTUAL_WIDTH_BUCKET_PX) *
+        CHAT_TIMELINE_VIRTUAL_WIDTH_BUCKET_PX
+    );
 }
 
 export function calculateChatTimelineVirtualScrollMarginTop({

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -1,0 +1,258 @@
+import type { AiToolCardExpansionMode } from "@shared/ipc";
+
+import type { ChatTimelineRow } from "./chatTimelineModel";
+
+export const CHAT_TIMELINE_VIRTUALIZATION_ENABLED = true;
+export const CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD = 200;
+export const CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN = 10;
+export const CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT = 720;
+export const CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX = 8;
+
+interface ShouldVirtualizeChatTimelineOptions {
+    readonly enabled?: boolean;
+    readonly threshold?: number;
+}
+
+export interface ChatTimelineRowEstimateContext {
+    readonly chatFontSize?: number;
+    readonly gapPx?: number;
+    readonly isLatestStreamingTool?: boolean;
+    readonly toolCardExpansionMode: AiToolCardExpansionMode;
+}
+
+export interface ChatTimelineVirtualScrollMarginOptions {
+    readonly historyElement: HTMLElement | null;
+    readonly scrollContainer: HTMLElement | null;
+}
+
+export function shouldVirtualizeChatTimeline(
+    rowCount: number,
+    options: ShouldVirtualizeChatTimelineOptions = {},
+): boolean {
+    const enabled = options.enabled ?? CHAT_TIMELINE_VIRTUALIZATION_ENABLED;
+    const threshold =
+        options.threshold ?? CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD;
+
+    return enabled && rowCount >= threshold;
+}
+
+export function getChatTimelineRowKey(
+    row: ChatTimelineRow,
+    _index: number,
+): string {
+    return row.id;
+}
+
+export function calculateChatTimelineVirtualScrollMarginTop({
+    historyElement,
+    scrollContainer,
+}: ChatTimelineVirtualScrollMarginOptions): number {
+    if (!historyElement || !scrollContainer) {
+        return 0;
+    }
+
+    const historyRect = historyElement.getBoundingClientRect();
+    const scrollRect = scrollContainer.getBoundingClientRect();
+    const marginTop =
+        historyRect.top - scrollRect.top + scrollContainer.scrollTop;
+
+    return Math.max(0, marginTop);
+}
+
+export function getChatTimelineVirtualMeasurementKey({
+    chatFontFamily,
+    chatFontSize,
+    hasFollowingTimelineContent,
+    latestStreamingEditedFileToolRowId,
+    toolCardExpansionMode,
+    width,
+}: {
+    readonly chatFontFamily?: string;
+    readonly chatFontSize?: number;
+    readonly hasFollowingTimelineContent: boolean;
+    readonly latestStreamingEditedFileToolRowId: string | null;
+    readonly toolCardExpansionMode: AiToolCardExpansionMode;
+    readonly width: number;
+}): string {
+    return [
+        chatFontFamily ?? "default",
+        chatFontSize ?? "default",
+        hasFollowingTimelineContent ? "tail" : "end",
+        latestStreamingEditedFileToolRowId ?? "none",
+        toolCardExpansionMode,
+        Math.max(0, Math.round(width)),
+    ].join(":");
+}
+
+export function getChatTimelineVirtualRowGapPx({
+    index,
+    rowCount,
+}: {
+    readonly hasFollowingTimelineContent: boolean;
+    readonly index: number;
+    readonly rowCount: number;
+}): number {
+    if (index < rowCount - 1) {
+        return CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX;
+    }
+
+    return 0;
+}
+
+export function estimateChatTimelineRowHeight(
+    row: ChatTimelineRow,
+    context: ChatTimelineRowEstimateContext,
+): number {
+    const gapPx = Math.max(0, context.gapPx ?? 0);
+
+    if (row.kind === "message") {
+        return Math.ceil(
+            estimateMessageRowHeight(row.message, context.chatFontSize) +
+                gapPx,
+        );
+    }
+
+    return Math.ceil(estimateToolRowHeight(row, context) + gapPx);
+}
+
+function estimateMessageRowHeight(
+    message: Extract<ChatTimelineRow, { readonly kind: "message" }>["message"],
+    chatFontSize: number | undefined,
+): number {
+    const fontScale = getFontScale(chatFontSize);
+    const content = message.content ?? "";
+    const estimatedLines = estimateTextLines(content, 96);
+    const contentHeight = Math.min(340, estimatedLines * 18 * fontScale);
+    const codeBlockCount = countCodeBlocks(content);
+    const attachmentHeight = message.attachments.length * 48;
+    const imageHeight = message.generatedImage ? 190 : 0;
+    const baseHeight =
+        message.kind === "user"
+            ? 54
+            : message.kind === "thinking"
+              ? 64
+              : 72;
+
+    return (
+        baseHeight +
+        contentHeight +
+        Math.min(260, codeBlockCount * 92) +
+        attachmentHeight +
+        imageHeight
+    );
+}
+
+function estimateToolRowHeight(
+    row: Extract<ChatTimelineRow, { readonly kind: "tool" }>,
+    context: ChatTimelineRowEstimateContext,
+): number {
+    const activity = row.reviewEntry.activity;
+    const trackedFiles = row.reviewEntry.trackedFiles;
+    const hasInlineReview = trackedFiles.length > 0 || activity.diffs.length > 0;
+    const hasLocations = activity.locations.length > 0;
+    const hasTerminalOutput = !!activity.terminalOutput;
+    const hasSummary = !!activity.summary;
+    const hasRawJson = !!activity.rawInputJson || !!activity.rawOutputJson;
+    const isExpandedByMode =
+        context.toolCardExpansionMode === "expanded" ||
+        (context.toolCardExpansionMode === "latest" &&
+            context.isLatestStreamingTool === true);
+
+    if (isTurnStartedActivityId(activity.id)) {
+        return 48;
+    }
+
+    if (isTerminalToolKind(activity.kind)) {
+        const startsExpanded =
+            hasTerminalOutput &&
+            (activity.status === "failed" ||
+                (activity.exitCode !== null && activity.exitCode !== 0));
+        return startsExpanded ? 210 : 58;
+    }
+
+    if (hasInlineReview) {
+        const detailHeight = Math.min(
+            360,
+            activity.diffs.length * 82 + trackedFiles.length * 58,
+        );
+        return isExpandedByMode ? 132 + detailHeight : 96;
+    }
+
+    if (isFileToolLike(row)) {
+        const hasDetail = hasSummary || hasLocations || activity.diffs.length > 0;
+        const detailHeight =
+            (hasSummary ? 76 : 0) +
+            (hasLocations ? Math.min(96, activity.locations.length * 28) : 0) +
+            Math.min(240, activity.diffs.length * 72);
+
+        return hasDetail && isExpandedByMode ? 64 + detailHeight : 58;
+    }
+
+    if (activity.status === "failed") {
+        return 72 + (hasSummary ? 72 : 0) + (hasRawJson ? 130 : 0);
+    }
+
+    return hasSummary || hasRawJson ? 90 : 42;
+}
+
+function getFontScale(chatFontSize: number | undefined): number {
+    if (!chatFontSize || !Number.isFinite(chatFontSize)) {
+        return 1;
+    }
+
+    return Math.min(1.8, Math.max(0.85, chatFontSize / 13));
+}
+
+function estimateTextLines(content: string, charactersPerLine: number): number {
+    if (!content.trim()) {
+        return 1;
+    }
+
+    const explicitLines = content.split("\n");
+    return explicitLines.reduce((total, line) => {
+        return total + Math.max(1, Math.ceil(line.length / charactersPerLine));
+    }, 0);
+}
+
+function countCodeBlocks(content: string): number {
+    return Math.floor((content.match(/```/g)?.length ?? 0) / 2);
+}
+
+function isTurnStartedActivityId(activityId: string): boolean {
+    return (
+        activityId.startsWith("codex-acp:status:turn:") ||
+        activityId.startsWith("comando:status:turn:")
+    );
+}
+
+function isTerminalToolKind(kind: string): boolean {
+    const normalizedKind = kind.toLowerCase();
+    return (
+        normalizedKind === "bash" ||
+        normalizedKind === "shell" ||
+        normalizedKind === "execute"
+    );
+}
+
+function isFileToolLike(
+    row: Extract<ChatTimelineRow, { readonly kind: "tool" }>,
+) {
+    const activity = row.reviewEntry.activity;
+    const normalizedKind = activity.kind.toLowerCase();
+
+    return (
+        row.reviewEntry.trackedFiles.length > 0 ||
+        activity.locations.length > 0 ||
+        activity.diffs.length > 0 ||
+        normalizedKind === "create" ||
+        normalizedKind === "delete" ||
+        normalizedKind === "edit" ||
+        normalizedKind === "move" ||
+        normalizedKind === "read" ||
+        normalizedKind === "remove" ||
+        normalizedKind === "rename" ||
+        normalizedKind === "search" ||
+        normalizedKind === "update" ||
+        normalizedKind === "write"
+    );
+}

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -1,6 +1,11 @@
 import type { AiToolCardExpansionMode } from "@shared/ipc";
 
 import type { ChatTimelineRow } from "./chatTimelineModel";
+import {
+    isFileToolActivity,
+    isTerminalToolActivity,
+    isTurnStartedActivity,
+} from "./toolActivityKinds";
 
 export const CHAT_TIMELINE_VIRTUALIZATION_ENABLED = true;
 export const CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD = 200;
@@ -265,11 +270,11 @@ function estimateToolRowHeight(
         (context.toolCardExpansionMode === "latest" &&
             context.isLatestStreamingTool === true);
 
-    if (isTurnStartedActivityId(activity.id)) {
+    if (isTurnStartedActivity(activity)) {
         return 48;
     }
 
-    if (isTerminalToolKind(activity.kind)) {
+    if (isTerminalToolActivity(activity)) {
         const startsExpanded =
             hasTerminalOutput &&
             (activity.status === "failed" ||
@@ -285,7 +290,7 @@ function estimateToolRowHeight(
         return isExpandedByMode ? 132 + detailHeight : 96;
     }
 
-    if (isFileToolLike(row)) {
+    if (isFileToolActivity(activity, trackedFiles)) {
         const hasDetail = hasSummary || hasLocations || activity.diffs.length > 0;
         const detailHeight =
             (hasSummary ? 76 : 0) +
@@ -323,43 +328,4 @@ function estimateTextLines(content: string, charactersPerLine: number): number {
 
 function countCodeBlocks(content: string): number {
     return Math.floor((content.match(/```/g)?.length ?? 0) / 2);
-}
-
-function isTurnStartedActivityId(activityId: string): boolean {
-    return (
-        activityId.startsWith("codex-acp:status:turn:") ||
-        activityId.startsWith("comando:status:turn:")
-    );
-}
-
-function isTerminalToolKind(kind: string): boolean {
-    const normalizedKind = kind.toLowerCase();
-    return (
-        normalizedKind === "bash" ||
-        normalizedKind === "shell" ||
-        normalizedKind === "execute"
-    );
-}
-
-function isFileToolLike(
-    row: Extract<ChatTimelineRow, { readonly kind: "tool" }>,
-) {
-    const activity = row.reviewEntry.activity;
-    const normalizedKind = activity.kind.toLowerCase();
-
-    return (
-        row.reviewEntry.trackedFiles.length > 0 ||
-        activity.locations.length > 0 ||
-        activity.diffs.length > 0 ||
-        normalizedKind === "create" ||
-        normalizedKind === "delete" ||
-        normalizedKind === "edit" ||
-        normalizedKind === "move" ||
-        normalizedKind === "read" ||
-        normalizedKind === "remove" ||
-        normalizedKind === "rename" ||
-        normalizedKind === "search" ||
-        normalizedKind === "update" ||
-        normalizedKind === "write"
-    );
 }

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -48,23 +48,55 @@ export function getChatTimelineRowKey(row: ChatTimelineRow): string {
     return row.id;
 }
 
-export function getChatTimelineRowMeasurementKey(
-    row: ChatTimelineRow,
+// Height-affecting layout dimensions that are independent of the row's width.
+// Shared by the measurement key and the width-invariant identity key below.
+function getChatTimelineRowLayoutBase(
     context: ChatTimelineRowMeasurementContext,
 ): string {
-    const measurementWidth = getChatTimelineVirtualMeasurementWidth(
-        context.width,
-    );
-    const layoutSignature = [
+    return [
         context.chatFontFamily ?? "default",
         context.chatFontSize ?? "default",
         context.gapPx ?? 0,
         context.isLatestStreamingTool ? "latest" : "history",
         context.toolCardExpansionMode,
-        measurementWidth,
     ].join(":");
+}
 
-    return `${row.id}:${layoutSignature}:${getRowMeasurementToken(row)}`;
+// Only message rows reflow their height with the available width; tool cards
+// lay out at width-invariant heights (fixed-height summaries, internally
+// scrolled diffs). So only messages fold the width bucket into their
+// measurement key — tool rows keep a stable key across a resize and never have
+// their measurement invalidated, which is what let the scroll settle during a
+// drag instead of collapsing the whole cache to rough estimates.
+export function isWidthSensitiveChatTimelineRow(row: ChatTimelineRow): boolean {
+    return row.kind === "message";
+}
+
+export function getChatTimelineRowMeasurementKey(
+    row: ChatTimelineRow,
+    context: ChatTimelineRowMeasurementContext,
+): string {
+    const widthSegment = isWidthSensitiveChatTimelineRow(row)
+        ? getChatTimelineVirtualMeasurementWidth(context.width)
+        : "static";
+
+    return `${row.id}:${getChatTimelineRowLayoutBase(
+        context,
+    )}:${widthSegment}:${getRowMeasurementToken(row)}`;
+}
+
+// Stable across width changes for the same row revision. The virtual list uses
+// it to carry a row's last measured height over a resize: when a width-sensitive
+// row's measurement key churns (the width bucket changed), the layout falls back
+// to this row's last real measurement instead of the heuristic estimate, so the
+// total size never snaps to a rough value mid-resize.
+export function getChatTimelineRowIdentityKey(
+    row: ChatTimelineRow,
+    context: ChatTimelineRowMeasurementContext,
+): string {
+    return `${row.id}:${getChatTimelineRowLayoutBase(
+        context,
+    )}:${getRowMeasurementToken(row)}`;
 }
 
 // The measurement key must change exactly when a row could render at a new

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -64,9 +64,30 @@ export function getChatTimelineRowMeasurementKey(
         measurementWidth,
     ].join(":");
 
-    return `${row.id}:${layoutSignature}:${getRowContentMeasurementSignature(
+    return `${row.id}:${layoutSignature}:${getCachedRowContentMeasurementSignature(
         row,
     )}`;
+}
+
+// The content signature hashes the full text of every row, so recomputing it
+// on each measurement key rebuild dominates resize/font changes (where only
+// the layout signature actually changes). Cache it by row identity: the
+// timeline model reconciles rows immutably (createRowById reuses the same
+// reference when content is unchanged and allocates a fresh object when it
+// changes), so "same reference" means "byte-identical content" — the cached
+// signature is always valid for that reference. A WeakMap keeps it bounded:
+// rows dropped from the timeline are collected automatically.
+const rowContentSignatureCache = new WeakMap<ChatTimelineRow, string>();
+
+function getCachedRowContentMeasurementSignature(row: ChatTimelineRow): string {
+    const cached = rowContentSignatureCache.get(row);
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const signature = getRowContentMeasurementSignature(row);
+    rowContentSignatureCache.set(row, signature);
+    return signature;
 }
 
 export function getChatTimelineVirtualMeasurementWidth(width: number): number {

--- a/src/renderer/src/components/workspace/chat/toolActivityKinds.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityKinds.ts
@@ -1,0 +1,63 @@
+import type { AiToolActivity, AiTrackedFile } from "@shared/ipc";
+
+/**
+ * Single source of truth for classifying an AiToolActivity into the card shape
+ * it renders as: terminal, file, or turn-started divider.
+ *
+ * Both the renderer (ToolActivityItem, which picks the component to paint) and
+ * the virtual-list height estimator (chatTimelineVirtualization, which predicts
+ * a row's height from the branch it expects the renderer to take) MUST agree on
+ * this classification. When they disagree, the estimator sizes a row against the
+ * wrong branch and the scroll jumps as the real card scrolls into view. Keeping
+ * the taxonomy here — rather than copied into each consumer — makes that drift
+ * impossible by construction.
+ *
+ * Note this only unifies the CLASSIFICATION. The estimator's per-branch pixel
+ * heights stay in chatTimelineVirtualization, where they belong.
+ */
+
+// Tool kinds that render as a terminal card (command + captured output).
+export const TERMINAL_TOOL_KINDS = new Set(["bash", "shell", "execute"]);
+
+// Tool kinds that touch files and render as a file card.
+export const FILE_TOOL_KINDS = new Set([
+    "create",
+    "delete",
+    "edit",
+    "move",
+    "read",
+    "remove",
+    "rename",
+    "search",
+    "update",
+    "write",
+]);
+
+// Activity-id prefixes the agents use to mark the start of a turn, which renders
+// as a divider rather than a tool card.
+const TURN_STARTED_ACTIVITY_ID_PREFIXES = [
+    "codex-acp:status:turn:",
+    "comando:status:turn:",
+];
+
+export function isTurnStartedActivity(activity: AiToolActivity): boolean {
+    return TURN_STARTED_ACTIVITY_ID_PREFIXES.some((prefix) =>
+        activity.id.startsWith(prefix),
+    );
+}
+
+export function isTerminalToolActivity(activity: AiToolActivity): boolean {
+    return TERMINAL_TOOL_KINDS.has(activity.kind.toLowerCase());
+}
+
+export function isFileToolActivity(
+    activity: AiToolActivity,
+    trackedFiles: readonly AiTrackedFile[],
+): boolean {
+    return (
+        trackedFiles.length > 0 ||
+        FILE_TOOL_KINDS.has(activity.kind.toLowerCase()) ||
+        activity.locations.length > 0 ||
+        activity.diffs.length > 0
+    );
+}

--- a/src/renderer/src/components/workspace/chat/toolExpansionStore.test.ts
+++ b/src/renderer/src/components/workspace/chat/toolExpansionStore.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    applyPersistentToolStateUpdate,
+    readStoredToolState,
+    resolvePersistentToolState,
+} from "./toolExpansionStore";
+
+describe("readStoredToolState", () => {
+    it("returns the default when the key is absent", () => {
+        expect(readStoredToolState(new Map(), "missing", "default")).toBe(
+            "default",
+        );
+    });
+
+    it("returns the stored value when the key is present", () => {
+        const store = new Map<string, unknown>([["k", "stored"]]);
+
+        expect(readStoredToolState(store, "k", "default")).toBe("stored");
+    });
+
+    it("treats a stored false/0 as a real value rather than a miss", () => {
+        const store = new Map<string, unknown>([
+            ["flag", false],
+            ["count", 0],
+        ]);
+
+        expect(readStoredToolState(store, "flag", true)).toBe(false);
+        expect(readStoredToolState(store, "count", 5)).toBe(0);
+    });
+
+    it("falls back to the default when there is no provider (null store)", () => {
+        expect(readStoredToolState(null, "k", "default")).toBe("default");
+    });
+});
+
+describe("resolvePersistentToolState", () => {
+    it("keeps the in-memory slot value while the key is unchanged", () => {
+        // The live value wins over the store while the key matches, so a local
+        // toggle is not clobbered by a stale stored value.
+        const store = new Map<string, unknown>([["k", "stored"]]);
+
+        expect(
+            resolvePersistentToolState(
+                { key: "k", value: "live" },
+                store,
+                "k",
+                "default",
+            ),
+        ).toBe("live");
+    });
+
+    it("re-hydrates from the store when the key changes", () => {
+        const store = new Map<string, unknown>([["next", "persisted"]]);
+
+        expect(
+            resolvePersistentToolState(
+                { key: "prev", value: "live" },
+                store,
+                "next",
+                "default",
+            ),
+        ).toBe("persisted");
+    });
+
+    it("re-hydrates to the default when the new key was never stored", () => {
+        expect(
+            resolvePersistentToolState(
+                { key: "prev", value: "live" },
+                new Map(),
+                "next",
+                "default",
+            ),
+        ).toBe("default");
+    });
+});
+
+describe("applyPersistentToolStateUpdate", () => {
+    it("writes a direct value into the store and returns the next slot", () => {
+        const store = new Map<string, unknown>();
+
+        const slot = applyPersistentToolStateUpdate(
+            { key: "k", value: false },
+            store,
+            "k",
+            false,
+            true,
+        );
+
+        expect(slot).toEqual({ key: "k", value: true });
+        expect(store.get("k")).toBe(true);
+    });
+
+    it("applies a functional updater against the current value", () => {
+        const store = new Map<string, unknown>();
+
+        const slot = applyPersistentToolStateUpdate(
+            { key: "k", value: 200 },
+            store,
+            "k",
+            200,
+            (previous: number) => previous + 40,
+        );
+
+        expect(slot.value).toBe(240);
+        expect(store.get("k")).toBe(240);
+    });
+
+    it("runs the updater against the re-hydrated previous after a key change", () => {
+        // The slot is stale (still on the old key); the updater must see the
+        // value persisted under the NEW key, not the stale slot value. Here the
+        // toggle flips the persisted `true`, not the slot's `false`.
+        const store = new Map<string, unknown>([["next", true]]);
+
+        const slot = applyPersistentToolStateUpdate(
+            { key: "prev", value: false },
+            store,
+            "next",
+            false,
+            (previous: boolean) => !previous,
+        );
+
+        expect(slot.value).toBe(false);
+        expect(store.get("next")).toBe(false);
+    });
+
+    it("persists across a remount: a written value is re-read by a fresh slot", () => {
+        // This is the whole point of the store: a card's UI state outlives its
+        // virtualized row scrolling out of view and remounting.
+        const store = new Map<string, unknown>();
+
+        // First mount: the user expands the card.
+        applyPersistentToolStateUpdate(
+            { key: "card", value: false },
+            store,
+            "card",
+            false,
+            true,
+        );
+
+        // The row scrolls away and remounts: a fresh slot initializes by reading
+        // the store rather than the default.
+        expect(readStoredToolState(store, "card", false)).toBe(true);
+    });
+
+    it("still returns the next slot when there is no provider to persist into", () => {
+        // Without a store the hook degrades to ordinary local state: the update
+        // resolves but has nowhere to persist, and must not throw.
+        const slot = applyPersistentToolStateUpdate(
+            { key: "k", value: 1 },
+            null,
+            "k",
+            1,
+            2,
+        );
+
+        expect(slot).toEqual({ key: "k", value: 2 });
+    });
+});

--- a/src/renderer/src/components/workspace/chat/toolExpansionStore.tsx
+++ b/src/renderer/src/components/workspace/chat/toolExpansionStore.tsx
@@ -9,19 +9,20 @@ import {
 } from "react";
 
 /**
- * Per-tab store of manual tool-card expansion, keyed by a caller-provided
+ * Per-tab store of transient tool-card UI state, keyed by a caller-provided
  * string. The timeline virtualizes its history, so a row's `ToolActivityItem`
- * unmounts when it scrolls out of range and would lose any locally-held
- * expansion state. The store lives in the scroller (which does not unmount on
- * scroll), so the expansion survives the row remounting.
+ * (and the `ChangeReviewPanel` it can render) unmounts when it scrolls out of
+ * range and would lose any locally-held state — which card is expanded, how
+ * tall the user dragged a diff preview. The store lives in the scroller (which
+ * does not unmount on scroll), so that state survives the row remounting.
  *
- * The store is a plain Map held in a ref: identity is stable, so providing it
- * through context does not trigger re-renders. When absent (no provider), the
- * hook degrades to ordinary local state.
+ * The store is a plain Map held in a stable state slot: its identity never
+ * changes, so providing it through context does not trigger re-renders. When
+ * absent (no provider), the hooks degrade to ordinary local state.
  */
-type ToolExpansionStore = Map<string, boolean>;
+type ToolUiStateStore = Map<string, unknown>;
 
-const ToolExpansionStoreContext = createContext<ToolExpansionStore | null>(null);
+const ToolUiStateStoreContext = createContext<ToolUiStateStore | null>(null);
 
 export function ToolExpansionStoreProvider({
     children,
@@ -30,54 +31,77 @@ export function ToolExpansionStoreProvider({
 }) {
     // Lazy-initialized once; the Map identity is stable across renders, so the
     // context value never changes and consumers don't re-render from it.
-    const [store] = useState<ToolExpansionStore>(() => new Map());
+    const [store] = useState<ToolUiStateStore>(() => new Map());
 
     return (
-        <ToolExpansionStoreContext.Provider value={store}>
+        <ToolUiStateStoreContext.Provider value={store}>
             {children}
-        </ToolExpansionStoreContext.Provider>
+        </ToolUiStateStoreContext.Provider>
     );
 }
 
+function readStoredValue<T>(
+    store: ToolUiStateStore | null,
+    key: string,
+    defaultValue: T,
+): T {
+    const stored = store?.get(key);
+    // Only an absent key falls back; a stored `false`/`0` is a real value.
+    return stored === undefined ? defaultValue : (stored as T);
+}
+
 /**
- * Like `useState<boolean>(defaultExpanded)`, but the value is persisted in the
+ * Like `useState<T>(defaultValue)`, but the value is persisted in the
  * surrounding `ToolExpansionStoreProvider` under `key` so it survives the
  * component unmounting (e.g. when its virtualized row scrolls out of view).
  *
- * When `key` changes without an unmount — the file card's reset key changes
- * with the expansion mode — the value re-hydrates from the store (or the
- * default), preserving the previous reset-on-mode-change behavior.
+ * When `key` changes without an unmount — e.g. a card's reset key changes with
+ * the expansion mode — the value re-hydrates from the store (or the default),
+ * preserving the previous reset-on-key-change behavior.
+ */
+export function usePersistentToolState<T>(
+    key: string,
+    defaultValue: T,
+): readonly [T, Dispatch<SetStateAction<T>>] {
+    const store = useContext(ToolUiStateStoreContext);
+    const [state, setState] = useState(() => ({
+        key,
+        value: readStoredValue(store, key, defaultValue),
+    }));
+
+    const value =
+        state.key === key
+            ? state.value
+            : readStoredValue(store, key, defaultValue);
+
+    const setValue = useCallback<Dispatch<SetStateAction<T>>>(
+        (next) => {
+            setState((current) => {
+                const previous =
+                    current.key === key
+                        ? current.value
+                        : readStoredValue(store, key, defaultValue);
+                const resolved =
+                    typeof next === "function"
+                        ? (next as (prev: T) => T)(previous)
+                        : next;
+                store?.set(key, resolved);
+                return { key, value: resolved };
+            });
+        },
+        [store, key, defaultValue],
+    );
+
+    return [value, setValue] as const;
+}
+
+/**
+ * Boolean specialization of {@link usePersistentToolState} for tool-card
+ * expansion toggles.
  */
 export function usePersistentToolExpansion(
     key: string,
     defaultExpanded: boolean,
 ): readonly [boolean, Dispatch<SetStateAction<boolean>>] {
-    const store = useContext(ToolExpansionStoreContext);
-    const [state, setState] = useState(() => ({
-        key,
-        expanded: store?.get(key) ?? defaultExpanded,
-    }));
-
-    const expanded =
-        state.key === key
-            ? state.expanded
-            : store?.get(key) ?? defaultExpanded;
-
-    const setExpanded = useCallback<Dispatch<SetStateAction<boolean>>>(
-        (next) => {
-            setState((current) => {
-                const previous =
-                    current.key === key
-                        ? current.expanded
-                        : store?.get(key) ?? defaultExpanded;
-                const value =
-                    typeof next === "function" ? next(previous) : next;
-                store?.set(key, value);
-                return { key, expanded: value };
-            });
-        },
-        [store, key, defaultExpanded],
-    );
-
-    return [expanded, setExpanded] as const;
+    return usePersistentToolState<boolean>(key, defaultExpanded);
 }

--- a/src/renderer/src/components/workspace/chat/toolExpansionStore.tsx
+++ b/src/renderer/src/components/workspace/chat/toolExpansionStore.tsx
@@ -40,14 +40,62 @@ export function ToolExpansionStoreProvider({
     );
 }
 
-function readStoredValue<T>(
+// The hook's persistence logic, factored out as pure functions so it can be
+// unit-tested without a DOM (the renderer test env is node-only). The hook
+// below is a thin wrapper that wires these to React state and the store.
+interface PersistentToolStateSlot<T> {
+    readonly key: string;
+    readonly value: T;
+}
+
+/**
+ * Reads a value from the store, treating only an absent key as a miss — a
+ * stored `false`/`0` is a real value. A null store (no provider) always misses.
+ */
+export function readStoredToolState<T>(
     store: ToolUiStateStore | null,
     key: string,
     defaultValue: T,
 ): T {
     const stored = store?.get(key);
-    // Only an absent key falls back; a stored `false`/`0` is a real value.
     return stored === undefined ? defaultValue : (stored as T);
+}
+
+/**
+ * Resolves the value to show for `key`. While the slot's key still matches we
+ * trust its in-memory value; once the key changes (e.g. a card's reset key
+ * flips with the expansion mode) we re-hydrate from the store — which is what
+ * lets persisted state survive a key change without an unmount.
+ */
+export function resolvePersistentToolState<T>(
+    slot: PersistentToolStateSlot<T>,
+    store: ToolUiStateStore | null,
+    key: string,
+    defaultValue: T,
+): T {
+    return slot.key === key
+        ? slot.value
+        : readStoredToolState(store, key, defaultValue);
+}
+
+/**
+ * Applies a state update for `key`: resolves the previous value (re-hydrating
+ * across a key change), runs the functional updater if given, writes the result
+ * back into the store so it survives the component unmounting, and returns the
+ * next slot.
+ */
+export function applyPersistentToolStateUpdate<T>(
+    slot: PersistentToolStateSlot<T>,
+    store: ToolUiStateStore | null,
+    key: string,
+    defaultValue: T,
+    next: SetStateAction<T>,
+): PersistentToolStateSlot<T> {
+    const previous = resolvePersistentToolState(slot, store, key, defaultValue);
+    const resolved =
+        typeof next === "function" ? (next as (prev: T) => T)(previous) : next;
+    store?.set(key, resolved);
+    return { key, value: resolved };
 }
 
 /**
@@ -56,38 +104,33 @@ function readStoredValue<T>(
  * component unmounting (e.g. when its virtualized row scrolls out of view).
  *
  * When `key` changes without an unmount — e.g. a card's reset key changes with
- * the expansion mode — the value re-hydrates from the store (or the default),
- * preserving the previous reset-on-key-change behavior.
+ * the expansion mode — the value re-hydrates from the store under the new key,
+ * so it restores whatever was last seen for that key (or the default the first
+ * time the key is encountered).
  */
 export function usePersistentToolState<T>(
     key: string,
     defaultValue: T,
 ): readonly [T, Dispatch<SetStateAction<T>>] {
     const store = useContext(ToolUiStateStoreContext);
-    const [state, setState] = useState(() => ({
+    const [slot, setSlot] = useState<PersistentToolStateSlot<T>>(() => ({
         key,
-        value: readStoredValue(store, key, defaultValue),
+        value: readStoredToolState(store, key, defaultValue),
     }));
 
-    const value =
-        state.key === key
-            ? state.value
-            : readStoredValue(store, key, defaultValue);
+    const value = resolvePersistentToolState(slot, store, key, defaultValue);
 
     const setValue = useCallback<Dispatch<SetStateAction<T>>>(
         (next) => {
-            setState((current) => {
-                const previous =
-                    current.key === key
-                        ? current.value
-                        : readStoredValue(store, key, defaultValue);
-                const resolved =
-                    typeof next === "function"
-                        ? (next as (prev: T) => T)(previous)
-                        : next;
-                store?.set(key, resolved);
-                return { key, value: resolved };
-            });
+            setSlot((current) =>
+                applyPersistentToolStateUpdate(
+                    current,
+                    store,
+                    key,
+                    defaultValue,
+                    next,
+                ),
+            );
         },
         [store, key, defaultValue],
     );

--- a/src/renderer/src/components/workspace/chat/toolExpansionStore.tsx
+++ b/src/renderer/src/components/workspace/chat/toolExpansionStore.tsx
@@ -1,0 +1,83 @@
+import {
+    createContext,
+    useCallback,
+    useContext,
+    useState,
+    type Dispatch,
+    type ReactNode,
+    type SetStateAction,
+} from "react";
+
+/**
+ * Per-tab store of manual tool-card expansion, keyed by a caller-provided
+ * string. The timeline virtualizes its history, so a row's `ToolActivityItem`
+ * unmounts when it scrolls out of range and would lose any locally-held
+ * expansion state. The store lives in the scroller (which does not unmount on
+ * scroll), so the expansion survives the row remounting.
+ *
+ * The store is a plain Map held in a ref: identity is stable, so providing it
+ * through context does not trigger re-renders. When absent (no provider), the
+ * hook degrades to ordinary local state.
+ */
+type ToolExpansionStore = Map<string, boolean>;
+
+const ToolExpansionStoreContext = createContext<ToolExpansionStore | null>(null);
+
+export function ToolExpansionStoreProvider({
+    children,
+}: {
+    readonly children: ReactNode;
+}) {
+    // Lazy-initialized once; the Map identity is stable across renders, so the
+    // context value never changes and consumers don't re-render from it.
+    const [store] = useState<ToolExpansionStore>(() => new Map());
+
+    return (
+        <ToolExpansionStoreContext.Provider value={store}>
+            {children}
+        </ToolExpansionStoreContext.Provider>
+    );
+}
+
+/**
+ * Like `useState<boolean>(defaultExpanded)`, but the value is persisted in the
+ * surrounding `ToolExpansionStoreProvider` under `key` so it survives the
+ * component unmounting (e.g. when its virtualized row scrolls out of view).
+ *
+ * When `key` changes without an unmount — the file card's reset key changes
+ * with the expansion mode — the value re-hydrates from the store (or the
+ * default), preserving the previous reset-on-mode-change behavior.
+ */
+export function usePersistentToolExpansion(
+    key: string,
+    defaultExpanded: boolean,
+): readonly [boolean, Dispatch<SetStateAction<boolean>>] {
+    const store = useContext(ToolExpansionStoreContext);
+    const [state, setState] = useState(() => ({
+        key,
+        expanded: store?.get(key) ?? defaultExpanded,
+    }));
+
+    const expanded =
+        state.key === key
+            ? state.expanded
+            : store?.get(key) ?? defaultExpanded;
+
+    const setExpanded = useCallback<Dispatch<SetStateAction<boolean>>>(
+        (next) => {
+            setState((current) => {
+                const previous =
+                    current.key === key
+                        ? current.expanded
+                        : store?.get(key) ?? defaultExpanded;
+                const value =
+                    typeof next === "function" ? next(previous) : next;
+                store?.set(key, value);
+                return { key, expanded: value };
+            });
+        },
+        [store, key, defaultExpanded],
+    );
+
+    return [expanded, setExpanded] as const;
+}


### PR DESCRIPTION
## Summary
- virtualize the live chat stable history rows above a high threshold while keeping liveTailRow and streaming indicator outside the virtual list
- add chat timeline virtualization helpers, measured row gaps, scrollMarginTop support, and per-row measurement keys to avoid stale height caches
- preserve the small-chat render path so existing spacing/visual structure remains unchanged below threshold

## Verification
- pnpm vitest run src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx src/renderer/src/components/workspace/chat/chatTimelineModel.test.ts src/renderer/src/components/virtual/MeasuredVirtualList.test.tsx
- pnpm run typecheck
- pnpm exec eslint src/renderer/src/components/virtual/MeasuredVirtualList.tsx src/renderer/src/components/workspace/ChatTabView.tsx src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts

## Known note
- pnpm test currently has one unrelated environment-dependent failure: src/main/ai/opencode/setup.test.ts expects OpenCode to be missing, but this machine reports it as ready.