### PR TITLE
Stabilize Monaco tab switching

### DIFF
--- a/src/renderer/src/app/debug/renderProbe.ts
+++ b/src/renderer/src/app/debug/renderProbe.ts
@@ -4,11 +4,13 @@ const RENDER_PROBE_STORAGE_KEY = "comando:render-probe";
 
 type RenderProbeValue = boolean | number | string | null | undefined;
 type RenderProbeDetails = Record<string, RenderProbeValue>;
+type RenderProbePhase = "commit" | "dispose" | "mount";
 
 interface RenderProbeEvent {
     readonly component: string;
     readonly count: number;
     readonly details: RenderProbeDetails;
+    readonly phase: RenderProbePhase;
     readonly sinceLastMs: number | null;
     readonly timestamp: number;
 }
@@ -78,6 +80,7 @@ function getRenderProbeStore(): RenderProbeStore {
 
 function formatRenderProbeLabel(
     component: string,
+    phase: RenderProbePhase,
     details: RenderProbeDetails,
 ): string {
     const identity = Object.entries(details)
@@ -85,7 +88,43 @@ function formatRenderProbeLabel(
         .map(([key, value]) => `${key}=${String(value)}`)
         .join(" ");
 
-    return identity ? `${component} ${identity}` : component;
+    const phaseLabel = phase === "commit" ? component : `${component}:${phase}`;
+
+    return identity ? `${phaseLabel} ${identity}` : phaseLabel;
+}
+
+function recordRenderProbeEvent(
+    component: string,
+    phase: RenderProbePhase,
+    details: RenderProbeDetails = {},
+    sinceLastMs: number | null = null,
+): void {
+    if (!isRenderProbeEnabled(component)) {
+        return;
+    }
+
+    const store = getRenderProbeStore();
+    const countKey = phase === "commit" ? component : `${component}:${phase}`;
+    const count = (store.counts[countKey] ?? 0) + 1;
+
+    store.counts[countKey] = count;
+    store.events.push({
+        component,
+        count,
+        details,
+        phase,
+        sinceLastMs,
+        timestamp: Date.now(),
+    });
+
+    if (store.events.length > 400) {
+        store.events.splice(0, store.events.length - 400);
+    }
+
+    console.debug("[render-probe]", formatRenderProbeLabel(component, phase, details), {
+        count,
+        sinceLastMs,
+    });
 }
 
 export function useRenderProbe(
@@ -101,38 +140,39 @@ export function useRenderProbe(
         }
 
         const now = performance.now();
-        const store = getRenderProbeStore();
-        const count = (store.counts[component] ?? 0) + 1;
         const sinceLastMs =
             lastCommitAtRef.current === null
                 ? null
                 : now - lastCommitAtRef.current;
+        const roundedSinceLastMs =
+            sinceLastMs === null ? null : Number(sinceLastMs.toFixed(2));
 
         lastCommitAtRef.current = now;
-        store.counts[component] = count;
-        store.events.push({
-            component,
-            count,
-            details,
-            sinceLastMs:
-                sinceLastMs === null ? null : Number(sinceLastMs.toFixed(2)),
-            timestamp: Date.now(),
-        });
-
-        if (store.events.length > 400) {
-            store.events.splice(0, store.events.length - 400);
-        }
-
-        console.debug(
-            "[render-probe]",
-            formatRenderProbeLabel(component, details),
-            {
-                count,
-                sinceLastMs:
-                    sinceLastMs === null
-                        ? null
-                        : Number(sinceLastMs.toFixed(2)),
-            },
-        );
+        recordRenderProbeEvent(component, "commit", details, roundedSinceLastMs);
     });
+}
+
+export function useLifecycleProbe(
+    component: string,
+    details: RenderProbeDetails = {},
+): void {
+    const detailsRef = useRef(details);
+
+    useEffect(() => {
+        const lifecycleDetails = detailsRef.current;
+
+        recordRenderProbeEvent(component, "mount", lifecycleDetails);
+
+        return () => {
+            recordRenderProbeEvent(component, "dispose", lifecycleDetails);
+        };
+    }, [component]);
+}
+
+export function recordProbeLifecycleEvent(
+    component: string,
+    phase: Exclude<RenderProbePhase, "commit">,
+    details: RenderProbeDetails = {},
+): void {
+    recordRenderProbeEvent(component, phase, details);
 }

--- a/src/renderer/src/app/debug/renderProbe.ts
+++ b/src/renderer/src/app/debug/renderProbe.ts
@@ -157,14 +157,13 @@ export function useLifecycleProbe(
     details: RenderProbeDetails = {},
 ): void {
     const detailsRef = useRef(details);
+    detailsRef.current = details;
 
     useEffect(() => {
-        const lifecycleDetails = detailsRef.current;
-
-        recordRenderProbeEvent(component, "mount", lifecycleDetails);
+        recordRenderProbeEvent(component, "mount", detailsRef.current);
 
         return () => {
-            recordRenderProbeEvent(component, "dispose", lifecycleDetails);
+            recordRenderProbeEvent(component, "dispose", detailsRef.current);
         };
     }, [component]);
 }

--- a/src/renderer/src/app/workspace/tree.test.ts
+++ b/src/renderer/src/app/workspace/tree.test.ts
@@ -354,22 +354,31 @@ describe("workspace tree helpers", () => {
 
     it("syncs shared file draft and save state across duplicate tabs", () => {
         const sourceTab = makeFileTab("file-1", "src/app.ts");
+        const sourceViewState = {
+            contributionsState: [],
+            cursorState: [],
+            viewState: { scrollTop: 120 },
+        } as never;
+        const duplicateViewState = {
+            contributionsState: [],
+            cursorState: [],
+            viewState: { scrollTop: 360 },
+        } as never;
         const duplicateTab: RuntimeWorkspaceFileTab = {
             ...makeFileTab("file-2", "src/app.ts"),
             reviewContext: {
                 path: "src/app.ts",
                 sessionId: "session-2",
             },
-            viewState: {
-                contributionsState: [],
-                cursorState: [],
-                viewState: {},
-            } as never,
+            viewState: duplicateViewState,
         };
         const baseState = {
             ...createDefaultWorkspaceState(),
             tabsById: {
-                "file-1": sourceTab,
+                "file-1": {
+                    ...sourceTab,
+                    viewState: sourceViewState,
+                },
                 "file-2": duplicateTab,
             },
         };
@@ -379,6 +388,7 @@ describe("workspace tree helpers", () => {
         expect(withDraft.tabsById["file-1"]).toMatchObject({
             draftContent: "next draft",
             isDirty: true,
+            viewState: sourceViewState,
         });
         expect(withDraft.tabsById["file-2"]).toMatchObject({
             draftContent: "next draft",
@@ -387,6 +397,7 @@ describe("workspace tree helpers", () => {
                 path: "src/app.ts",
                 sessionId: "session-2",
             },
+            viewState: duplicateViewState,
         });
 
         const withSaving = setFileTabSaving(withDraft, "file-2", true, null);
@@ -413,6 +424,7 @@ describe("workspace tree helpers", () => {
             isDirty: false,
             isSaving: false,
             savedContent: "saved content",
+            viewState: sourceViewState,
         });
         expect(withSavedDocument.tabsById["file-2"]).toMatchObject({
             draftContent: "saved content",
@@ -422,6 +434,55 @@ describe("workspace tree helpers", () => {
                 path: "src/app.ts",
                 sessionId: "session-2",
             },
+            viewState: duplicateViewState,
+        });
+    });
+
+    it("updates view state only for the target duplicate file tab", () => {
+        const firstViewState = {
+            contributionsState: [],
+            cursorState: [],
+            viewState: { scrollTop: 120 },
+        } as never;
+        const secondViewState = {
+            contributionsState: [],
+            cursorState: [],
+            viewState: { scrollTop: 360 },
+        } as never;
+        const nextSecondViewState = {
+            contributionsState: [],
+            cursorState: [],
+            viewState: { scrollTop: 720 },
+        } as never;
+        const baseState = {
+            ...createDefaultWorkspaceState(),
+            tabsById: {
+                "file-1": {
+                    ...makeFileTab("file-1", "src/app.ts"),
+                    viewState: firstViewState,
+                },
+                "file-2": {
+                    ...makeFileTab("file-2", "src/app.ts"),
+                    viewState: secondViewState,
+                },
+            },
+        };
+
+        const nextState = setFileTabViewState(
+            baseState,
+            "file-2",
+            nextSecondViewState,
+        );
+
+        expect(nextState.tabsById["file-1"]).toMatchObject({
+            draftContent: "",
+            relativePath: "src/app.ts",
+            viewState: firstViewState,
+        });
+        expect(nextState.tabsById["file-2"]).toMatchObject({
+            draftContent: "",
+            relativePath: "src/app.ts",
+            viewState: nextSecondViewState,
         });
     });
 

--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -876,4 +876,79 @@ describe("WorkspaceFileEditorHost", () => {
         expect(normalEditor?.disposed).toBe(false);
         expect(diffEditor?.disposed).toBe(true);
     });
+
+    it("reinstalls inline review models when a hidden file tab resumes with shell models", async () => {
+        const fileTab = createFileTab("file-1");
+        mockAiStoreState.current.sessions = {
+            "session-1": {
+                snapshot: {
+                    trackedFiles: [createTrackedFile()],
+                },
+            },
+        };
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: fileTab,
+                    fileTabs: [fileTab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const diffEditor = monacoHarness.diffEditors[0];
+        expect(diffEditor).toBeDefined();
+        if (!diffEditor) {
+            throw new Error("Expected inline review diff editor to mount.");
+        }
+
+        expect(diffEditor.originalModel?.getValue()).toBe("const value = 1;\n");
+        expect(diffEditor.modifiedModel?.getValue()).toBe("const value = 2;\n");
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: null,
+                    fileTabs: [fileTab],
+                    recentActiveTabIds: ["file-1"],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const shellOriginalModel = monacoHarness.monaco.editor.createModel(
+            "",
+            "typescript",
+            monacoHarness.monaco.Uri.parse(
+                "inmemory://inline-review-shell-original",
+            ),
+        );
+        const shellModifiedModel = monacoHarness.monaco.editor.createModel(
+            "",
+            "typescript",
+            monacoHarness.monaco.Uri.parse(
+                "inmemory://inline-review-shell-modified",
+            ),
+        );
+        diffEditor.setModel({
+            modified: shellModifiedModel,
+            original: shellOriginalModel,
+        });
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: fileTab,
+                    fileTabs: [fileTab],
+                    recentActiveTabIds: ["file-1"],
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(diffEditor.disposed).toBe(false);
+        expect(diffEditor.originalModel?.getValue()).toBe("const value = 1;\n");
+        expect(diffEditor.modifiedModel?.getValue()).toBe("const value = 2;\n");
+    });
 });

--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -1,0 +1,879 @@
+/** @vitest-environment jsdom */
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from "vitest";
+
+import type {
+    AiTrackedFile,
+    ProjectFileDocument,
+} from "@shared/ipc";
+import type { RuntimeWorkspaceFileTab } from "@renderer/app/workspace/tree";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockWorkspaceStoreState = vi.hoisted(() => ({
+    current: {
+        updateFileViewState: vi.fn(),
+    },
+}));
+
+const mockAiStoreState = vi.hoisted(() => ({
+    current: {
+        keepTrackedFile: vi.fn(),
+        keepTrackedFileHunks: vi.fn(),
+        rejectTrackedFile: vi.fn(),
+        rejectTrackedFileHunks: vi.fn(),
+        sessions: {},
+    },
+}));
+
+const mockGitStoreState = vi.hoisted(() => ({
+    current: {
+        snapshots: {},
+    },
+}));
+
+const mockProjectsStoreState = vi.hoisted(() => ({
+    current: {
+        projects: [
+            {
+                id: "project-1",
+                name: "Comando",
+            },
+        ],
+    },
+}));
+
+const mockEditorRuntime = vi.hoisted(() => ({
+    applyMonacoThemeFromDom: vi.fn(),
+    applyProjectTypeScriptConfigForPath: vi.fn(() => Promise.resolve()),
+    ensureMonacoTextMateForLanguage: vi.fn(() => Promise.resolve()),
+    installMonacoTokenDebugAction: vi.fn(() => ({
+        dispose: vi.fn(),
+    })),
+}));
+
+const monacoHarness = vi.hoisted(() => {
+    type FakeUri = {
+        readonly value: string;
+        readonly toString: () => string;
+    };
+
+    type Disposable = {
+        readonly dispose: () => void;
+    };
+
+    type FakeModel = {
+        readonly dispose: () => void;
+        readonly getFullModelRange: () => {
+            readonly endColumn: number;
+            readonly endLineNumber: number;
+            readonly startColumn: number;
+            readonly startLineNumber: number;
+        };
+        readonly getLineCount: () => number;
+        readonly getLineMaxColumn: (lineNumber: number) => number;
+        readonly getOffsetAt: (position: {
+            readonly column: number;
+            readonly lineNumber: number;
+        }) => number;
+        readonly getOptions: () => { readonly tabSize: number };
+        readonly getPositionAt: (offset: number) => {
+            readonly column: number;
+            readonly lineNumber: number;
+        };
+        readonly getValue: () => string;
+        readonly isDisposed: () => boolean;
+        readonly setValue: (value: string) => void;
+        disposed: boolean;
+        language: string;
+        readonly uri: string;
+        value: string;
+    };
+
+    type FakeCodeEditor = {
+        readonly createDecorationsCollection: () => {
+            readonly clear: () => void;
+            readonly set: (decorations: readonly unknown[]) => void;
+        };
+        readonly dispose: () => void;
+        readonly getContribution: () => null;
+        readonly getDomNode: () => HTMLElement;
+        readonly getModel: () => FakeModel | null;
+        readonly getPosition: () => { column: number; lineNumber: number };
+        readonly getScrollLeft: () => number;
+        readonly getScrollTop: () => number;
+        readonly getSelection: () => null;
+        readonly getSelections: () => readonly unknown[];
+        readonly hasTextFocus: () => boolean;
+        readonly hasWidgetFocus: () => boolean;
+        readonly layout: () => void;
+        readonly onDidChangeCursorSelection: () => Disposable;
+        readonly onDidChangeHiddenAreas: () => Disposable;
+        readonly onDidDispose: (listener: () => void) => Disposable;
+        readonly onDidLayoutChange: () => Disposable;
+        readonly onDidScrollChange: () => Disposable;
+        readonly onMouseLeave: () => Disposable;
+        readonly onMouseMove: () => Disposable;
+        readonly pushUndoStop: () => void;
+        readonly restoreViewState: (viewState: unknown) => void;
+        readonly saveViewState: () => {
+            readonly contributionsState: readonly unknown[];
+            readonly cursorState: readonly unknown[];
+            readonly viewState: {
+                readonly editorName: string;
+                readonly modelUri: string | null;
+            };
+        };
+        readonly setModel: (model: FakeModel | null) => void;
+        readonly setPosition: (position: unknown) => void;
+        readonly setScrollLeft: (scrollLeft: number) => void;
+        readonly setScrollTop: (scrollTop: number) => void;
+        readonly updateOptions: (options: unknown) => void;
+        disposed: boolean;
+        model: FakeModel | null;
+        readonly name: string;
+    };
+
+    type FakeDiffEditor = {
+        readonly dispose: () => void;
+        readonly getContainerDomNode: () => HTMLElement;
+        readonly getModel: () => {
+            readonly modified: FakeModel | null;
+            readonly original: FakeModel | null;
+        } | null;
+        readonly getModifiedEditor: () => FakeCodeEditor;
+        readonly getOriginalEditor: () => FakeCodeEditor;
+        readonly layout: () => void;
+        readonly onDidDispose: (listener: () => void) => Disposable;
+        readonly setModel: (
+            modelsInput: {
+                readonly modified: FakeModel;
+                readonly original: FakeModel;
+            } | null,
+        ) => void;
+        disposed: boolean;
+        modifiedModel: FakeModel | null;
+        originalModel: FakeModel | null;
+    };
+
+    const models = new Map<string, FakeModel>();
+    const createdModels: FakeModel[] = [];
+    const codeEditors: FakeCodeEditor[] = [];
+    const diffEditors: FakeDiffEditor[] = [];
+    let editorCounter = 0;
+    let diffEditorCounter = 0;
+
+    const toLines = (value: string) => value.split("\n");
+
+    const createDisposable = (): Disposable => ({
+        dispose: vi.fn(),
+    });
+
+    const createModel = (
+        value: string,
+        language: string,
+        uri: FakeUri,
+    ): FakeModel => {
+        const model: FakeModel = {
+            dispose: vi.fn(() => {
+                model.disposed = true;
+                models.delete(uri.toString());
+            }),
+            disposed: false,
+            getFullModelRange: () => ({
+                endColumn: toLines(model.value).at(-1)!.length + 1,
+                endLineNumber: model.getLineCount(),
+                startColumn: 1,
+                startLineNumber: 1,
+            }),
+            getLineCount: () => toLines(model.value).length,
+            getLineMaxColumn: (lineNumber) =>
+                (toLines(model.value)[lineNumber - 1] ?? "").length + 1,
+            getOffsetAt: ({ column, lineNumber }) => {
+                const previousLines = toLines(model.value).slice(
+                    0,
+                    Math.max(lineNumber - 1, 0),
+                );
+                return (
+                    previousLines.reduce(
+                        (total, line) => total + line.length + 1,
+                        0,
+                    ) +
+                    column -
+                    1
+                );
+            },
+            getOptions: () => ({ tabSize: 4 }),
+            getPositionAt: (offset) => {
+                const lines = toLines(model.value);
+                let remaining = offset;
+                for (let index = 0; index < lines.length; index += 1) {
+                    const lineLengthWithBreak = lines[index].length + 1;
+                    if (remaining < lineLengthWithBreak) {
+                        return {
+                            column: remaining + 1,
+                            lineNumber: index + 1,
+                        };
+                    }
+                    remaining -= lineLengthWithBreak;
+                }
+                return {
+                    column: lines.at(-1)!.length + 1,
+                    lineNumber: lines.length,
+                };
+            },
+            getValue: () => model.value,
+            isDisposed: () => model.disposed,
+            language,
+            setValue: (nextValue) => {
+                model.value = nextValue;
+            },
+            uri: uri.toString(),
+            value,
+        };
+        models.set(uri.toString(), model);
+        createdModels.push(model);
+        return model;
+    };
+
+    const monaco = {
+        Uri: {
+            parse: (value: string): FakeUri => ({
+                toString: () => value,
+                value,
+            }),
+        },
+        editor: {
+            createModel: vi.fn(createModel),
+            getModel: vi.fn((uri: FakeUri) => models.get(uri.toString()) ?? null),
+            setModelLanguage: vi.fn((model: FakeModel, language: string) => {
+                model.language = language;
+            }),
+        },
+    };
+
+    const createCodeEditor = (name = `editor-${++editorCounter}`) => {
+        const domNode = document.createElement("div");
+        const disposeListeners = new Set<() => void>();
+        const editor: FakeCodeEditor = {
+            createDecorationsCollection: vi.fn(() => ({
+                clear: vi.fn(),
+                set: vi.fn(),
+            })),
+            dispose: () => {
+                if (editor.disposed) {
+                    return;
+                }
+                editor.disposed = true;
+                for (const listener of disposeListeners) {
+                    listener();
+                }
+                disposeListeners.clear();
+            },
+            disposed: false,
+            getContribution: () => null,
+            getDomNode: () => domNode,
+            getModel: () => editor.model,
+            getPosition: () => ({ column: 1, lineNumber: 1 }),
+            getScrollLeft: () => 0,
+            getScrollTop: () => 0,
+            getSelection: () => null,
+            getSelections: () => [],
+            hasTextFocus: () => true,
+            hasWidgetFocus: () => false,
+            layout: vi.fn(),
+            model: null,
+            name,
+            onDidChangeCursorSelection: () => createDisposable(),
+            onDidChangeHiddenAreas: () => createDisposable(),
+            onDidDispose: (listener) => {
+                disposeListeners.add(listener);
+                return {
+                    dispose: () => {
+                        disposeListeners.delete(listener);
+                    },
+                };
+            },
+            onDidLayoutChange: () => createDisposable(),
+            onDidScrollChange: () => createDisposable(),
+            onMouseLeave: () => createDisposable(),
+            onMouseMove: () => createDisposable(),
+            pushUndoStop: vi.fn(),
+            restoreViewState: vi.fn(),
+            saveViewState: vi.fn(() => ({
+                contributionsState: [],
+                cursorState: [],
+                viewState: {
+                    editorName: editor.name,
+                    modelUri: editor.model?.uri ?? null,
+                },
+            })),
+            setModel: (model: FakeModel | null) => {
+                editor.model = model;
+            },
+            setPosition: vi.fn(),
+            setScrollLeft: vi.fn(),
+            setScrollTop: vi.fn(),
+            updateOptions: vi.fn(),
+        };
+        codeEditors.push(editor);
+        return editor;
+    };
+
+    const createDiffEditor = () => {
+        const originalEditor = createCodeEditor(
+            `diff-original-${++diffEditorCounter}`,
+        );
+        const modifiedEditor = createCodeEditor(
+            `diff-modified-${diffEditorCounter}`,
+        );
+        const container = document.createElement("div");
+        const disposeListeners = new Set<() => void>();
+        const diffEditor: FakeDiffEditor = {
+            dispose: () => {
+                if (diffEditor.disposed) {
+                    return;
+                }
+                diffEditor.disposed = true;
+                for (const listener of disposeListeners) {
+                    listener();
+                }
+                disposeListeners.clear();
+                originalEditor.dispose();
+                modifiedEditor.dispose();
+            },
+            disposed: false,
+            getContainerDomNode: () => container,
+            getModel: () => ({
+                modified: diffEditor.modifiedModel,
+                original: diffEditor.originalModel,
+            }),
+            getModifiedEditor: () => modifiedEditor,
+            getOriginalEditor: () => originalEditor,
+            layout: vi.fn(),
+            modifiedModel: null,
+            onDidDispose: (listener) => {
+                disposeListeners.add(listener);
+                return {
+                    dispose: () => {
+                        disposeListeners.delete(listener);
+                    },
+                };
+            },
+            originalModel: null,
+            setModel: (modelsInput) => {
+                diffEditor.modifiedModel = modelsInput?.modified ?? null;
+                diffEditor.originalModel = modelsInput?.original ?? null;
+                modifiedEditor.setModel(diffEditor.modifiedModel);
+                originalEditor.setModel(diffEditor.originalModel);
+            },
+        };
+        diffEditors.push(diffEditor);
+        return diffEditor;
+    };
+
+    return {
+        codeEditors,
+        createdModels,
+        createCodeEditor,
+        createDiffEditor,
+        diffEditors,
+        models,
+        monaco,
+        reset: () => {
+            models.clear();
+            createdModels.length = 0;
+            codeEditors.length = 0;
+            diffEditors.length = 0;
+            editorCounter = 0;
+            diffEditorCounter = 0;
+            monaco.editor.createModel.mockClear();
+            monaco.editor.getModel.mockClear();
+            monaco.editor.setModelLanguage.mockClear();
+        },
+    };
+});
+
+vi.mock("@renderer/app/hooks/use-resolved-editor-settings", () => ({
+    useResolvedEditorSettings: () => ({
+        autoSaveDelayMs: 1000,
+        fontFamily: "system",
+        fontSize: 14,
+        lineHeight: 1.5,
+        minimapEnabled: false,
+        suggestionsEnabled: true,
+    }),
+}));
+
+vi.mock("@renderer/app/settings/client", () => ({
+    loadAppEditorSettings: vi.fn(() =>
+        Promise.resolve({
+            fontFamily: "system",
+            fontSize: 14,
+        }),
+    ),
+    saveAppEditorSettings: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@renderer/app/editor/monaco", () => mockEditorRuntime);
+
+vi.mock("@renderer/app/store/workspace-store", () => ({
+    getBestMatchingChatTabId: vi.fn(() => null),
+    useWorkspaceStore: (selector: (state: unknown) => unknown) =>
+        selector(mockWorkspaceStoreState.current),
+}));
+
+vi.mock("@renderer/app/store/ai-store", () => ({
+    useAiStore: (selector: (state: unknown) => unknown) =>
+        selector(mockAiStoreState.current),
+}));
+
+vi.mock("@renderer/app/store/git-store", () => ({
+    useGitStore: (selector: (state: unknown) => unknown) =>
+        selector(mockGitStoreState.current),
+}));
+
+vi.mock("@renderer/app/store/github-store", () => ({
+    getGitHubRepoKey: vi.fn(() => "repo"),
+    useGitHubStore: (selector: (state: unknown) => unknown) =>
+        selector({
+            repositoriesByProjectId: {},
+        }),
+}));
+
+vi.mock("@renderer/app/store/projects-store", () => ({
+    useProjectsStore: (selector: (state: unknown) => unknown) =>
+        selector(mockProjectsStoreState.current),
+}));
+
+vi.mock("@renderer/features/terminal/WorkspaceTerminalView", () => ({
+    WorkspaceTerminalView: () => null,
+}));
+
+vi.mock("@monaco-editor/react", async () => {
+    const React = await import("react");
+
+    const MockEditor = ({
+        beforeMount,
+        language,
+        onMount,
+        path,
+        value,
+    }: {
+        readonly beforeMount?: () => void;
+        readonly language?: string;
+        readonly onMount?: (editor: unknown, monaco: unknown) => void;
+        readonly path?: string;
+        readonly value?: string;
+    }) => {
+        const editorRef = React.useRef<ReturnType<
+            typeof monacoHarness.createCodeEditor
+        > | null>(null);
+        const mountPropsRef = React.useRef({
+            beforeMount,
+            language,
+            onMount,
+            path,
+            value,
+        });
+
+        React.useEffect(() => {
+            const mountProps = mountPropsRef.current;
+            mountProps.beforeMount?.();
+            const editor = monacoHarness.createCodeEditor();
+            const modelPath =
+                mountProps.path ?? `inmemory://model-${Date.now()}`;
+            const uri = monacoHarness.monaco.Uri.parse(modelPath);
+            const model =
+                monacoHarness.monaco.editor.getModel(uri) ??
+                monacoHarness.monaco.editor.createModel(
+                    mountProps.value ?? "",
+                    mountProps.language ?? "plaintext",
+                    uri,
+                );
+            editor.setModel(model);
+            editorRef.current = editor;
+            mountProps.onMount?.(editor, monacoHarness.monaco);
+
+            return () => {
+                editor.dispose();
+                editorRef.current = null;
+            };
+        }, []);
+
+        return React.createElement("div", {
+            "data-mock-editor": path ?? "",
+        });
+    };
+
+    const MockDiffEditor = ({
+        beforeMount,
+        language,
+        modified,
+        modifiedModelPath,
+        onMount,
+        original,
+        originalModelPath,
+    }: {
+        readonly beforeMount?: () => void;
+        readonly language?: string;
+        readonly modified?: string;
+        readonly modifiedModelPath?: string;
+        readonly onMount?: (editor: unknown, monaco: unknown) => void;
+        readonly original?: string;
+        readonly originalModelPath?: string;
+    }) => {
+        const mountPropsRef = React.useRef({
+            beforeMount,
+            language,
+            modified,
+            modifiedModelPath,
+            onMount,
+            original,
+            originalModelPath,
+        });
+
+        React.useEffect(() => {
+            const mountProps = mountPropsRef.current;
+            mountProps.beforeMount?.();
+            const diffEditor = monacoHarness.createDiffEditor();
+            const originalUri = monacoHarness.monaco.Uri.parse(
+                mountProps.originalModelPath ??
+                    `inmemory://original-${Date.now()}`,
+            );
+            const modifiedUri = monacoHarness.monaco.Uri.parse(
+                mountProps.modifiedModelPath ??
+                    `inmemory://modified-${Date.now()}`,
+            );
+            const originalModel =
+                monacoHarness.monaco.editor.getModel(originalUri) ??
+                monacoHarness.monaco.editor.createModel(
+                    mountProps.original ?? "",
+                    mountProps.language ?? "plaintext",
+                    originalUri,
+                );
+            const modifiedModel =
+                monacoHarness.monaco.editor.getModel(modifiedUri) ??
+                monacoHarness.monaco.editor.createModel(
+                    mountProps.modified ?? "",
+                    mountProps.language ?? "plaintext",
+                    modifiedUri,
+                );
+            diffEditor.setModel({
+                modified: modifiedModel,
+                original: originalModel,
+            });
+            mountProps.onMount?.(diffEditor, monacoHarness.monaco);
+
+            return () => {
+                diffEditor.dispose();
+            };
+        }, []);
+
+        return React.createElement("div", {
+            "data-mock-diff-editor": modifiedModelPath ?? "",
+        });
+    };
+
+    return {
+        DiffEditor: MockDiffEditor,
+        default: MockEditor,
+    };
+});
+
+import { WorkspaceFileEditorHost } from "./WorkspaceView";
+
+function createDocument(
+    relativePath: string,
+    content: string,
+): ProjectFileDocument {
+    return {
+        absolutePath: `/workspace/comando/${relativePath}`,
+        content,
+        imageDataBase64: null,
+        isBinary: false,
+        isTooLarge: false,
+        kind: "text",
+        languageId: "typescript",
+        languageLabel: "TypeScript",
+        mimeType: "text/typescript",
+        modifiedAtMs: 1,
+        name: relativePath.split("/").at(-1) ?? relativePath,
+        projectId: "project-1",
+        relativePath,
+        sizeBytes: content.length,
+    };
+}
+
+function createFileTab(
+    id: string,
+    relativePath = "src/app.ts",
+    content = "const value = 1;\n",
+): RuntimeWorkspaceFileTab {
+    const document = createDocument(relativePath, content);
+
+    return {
+        createdAt: "2026-06-05T00:00:00.000Z",
+        document,
+        draftContent: content,
+        hasExternalChange: false,
+        id,
+        isDirty: false,
+        isLoading: false,
+        isSaving: false,
+        kind: "file",
+        loadError: null,
+        projectId: "project-1",
+        relativePath,
+        reviewContext: null,
+        saveError: null,
+        savedContent: content,
+        title: document.name,
+        viewState: null,
+        worktreeId: null,
+    };
+}
+
+function createTrackedFile(): AiTrackedFile {
+    return {
+        hunks: [
+            {
+                id: "hunk-1",
+                lines: [],
+                newCount: 1,
+                newStart: 1,
+                oldCount: 1,
+                oldStart: 1,
+            },
+        ],
+        identityKey: "tracked:src/app.ts",
+        isText: true,
+        kind: "update",
+        newText: "const value = 2;\n",
+        oldText: "const value = 1;\n",
+        path: "src/app.ts",
+        previousPath: null,
+        reversible: true,
+        reviewState: "pending",
+        sessionId: "session-1",
+        toolCallId: null,
+        updatedAt: "2026-06-05T00:01:00.000Z",
+        version: 2,
+    };
+}
+
+function renderHost({
+    activeFileTab,
+    fileTabs,
+    recentActiveTabIds = [],
+}: {
+    readonly activeFileTab: RuntimeWorkspaceFileTab | null;
+    readonly fileTabs: readonly RuntimeWorkspaceFileTab[];
+    readonly recentActiveTabIds?: readonly string[];
+}): ReactNode {
+    return (
+        <WorkspaceFileEditorHost
+            activeFileTab={activeFileTab}
+            fileTabs={fileTabs}
+            isActivePane={true}
+            onAttachLineFragment={vi.fn()}
+            onDraftChange={vi.fn()}
+            onReload={vi.fn(() => Promise.resolve())}
+            onSave={vi.fn(() => Promise.resolve())}
+            recentActiveTabIds={recentActiveTabIds}
+        />
+    );
+}
+
+class MemoryStorage implements Storage {
+    private readonly values = new Map<string, string>();
+
+    get length() {
+        return this.values.size;
+    }
+
+    clear() {
+        this.values.clear();
+    }
+
+    getItem(key: string) {
+        return this.values.get(key) ?? null;
+    }
+
+    key(index: number) {
+        return [...this.values.keys()][index] ?? null;
+    }
+
+    removeItem(key: string) {
+        this.values.delete(key);
+    }
+
+    setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+}
+
+async function flushEffects() {
+    await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+describe("WorkspaceFileEditorHost", () => {
+    let container: HTMLDivElement;
+    let root: Root;
+
+    beforeEach(() => {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        root = createRoot(container);
+        Object.defineProperty(window, "localStorage", {
+            configurable: true,
+            value: new MemoryStorage(),
+        });
+        vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+            window.setTimeout(() => callback(performance.now()), 0),
+        );
+        vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+            window.clearTimeout(id);
+        });
+        monacoHarness.reset();
+        mockEditorRuntime.applyMonacoThemeFromDom.mockClear();
+        mockEditorRuntime.applyProjectTypeScriptConfigForPath.mockClear();
+        mockEditorRuntime.ensureMonacoTextMateForLanguage.mockClear();
+        mockEditorRuntime.installMonacoTokenDebugAction.mockClear();
+        mockWorkspaceStoreState.current.updateFileViewState.mockClear();
+        mockAiStoreState.current.sessions = {};
+    });
+
+    afterEach(() => {
+        act(() => {
+            root.unmount();
+        });
+        container.remove();
+        vi.unstubAllGlobals();
+    });
+
+    it("keeps one Monaco editor mounted while switching duplicate file tabs and saves the previous tab view state", async () => {
+        const firstTab = createFileTab("file-1");
+        const secondTab = createFileTab("file-2");
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: firstTab,
+                    fileTabs: [firstTab, secondTab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(monacoHarness.codeEditors).toHaveLength(1);
+        expect(monacoHarness.createdModels).toHaveLength(1);
+        expect(monacoHarness.createdModels[0]?.uri).toBe(
+            "/workspace/comando/src/app.ts",
+        );
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: secondTab,
+                    fileTabs: [firstTab, secondTab],
+                    recentActiveTabIds: ["file-1"],
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(monacoHarness.codeEditors).toHaveLength(1);
+        expect(monacoHarness.createdModels).toHaveLength(1);
+        expect(monacoHarness.codeEditors[0]?.disposed).toBe(false);
+        const persistedFirstTabViewState =
+            mockWorkspaceStoreState.current.updateFileViewState.mock.calls.find(
+                ([tabId]) => tabId === "file-1",
+            )?.[1] as
+                | {
+                      readonly viewState?: {
+                          readonly modelUri?: string | null;
+                      };
+                  }
+                | undefined;
+        expect(persistedFirstTabViewState?.viewState?.modelUri).toBe(
+            "/workspace/comando/src/app.ts",
+        );
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: null,
+                    fileTabs: [firstTab, secondTab],
+                    recentActiveTabIds: ["file-2"],
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(monacoHarness.codeEditors).toHaveLength(1);
+        expect(monacoHarness.codeEditors[0]?.disposed).toBe(false);
+        expect(container.querySelector("[aria-hidden='true']")).not.toBeNull();
+    });
+
+    it("mounts inline review diff models without unmounting the normal file editor", async () => {
+        const fileTab = createFileTab("file-1");
+        mockAiStoreState.current.sessions = {
+            "session-1": {
+                snapshot: {
+                    trackedFiles: [createTrackedFile()],
+                },
+            },
+        };
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: fileTab,
+                    fileTabs: [fileTab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const normalEditor = monacoHarness.codeEditors.find((editor) =>
+            editor.name.startsWith("editor-"),
+        );
+        const diffEditor = monacoHarness.diffEditors[0];
+        expect(normalEditor).toBeDefined();
+        expect(diffEditor).toBeDefined();
+        expect(diffEditor?.originalModel?.getValue()).toBe(
+            "const value = 1;\n",
+        );
+        expect(diffEditor?.modifiedModel?.getValue()).toBe(
+            "const value = 2;\n",
+        );
+
+        mockAiStoreState.current.sessions = {};
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: fileTab,
+                    fileTabs: [fileTab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(normalEditor?.disposed).toBe(false);
+        expect(diffEditor?.disposed).toBe(true);
+    });
+});

--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -135,13 +135,19 @@ const monacoHarness = vi.hoisted(() => {
             };
         };
         readonly setModel: (model: FakeModel | null) => void;
-        readonly setPosition: (position: unknown) => void;
+        readonly setPosition: (position: {
+            readonly column: number;
+            readonly lineNumber: number;
+        }) => void;
         readonly setScrollLeft: (scrollLeft: number) => void;
         readonly setScrollTop: (scrollTop: number) => void;
         readonly updateOptions: (options: unknown) => void;
         disposed: boolean;
         model: FakeModel | null;
         readonly name: string;
+        position: { column: number; lineNumber: number };
+        scrollLeft: number;
+        scrollTop: number;
     };
 
     type FakeDiffEditor = {
@@ -284,9 +290,9 @@ const monacoHarness = vi.hoisted(() => {
             getContribution: () => null,
             getDomNode: () => domNode,
             getModel: () => editor.model,
-            getPosition: () => ({ column: 1, lineNumber: 1 }),
-            getScrollLeft: () => 0,
-            getScrollTop: () => 0,
+            getPosition: () => editor.position,
+            getScrollLeft: () => editor.scrollLeft,
+            getScrollTop: () => editor.scrollTop,
             getSelection: () => null,
             getSelections: () => [],
             hasTextFocus: () => true,
@@ -318,12 +324,26 @@ const monacoHarness = vi.hoisted(() => {
                     modelUri: editor.model?.uri ?? null,
                 },
             })),
+            position: { column: 1, lineNumber: 1 },
+            scrollLeft: 0,
+            scrollTop: 0,
             setModel: (model: FakeModel | null) => {
                 editor.model = model;
             },
-            setPosition: vi.fn(),
-            setScrollLeft: vi.fn(),
-            setScrollTop: vi.fn(),
+            setPosition: vi.fn(
+                (position: {
+                    readonly column: number;
+                    readonly lineNumber: number;
+                }) => {
+                    editor.position = position;
+                },
+            ),
+            setScrollLeft: vi.fn((scrollLeft: number) => {
+                editor.scrollLeft = scrollLeft;
+            }),
+            setScrollTop: vi.fn((scrollTop: number) => {
+                editor.scrollTop = scrollTop;
+            }),
             updateOptions: vi.fn(),
         };
         codeEditors.push(editor);
@@ -672,6 +692,20 @@ function createTrackedFile(): AiTrackedFile {
     };
 }
 
+function createTrackedFileUpdate(): AiTrackedFile {
+    return {
+        ...createTrackedFile(),
+        newText: [
+            "const value = 2;",
+            "const nextValue = 3;",
+            "const finalValue = 4;",
+            "",
+        ].join("\n"),
+        updatedAt: "2026-06-05T00:02:00.000Z",
+        version: 3,
+    };
+}
+
 function renderHost({
     activeFileTab,
     fileTabs,
@@ -950,5 +984,69 @@ describe("WorkspaceFileEditorHost", () => {
         expect(diffEditor.disposed).toBe(false);
         expect(diffEditor.originalModel?.getValue()).toBe("const value = 1;\n");
         expect(diffEditor.modifiedModel?.getValue()).toBe("const value = 2;\n");
+    });
+
+    it("preserves inline review viewport when the agent updates the same file", async () => {
+        const fileTab = createFileTab("file-1");
+        mockAiStoreState.current.sessions = {
+            "session-1": {
+                snapshot: {
+                    trackedFiles: [createTrackedFile()],
+                },
+            },
+        };
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: fileTab,
+                    fileTabs: [fileTab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const diffEditor = monacoHarness.diffEditors[0];
+        expect(diffEditor).toBeDefined();
+        if (!diffEditor) {
+            throw new Error("Expected inline review diff editor to mount.");
+        }
+
+        const modifiedEditor = diffEditor.getModifiedEditor();
+        modifiedEditor.setPosition({ column: 7, lineNumber: 2 });
+        modifiedEditor.setScrollLeft(11);
+        modifiedEditor.setScrollTop(240);
+        diffEditor.getOriginalEditor().setScrollLeft(5);
+        diffEditor.getOriginalEditor().setScrollTop(200);
+
+        mockAiStoreState.current.sessions = {
+            "session-1": {
+                snapshot: {
+                    trackedFiles: [createTrackedFileUpdate()],
+                },
+            },
+        };
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: fileTab,
+                    fileTabs: [fileTab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(diffEditor.disposed).toBe(false);
+        expect(diffEditor.modifiedModel?.getValue()).toBe(
+            "const value = 2;\nconst nextValue = 3;\nconst finalValue = 4;\n",
+        );
+        expect(modifiedEditor.getPosition()).toEqual({
+            column: 7,
+            lineNumber: 2,
+        });
+        expect(modifiedEditor.getScrollLeft()).toBe(11);
+        expect(modifiedEditor.getScrollTop()).toBe(240);
+        expect(diffEditor.getOriginalEditor().getScrollLeft()).toBe(11);
+        expect(diffEditor.getOriginalEditor().getScrollTop()).toBe(240);
     });
 });

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -3621,6 +3621,7 @@ function FileTabView({
         trackedFile?.newText !== null
             ? trackedFile
             : null;
+    const isInlineReviewActive = inlineReviewTrackedFile !== null;
     const reviewSignature = useMemo(
         () => getInlineReviewSignature(inlineReviewTrackedFile),
         [inlineReviewTrackedFile],
@@ -3989,6 +3990,27 @@ function FileTabView({
         pendingEditorViewStateRef.current = tab.viewState ?? null;
         pendingEditorViewStateTabIdRef.current = tab.id;
     }, [tab.id, tab.viewState]);
+
+    useLayoutEffect(() => {
+        return () => {
+            if (isInlineReviewActive) {
+                captureInlineReviewModifiedEditorState();
+                return;
+            }
+
+            if (editorRef.current) {
+                captureEditorStateForInlineReview(editorRef.current);
+            }
+        };
+    }, [
+        captureEditorStateForInlineReview,
+        captureInlineReviewModifiedEditorState,
+        isInlineReviewActive,
+    ]);
+
+    useLayoutEffect(() => {
+        restoredEditorViewStateTabIdRef.current = null;
+    }, [isInlineReviewActive]);
 
     const getPendingEditorViewStateForTab = useCallback(
         (
@@ -5273,6 +5295,13 @@ function FileTabView({
                                 applyInlineReviewModels(inlineReviewTrackedFile);
 
                                 editor.onDidDispose(() => {
+                                    try {
+                                        captureInlineReviewModifiedEditorState();
+                                    } catch (error) {
+                                        if (!isMonacoDisposedError(error)) {
+                                            throw error;
+                                        }
+                                    }
                                     recordProbeLifecycleEvent(
                                         "WorkspaceInlineReviewDiffEditor",
                                         "dispose",
@@ -5355,12 +5384,18 @@ function FileTabView({
                             />
                         ) : null}
                     </div>
-                ) : (
+                ) : null}
+                <div
+                    className={inlineReviewTrackedFile ? "hidden" : "h-full"}
+                >
                     <EditorComponent
                         beforeMount={handleEditorBeforeMount}
                         language={monacoLanguageId}
                         onChange={(value: string | undefined) => {
-                            if (suppressEditorChangeRef.current) {
+                            if (
+                                suppressEditorChangeRef.current ||
+                                inlineReviewTrackedFile
+                            ) {
                                 return;
                             }
 
@@ -5542,7 +5577,7 @@ function FileTabView({
                         theme={editorTheme}
                         value={tab.draftContent}
                     />
-                )}
+                </div>
             </div>
         </div>
     );

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -3836,19 +3836,8 @@ function FileTabView({
             const tabId = fileTabIdRef.current;
             pendingEditorViewStateRef.current = editor.saveViewState();
             pendingEditorViewStateTabIdRef.current = tabId;
-            if (viewStatePersistTimerRef.current != null) {
-                return;
-            }
-
-            viewStatePersistTimerRef.current = window.setTimeout(() => {
-                viewStatePersistTimerRef.current = null;
-                persistEditorViewState(
-                    tabId,
-                    pendingEditorViewStateRef.current,
-                );
-            }, 120);
         },
-        [persistEditorViewState],
+        [],
     );
 
     const captureEditorStateForInlineReview = useCallback(
@@ -3959,6 +3948,10 @@ function FileTabView({
 
         if (diffEditorRef.current) {
             captureInlineReviewModifiedEditorState();
+            persistEditorViewState(
+                previousTabId,
+                pendingEditorViewStateRef.current,
+            );
         }
 
         fileTabIdRef.current = tab.id;
@@ -3967,6 +3960,7 @@ function FileTabView({
         restoredEditorViewStateTabIdRef.current = null;
     }, [
         captureInlineReviewModifiedEditorState,
+        persistEditorViewState,
         tab.id,
         tab.viewState,
         updateFileViewState,
@@ -3995,22 +3989,39 @@ function FileTabView({
         return () => {
             if (isInlineReviewActive) {
                 captureInlineReviewModifiedEditorState();
+                persistEditorViewState(
+                    fileTabIdRef.current,
+                    pendingEditorViewStateRef.current,
+                );
                 return;
             }
 
             if (editorRef.current) {
                 captureEditorStateForInlineReview(editorRef.current);
+                persistEditorViewState(
+                    fileTabIdRef.current,
+                    editorRef.current.saveViewState(),
+                );
             }
         };
     }, [
         captureEditorStateForInlineReview,
         captureInlineReviewModifiedEditorState,
         isInlineReviewActive,
+        persistEditorViewState,
     ]);
 
     useLayoutEffect(() => {
         restoredEditorViewStateTabIdRef.current = null;
     }, [isInlineReviewActive]);
+
+    useEffect(() => {
+        if (isVisible) {
+            return;
+        }
+
+        flushScheduledEditorViewStatePersist();
+    }, [flushScheduledEditorViewStatePersist, isVisible]);
 
     const getPendingEditorViewStateForTab = useCallback(
         (

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -3248,15 +3248,21 @@ function getAttachSelectionDiffEditorCandidates(
     return [...editors];
 }
 
-function bindInlineReviewAttachSelectionShortcut(
-    input: AttachSelectionShortcutInput & {
-        readonly diffEditor: MonacoEditor.IStandaloneDiffEditor;
-    },
-): (() => void) {
+function bindInlineReviewAttachSelectionShortcut(input: {
+    readonly diffEditor: MonacoEditor.IStandaloneDiffEditor;
+    readonly inputRef: {
+        readonly current: AttachSelectionShortcutInput | null;
+    };
+}): (() => void) {
     const containerDomNode = input.diffEditor.getContainerDomNode();
 
     const handleDiffEditorKeyDown = (event: KeyboardEvent) => {
         if (!isAttachSelectionShortcutEvent(event)) {
+            return;
+        }
+
+        const shortcutInput = input.inputRef.current;
+        if (!shortcutInput) {
             return;
         }
 
@@ -3268,7 +3274,7 @@ function bindInlineReviewAttachSelectionShortcut(
         if (
             !candidates.some((editor) =>
                 tryAttachEditorSelectionWithShortcutInput({
-                    ...input,
+                    ...shortcutInput,
                     editor,
                 }),
             )
@@ -3568,6 +3574,8 @@ function FileTabView({
     const editorMonacoRef = useRef<MonacoNamespace | null>(null);
     const editorAttachSelectionShortcutInputRef =
         useRef<AttachSelectionShortcutInput | null>(null);
+    const inlineReviewAttachSelectionShortcutInputRef =
+        useRef<AttachSelectionShortcutInput | null>(null);
     const editorMarkdownLanguageIdRef = useRef(
         document?.languageId ?? "plaintext",
     );
@@ -3681,6 +3689,22 @@ function FileTabView({
         };
     }, [
         documentAbsolutePath,
+        tab.id,
+    ]);
+    const inlineReviewDiffEditorKey = useMemo(() => {
+        if (!inlineReviewShellModelPaths) {
+            return `inline-review:${tab.id}`;
+        }
+
+        // @monaco-editor/react owns shell models through these path props, while
+        // applyInlineReviewModels installs the real review models. Remount when
+        // the file identity changes so the wrapper cannot replay stale shells.
+        return [
+            inlineReviewShellModelPaths.original,
+            inlineReviewShellModelPaths.modified,
+        ].join("|");
+    }, [
+        inlineReviewShellModelPaths,
         tab.id,
     ]);
     const reviewDiff = useMemo(
@@ -3963,12 +3987,41 @@ function FileTabView({
             tab.worktreeId,
         ]);
 
+    const buildInlineReviewAttachSelectionShortcutInput =
+        useCallback((): AttachSelectionShortcutInput | null => {
+            if (!isVisible || !document || !canEdit || !inlineReviewTrackedFile) {
+                return null;
+            }
+
+            return {
+                documentLanguageId: document.languageId,
+                onAttachLineFragment,
+                projectId: tab.projectId,
+                relativePath: tab.relativePath,
+                tabTitle: tab.title,
+                worktreeId: tab.worktreeId ?? null,
+            };
+        }, [
+            canEdit,
+            document,
+            inlineReviewTrackedFile,
+            isVisible,
+            onAttachLineFragment,
+            tab.projectId,
+            tab.relativePath,
+            tab.title,
+            tab.worktreeId,
+        ]);
+
     useLayoutEffect(() => {
         editorMarkdownLanguageIdRef.current = documentLanguageId;
         editorAttachSelectionShortcutInputRef.current =
             buildEditorAttachSelectionShortcutInput();
+        inlineReviewAttachSelectionShortcutInputRef.current =
+            buildInlineReviewAttachSelectionShortcutInput();
     }, [
         buildEditorAttachSelectionShortcutInput,
+        buildInlineReviewAttachSelectionShortcutInput,
         documentLanguageId,
     ]);
 
@@ -5228,6 +5281,7 @@ function FileTabView({
                     >
                         <DiffEditorComponent
                             beforeMount={handleEditorBeforeMount}
+                            key={inlineReviewDiffEditorKey}
                             language={monacoLanguageId}
                             modified=""
                             modifiedModelPath={
@@ -5298,13 +5352,9 @@ function FileTabView({
                                 };
                                 const cleanupAttachShortcut =
                                     bindInlineReviewAttachSelectionShortcut({
-                                        documentLanguageId: document.languageId,
                                         diffEditor: editor,
-                                        onAttachLineFragment,
-                                        projectId: tab.projectId,
-                                        relativePath: tab.relativePath,
-                                        tabTitle: tab.title,
-                                        worktreeId: tab.worktreeId ?? null,
+                                        inputRef:
+                                            inlineReviewAttachSelectionShortcutInputRef,
                                     });
                                 const cleanupFindWidgetEscape =
                                     bindCloseFindWidgetOnEscape(modifiedEditor);

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -4797,9 +4797,17 @@ function FileTabView({
                 return;
             }
 
+            const installedModels = diffEditorRef.current.getModel();
+            const currentReviewModels = inlineReviewCurrentModelsRef.current;
             if (
-                inlineReviewCurrentModelsRef.current.revision ===
-                inlineReviewModelRevision
+                currentReviewModels.revision ===
+                    inlineReviewModelRevision &&
+                currentReviewModels.original &&
+                currentReviewModels.modified &&
+                !currentReviewModels.original.isDisposed() &&
+                !currentReviewModels.modified.isDisposed() &&
+                installedModels?.original === currentReviewModels.original &&
+                installedModels?.modified === currentReviewModels.modified
             ) {
                 return;
             }
@@ -5181,8 +5189,17 @@ function FileTabView({
     ]);
 
     useLayoutEffect(() => {
+        if (!isVisible) {
+            return;
+        }
+
         applyInlineReviewModels(inlineReviewTrackedFile);
-    }, [applyInlineReviewModels, inlineReviewTrackedFile]);
+    }, [
+        applyInlineReviewModels,
+        diffEditorMountVersion,
+        inlineReviewTrackedFile,
+        isVisible,
+    ]);
 
     useEffect(() => {
         if (inlineReviewTrackedFile) {

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -3617,6 +3617,10 @@ function FileTabView({
         useRef<MonacoEditor.ICodeEditorViewState | null>(tab.viewState ?? null);
     const pendingEditorViewStateTabIdRef = useRef(tab.id);
     const viewStatePersistTimerRef = useRef<number | null>(null);
+    const scheduledEditorViewStatePersistRef = useRef<{
+        readonly tabId: string;
+        readonly viewState: MonacoEditor.ICodeEditorViewState | null;
+    } | null>(null);
     const viewStateRestoreFrameRef = useRef<number | null>(null);
     const restoredEditorViewStateTabIdRef = useRef<string | null>(null);
     const suppressEditorChangeRef = useRef(false);
@@ -3778,9 +3782,24 @@ function FileTabView({
     );
 
     const flushScheduledEditorViewStatePersist = useCallback(() => {
+        const scheduledPersist = scheduledEditorViewStatePersistRef.current;
+        scheduledEditorViewStatePersistRef.current = null;
+
         if (viewStatePersistTimerRef.current != null) {
             window.clearTimeout(viewStatePersistTimerRef.current);
             viewStatePersistTimerRef.current = null;
+        }
+
+        if (scheduledPersist) {
+            persistEditorViewState(
+                scheduledPersist.tabId,
+                scheduledPersist.viewState,
+            );
+            if (
+                scheduledPersist.tabId === pendingEditorViewStateTabIdRef.current
+            ) {
+                return;
+            }
         }
 
         persistEditorViewState(
@@ -3928,10 +3947,35 @@ function FileTabView({
     const scheduleEditorViewStatePersist = useCallback(
         (editor: MonacoEditor.IStandaloneCodeEditor) => {
             const tabId = fileTabIdRef.current;
-            pendingEditorViewStateRef.current = editor.saveViewState();
+            const viewState = editor.saveViewState();
+            pendingEditorViewStateRef.current = viewState;
             pendingEditorViewStateTabIdRef.current = tabId;
+            scheduledEditorViewStatePersistRef.current = {
+                tabId,
+                viewState,
+            };
+
+            if (viewStatePersistTimerRef.current != null) {
+                return;
+            }
+
+            viewStatePersistTimerRef.current = window.setTimeout(() => {
+                viewStatePersistTimerRef.current = null;
+                const scheduledPersist =
+                    scheduledEditorViewStatePersistRef.current;
+                scheduledEditorViewStatePersistRef.current = null;
+
+                if (!scheduledPersist) {
+                    return;
+                }
+
+                persistEditorViewState(
+                    scheduledPersist.tabId,
+                    scheduledPersist.viewState,
+                );
+            }, 120);
         },
-        [],
+        [persistEditorViewState],
     );
 
     const captureEditorStateForInlineReview = useCallback(
@@ -4076,6 +4120,16 @@ function FileTabView({
             pendingEditorViewStateRef.current = previousViewState;
             pendingEditorViewStateTabIdRef.current = previousTabId;
             updateFileViewState(previousTabId, previousViewState);
+        }
+
+        if (
+            scheduledEditorViewStatePersistRef.current?.tabId === previousTabId
+        ) {
+            scheduledEditorViewStatePersistRef.current = null;
+        }
+        if (viewStatePersistTimerRef.current != null) {
+            window.clearTimeout(viewStatePersistTimerRef.current);
+            viewStatePersistTimerRef.current = null;
         }
 
         if (diffEditorRef.current) {

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -4571,9 +4571,7 @@ function FileTabView({
         if (
             !document ||
             document.kind === "image" ||
-            !canEdit ||
-            inlineReviewTrackedFile ||
-            !isVisible
+            !canEdit
         ) {
             return;
         }
@@ -4599,6 +4597,10 @@ function FileTabView({
             });
         }
         previousLease?.release();
+
+        if (!isVisible || inlineReviewTrackedFile) {
+            return;
+        }
 
         restoreEditorViewStateForTab(
             editor,

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -2452,7 +2452,7 @@ function WorkspacePaneView({
     );
 }
 
-function WorkspaceFileEditorHost({
+export function WorkspaceFileEditorHost({
     activeFileTab,
     fileTabs,
     isActivePane,

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -116,7 +116,11 @@ import {
 } from "@renderer/components/workspace/gitGutter";
 import { buildInlineReviewDecorations } from "@renderer/components/workspace/inlineReviewDecorations";
 import { buildInlineReviewDiffEditorOptions } from "@renderer/components/workspace/inlineReviewDiffEditorOptions";
-import { buildWorkspaceEditorModelPath } from "@renderer/components/workspace/editorModelPath";
+import {
+    buildWorkspaceEditorModelPath,
+    buildWorkspaceFileEditorModelPath,
+    getOrCreateWorkspaceFileModel,
+} from "@renderer/components/workspace/editorModelPath";
 import { appendSelectionMentionToRegisteredComposer } from "@renderer/components/workspace/chat/composerSelectionBridge";
 import { canResolveFileHunks } from "@renderer/components/workspace/review/editedFilesPresentationModel";
 import { createDiffFromTrackedFile } from "@renderer/components/workspace/review/reviewDiff";
@@ -3522,6 +3526,7 @@ function FileTabView({
     const inlineReviewHoverHideTimerRef = useRef<number | null>(null);
     const hoveredInlineReviewHunkIdRef = useRef<string | null>(null);
     const editorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
+    const editorMonacoRef = useRef<MonacoNamespace | null>(null);
     const inlineReviewMonacoRef = useRef<MonacoNamespace | null>(null);
     const inlineReviewCurrentModelsRef = useRef<InlineReviewModelState>({
         modified: null,
@@ -4265,6 +4270,40 @@ function FileTabView({
         runtime?.applyMonacoThemeFromDom();
     }, [runtime]);
 
+    useLayoutEffect(() => {
+        if (
+            !document ||
+            document.kind === "image" ||
+            !canEdit ||
+            inlineReviewTrackedFile
+        ) {
+            return;
+        }
+
+        const editor = editorRef.current;
+        const monaco = editorMonacoRef.current;
+        if (!editor || !monaco) {
+            return;
+        }
+
+        const model = getOrCreateWorkspaceFileModel({
+            absolutePath: document.absolutePath,
+            language: monacoLanguageId,
+            monaco,
+            value: tab.draftContent,
+        });
+
+        if (editor.getModel() !== model) {
+            editor.setModel(model);
+        }
+    }, [
+        canEdit,
+        document,
+        inlineReviewTrackedFile,
+        monacoLanguageId,
+        tab.draftContent,
+    ]);
+
     useEffect(() => {
         if (!runtime || !document || document.kind === "image") {
             return;
@@ -4273,6 +4312,19 @@ function FileTabView({
         void runtime.applyProjectTypeScriptConfigForPath(document.absolutePath);
     }, [
         document,
+        runtime,
+    ]);
+
+    useEffect(() => {
+        if (!runtime || !document || document.kind === "image" || !canEdit) {
+            return;
+        }
+
+        void runtime.ensureMonacoTextMateForLanguage(monacoLanguageId);
+    }, [
+        canEdit,
+        document,
+        monacoLanguageId,
         runtime,
     ]);
 
@@ -5198,7 +5250,10 @@ function FileTabView({
                         onChange={(value: string | undefined) =>
                             onDraftChange(tab.id, value ?? "")
                         }
-                        onMount={(editor) => {
+                        onMount={(
+                            editor: MonacoEditor.IStandaloneCodeEditor,
+                            monaco: MonacoNamespace,
+                        ) => {
                             recordProbeLifecycleEvent(
                                 "WorkspaceMonacoEditor",
                                 "mount",
@@ -5209,6 +5264,16 @@ function FileTabView({
                                 },
                             );
                             editorRef.current = editor;
+                            editorMonacoRef.current = monaco;
+                            const model = getOrCreateWorkspaceFileModel({
+                                absolutePath: document.absolutePath,
+                                language: monacoLanguageId,
+                                monaco,
+                                value: tab.draftContent,
+                            });
+                            if (editor.getModel() !== model) {
+                                editor.setModel(model);
+                            }
                             void runtime?.ensureMonacoTextMateForLanguage(
                                 monacoLanguageId,
                             );
@@ -5292,6 +5357,7 @@ function FileTabView({
                                 // view state captured during unmount cleanup.
                                 flushScheduledEditorViewStatePersist();
                                 editorRef.current = null;
+                                editorMonacoRef.current = null;
                                 gitGutterDecorationsRef.current = null;
                                 cleanupTokenDebug?.dispose();
                                 scrollListener.dispose();
@@ -5349,10 +5415,8 @@ function FileTabView({
                                 : "off",
                         }}
                         saveViewState
-                        path={buildWorkspaceEditorModelPath(
+                        path={buildWorkspaceFileEditorModelPath(
                             document.absolutePath,
-                            tab.id,
-                            "editor",
                         )}
                         theme={editorTheme}
                         value={tab.draftContent}

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -69,7 +69,11 @@ import {
     saveAppEditorSettings,
 } from "@renderer/app/settings/client";
 import { buildEditorFontFamily } from "@renderer/app/settings/theme";
-import { useRenderProbe } from "@renderer/app/debug/renderProbe";
+import {
+    recordProbeLifecycleEvent,
+    useLifecycleProbe,
+    useRenderProbe,
+} from "@renderer/app/debug/renderProbe";
 import { useAiStore } from "@renderer/app/store/ai-store";
 import { useGitStore } from "@renderer/app/store/git-store";
 import {
@@ -3361,6 +3365,14 @@ function FileTabView({
     readonly tab: RuntimeWorkspaceFileTab;
 }) {
     const document = tab.document;
+    useRenderProbe("FileTabView", {
+        path: tab.relativePath,
+        tabId: tab.id,
+    });
+    useLifecycleProbe("FileTabView", {
+        path: tab.relativePath,
+        tabId: tab.id,
+    });
     const projectSummary = useProjectsStore((state) =>
         state.projects.find((project) => project.id === tab.projectId) ?? null,
     );
@@ -4834,6 +4846,15 @@ function FileTabView({
                                 editor: MonacoEditor.IStandaloneDiffEditor,
                                 monaco: MonacoNamespace,
                             ) => {
+                                recordProbeLifecycleEvent(
+                                    "WorkspaceInlineReviewDiffEditor",
+                                    "mount",
+                                    {
+                                        language: monacoLanguageId,
+                                        path: tab.relativePath,
+                                        tabId: tab.id,
+                                    },
+                                );
                                 diffEditorRef.current = editor;
                                 void runtime?.ensureMonacoTextMateForLanguage(
                                     monacoLanguageId,
@@ -4931,6 +4952,15 @@ function FileTabView({
                                 applyInlineReviewModels(inlineReviewTrackedFile);
 
                                 editor.onDidDispose(() => {
+                                    recordProbeLifecycleEvent(
+                                        "WorkspaceInlineReviewDiffEditor",
+                                        "dispose",
+                                        {
+                                            language: monacoLanguageId,
+                                            path: tab.relativePath,
+                                            tabId: tab.id,
+                                        },
+                                    );
                                     const ownedModels =
                                         inlineReviewOwnedModelsRef.current;
                                     cleanupOriginalTokenDebug?.dispose();
@@ -5012,6 +5042,15 @@ function FileTabView({
                             onDraftChange(tab.id, value ?? "")
                         }
                         onMount={(editor) => {
+                            recordProbeLifecycleEvent(
+                                "WorkspaceMonacoEditor",
+                                "mount",
+                                {
+                                    language: monacoLanguageId,
+                                    path: tab.relativePath,
+                                    tabId: tab.id,
+                                },
+                            );
                             editorRef.current = editor;
                             void runtime?.ensureMonacoTextMateForLanguage(
                                 monacoLanguageId,
@@ -5079,6 +5118,15 @@ function FileTabView({
                             setEditorMountVersion((previous) => previous + 1);
 
                             editor.onDidDispose(() => {
+                                recordProbeLifecycleEvent(
+                                    "WorkspaceMonacoEditor",
+                                    "dispose",
+                                    {
+                                        language: monacoLanguageId,
+                                        path: tab.relativePath,
+                                        tabId: tab.id,
+                                    },
+                                );
                                 clearScheduledEditorViewStateRestore();
                                 // Do not call editor.saveViewState() here.
                                 // @monaco-editor/react disposes the model

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -117,9 +117,11 @@ import {
 import { buildInlineReviewDecorations } from "@renderer/components/workspace/inlineReviewDecorations";
 import { buildInlineReviewDiffEditorOptions } from "@renderer/components/workspace/inlineReviewDiffEditorOptions";
 import {
+    acquireWorkspaceFileModel,
     buildWorkspaceEditorModelPath,
     buildWorkspaceFileEditorModelPath,
     getOrCreateWorkspaceFileModel,
+    type WorkspaceFileModelLease,
 } from "@renderer/components/workspace/editorModelPath";
 import { appendSelectionMentionToRegisteredComposer } from "@renderer/components/workspace/chat/composerSelectionBridge";
 import { canResolveFileHunks } from "@renderer/components/workspace/review/editedFilesPresentationModel";
@@ -3572,6 +3574,8 @@ function FileTabView({
     const hoveredInlineReviewHunkIdRef = useRef<string | null>(null);
     const editorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
     const editorMonacoRef = useRef<MonacoNamespace | null>(null);
+    const workspaceFileModelLeaseRef =
+        useRef<WorkspaceFileModelLease | null>(null);
     const editorAttachSelectionShortcutInputRef =
         useRef<AttachSelectionShortcutInput | null>(null);
     const inlineReviewAttachSelectionShortcutInputRef =
@@ -3884,6 +3888,42 @@ function FileTabView({
             suppressEditorChangeRef.current = false;
         }
     }, []);
+
+    const acquireFileEditorModel = useCallback(
+        (input: {
+            readonly absolutePath: string;
+            readonly language: string;
+            readonly monaco: MonacoNamespace;
+            readonly value: string;
+        }): {
+            readonly model: MonacoEditor.ITextModel;
+            readonly previousLease: WorkspaceFileModelLease | null;
+        } => {
+            const modelPath = buildWorkspaceFileEditorModelPath(
+                input.absolutePath,
+            );
+            const currentLease = workspaceFileModelLeaseRef.current;
+
+            if (
+                currentLease?.modelPath === modelPath &&
+                !currentLease.model.isDisposed()
+            ) {
+                const model = getOrCreateWorkspaceFileModel(input);
+                if (model === currentLease.model) {
+                    return { model, previousLease: null };
+                }
+            }
+
+            const nextLease = acquireWorkspaceFileModel(input);
+            workspaceFileModelLeaseRef.current = nextLease;
+
+            return {
+                model: nextLease.model,
+                previousLease: currentLease,
+            };
+        },
+        [],
+    );
 
     const scheduleEditorViewStatePersist = useCallback(
         (editor: MonacoEditor.IStandaloneCodeEditor) => {
@@ -4490,8 +4530,8 @@ function FileTabView({
             return;
         }
 
-        const model = runWithoutEditorChangeNotification(() =>
-            getOrCreateWorkspaceFileModel({
+        const { model, previousLease } = runWithoutEditorChangeNotification(() =>
+            acquireFileEditorModel({
                 absolutePath: document.absolutePath,
                 language: monacoLanguageId,
                 monaco,
@@ -4504,6 +4544,7 @@ function FileTabView({
                 editor.setModel(model);
             });
         }
+        previousLease?.release();
 
         restoreEditorViewStateForTab(
             editor,
@@ -4512,6 +4553,7 @@ function FileTabView({
         );
     }, [
         canEdit,
+        acquireFileEditorModel,
         document,
         getPendingEditorViewStateForTab,
         inlineReviewTrackedFile,
@@ -5516,20 +5558,22 @@ function FileTabView({
                             );
                             editorRef.current = editor;
                             editorMonacoRef.current = monaco;
-                            const model = runWithoutEditorChangeNotification(
-                                () =>
-                                    getOrCreateWorkspaceFileModel({
-                                        absolutePath: document.absolutePath,
-                                        language: monacoLanguageId,
-                                        monaco,
-                                        value: tab.draftContent,
-                                    }),
-                            );
+                            const { model, previousLease } =
+                                runWithoutEditorChangeNotification(
+                                    () =>
+                                        acquireFileEditorModel({
+                                            absolutePath: document.absolutePath,
+                                            language: monacoLanguageId,
+                                            monaco,
+                                            value: tab.draftContent,
+                                        }),
+                                );
                             if (editor.getModel() !== model) {
                                 runWithoutEditorChangeNotification(() => {
                                     editor.setModel(model);
                                 });
                             }
+                            previousLease?.release();
                             void runtime?.ensureMonacoTextMateForLanguage(
                                 monacoLanguageId,
                             );
@@ -5608,11 +5652,12 @@ function FileTabView({
                                     },
                                 );
                                 clearScheduledEditorViewStateRestore();
-                                // Do not call editor.saveViewState() here.
-                                // @monaco-editor/react disposes the model
-                                // before disposing the editor, so saveViewState
-                                // would return null and overwrite the valid
-                                // view state captured during unmount cleanup.
+                                const workspaceFileModelLease =
+                                    workspaceFileModelLeaseRef.current;
+                                workspaceFileModelLeaseRef.current = null;
+                                // Do not call editor.saveViewState() here. The
+                                // editor can already be tearing down, so keep
+                                // the valid state captured during cleanup.
                                 flushScheduledEditorViewStatePersist();
                                 editorRef.current = null;
                                 editorMonacoRef.current = null;
@@ -5623,11 +5668,13 @@ function FileTabView({
                                 hiddenAreasListener.dispose();
                                 cleanupAttachShortcut?.();
                                 cleanupMarkdownListShortcut?.();
+                                workspaceFileModelLease?.release();
                                 setEditorMountVersion(
                                     (previous) => previous + 1,
                                 );
                             });
                         }}
+                        keepCurrentModel
                         options={{
                             automaticLayout: true,
                             fontFamily: editorFontFamily,

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -4815,6 +4815,12 @@ function FileTabView({
             const diffEditor = diffEditorRef.current;
             const monaco = inlineReviewMonacoRef.current;
             const previousModels = diffEditor.getModel();
+            const currentInlineReviewRestoreState =
+                currentReviewModels.revision && previousModels?.modified
+                    ? capturePortableEditorRestoreState(
+                          diffEditor.getModifiedEditor(),
+                      )
+                    : null;
             const scrollState = inlineReviewScrollStateRef.current;
             const persistedInlineReviewViewState =
                 tab.viewState ?? pendingEditorViewStateRef.current;
@@ -4862,7 +4868,12 @@ function FileTabView({
                     modified: nextModifiedModel,
                     original: nextOriginalModel,
                 };
-                if (pendingInlineReviewRestoreState) {
+                if (currentInlineReviewRestoreState) {
+                    restorePortableInlineReviewState(
+                        diffEditor,
+                        currentInlineReviewRestoreState,
+                    );
+                } else if (pendingInlineReviewRestoreState) {
                     restorePortableInlineReviewState(
                         diffEditor,
                         pendingInlineReviewRestoreState,

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -3160,24 +3160,27 @@ function tryAttachEditorSelectionWithShortcutInput(
     });
 }
 
-function bindAttachSelectionShortcut(
-    input: AttachSelectionShortcutInput & {
-        readonly editor: MonacoEditor.IStandaloneCodeEditor;
-    },
-): (() => void) | null {
+function bindAttachSelectionShortcutWithInputRef(input: {
+    readonly editor: MonacoEditor.IStandaloneCodeEditor;
+    readonly inputRef: {
+        readonly current: AttachSelectionShortcutInput | null;
+    };
+}): (() => void) | null {
     const editorDomNode = input.editor.getDomNode();
     if (!editorDomNode) {
         return null;
     }
 
     const handleEditorKeyDown = (event: KeyboardEvent) => {
-        if (!isAttachSelectionShortcutEvent(event)) {
+        const shortcutInput = input.inputRef.current;
+        if (!shortcutInput || !isAttachSelectionShortcutEvent(event)) {
             return;
         }
 
-        // Intercept in capture so Monaco doesn't expand line selection
-        // before we can attach the current selection.
-        const attached = tryAttachEditorSelectionWithShortcutInput(input);
+        const attached = tryAttachEditorSelectionWithShortcutInput({
+            ...shortcutInput,
+            editor: input.editor,
+        });
 
         if (!attached) {
             return;
@@ -3297,93 +3300,99 @@ function bindCloseFindWidgetOnEscape(
     };
 }
 
-function bindMarkdownListEditingShortcuts(input: {
-    readonly documentLanguageId: string;
-    readonly editor: MonacoEditor.IStandaloneCodeEditor;
-}): (() => void) | null {
-    if (input.documentLanguageId !== "markdown") {
-        return null;
+function handleMarkdownListEditingShortcut(
+    editor: MonacoEditor.IStandaloneCodeEditor,
+    event: KeyboardEvent,
+): void {
+    if (
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.isComposing
+    ) {
+        return;
     }
 
+    const model = editor.getModel();
+    const selections = editor.getSelections();
+    const selection = editor.getSelection();
+    if (!model || !selection || (selections?.length ?? 0) > 1) {
+        return;
+    }
+
+    const text = model.getValue();
+    const tabSize = model.getOptions().tabSize;
+    const selectionStartOffset = model.getOffsetAt(
+        selection.getStartPosition(),
+    );
+    const selectionEndOffset = model.getOffsetAt(selection.getEndPosition());
+    const result =
+        event.key === "Enter" && !event.shiftKey && selection.isEmpty()
+            ? continueMarkdownList(text, selectionEndOffset)
+            : event.key === "Tab" && !event.shiftKey
+              ? indentMarkdownListItems(
+                    text,
+                    selectionStartOffset,
+                    selectionEndOffset,
+                    tabSize,
+                )
+              : event.key === "Tab" && event.shiftKey
+                ? outdentMarkdownListItems(
+                      text,
+                      selectionStartOffset,
+                      selectionEndOffset,
+                      tabSize,
+                  )
+                : null;
+    if (!result) {
+        return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+
+    editor.pushUndoStop();
+    editor.executeEdits("markdown-list-continuation", [
+        {
+            forceMoveMarkers: true,
+            range: model.getFullModelRange(),
+            text: result.text,
+        },
+    ]);
+
+    const nextModel = editor.getModel();
+    if (!nextModel) {
+        return;
+    }
+
+    editor.setSelection({
+        endColumn: nextModel.getPositionAt(result.selectionEnd).column,
+        endLineNumber: nextModel.getPositionAt(result.selectionEnd).lineNumber,
+        startColumn: nextModel.getPositionAt(result.selectionStart).column,
+        startLineNumber: nextModel.getPositionAt(result.selectionStart)
+            .lineNumber,
+    });
+    editor.pushUndoStop();
+}
+
+function bindMarkdownListEditingShortcutsWithLanguageRef(input: {
+    readonly documentLanguageIdRef: {
+        readonly current: string;
+    };
+    readonly editor: MonacoEditor.IStandaloneCodeEditor;
+}): (() => void) | null {
     const editorDomNode = input.editor.getDomNode();
     if (!editorDomNode) {
         return null;
     }
 
     const handleEditorKeyDown = (event: KeyboardEvent) => {
-        if (
-            event.altKey ||
-            event.ctrlKey ||
-            event.metaKey ||
-            event.isComposing
-        ) {
+        if (input.documentLanguageIdRef.current !== "markdown") {
             return;
         }
 
-        const model = input.editor.getModel();
-        const selections = input.editor.getSelections();
-        const selection = input.editor.getSelection();
-        if (!model || !selection || (selections?.length ?? 0) > 1) {
-            return;
-        }
-
-        const text = model.getValue();
-        const tabSize = model.getOptions().tabSize;
-        const selectionStartOffset = model.getOffsetAt(
-            selection.getStartPosition(),
-        );
-        const selectionEndOffset = model.getOffsetAt(
-            selection.getEndPosition(),
-        );
-        const result =
-            event.key === "Enter" && !event.shiftKey && selection.isEmpty()
-                ? continueMarkdownList(text, selectionEndOffset)
-                : event.key === "Tab" && !event.shiftKey
-                  ? indentMarkdownListItems(
-                        text,
-                        selectionStartOffset,
-                        selectionEndOffset,
-                        tabSize,
-                    )
-                  : event.key === "Tab" && event.shiftKey
-                    ? outdentMarkdownListItems(
-                          text,
-                          selectionStartOffset,
-                          selectionEndOffset,
-                          tabSize,
-                      )
-                    : null;
-        if (!result) {
-            return;
-        }
-
-        event.preventDefault();
-        event.stopPropagation();
-        event.stopImmediatePropagation();
-
-        input.editor.pushUndoStop();
-        input.editor.executeEdits("markdown-list-continuation", [
-            {
-                forceMoveMarkers: true,
-                range: model.getFullModelRange(),
-                text: result.text,
-            },
-        ]);
-
-        const nextModel = input.editor.getModel();
-        if (!nextModel) {
-            return;
-        }
-
-        input.editor.setSelection({
-            endColumn: nextModel.getPositionAt(result.selectionEnd).column,
-            endLineNumber: nextModel.getPositionAt(result.selectionEnd)
-                .lineNumber,
-            startColumn: nextModel.getPositionAt(result.selectionStart).column,
-            startLineNumber: nextModel.getPositionAt(result.selectionStart)
-                .lineNumber,
-        });
-        input.editor.pushUndoStop();
+        handleMarkdownListEditingShortcut(input.editor, event);
     };
 
     editorDomNode.addEventListener("keydown", handleEditorKeyDown, true);
@@ -3527,6 +3536,11 @@ function FileTabView({
     const hoveredInlineReviewHunkIdRef = useRef<string | null>(null);
     const editorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
     const editorMonacoRef = useRef<MonacoNamespace | null>(null);
+    const editorAttachSelectionShortcutInputRef =
+        useRef<AttachSelectionShortcutInput | null>(null);
+    const editorMarkdownLanguageIdRef = useRef(
+        document?.languageId ?? "plaintext",
+    );
     const inlineReviewMonacoRef = useRef<MonacoNamespace | null>(null);
     const inlineReviewCurrentModelsRef = useRef<InlineReviewModelState>({
         modified: null,
@@ -3901,6 +3915,32 @@ function FileTabView({
         captureInlineReviewModifiedEditorState,
         inlineReviewTrackedFile,
         rejectTrackedFile,
+    ]);
+
+    useLayoutEffect(() => {
+        editorMarkdownLanguageIdRef.current = documentLanguageId;
+        editorAttachSelectionShortcutInputRef.current =
+            isVisible && document && canEdit && !inlineReviewTrackedFile
+                ? {
+                      documentLanguageId: document.languageId,
+                      onAttachLineFragment,
+                      projectId: tab.projectId,
+                      relativePath: tab.relativePath,
+                      tabTitle: tab.title,
+                      worktreeId: tab.worktreeId ?? null,
+                  }
+                : null;
+    }, [
+        canEdit,
+        document,
+        documentLanguageId,
+        inlineReviewTrackedFile,
+        isVisible,
+        onAttachLineFragment,
+        tab.projectId,
+        tab.relativePath,
+        tab.title,
+        tab.worktreeId,
     ]);
 
     useLayoutEffect(() => {
@@ -4654,6 +4694,9 @@ function FileTabView({
         }
 
         const controller = new AbortController();
+        const cancelPendingReset = scheduleEffectStateUpdate(() => {
+            setGitGutterDiff(null);
+        });
 
         const loadGitDiff = async () => {
             try {
@@ -4681,6 +4724,7 @@ function FileTabView({
         void loadGitDiff();
 
         return () => {
+            cancelPendingReset();
             controller.abort();
         };
     }, [
@@ -4723,7 +4767,13 @@ function FileTabView({
                 : [],
         );
         gitGutterDecorationsRef.current = collection;
-    }, [editorMountVersion, gitGutterDiff]);
+    }, [
+        documentAbsolutePath,
+        editorMountVersion,
+        gitGutterDiff,
+        tab.draftContent,
+        tab.id,
+    ]);
 
     useEffect(() => {
         if (
@@ -4837,6 +4887,10 @@ function FileTabView({
             fontFamily: editorFontFamily,
             fontSize: editorSettings.fontSize,
             lineHeight: editorLineHeightPx,
+            lineDecorationsWidth: 0,
+            lineNumbersMinChars: shouldShowGitGutter
+                ? gitGutterLineNumbersMinChars
+                : 4,
             minimap: {
                 enabled: editorSettings.minimapEnabled,
             },
@@ -4855,6 +4909,7 @@ function FileTabView({
             wordBasedSuggestions: areSuggestionsEnabled
                 ? "matchingDocuments"
                 : "off",
+            wordWrap: shouldEnableDocumentWrapping(document) ? "on" : "off",
         });
         editor.layout();
     }, [
@@ -4865,6 +4920,8 @@ function FileTabView({
         editorLineHeightPx,
         editorSettings.fontSize,
         editorSettings.minimapEnabled,
+        gitGutterLineNumbersMinChars,
+        shouldShowGitGutter,
     ]);
 
     useEffect(() => {
@@ -5374,18 +5431,15 @@ function FileTabView({
                                 }
                             }
                             const cleanupAttachShortcut =
-                                bindAttachSelectionShortcut({
-                                    documentLanguageId: document.languageId,
+                                bindAttachSelectionShortcutWithInputRef({
                                     editor,
-                                    onAttachLineFragment,
-                                    projectId: tab.projectId,
-                                    relativePath: tab.relativePath,
-                                    tabTitle: tab.title,
-                                    worktreeId: tab.worktreeId ?? null,
+                                    inputRef:
+                                        editorAttachSelectionShortcutInputRef,
                                 });
                             const cleanupMarkdownListShortcut =
-                                bindMarkdownListEditingShortcuts({
-                                    documentLanguageId: document.languageId,
+                                bindMarkdownListEditingShortcutsWithLanguageRef({
+                                    documentLanguageIdRef:
+                                        editorMarkdownLanguageIdRef,
                                     editor,
                                 });
                             const scrollListener = editor.onDidScrollChange(

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -3167,13 +3167,29 @@ function bindAttachSelectionShortcutWithInputRef(input: {
     };
 }): (() => void) | null {
     const editorDomNode = input.editor.getDomNode();
-    if (!editorDomNode) {
+    const ownerDocument =
+        editorDomNode?.ownerDocument ??
+        (typeof document === "undefined" ? null : document);
+    if (!editorDomNode && !ownerDocument) {
         return null;
     }
 
     const handleEditorKeyDown = (event: KeyboardEvent) => {
+        if (!isAttachSelectionShortcutEvent(event)) {
+            return;
+        }
+
+        const isEditorDomListener = event.currentTarget === editorDomNode;
+        if (
+            !isEditorDomListener &&
+            !input.editor.hasTextFocus() &&
+            !input.editor.hasWidgetFocus()
+        ) {
+            return;
+        }
+
         const shortcutInput = input.inputRef.current;
-        if (!shortcutInput || !isAttachSelectionShortcutEvent(event)) {
+        if (!shortcutInput) {
             return;
         }
 
@@ -3189,10 +3205,24 @@ function bindAttachSelectionShortcutWithInputRef(input: {
         stopHandledAttachSelectionShortcut(event);
     };
 
-    editorDomNode.addEventListener("keydown", handleEditorKeyDown, true);
+    // Monaco can keep an editor instance alive while its model or DOM subtree
+    // changes. The document-level capture listener keeps Cmd+L stable across
+    // those transitions, while the focus guard prevents inactive editors from
+    // handling global shortcuts.
+    editorDomNode?.addEventListener("keydown", handleEditorKeyDown, true);
+    ownerDocument?.addEventListener("keydown", handleEditorKeyDown, true);
 
     return () => {
-        editorDomNode.removeEventListener("keydown", handleEditorKeyDown, true);
+        editorDomNode?.removeEventListener(
+            "keydown",
+            handleEditorKeyDown,
+            true,
+        );
+        ownerDocument?.removeEventListener(
+            "keydown",
+            handleEditorKeyDown,
+            true,
+        );
     };
 }
 
@@ -3907,30 +3937,39 @@ function FileTabView({
         rejectTrackedFile,
     ]);
 
+    const buildEditorAttachSelectionShortcutInput =
+        useCallback((): AttachSelectionShortcutInput | null => {
+            if (!isVisible || !document || !canEdit || inlineReviewTrackedFile) {
+                return null;
+            }
+
+            return {
+                documentLanguageId: document.languageId,
+                onAttachLineFragment,
+                projectId: tab.projectId,
+                relativePath: tab.relativePath,
+                tabTitle: tab.title,
+                worktreeId: tab.worktreeId ?? null,
+            };
+        }, [
+            canEdit,
+            document,
+            inlineReviewTrackedFile,
+            isVisible,
+            onAttachLineFragment,
+            tab.projectId,
+            tab.relativePath,
+            tab.title,
+            tab.worktreeId,
+        ]);
+
     useLayoutEffect(() => {
         editorMarkdownLanguageIdRef.current = documentLanguageId;
         editorAttachSelectionShortcutInputRef.current =
-            isVisible && document && canEdit && !inlineReviewTrackedFile
-                ? {
-                      documentLanguageId: document.languageId,
-                      onAttachLineFragment,
-                      projectId: tab.projectId,
-                      relativePath: tab.relativePath,
-                      tabTitle: tab.title,
-                      worktreeId: tab.worktreeId ?? null,
-                  }
-                : null;
+            buildEditorAttachSelectionShortcutInput();
     }, [
-        canEdit,
-        document,
+        buildEditorAttachSelectionShortcutInput,
         documentLanguageId,
-        inlineReviewTrackedFile,
-        isVisible,
-        onAttachLineFragment,
-        tab.projectId,
-        tab.relativePath,
-        tab.title,
-        tab.worktreeId,
     ]);
 
     useLayoutEffect(() => {
@@ -5444,6 +5483,8 @@ function FileTabView({
                             void runtime?.ensureMonacoTextMateForLanguage(
                                 monacoLanguageId,
                             );
+                            editorAttachSelectionShortcutInputRef.current =
+                                buildEditorAttachSelectionShortcutInput();
                             const cleanupTokenDebug =
                                 runtime?.installMonacoTokenDebugAction(editor) ??
                                 null;

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -1538,6 +1538,17 @@ function WorkspacePaneView({
         ? (paneTabs.find((tab) => tab.id === paneActiveTabId) ?? null)
         : null;
     const activeChatTab = activeTab?.kind === "chat" ? activeTab : null;
+    const activeFileTab = activeTab?.kind === "file" ? activeTab : null;
+    const paneFileTabs = useMemo(
+        () =>
+            paneTabs.filter(
+                (tab): tab is RuntimeWorkspaceFileTab => tab.kind === "file",
+            ),
+        [paneTabs],
+    );
+    const recentActiveTabIds = useWorkspaceStore(
+        (state) => state.recentActiveTabIds,
+    );
     const isActivePane = activePaneId === paneNodeId;
     const activeTabWorktreeId = activeTab?.worktreeId ?? null;
 
@@ -2361,17 +2372,19 @@ function WorkspacePaneView({
                                 tab={tab}
                             />
                         ))}
+                    <WorkspaceFileEditorHost
+                        activeFileTab={activeFileTab}
+                        fileTabs={paneFileTabs}
+                        isActivePane={isActivePane}
+                        onAttachLineFragment={handleAttachLineFragment}
+                        onDraftChange={updateFileDraft}
+                        onReload={reloadFileTab}
+                        onSave={saveFileTab}
+                        recentActiveTabIds={recentActiveTabIds}
+                    />
                     {activeTab ? (
                         activeTab.kind === "file" ? (
-                            <FileTabView
-                                key={activeTab.id}
-                                isActivePane={isActivePane}
-                                onAttachLineFragment={handleAttachLineFragment}
-                                onDraftChange={updateFileDraft}
-                                onReload={reloadFileTab}
-                                onSave={saveFileTab}
-                                tab={activeTab}
-                            />
+                            null
                         ) : activeTab.kind === "git" ? (
                             <GitTabView tab={activeTab} />
                         ) : activeTab.kind === "git_worktree_diff" ? (
@@ -2430,6 +2443,76 @@ function WorkspacePaneView({
                 />
             ) : null}
         </>
+    );
+}
+
+function WorkspaceFileEditorHost({
+    activeFileTab,
+    fileTabs,
+    isActivePane,
+    onAttachLineFragment,
+    onDraftChange,
+    onReload,
+    onSave,
+    recentActiveTabIds,
+}: {
+    readonly activeFileTab: RuntimeWorkspaceFileTab | null;
+    readonly fileTabs: readonly RuntimeWorkspaceFileTab[];
+    readonly isActivePane: boolean;
+    readonly onAttachLineFragment: (input: {
+        readonly context: AiFileContextAttachment;
+        readonly worktreeId: string | null;
+    }) => Promise<void>;
+    readonly onDraftChange: (tabId: string, draft: string) => void;
+    readonly onReload: (tabId: string) => Promise<void>;
+    readonly onSave: (
+        tabId: string,
+        options?: {
+            readonly force?: boolean;
+        },
+    ) => Promise<void>;
+    readonly recentActiveTabIds: readonly string[];
+}) {
+    const hostedTab = useMemo(() => {
+        if (activeFileTab) {
+            return activeFileTab;
+        }
+
+        for (const tabId of recentActiveTabIds) {
+            const recentFileTab = fileTabs.find((tab) => tab.id === tabId);
+            if (recentFileTab) {
+                return recentFileTab;
+            }
+        }
+
+        return fileTabs[0] ?? null;
+    }, [activeFileTab, fileTabs, recentActiveTabIds]);
+    const isVisible = activeFileTab !== null;
+
+    useRenderProbe("WorkspaceFileEditorHost", {
+        hostedTabId: hostedTab?.id ?? null,
+        visible: isVisible,
+    });
+
+    if (!hostedTab) {
+        return null;
+    }
+
+    return (
+        <div
+            aria-hidden={!isVisible}
+            className={isVisible ? "h-full" : "hidden"}
+        >
+            <FileTabView
+                isActivePane={isActivePane && isVisible}
+                isVisible={isVisible}
+                onAttachLineFragment={onAttachLineFragment}
+                onDraftChange={onDraftChange}
+                onReload={onReload}
+                onSave={onSave}
+                tab={hostedTab}
+            />
+        </div>
     );
 }
 
@@ -3343,6 +3426,7 @@ function buildProjectScopedFilePath(input: {
 
 function FileTabView({
     isActivePane,
+    isVisible,
     onAttachLineFragment,
     onDraftChange,
     onReload,
@@ -3350,6 +3434,7 @@ function FileTabView({
     tab,
 }: {
     readonly isActivePane: boolean;
+    readonly isVisible: boolean;
     readonly onAttachLineFragment: (input: {
         readonly context: AiFileContextAttachment;
         readonly worktreeId: string | null;
@@ -3472,6 +3557,7 @@ function FileTabView({
     const pendingEditorViewStateTabIdRef = useRef(tab.id);
     const viewStatePersistTimerRef = useRef<number | null>(null);
     const viewStateRestoreFrameRef = useRef<number | null>(null);
+    const restoredEditorViewStateTabIdRef = useRef<string | null>(null);
     const [editorMountVersion, setEditorMountVersion] = useState(0);
     const [diffEditorMountVersion, setDiffEditorMountVersion] = useState(0);
     const [
@@ -3800,9 +3886,33 @@ function FileTabView({
         rejectTrackedFile,
     ]);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
+        const previousTabId = fileTabIdRef.current;
+        if (previousTabId === tab.id) {
+            return;
+        }
+
+        if (editorRef.current) {
+            const previousViewState = editorRef.current.saveViewState();
+            pendingEditorViewStateRef.current = previousViewState;
+            pendingEditorViewStateTabIdRef.current = previousTabId;
+            updateFileViewState(previousTabId, previousViewState);
+        }
+
+        if (diffEditorRef.current) {
+            captureInlineReviewModifiedEditorState();
+        }
+
         fileTabIdRef.current = tab.id;
-    }, [tab.id]);
+        pendingEditorViewStateRef.current = tab.viewState ?? null;
+        pendingEditorViewStateTabIdRef.current = tab.id;
+        restoredEditorViewStateTabIdRef.current = null;
+    }, [
+        captureInlineReviewModifiedEditorState,
+        tab.id,
+        tab.viewState,
+        updateFileViewState,
+    ]);
 
     useEffect(() => {
         const pendingState = pendingEditorInlineReviewRestoreStateRef.current;
@@ -3822,6 +3932,53 @@ function FileTabView({
         pendingEditorViewStateRef.current = tab.viewState ?? null;
         pendingEditorViewStateTabIdRef.current = tab.id;
     }, [tab.id, tab.viewState]);
+
+    useEffect(() => {
+        if (!isVisible) {
+            return;
+        }
+
+        const frameId = window.requestAnimationFrame(() => {
+            editorRef.current?.layout();
+            diffEditorRef.current?.layout();
+        });
+
+        return () => {
+            window.cancelAnimationFrame(frameId);
+        };
+    }, [isVisible, tab.id]);
+
+    useEffect(() => {
+        const editor = editorRef.current;
+        if (
+            !isVisible ||
+            !editor ||
+            inlineReviewTrackedFile ||
+            restoredEditorViewStateTabIdRef.current === tab.id
+        ) {
+            return;
+        }
+
+        const viewState =
+            tab.viewState ??
+            (pendingEditorViewStateTabIdRef.current === tab.id
+                ? pendingEditorViewStateRef.current
+                : null);
+
+        if (viewState) {
+            restoreEditorViewState(editor, viewState);
+        } else {
+            editor.layout();
+        }
+
+        restoredEditorViewStateTabIdRef.current = tab.id;
+    }, [
+        inlineReviewTrackedFile,
+        isVisible,
+        restoreEditorViewState,
+        tab.id,
+        tab.viewState,
+    ]);
 
     useEffect(() => {
         return () => {

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -3563,6 +3563,7 @@ function FileTabView({
     const viewStatePersistTimerRef = useRef<number | null>(null);
     const viewStateRestoreFrameRef = useRef<number | null>(null);
     const restoredEditorViewStateTabIdRef = useRef<string | null>(null);
+    const suppressEditorChangeRef = useRef(false);
     const [editorMountVersion, setEditorMountVersion] = useState(0);
     const [diffEditorMountVersion, setDiffEditorMountVersion] = useState(0);
     const [
@@ -3804,6 +3805,17 @@ function FileTabView({
         [clearScheduledEditorViewStateRestore],
     );
 
+    const runWithoutEditorChangeNotification = useCallback(<T,>(
+        action: () => T,
+    ): T => {
+        suppressEditorChangeRef.current = true;
+        try {
+            return action();
+        } finally {
+            suppressEditorChangeRef.current = false;
+        }
+    }, []);
+
     const scheduleEditorViewStatePersist = useCallback(
         (editor: MonacoEditor.IStandaloneCodeEditor) => {
             const tabId = fileTabIdRef.current;
@@ -3938,6 +3950,39 @@ function FileTabView({
         pendingEditorViewStateTabIdRef.current = tab.id;
     }, [tab.id, tab.viewState]);
 
+    const getPendingEditorViewStateForTab = useCallback(
+        (
+            tabId: string,
+            viewState: MonacoEditor.ICodeEditorViewState | null,
+        ) =>
+            viewState ??
+            (pendingEditorViewStateTabIdRef.current === tabId
+                ? pendingEditorViewStateRef.current
+                : null),
+        [],
+    );
+
+    const restoreEditorViewStateForTab = useCallback(
+        (
+            editor: MonacoEditor.IStandaloneCodeEditor,
+            tabId: string,
+            viewState: MonacoEditor.ICodeEditorViewState | null,
+        ) => {
+            if (restoredEditorViewStateTabIdRef.current === tabId) {
+                return;
+            }
+
+            if (viewState) {
+                restoreEditorViewState(editor, viewState);
+            } else {
+                editor.layout();
+            }
+
+            restoredEditorViewStateTabIdRef.current = tabId;
+        },
+        [restoreEditorViewState],
+    );
+
     useEffect(() => {
         if (!isVisible) {
             return;
@@ -3964,23 +4009,16 @@ function FileTabView({
             return;
         }
 
-        const viewState =
-            tab.viewState ??
-            (pendingEditorViewStateTabIdRef.current === tab.id
-                ? pendingEditorViewStateRef.current
-                : null);
-
-        if (viewState) {
-            restoreEditorViewState(editor, viewState);
-        } else {
-            editor.layout();
-        }
-
-        restoredEditorViewStateTabIdRef.current = tab.id;
+        restoreEditorViewStateForTab(
+            editor,
+            tab.id,
+            getPendingEditorViewStateForTab(tab.id, tab.viewState ?? null),
+        );
     }, [
+        getPendingEditorViewStateForTab,
         inlineReviewTrackedFile,
         isVisible,
-        restoreEditorViewState,
+        restoreEditorViewStateForTab,
         tab.id,
         tab.viewState,
     ]);
@@ -4275,7 +4313,8 @@ function FileTabView({
             !document ||
             document.kind === "image" ||
             !canEdit ||
-            inlineReviewTrackedFile
+            inlineReviewTrackedFile ||
+            !isVisible
         ) {
             return;
         }
@@ -4286,22 +4325,38 @@ function FileTabView({
             return;
         }
 
-        const model = getOrCreateWorkspaceFileModel({
-            absolutePath: document.absolutePath,
-            language: monacoLanguageId,
-            monaco,
-            value: tab.draftContent,
-        });
+        const model = runWithoutEditorChangeNotification(() =>
+            getOrCreateWorkspaceFileModel({
+                absolutePath: document.absolutePath,
+                language: monacoLanguageId,
+                monaco,
+                value: tab.draftContent,
+            }),
+        );
 
         if (editor.getModel() !== model) {
-            editor.setModel(model);
+            runWithoutEditorChangeNotification(() => {
+                editor.setModel(model);
+            });
         }
+
+        restoreEditorViewStateForTab(
+            editor,
+            tab.id,
+            getPendingEditorViewStateForTab(tab.id, tab.viewState ?? null),
+        );
     }, [
         canEdit,
         document,
+        getPendingEditorViewStateForTab,
         inlineReviewTrackedFile,
+        isVisible,
         monacoLanguageId,
+        restoreEditorViewStateForTab,
+        runWithoutEditorChangeNotification,
         tab.draftContent,
+        tab.id,
+        tab.viewState,
     ]);
 
     useEffect(() => {
@@ -5247,9 +5302,13 @@ function FileTabView({
                     <EditorComponent
                         beforeMount={handleEditorBeforeMount}
                         language={monacoLanguageId}
-                        onChange={(value: string | undefined) =>
-                            onDraftChange(tab.id, value ?? "")
-                        }
+                        onChange={(value: string | undefined) => {
+                            if (suppressEditorChangeRef.current) {
+                                return;
+                            }
+
+                            onDraftChange(tab.id, value ?? "");
+                        }}
                         onMount={(
                             editor: MonacoEditor.IStandaloneCodeEditor,
                             monaco: MonacoNamespace,
@@ -5265,14 +5324,19 @@ function FileTabView({
                             );
                             editorRef.current = editor;
                             editorMonacoRef.current = monaco;
-                            const model = getOrCreateWorkspaceFileModel({
-                                absolutePath: document.absolutePath,
-                                language: monacoLanguageId,
-                                monaco,
-                                value: tab.draftContent,
-                            });
+                            const model = runWithoutEditorChangeNotification(
+                                () =>
+                                    getOrCreateWorkspaceFileModel({
+                                        absolutePath: document.absolutePath,
+                                        language: monacoLanguageId,
+                                        monaco,
+                                        value: tab.draftContent,
+                                    }),
+                            );
                             if (editor.getModel() !== model) {
-                                editor.setModel(model);
+                                runWithoutEditorChangeNotification(() => {
+                                    editor.setModel(model);
+                                });
                             }
                             void runtime?.ensureMonacoTextMateForLanguage(
                                 monacoLanguageId,
@@ -5295,11 +5359,14 @@ function FileTabView({
                                     null;
                             } else {
                                 const persistedViewState =
-                                    tab.viewState ??
-                                    pendingEditorViewStateRef.current;
+                                    getPendingEditorViewStateForTab(
+                                        tab.id,
+                                        tab.viewState ?? null,
+                                    );
                                 if (persistedViewState) {
-                                    restoreEditorViewState(
+                                    restoreEditorViewStateForTab(
                                         editor,
+                                        tab.id,
                                         persistedViewState,
                                     );
                                     pendingEditorViewStateRef.current =

--- a/src/renderer/src/components/workspace/editorModelPath.test.ts
+++ b/src/renderer/src/components/workspace/editorModelPath.test.ts
@@ -1,16 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { buildWorkspaceEditorModelPath } from "./editorModelPath";
+import {
+    buildWorkspaceEditorModelPath,
+    buildWorkspaceFileEditorModelPath,
+    getOrCreateWorkspaceFileModel,
+} from "./editorModelPath";
 
 describe("buildWorkspaceEditorModelPath", () => {
-    it("creates stable model paths for a specific tab and variant", () => {
+    it("creates review model paths for a specific tab and variant", () => {
         expect(
             buildWorkspaceEditorModelPath(
                 "/workspace/comando/src/app.ts",
                 "tab-1",
-                "editor",
+                "review-modified",
             ),
-        ).toBe("/workspace/comando/src/app__workspace-tab__tab-1__editor.ts");
+        ).toBe(
+            "/workspace/comando/src/app__workspace-tab__tab-1__review-modified.ts",
+        );
     });
 
     it("preserves the real extension for TSX files", () => {
@@ -18,9 +24,11 @@ describe("buildWorkspaceEditorModelPath", () => {
             buildWorkspaceEditorModelPath(
                 "/workspace/comando/src/App.tsx",
                 "tab-1",
-                "editor",
+                "review-modified",
             ),
-        ).toBe("/workspace/comando/src/App__workspace-tab__tab-1__editor.tsx");
+        ).toBe(
+            "/workspace/comando/src/App__workspace-tab__tab-1__review-modified.tsx",
+        );
     });
 
     it("preserves compound declaration extensions", () => {
@@ -28,10 +36,10 @@ describe("buildWorkspaceEditorModelPath", () => {
             buildWorkspaceEditorModelPath(
                 "/workspace/comando/src/types.d.ts",
                 "tab-1",
-                "editor",
+                "review-modified",
             ),
         ).toBe(
-            "/workspace/comando/src/types__workspace-tab__tab-1__editor.d.ts",
+            "/workspace/comando/src/types__workspace-tab__tab-1__review-modified.d.ts",
         );
     });
 
@@ -40,33 +48,71 @@ describe("buildWorkspaceEditorModelPath", () => {
             buildWorkspaceEditorModelPath(
                 "/workspace/comando/Makefile",
                 "tab-1",
-                "editor",
+                "review-modified",
             ),
-        ).toBe("/workspace/comando/Makefile__workspace-tab__tab-1__editor");
+        ).toBe(
+            "/workspace/comando/Makefile__workspace-tab__tab-1__review-modified",
+        );
     });
 
-    it("creates different model paths for duplicate tabs of the same file", () => {
+    it("keeps review model paths isolated per duplicate tab", () => {
         expect(
             buildWorkspaceEditorModelPath(
                 "/workspace/comando/src/app.ts",
                 "tab-1",
-                "editor",
+                "review-modified",
             ),
         ).not.toBe(
             buildWorkspaceEditorModelPath(
                 "/workspace/comando/src/app.ts",
                 "tab-2",
-                "editor",
+                "review-modified",
             ),
         );
     });
 
-    it("creates different model paths for editor and review variants", () => {
+    it("creates different model paths for review variants", () => {
         expect(
             buildWorkspaceEditorModelPath(
                 "/workspace/comando/src/app.ts",
                 "tab-1",
-                "editor",
+                "review-modified",
+            ),
+        ).not.toBe(
+            buildWorkspaceEditorModelPath(
+                "/workspace/comando/src/app.ts",
+                "tab-1",
+                "review-original",
+            ),
+        );
+    });
+});
+
+describe("buildWorkspaceFileEditorModelPath", () => {
+    it("uses the real absolute path as the normal editor model identity", () => {
+        expect(
+            buildWorkspaceFileEditorModelPath(
+                "/workspace/comando/src/app.ts",
+            ),
+        ).toBe("/workspace/comando/src/app.ts");
+    });
+
+    it("shares the normal editor model path across duplicate tabs", () => {
+        expect(
+            buildWorkspaceFileEditorModelPath(
+                "/workspace/comando/src/app.ts",
+            ),
+        ).toBe(
+            buildWorkspaceFileEditorModelPath(
+                "/workspace/comando/src/app.ts",
+            ),
+        );
+    });
+
+    it("keeps normal editor models separate from review models", () => {
+        expect(
+            buildWorkspaceFileEditorModelPath(
+                "/workspace/comando/src/app.ts",
             ),
         ).not.toBe(
             buildWorkspaceEditorModelPath(
@@ -77,3 +123,105 @@ describe("buildWorkspaceEditorModelPath", () => {
         );
     });
 });
+
+describe("getOrCreateWorkspaceFileModel", () => {
+    it("reuses an existing model without resetting matching content", () => {
+        const { createdModels, monaco } = createFakeMonaco();
+        const firstModel = getOrCreateWorkspaceFileModel({
+            absolutePath: "/workspace/comando/src/app.ts",
+            language: "typescript",
+            monaco,
+            value: "const a = 1;",
+        });
+        const secondModel = getOrCreateWorkspaceFileModel({
+            absolutePath: "/workspace/comando/src/app.ts",
+            language: "typescript",
+            monaco,
+            value: "const a = 1;",
+        });
+
+        expect(firstModel).toBe(secondModel);
+        expect(createdModels).toHaveLength(1);
+        expect(createdModels[0]?.setValueCalls).toEqual([]);
+        expect(monaco.editor.setModelLanguage).toHaveBeenCalledWith(
+            firstModel,
+            "typescript",
+        );
+    });
+
+    it("updates an existing model only when content changes", () => {
+        const { createdModels, monaco } = createFakeMonaco();
+        getOrCreateWorkspaceFileModel({
+            absolutePath: "/workspace/comando/src/app.ts",
+            language: "typescript",
+            monaco,
+            value: "const a = 1;",
+        });
+
+        getOrCreateWorkspaceFileModel({
+            absolutePath: "/workspace/comando/src/app.ts",
+            language: "typescript",
+            monaco,
+            value: "const a = 2;",
+        });
+
+        expect(createdModels[0]?.setValueCalls).toEqual(["const a = 2;"]);
+    });
+});
+
+function createFakeMonaco() {
+    type FakeUri = {
+        readonly value: string;
+        readonly toString: () => string;
+    };
+    type FakeModel = {
+        readonly getValue: () => string;
+        readonly setValue: (value: string) => void;
+        readonly setValueCalls: string[];
+        language: string;
+        value: string;
+    };
+
+    const models = new Map<string, FakeModel>();
+    const createdModels: FakeModel[] = [];
+    const monaco = {
+        Uri: {
+            parse: (value: string): FakeUri => ({
+                toString: () => value,
+                value,
+            }),
+        },
+        editor: {
+            createModel: vi.fn(
+                (value: string, language: string, uri: FakeUri) => {
+                    const model: FakeModel = {
+                        getValue: () => model.value,
+                        language,
+                        setValue: (nextValue: string) => {
+                            model.setValueCalls.push(nextValue);
+                            model.value = nextValue;
+                        },
+                        setValueCalls: [],
+                        value,
+                    };
+                    models.set(uri.toString(), model);
+                    createdModels.push(model);
+                    return model;
+                },
+            ),
+            getModel: vi.fn((uri: FakeUri) => models.get(uri.toString()) ?? null),
+            setModelLanguage: vi.fn(
+                (model: FakeModel, language: string) => {
+                    model.language = language;
+                },
+            ),
+        },
+    };
+
+    return {
+        createdModels,
+        monaco: monaco as unknown as Parameters<
+            typeof getOrCreateWorkspaceFileModel
+        >[0]["monaco"],
+    };
+}

--- a/src/renderer/src/components/workspace/editorModelPath.test.ts
+++ b/src/renderer/src/components/workspace/editorModelPath.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+    acquireWorkspaceFileModel,
     buildWorkspaceEditorModelPath,
     buildWorkspaceFileEditorModelPath,
     getOrCreateWorkspaceFileModel,
@@ -169,15 +170,60 @@ describe("getOrCreateWorkspaceFileModel", () => {
     });
 });
 
+describe("acquireWorkspaceFileModel", () => {
+    it("retains a shared file model until the final lease is released", () => {
+        const { createdModels, monaco } = createFakeMonaco();
+        const firstLease = acquireWorkspaceFileModel({
+            absolutePath: "/workspace/comando/src/app.ts",
+            language: "typescript",
+            monaco,
+            value: "const a = 1;",
+        });
+        const secondLease = acquireWorkspaceFileModel({
+            absolutePath: "/workspace/comando/src/app.ts",
+            language: "typescript",
+            monaco,
+            value: "const a = 1;",
+        });
+
+        expect(firstLease.model).toBe(secondLease.model);
+        expect(createdModels).toHaveLength(1);
+
+        firstLease.release();
+        expect(createdModels[0]?.dispose).not.toHaveBeenCalled();
+
+        secondLease.release();
+        expect(createdModels[0]?.dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("makes lease release idempotent", () => {
+        const { createdModels, monaco } = createFakeMonaco();
+        const lease = acquireWorkspaceFileModel({
+            absolutePath: "/workspace/comando/src/app.ts",
+            language: "typescript",
+            monaco,
+            value: "const a = 1;",
+        });
+
+        lease.release();
+        lease.release();
+
+        expect(createdModels[0]?.dispose).toHaveBeenCalledTimes(1);
+    });
+});
+
 function createFakeMonaco() {
     type FakeUri = {
         readonly value: string;
         readonly toString: () => string;
     };
     type FakeModel = {
+        readonly dispose: () => void;
         readonly getValue: () => string;
+        readonly isDisposed: () => boolean;
         readonly setValue: (value: string) => void;
         readonly setValueCalls: string[];
+        disposed: boolean;
         language: string;
         value: string;
     };
@@ -195,7 +241,13 @@ function createFakeMonaco() {
             createModel: vi.fn(
                 (value: string, language: string, uri: FakeUri) => {
                     const model: FakeModel = {
+                        dispose: vi.fn(() => {
+                            model.disposed = true;
+                            models.delete(uri.toString());
+                        }),
+                        disposed: false,
                         getValue: () => model.value,
+                        isDisposed: () => model.disposed,
                         language,
                         setValue: (nextValue: string) => {
                             model.setValueCalls.push(nextValue);

--- a/src/renderer/src/components/workspace/editorModelPath.ts
+++ b/src/renderer/src/components/workspace/editorModelPath.ts
@@ -6,6 +6,20 @@ export type WorkspaceEditorModelVariant =
 
 type MonacoNamespace = typeof import("monaco-editor");
 
+export interface WorkspaceFileModelLease {
+    readonly model: MonacoEditor.ITextModel;
+    readonly modelPath: string;
+    readonly release: () => void;
+}
+
+const retainedWorkspaceFileModels = new Map<
+    string,
+    {
+        readonly model: MonacoEditor.ITextModel;
+        retainCount: number;
+    }
+>();
+
 function sanitizeModelSegment(value: string): string {
     return value.replace(/[^A-Za-z0-9_-]/g, "_");
 }
@@ -89,4 +103,53 @@ export function getOrCreateWorkspaceFileModel(input: {
     }
 
     return input.monaco.editor.createModel(input.value, input.language, uri);
+}
+
+export function acquireWorkspaceFileModel(input: {
+    readonly absolutePath: string;
+    readonly language: string;
+    readonly monaco: MonacoNamespace;
+    readonly value: string;
+}): WorkspaceFileModelLease {
+    const modelPath = buildWorkspaceFileEditorModelPath(input.absolutePath);
+    const model = getOrCreateWorkspaceFileModel(input);
+    const retainedModel = retainedWorkspaceFileModels.get(modelPath);
+
+    if (retainedModel?.model === model) {
+        retainedModel.retainCount += 1;
+    } else {
+        retainedWorkspaceFileModels.set(modelPath, {
+            model,
+            retainCount: 1,
+        });
+    }
+
+    let released = false;
+
+    return {
+        model,
+        modelPath,
+        release: () => {
+            if (released) {
+                return;
+            }
+            released = true;
+
+            const currentRetainedModel =
+                retainedWorkspaceFileModels.get(modelPath);
+            if (!currentRetainedModel || currentRetainedModel.model !== model) {
+                return;
+            }
+
+            currentRetainedModel.retainCount -= 1;
+            if (currentRetainedModel.retainCount > 0) {
+                return;
+            }
+
+            retainedWorkspaceFileModels.delete(modelPath);
+            if (!model.isDisposed()) {
+                model.dispose();
+            }
+        },
+    };
 }

--- a/src/renderer/src/components/workspace/editorModelPath.ts
+++ b/src/renderer/src/components/workspace/editorModelPath.ts
@@ -1,7 +1,10 @@
+import type { editor as MonacoEditor } from "monaco-editor";
+
 export type WorkspaceEditorModelVariant =
-    | "editor"
     | "review-modified"
     | "review-original";
+
+type MonacoNamespace = typeof import("monaco-editor");
 
 function sanitizeModelSegment(value: string): string {
     return value.replace(/[^A-Za-z0-9_-]/g, "_");
@@ -60,4 +63,30 @@ export function buildWorkspaceEditorModelPath(
     return extension
         ? `${stem}${modelSuffix}${extension}`
         : `${absolutePath}${modelSuffix}`;
+}
+
+export function buildWorkspaceFileEditorModelPath(absolutePath: string): string {
+    return absolutePath;
+}
+
+export function getOrCreateWorkspaceFileModel(input: {
+    readonly absolutePath: string;
+    readonly language: string;
+    readonly monaco: MonacoNamespace;
+    readonly value: string;
+}): MonacoEditor.ITextModel {
+    const uri = input.monaco.Uri.parse(
+        buildWorkspaceFileEditorModelPath(input.absolutePath),
+    );
+    const existingModel = input.monaco.editor.getModel(uri);
+
+    if (existingModel) {
+        if (existingModel.getValue() !== input.value) {
+            existingModel.setValue(input.value);
+        }
+        input.monaco.editor.setModelLanguage(existingModel, input.language);
+        return existingModel;
+    }
+
+    return input.monaco.editor.createModel(input.value, input.language, uri);
 }


### PR DESCRIPTION
## Summary

- Keep the file editor host mounted across tab switches to avoid Monaco teardown flicker.
- Reuse stable Monaco models per file while preserving separate inline review/diff models.
- Preserve and flush editor view state across file switches, inline review transitions, and duplicate file tabs.
- Keep editor listeners tied to the active file context, including the Cmd+L selection-to-composer shortcut.

## Why

Switching tabs and opening files could remount Monaco surfaces and recreate models/listeners too aggressively. That caused visible flicker and made editor state restoration fragile. The refactor keeps editor ownership stable while keeping TextMate highlighting and inline review behavior isolated.

## Validation

- `pnpm exec eslint src/renderer/src/components/workspace/WorkspaceView.tsx`
- `pnpm exec tsc --noEmit -p tsconfig.web.json --pretty false`
- `pnpm exec vitest run src/renderer/src/components/workspace/editorModelPath.test.ts`
- `pnpm exec vitest run src/renderer/src/stores/workspace/tabs/tree.test.ts`
- `git diff --check`

Draft while we do final manual QA around Monaco tab switching, inline review, TextMate highlighting, and Cmd+L attachment behavior.