### PR TITLE
Constrain chat content width

### DIFF
--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -63,6 +63,7 @@ import {
     type ChatTimelineModel,
     type ChatTimelineRow,
 } from "./chat/chatTimelineModel";
+import { CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX } from "./chat/chatTimelineVirtualization";
 import {
     isActiveChatTurnStatus,
     isChatStreamingStatus,
@@ -2239,7 +2240,12 @@ const ChatTimeline = memo(function ChatTimeline({
                     <div
                         ref={timelineContentRef}
                         className="min-w-0 space-y-2"
-                        style={{ fontFamily: chatFontFamily }}
+                        style={{
+                            fontFamily: chatFontFamily,
+                            marginInline: "auto",
+                            maxWidth: CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
+                            width: "100%",
+                        }}
                     >
                         <ChatTimelineHistory
                             canRenderRawFileReference={

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -1716,48 +1716,57 @@ export const ChatTabView = memo(function ChatTabView({
                             backgroundColor: "transparent",
                         }}
                     >
-                        {pendingPermission
-                            ? renderPermissionRequest(
-                                  pendingPermission,
-                                  respondPermission,
-                                  tab.sessionId,
-                              )
-                            : null}
-                        {pendingUserInput ? (
-                            <UserInputRequestCard
-                                onRespond={respondUserInput}
-                                request={pendingUserInput}
-                            />
-                        ) : null}
-                        {queuedPrompts.length > 0 || editingQueuedPrompt ? (
-                            <QueuedMessagesPanel
-                                editingItem={editingQueuedPrompt}
-                                items={queuedPrompts}
-                                onCancelEdit={handleCancelQueuedPromptEdit}
-                                onClearAll={handleClearQueuedPrompts}
-                                onDelete={handleRemoveQueuedPrompt}
-                                onEdit={handleEditQueuedPrompt}
-                                onSendNow={handleSendQueuedPromptNow}
-                            />
-                        ) : null}
-                        {currentError ? renderError(currentError) : null}
-                        {composerError ? renderError(composerError) : null}
+                        <div
+                            className="flex w-full flex-col gap-2"
+                            style={{
+                                marginInline: "auto",
+                                maxWidth: CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
+                            }}
+                        >
+                            {pendingPermission
+                                ? renderPermissionRequest(
+                                      pendingPermission,
+                                      respondPermission,
+                                      tab.sessionId,
+                                  )
+                                : null}
+                            {pendingUserInput ? (
+                                <UserInputRequestCard
+                                    onRespond={respondUserInput}
+                                    request={pendingUserInput}
+                                />
+                            ) : null}
+                            {queuedPrompts.length > 0 ||
+                            editingQueuedPrompt ? (
+                                <QueuedMessagesPanel
+                                    editingItem={editingQueuedPrompt}
+                                    items={queuedPrompts}
+                                    onCancelEdit={handleCancelQueuedPromptEdit}
+                                    onClearAll={handleClearQueuedPrompts}
+                                    onDelete={handleRemoveQueuedPrompt}
+                                    onEdit={handleEditQueuedPrompt}
+                                    onSendNow={handleSendQueuedPromptNow}
+                                />
+                            ) : null}
+                            {currentError ? renderError(currentError) : null}
+                            {composerError ? renderError(composerError) : null}
 
-                        {pendingReviewCount > 0 ? (
-                            <EditedFilesBufferPanel
-                                diffZoom={diffZoom}
-                                items={pendingReviewItems}
-                                onKeepAll={handleKeepAllPendingReview}
-                                onKeepHunk={handleKeepPendingReviewHunk}
-                                onKeepItem={handleKeepPendingReviewItem}
-                                onOpenItem={handleOpenPendingReviewItem}
-                                onOpenReview={handleOpenReviewTab}
-                                onRejectAll={handleRejectAllPendingReview}
-                                onRejectHunk={handleRejectPendingReviewHunk}
-                                onRejectItem={handleRejectPendingReviewItem}
-                                summary={pendingReviewSummary}
-                            />
-                        ) : null}
+                            {pendingReviewCount > 0 ? (
+                                <EditedFilesBufferPanel
+                                    diffZoom={diffZoom}
+                                    items={pendingReviewItems}
+                                    onKeepAll={handleKeepAllPendingReview}
+                                    onKeepHunk={handleKeepPendingReviewHunk}
+                                    onKeepItem={handleKeepPendingReviewItem}
+                                    onOpenItem={handleOpenPendingReviewItem}
+                                    onOpenReview={handleOpenReviewTab}
+                                    onRejectAll={handleRejectAllPendingReview}
+                                    onRejectHunk={handleRejectPendingReviewHunk}
+                                    onRejectItem={handleRejectPendingReviewItem}
+                                    summary={pendingReviewSummary}
+                                />
+                            ) : null}
+                        </div>
                     </div>
                 ) : null}
 
@@ -1771,87 +1780,101 @@ export const ChatTabView = memo(function ChatTabView({
                             "color-mix(in srgb, var(--color-accent) 14%, var(--color-border))",
                     }}
                 >
-                    <AIChatComposer
-                        autoFocusKey={tab.id}
-                        composerFontFamily={composerFontFamily}
-                        composerFontSize={aiChatSettings.composerFontSize}
-                        requireCmdEnterToSend={
-                            aiChatSettings.requireCmdEnterToSend
-                        }
-                        bottomAccent={
-                            aiChatSettings.contextUsageBarEnabled ? (
-                                <AIChatContextUsageBar
-                                    usage={snapshot.tokenUsage}
-                                />
-                            ) : null
-                        }
-                        agentControls={
-                            hasAgentControls ? (
-                                <AIChatAgentControls
-                                    configOptions={snapshot.configOptions}
-                                    modeId={snapshot.modeId ?? ""}
-                                    modelId={snapshot.modelId ?? ""}
-                                    modes={snapshot.modes}
-                                    models={snapshot.models}
-                                    onConfigOptionChange={(optionId, value) => {
-                                        void setSessionConfigOption({
-                                            optionId,
-                                            sessionId: tab.sessionId,
-                                            value,
-                                        });
-                                    }}
-                                    onModeChange={(modeId) => {
-                                        void setSessionMode({
-                                            modeId,
-                                            sessionId: tab.sessionId,
-                                        });
-                                    }}
-                                    onModelChange={(modelId) => {
-                                        void setSessionModel({
-                                            modelId,
-                                            sessionId: tab.sessionId,
-                                        });
-                                    }}
-                                    runtimeId={tab.runtimeId}
-                                />
-                            ) : undefined
-                        }
-                        availableCommands={availableCommands}
-                        disabled={closedSubagentMessage !== null}
-                        disabledReason={closedSubagentMessage}
-                        draftAttachments={draftAttachments}
-                        draftFileContexts={draftFileContexts}
-                        fileInputRef={fileInputRef}
-                        onChange={handleComposerPartsChange}
-                        onPasteImage={handlePasteImage}
-                        onRemoveAttachment={removeDraftAttachment}
-                        onRemoveFileContext={(contextId) =>
-                            removeDraftFileContext(tab.sessionId, contextId)
-                        }
-                        onSearchProjectEntries={handleSearchProjectEntries}
-                        onStop={handleStopSession}
-                        onSubmit={() => {
-                            void handleSubmit();
+                    <div
+                        className="w-full"
+                        style={{
+                            marginInline: "auto",
+                            maxWidth: CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
                         }}
-                        resetNonce={composerResetNonce}
-                        parts={composerParts}
-                        renderFileContextPill={(fc) => (
-                            <FileContextPill
-                                context={fc}
-                                onRemove={() =>
-                                    removeDraftFileContext(tab.sessionId, fc.id)
-                                }
-                            />
-                        )}
-                        renderImageChip={(att) => (
-                            <ImageAttachmentChip
-                                attachment={att}
-                                onRemove={removeDraftAttachment}
-                            />
-                        )}
-                        runtimeName={runtimeDisplayName}
-                        status={snapshot.status}
-                    />
+                    >
+                        <AIChatComposer
+                            autoFocusKey={tab.id}
+                            composerFontFamily={composerFontFamily}
+                            composerFontSize={aiChatSettings.composerFontSize}
+                            requireCmdEnterToSend={
+                                aiChatSettings.requireCmdEnterToSend
+                            }
+                            bottomAccent={
+                                aiChatSettings.contextUsageBarEnabled ? (
+                                    <AIChatContextUsageBar
+                                        usage={snapshot.tokenUsage}
+                                    />
+                                ) : null
+                            }
+                            agentControls={
+                                hasAgentControls ? (
+                                    <AIChatAgentControls
+                                        configOptions={snapshot.configOptions}
+                                        modeId={snapshot.modeId ?? ""}
+                                        modelId={snapshot.modelId ?? ""}
+                                        modes={snapshot.modes}
+                                        models={snapshot.models}
+                                        onConfigOptionChange={(
+                                            optionId,
+                                            value,
+                                        ) => {
+                                            void setSessionConfigOption({
+                                                optionId,
+                                                sessionId: tab.sessionId,
+                                                value,
+                                            });
+                                        }}
+                                        onModeChange={(modeId) => {
+                                            void setSessionMode({
+                                                modeId,
+                                                sessionId: tab.sessionId,
+                                            });
+                                        }}
+                                        onModelChange={(modelId) => {
+                                            void setSessionModel({
+                                                modelId,
+                                                sessionId: tab.sessionId,
+                                            });
+                                        }}
+                                        runtimeId={tab.runtimeId}
+                                    />
+                                ) : undefined
+                            }
+                            availableCommands={availableCommands}
+                            disabled={closedSubagentMessage !== null}
+                            disabledReason={closedSubagentMessage}
+                            draftAttachments={draftAttachments}
+                            draftFileContexts={draftFileContexts}
+                            fileInputRef={fileInputRef}
+                            onChange={handleComposerPartsChange}
+                            onPasteImage={handlePasteImage}
+                            onRemoveAttachment={removeDraftAttachment}
+                            onRemoveFileContext={(contextId) =>
+                                removeDraftFileContext(tab.sessionId, contextId)
+                            }
+                            onSearchProjectEntries={handleSearchProjectEntries}
+                            onStop={handleStopSession}
+                            onSubmit={() => {
+                                void handleSubmit();
+                            }}
+                            resetNonce={composerResetNonce}
+                            parts={composerParts}
+                            renderFileContextPill={(fc) => (
+                                <FileContextPill
+                                    context={fc}
+                                    onRemove={() =>
+                                        removeDraftFileContext(
+                                            tab.sessionId,
+                                            fc.id,
+                                        )
+                                    }
+                                />
+                            )}
+                            renderImageChip={(att) => (
+                                <ImageAttachmentChip
+                                    attachment={att}
+                                    onRemove={removeDraftAttachment}
+                                />
+                            )}
+                            runtimeName={runtimeDisplayName}
+                            status={snapshot.status}
+                        />
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -353,7 +353,13 @@ describe("ChatTimelineHistoryRows", () => {
         expect(historyElement?.style.width).toBe(
             `${CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX}px`,
         );
-        expect(latestFirstMeasurementKey()).toMatch(/:840:\d+$/);
+        expect(latestFirstMeasurementKey()).toMatch(
+            new RegExp(
+                `:${getChatTimelineVirtualMeasurementWidth(
+                    CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
+                )}:\\d+$`,
+            ),
+        );
 
         act(() => {
             useShellStore.getState().setResizingPanel(false);

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -1,11 +1,19 @@
+/** @vitest-environment jsdom */
+import { act } from "react";
 import type { ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AiSessionSnapshot } from "@shared/ipc";
+import { useShellStore } from "@renderer/app/store/shell-store";
 
 import type { ChatTimelineRow } from "./chatTimelineModel";
-import { CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD } from "./chatTimelineVirtualization";
+import {
+    CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
+    CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
+    getChatTimelineVirtualMeasurementWidth,
+} from "./chatTimelineVirtualization";
 
 interface MeasuredVirtualListMockSnapshot {
     readonly firstEstimate: number | null;
@@ -26,6 +34,9 @@ type MeasuredVirtualListMock = (
 const measuredVirtualListMock = vi.hoisted(() =>
     vi.fn<MeasuredVirtualListMock>(),
 );
+
+let rectWidthsByElement = new WeakMap<Element, number>();
+let rectWidthFallback = 0;
 
 vi.mock("@renderer/components/virtual/MeasuredVirtualList", async () => {
     const { createElement } =
@@ -153,9 +164,118 @@ function renderHistoryRows(historyRows: readonly ChatTimelineRow[]) {
     );
 }
 
+interface MountedHistoryRows {
+    readonly root: Root;
+    readonly mountNode: HTMLElement;
+    readonly scrollContainer: HTMLElement;
+    readonly setContentWidth: (width: number) => void;
+}
+
+function mountHistoryRows(
+    historyRows: readonly ChatTimelineRow[],
+): MountedHistoryRows {
+    const scrollContainer = document.createElement("div");
+    Object.defineProperty(scrollContainer, "clientWidth", {
+        configurable: true,
+        get: () => 1200,
+    });
+    document.body.appendChild(scrollContainer);
+
+    const mountNode = document.createElement("div");
+    document.body.appendChild(mountNode);
+
+    const root = createRoot(mountNode);
+    const scrollRef = { current: scrollContainer };
+
+    act(() => {
+        root.render(
+            <ChatTimelineHistoryRows
+                historyRows={historyRows}
+                latestStreamingEditedFileToolRowId={null}
+                renderRow={({ row }) => (
+                    <div data-row-id={row.id} key={row.id}>
+                        {row.id}
+                    </div>
+                )}
+                scrollRef={scrollRef}
+                toolCardExpansionMode="collapsed"
+            />,
+        );
+    });
+
+    const virtualList = mountNode.querySelector(
+        "[data-testid='mock-measured-virtual-list']",
+    );
+    const historyElement = virtualList?.parentElement;
+    if (!historyElement) {
+        throw new Error("expected virtualized history element");
+    }
+
+    return {
+        root,
+        mountNode,
+        scrollContainer,
+        setContentWidth: (width: number) => {
+            rectWidthsByElement.set(historyElement, width);
+        },
+    };
+}
+
+function latestFirstMeasurementKey(): string {
+    const call =
+        measuredVirtualListMock.mock.calls[
+            measuredVirtualListMock.mock.calls.length - 1
+        ]?.[0];
+
+    if (!call?.firstMeasurementKey) {
+        throw new Error("expected a measured virtual list call");
+    }
+
+    return call.firstMeasurementKey;
+}
+
 describe("ChatTimelineHistoryRows", () => {
     beforeEach(() => {
+        (
+            globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+        ).IS_REACT_ACT_ENVIRONMENT = true;
+        rectWidthsByElement = new WeakMap<Element, number>();
+        rectWidthFallback = 0;
         measuredVirtualListMock.mockClear();
+        useShellStore.setState({ isResizingPanel: false });
+        vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+            function getBoundingClientRect(this: Element): DOMRect {
+                const width =
+                    rectWidthsByElement.get(this) ?? rectWidthFallback;
+
+                return {
+                    bottom: 0,
+                    height: 0,
+                    left: 0,
+                    right: width,
+                    toJSON: () => ({}),
+                    top: 0,
+                    width,
+                    x: 0,
+                    y: 0,
+                };
+            },
+        );
+        vi.stubGlobal(
+            "requestAnimationFrame",
+            (callback: FrameRequestCallback) => {
+                callback(0);
+                return 1;
+            },
+        );
+        vi.stubGlobal("cancelAnimationFrame", () => {});
+    });
+
+    afterEach(() => {
+        useShellStore.setState({ isResizingPanel: false });
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
     });
 
     it("keeps the non-virtualized path below the threshold", () => {
@@ -194,5 +314,109 @@ describe("ChatTimelineHistoryRows", () => {
             `message:message-${CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD - 1}`,
         );
         expect(markup.match(/padding-bottom:8px/g)).toHaveLength(1);
+    });
+
+    it("freezes content width during panel resize and re-syncs on release", () => {
+        const rows = createRows(CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD);
+        rectWidthFallback = CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX;
+        const mounted = mountHistoryRows(rows);
+
+        mounted.setContentWidth(CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX);
+        act(() => {
+            window.dispatchEvent(new Event("resize"));
+        });
+
+        expect(latestFirstMeasurementKey()).toMatch(
+            new RegExp(
+                `:${getChatTimelineVirtualMeasurementWidth(
+                    CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
+                )}:\\d+$`,
+            ),
+        );
+
+        act(() => {
+            useShellStore.getState().setResizingPanel(true);
+        });
+
+        const historyElement = mounted.mountNode.querySelector(
+            "[data-testid='mock-measured-virtual-list']",
+        )?.parentElement as HTMLElement | null;
+        expect(historyElement?.style.width).toBe(
+            `${CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX}px`,
+        );
+
+        mounted.setContentWidth(620);
+        act(() => {
+            window.dispatchEvent(new Event("resize"));
+        });
+
+        expect(historyElement?.style.width).toBe(
+            `${CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX}px`,
+        );
+        expect(latestFirstMeasurementKey()).toMatch(/:840:\d+$/);
+
+        act(() => {
+            useShellStore.getState().setResizingPanel(false);
+        });
+
+        expect(historyElement?.style.width).toBe("");
+        expect(latestFirstMeasurementKey()).toMatch(
+            new RegExp(
+                `:${getChatTimelineVirtualMeasurementWidth(620)}:\\d+$`,
+            ),
+        );
+
+        mounted.root.unmount();
+        mounted.scrollContainer.remove();
+    });
+
+    it("keeps resize release capped when the panel grows beyond the timeline max", () => {
+        const rows = createRows(CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD);
+        rectWidthFallback = 620;
+        const mounted = mountHistoryRows(rows);
+
+        mounted.setContentWidth(620);
+        expect(latestFirstMeasurementKey()).toMatch(
+            new RegExp(
+                `:${getChatTimelineVirtualMeasurementWidth(620)}:\\d+$`,
+            ),
+        );
+
+        act(() => {
+            useShellStore.getState().setResizingPanel(true);
+        });
+
+        const historyElement = mounted.mountNode.querySelector(
+            "[data-testid='mock-measured-virtual-list']",
+        )?.parentElement as HTMLElement | null;
+        expect(historyElement?.style.width).toBe("620px");
+
+        mounted.setContentWidth(CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX);
+        act(() => {
+            window.dispatchEvent(new Event("resize"));
+        });
+
+        expect(historyElement?.style.width).toBe("620px");
+        expect(latestFirstMeasurementKey()).toMatch(
+            new RegExp(
+                `:${getChatTimelineVirtualMeasurementWidth(620)}:\\d+$`,
+            ),
+        );
+
+        act(() => {
+            useShellStore.getState().setResizingPanel(false);
+        });
+
+        expect(historyElement?.style.width).toBe("");
+        expect(latestFirstMeasurementKey()).toMatch(
+            new RegExp(
+                `:${getChatTimelineVirtualMeasurementWidth(
+                    CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
+                )}:\\d+$`,
+            ),
+        );
+
+        mounted.root.unmount();
+        mounted.scrollContainer.remove();
     });
 });

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -25,6 +25,7 @@ import {
     CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN,
     calculateChatTimelineVirtualScrollMarginTop,
     estimateChatTimelineRowHeight,
+    getChatTimelineEffectiveContentWidth,
     getChatTimelineRowIdentityKey,
     getChatTimelineRowMeasurementKey,
     getChatTimelineRowKey,
@@ -74,13 +75,14 @@ export const ChatTimelineHistoryRows = memo(
         const pendingResizeAnchorRef =
             useRef<MeasuredVirtualViewportAnchor | null>(null);
         const pendingVirtualResizeEndRef = useRef(false);
-        const previousScrollContainerWidthRef = useRef<number | null>(null);
+        const previousContentMeasurementWidthRef = useRef<number | null>(null);
         const virtualListHandleRef = useRef<MeasuredVirtualListHandle | null>(
             null,
         );
         const virtualResizeActiveRef = useRef(false);
         const [scrollMarginTop, setScrollMarginTop] = useState(0);
-        const [scrollContainerWidth, setScrollContainerWidth] = useState(0);
+        const [contentMeasurementWidth, setContentMeasurementWidth] =
+            useState(0);
         // While the pane splitter is being dragged we freeze the timeline: the
         // content keeps its pre-drag width (so rows don't reflow) and all metric
         // updates are skipped, then we re-sync once on release. frozenContentWidth
@@ -137,15 +139,23 @@ export const ChatTimelineHistoryRows = memo(
 
             const historyElement = historyRef.current;
             const scrollContainer = scrollRef.current;
-            const nextScrollContainerWidth = scrollContainer?.clientWidth ?? 0;
-            const previousScrollContainerWidth =
-                previousScrollContainerWidthRef.current;
-            previousScrollContainerWidthRef.current = nextScrollContainerWidth;
+            const nextContentWidth =
+                historyElement?.getBoundingClientRect().width ??
+                getChatTimelineEffectiveContentWidth(
+                    scrollContainer?.clientWidth ?? 0,
+                );
+            const nextContentMeasurementWidth =
+                getChatTimelineVirtualMeasurementWidth(nextContentWidth);
+            const previousContentMeasurementWidth =
+                previousContentMeasurementWidthRef.current;
+            previousContentMeasurementWidthRef.current =
+                nextContentMeasurementWidth;
 
             if (
                 shouldVirtualize &&
-                previousScrollContainerWidth !== null &&
-                previousScrollContainerWidth !== nextScrollContainerWidth
+                previousContentMeasurementWidth !== null &&
+                previousContentMeasurementWidth !==
+                    nextContentMeasurementWidth
             ) {
                 if (shouldPreserveVirtualResizeAnchor?.() ?? true) {
                     pendingResizeAnchorRef.current =
@@ -164,11 +174,7 @@ export const ChatTimelineHistoryRows = memo(
                     scrollContainer,
                 }),
             );
-            setScrollContainerWidth(
-                getChatTimelineVirtualMeasurementWidth(
-                    nextScrollContainerWidth,
-                ),
-            );
+            setContentMeasurementWidth(nextContentMeasurementWidth);
         }, [
             onVirtualResizeAutoFollow,
             scheduleResizeAnchorRestore,
@@ -221,7 +227,7 @@ export const ChatTimelineHistoryRows = memo(
 
         useLayoutEffect(() => {
             restorePendingResizeAnchor();
-        }, [restorePendingResizeAnchor, scrollContainerWidth]);
+        }, [contentMeasurementWidth, restorePendingResizeAnchor]);
 
         useEffect(() => {
             return () => {
@@ -322,14 +328,14 @@ export const ChatTimelineHistoryRows = memo(
                 isLatestStreamingTool:
                     row.id === latestStreamingEditedFileToolRowId,
                 toolCardExpansionMode,
-                width: scrollContainerWidth,
+                width: contentMeasurementWidth,
             }),
             [
                 chatFontFamily,
+                contentMeasurementWidth,
                 chatFontSize,
                 latestStreamingEditedFileToolRowId,
                 resolveRowGapPx,
-                scrollContainerWidth,
                 toolCardExpansionMode,
             ],
         );

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -7,10 +7,12 @@ import {
     type ChatTimelineRow,
 } from "./chatTimelineModel";
 import {
+    CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
     CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
     CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
     calculateChatTimelineVirtualScrollMarginTop,
     estimateChatTimelineRowHeight,
+    getChatTimelineEffectiveContentWidth,
     getChatTimelineRowIdentityKey,
     getChatTimelineRowMeasurementKey,
     getChatTimelineRowKey,
@@ -505,6 +507,20 @@ describe("chatTimelineVirtualization", () => {
         expect(getChatTimelineVirtualMeasurementWidth(640)).toBe(648);
         expect(getChatTimelineVirtualMeasurementWidth(641)).toBe(648);
         expect(getChatTimelineVirtualMeasurementWidth(672)).toBe(672);
+    });
+
+    it("caps effective timeline content width at the timeline max", () => {
+        expect(getChatTimelineEffectiveContentWidth(0)).toBe(0);
+        expect(getChatTimelineEffectiveContentWidth(Number.NaN)).toBe(0);
+        expect(getChatTimelineEffectiveContentWidth(320)).toBe(320);
+        expect(
+            getChatTimelineEffectiveContentWidth(
+                CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
+            ),
+        ).toBe(CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX);
+        expect(getChatTimelineEffectiveContentWidth(1200)).toBe(
+            CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
+        );
     });
 
     it("keys measurement by row identity, not by content", () => {

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -13,7 +13,7 @@ export const CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN = 10;
 export const CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT = 720;
 export const CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX = 8;
 export const CHAT_TIMELINE_VIRTUAL_WIDTH_BUCKET_PX = 24;
-export const CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX = 840;
+export const CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX = 740;
 
 interface ShouldVirtualizeChatTimelineOptions {
     readonly enabled?: boolean;

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -13,6 +13,7 @@ export const CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN = 10;
 export const CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT = 720;
 export const CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX = 8;
 export const CHAT_TIMELINE_VIRTUAL_WIDTH_BUCKET_PX = 24;
+export const CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX = 840;
 
 interface ShouldVirtualizeChatTimelineOptions {
     readonly enabled?: boolean;
@@ -144,6 +145,14 @@ export function getChatTimelineVirtualMeasurementWidth(width: number): number {
         Math.round(width / CHAT_TIMELINE_VIRTUAL_WIDTH_BUCKET_PX) *
         CHAT_TIMELINE_VIRTUAL_WIDTH_BUCKET_PX
     );
+}
+
+export function getChatTimelineEffectiveContentWidth(width: number): number {
+    if (!Number.isFinite(width) || width <= 0) {
+        return 0;
+    }
+
+    return Math.min(width, CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX);
 }
 
 export function calculateChatTimelineVirtualScrollMarginTop({


### PR DESCRIPTION
## Summary
- cap chat timeline, context cards, and composer content to a shared 740px column
- align virtualized row measurement with the effective content width
- cover resize freeze behavior while the timeline is capped

## Verification
- pnpm exec vitest run src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
- pnpm exec tsc --noEmit -p tsconfig.web.json
- pnpm exec eslint src/renderer/src/components/workspace/ChatTabView.tsx
- pnpm exec eslint src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx