### PR TITLE
Fix stale worktree invalidations on Windows

### DIFF
--- a/src/main/db/client.ts
+++ b/src/main/db/client.ts
@@ -105,6 +105,10 @@ const DB_WORKER_METHOD_TIMEOUTS_MS: Readonly<Record<string, number>> = {
     // Project imports can synchronously touch the filesystem and invoke git
     // path discovery, so they need more headroom than pure SQLite calls.
     "projects.addProjectPaths": 30_000,
+    // Git refreshes sync worktree rows after potentially expensive branch or
+    // worktree operations. Avoid treating a busy SQLite worker as a fatal git
+    // snapshot failure too aggressively.
+    "projects.syncProjectWorktrees": 30_000,
 };
 
 class DbRpcClient {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -2700,7 +2700,10 @@ function stripRemotePrefix(referenceName: string): string {
 }
 
 function normalizePathKey(filePath: string): string {
-    return path.resolve(filePath).split(path.sep).join("/");
+    const normalizedPath = path.resolve(filePath).split(path.sep).join("/");
+    return process.platform === "win32"
+        ? normalizedPath.toLowerCase()
+        : normalizedPath;
 }
 
 function normalizeGitPath(filePath: string): string {

--- a/src/main/projects/service.test.ts
+++ b/src/main/projects/service.test.ts
@@ -279,6 +279,312 @@ describe("ProjectService", () => {
         expect(result.project.rootPath).toBe(hiddenRoot);
     });
 
+    it("drops stale tree invalidations for worktrees removed during git sync", async () => {
+        const connection = createTestConnection();
+        const onProjectTreeInvalidated = vi.fn();
+        const projectService = createProjectService(
+            connection,
+            onProjectTreeInvalidated,
+        );
+        const projectRoot = createTempProject(tempDirs, "worktree-primary");
+        const worktreeRoot = createTempProject(tempDirs, "worktree-stale");
+
+        const [project] = (
+            await projectService.addProjectPaths([projectRoot])
+        ).projects;
+        if (!project) {
+            throw new Error("Expected the project to be created.");
+        }
+
+        await projectService.syncProjectWorktrees(project.id, [
+            {
+                branchName: "main",
+                headSha: "primary-head",
+                rootPath: projectRoot,
+            },
+            {
+                branchName: "stale-branch",
+                headSha: "stale-head",
+                rootPath: worktreeRoot,
+            },
+        ]);
+
+        const staleWorktree = projectService
+            .listProjectWorktrees(project.id)
+            .find((worktree) => worktree.rootPath === worktreeRoot);
+        expect(staleWorktree).toBeDefined();
+        if (!staleWorktree) {
+            throw new Error("Expected the secondary worktree to be synced.");
+        }
+
+        await projectService.syncProjectWorktrees(project.id, [
+            {
+                branchName: "main",
+                headSha: "next-primary-head",
+                rootPath: projectRoot,
+            },
+        ]);
+        expect(
+            projectService
+                .listProjectWorktrees(project.id)
+                .some((worktree) => worktree.id === staleWorktree.id),
+        ).toBe(false);
+
+        expect(() => {
+            projectService.handleProjectTreeInvalidation({
+                occurredAt: "2026-06-08T00:00:00.000Z",
+                projectId: project.id,
+                relativePaths: null,
+                worktreeId: staleWorktree.id,
+            });
+        }).not.toThrow();
+        expect(onProjectTreeInvalidated).not.toHaveBeenCalled();
+    });
+
+    it("keeps forwarding valid primary invalidations after a sibling worktree is removed", async () => {
+        const connection = createTestConnection();
+        const onProjectTreeInvalidated = vi.fn();
+        const projectService = createProjectService(
+            connection,
+            onProjectTreeInvalidated,
+        );
+        const projectRoot = createTempProject(tempDirs, "valid-primary");
+        const worktreeRoot = createTempProject(tempDirs, "removed-sibling");
+
+        const [project] = (
+            await projectService.addProjectPaths([projectRoot])
+        ).projects;
+        if (!project) {
+            throw new Error("Expected the project to be created.");
+        }
+
+        await projectService.syncProjectWorktrees(project.id, [
+            {
+                branchName: "main",
+                headSha: "primary-head",
+                rootPath: projectRoot,
+            },
+            {
+                branchName: "removed",
+                headSha: "removed-head",
+                rootPath: worktreeRoot,
+            },
+        ]);
+        await projectService.syncProjectWorktrees(project.id, [
+            {
+                branchName: "main",
+                headSha: "next-primary-head",
+                rootPath: projectRoot,
+            },
+        ]);
+
+        const payload = {
+            occurredAt: "2026-06-08T00:00:00.000Z",
+            projectId: project.id,
+            relativePaths: ["src/index.ts"],
+            worktreeId: `${project.id}:primary`,
+        };
+        projectService.handleProjectTreeInvalidation(payload);
+
+        expect(onProjectTreeInvalidated).toHaveBeenCalledTimes(1);
+        expect(onProjectTreeInvalidated).toHaveBeenCalledWith(payload);
+    });
+
+    it("preserves worktree ids on Windows when git returns paths with different casing", async () => {
+        const connection = createTestConnection();
+        const projectService = createProjectService(connection);
+        const projectRoot = createTempProject(tempDirs, "windows-primary-case");
+        const worktreeRoot = createTempProject(
+            tempDirs,
+            "windows-worktree-case",
+        );
+
+        const [project] = (
+            await projectService.addProjectPaths([projectRoot])
+        ).projects;
+        if (!project) {
+            throw new Error("Expected the project to be created.");
+        }
+
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, "platform", {
+            configurable: true,
+            value: "win32",
+        });
+        try {
+            await projectService.syncProjectWorktrees(project.id, [
+                {
+                    branchName: "main",
+                    headSha: "primary-head",
+                    rootPath: projectRoot,
+                },
+                {
+                    branchName: "feature/windows-case",
+                    headSha: "feature-head",
+                    rootPath: worktreeRoot,
+                },
+            ]);
+
+            const before = projectService.listProjectWorktrees(project.id);
+            const beforePrimary = before.find((worktree) => worktree.isPrimary);
+            const beforeFeature = before.find(
+                (worktree) => worktree.branchName === "feature/windows-case",
+            );
+            expect(beforePrimary?.id).toBe(`${project.id}:primary`);
+            expect(beforeFeature).toBeDefined();
+            if (!beforePrimary || !beforeFeature) {
+                throw new Error("Expected both worktrees to be synced.");
+            }
+
+            await projectService.syncProjectWorktrees(project.id, [
+                {
+                    branchName: "main",
+                    headSha: "next-primary-head",
+                    rootPath: projectRoot.toUpperCase(),
+                },
+                {
+                    branchName: "feature/windows-case",
+                    headSha: "next-feature-head",
+                    rootPath: worktreeRoot.toUpperCase(),
+                },
+            ]);
+
+            const after = projectService.listProjectWorktrees(project.id);
+            expect(after).toHaveLength(2);
+            expect(after.find((worktree) => worktree.isPrimary)?.id).toBe(
+                beforePrimary.id,
+            );
+            expect(
+                after.find(
+                    (worktree) =>
+                        worktree.branchName === "feature/windows-case",
+                )?.id,
+            ).toBe(beforeFeature.id);
+        } finally {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: originalPlatform,
+            });
+        }
+    });
+
+    it("removes legacy Windows worktree duplicates before syncing casing changes", async () => {
+        const connection = createTestConnection();
+        const projectService = createProjectService(connection);
+        const projectRoot = createTempProject(tempDirs, "legacy-case-primary");
+
+        const [project] = (
+            await projectService.addProjectPaths([projectRoot])
+        ).projects;
+        if (!project) {
+            throw new Error("Expected the project to be created.");
+        }
+
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, "platform", {
+            configurable: true,
+            value: "win32",
+        });
+        try {
+            const duplicateRootPath = projectRoot.toUpperCase();
+            const now = new Date().toISOString();
+            connection
+                .prepare<
+                    [
+                        string,
+                        string,
+                        string,
+                        string,
+                        string,
+                        number,
+                        string,
+                        string,
+                    ],
+                    void
+                >(
+                    `
+                    INSERT INTO project_worktrees (
+                        id,
+                        project_id,
+                        root_path,
+                        branch_name,
+                        head_sha,
+                        is_primary,
+                        created_at,
+                        updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    `,
+                )
+                .run(
+                    `${project.id}:legacy-case-duplicate`,
+                    project.id,
+                    duplicateRootPath,
+                    "legacy-case",
+                    "legacy-head",
+                    0,
+                    now,
+                    now,
+                );
+
+            expect(projectService.listProjectWorktrees(project.id)).toHaveLength(
+                2,
+            );
+
+            await projectService.syncProjectWorktrees(project.id, [
+                {
+                    branchName: "main",
+                    headSha: "next-primary-head",
+                    rootPath: duplicateRootPath,
+                },
+            ]);
+
+            const after = projectService.listProjectWorktrees(project.id);
+            expect(after).toHaveLength(1);
+            expect(after[0]).toMatchObject({
+                branchName: "main",
+                headSha: "next-primary-head",
+                id: `${project.id}:primary`,
+                isPrimary: true,
+                rootPath: path.resolve(duplicateRootPath),
+            });
+        } finally {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: originalPlatform,
+            });
+        }
+    });
+
+    it("drops stale tree invalidations for projects removed while watchers flush", async () => {
+        const connection = createTestConnection();
+        const onProjectTreeInvalidated = vi.fn();
+        const projectService = createProjectService(
+            connection,
+            onProjectTreeInvalidated,
+        );
+        const projectRoot = createTempProject(tempDirs, "removed-project");
+
+        const [project] = (
+            await projectService.addProjectPaths([projectRoot])
+        ).projects;
+        if (!project) {
+            throw new Error("Expected the project to be created.");
+        }
+
+        await projectService.removeProject(project.id);
+
+        expect(() => {
+            projectService.handleProjectTreeInvalidation({
+                occurredAt: "2026-06-08T00:00:00.000Z",
+                projectId: project.id,
+                relativePaths: null,
+                worktreeId: null,
+            });
+        }).not.toThrow();
+        expect(onProjectTreeInvalidated).not.toHaveBeenCalled();
+    });
+
     it("reuses the cached search index until project contents change", async () => {
         const connection = createTestConnection();
         const projectService = createProjectService(connection);

--- a/src/main/projects/service.ts
+++ b/src/main/projects/service.ts
@@ -577,8 +577,11 @@ export class ProjectService {
             );
             this.#indexedRoots.delete(normalizeRootPath(project.rootPath));
         } catch (error) {
-            // Invalidation for a project removed while the worker was flushing.
+            // Watchers can flush after a project or worktree has already been
+            // removed. Dropping the stale event prevents downstream refreshes
+            // from resolving ids that no longer exist.
             debugBenignError("projects.handleTreeInvalidation", error);
+            return;
         }
 
         this.#onProjectTreeInvalidated(payload);

--- a/src/main/projects/store.ts
+++ b/src/main/projects/store.ts
@@ -836,22 +836,27 @@ export class SqliteProjectStore implements ProjectStore {
             throw new Error("The requested project does not exist anymore.");
         }
 
+        const projectRootPath = path.resolve(project.canonicalRootPath);
+        const projectRootKey = normalizeWorktreePathKey(projectRootPath);
         const desiredWorktrees = new Map(
-            worktrees.map((worktree) => [
-                path.resolve(worktree.rootPath),
-                {
-                    branchName: worktree.branchName,
-                    headSha: worktree.headSha,
-                    rootPath: path.resolve(worktree.rootPath),
-                },
-            ]),
+            worktrees.map((worktree) => {
+                const rootPath = path.resolve(worktree.rootPath);
+                return [
+                    normalizeWorktreePathKey(rootPath),
+                    {
+                        branchName: worktree.branchName,
+                        headSha: worktree.headSha,
+                        rootPath,
+                    },
+                ];
+            }),
         );
 
-        if (!desiredWorktrees.has(project.canonicalRootPath)) {
-            desiredWorktrees.set(project.canonicalRootPath, {
+        if (!desiredWorktrees.has(projectRootKey)) {
+            desiredWorktrees.set(projectRootKey, {
                 branchName: null,
                 headSha: null,
-                rootPath: project.canonicalRootPath,
+                rootPath: projectRootPath,
             });
         }
 
@@ -871,8 +876,16 @@ export class SqliteProjectStore implements ProjectStore {
                 `,
             )
             .all(projectId);
-        const existingByPath = new Map(
-            existingRows.map((row) => [path.resolve(row.root_path), row]),
+        const existingByPath = createPreferredExistingWorktreeMap({
+            desiredWorktrees,
+            existingRows,
+            primaryWorktreeId: `${projectId}:primary`,
+            projectRootKey,
+        });
+        const retainedExistingIds = new Set(
+            [...existingByPath]
+                .filter(([rootKey]) => desiredWorktrees.has(rootKey))
+                .map(([, row]) => row.id),
         );
         const upsertWorktree = this.#connection.prepare<
             [
@@ -914,12 +927,17 @@ export class SqliteProjectStore implements ProjectStore {
 
         const transaction = this.#connection.transaction(() => {
             for (const existingRow of existingRows) {
-                const normalizedRootPath = path.resolve(existingRow.root_path);
-                if (desiredWorktrees.has(normalizedRootPath)) {
+                const normalizedRootKey = normalizeWorktreePathKey(
+                    existingRow.root_path,
+                );
+                if (retainedExistingIds.has(existingRow.id)) {
                     continue;
                 }
 
-                if (existingRow.is_primary === 1) {
+                if (
+                    existingRow.is_primary === 1 &&
+                    !desiredWorktrees.has(normalizedRootKey)
+                ) {
                     continue;
                 }
 
@@ -928,10 +946,11 @@ export class SqliteProjectStore implements ProjectStore {
 
             for (const desiredWorktree of desiredWorktrees.values()) {
                 const existingRow = existingByPath.get(
-                    desiredWorktree.rootPath,
+                    normalizeWorktreePathKey(desiredWorktree.rootPath),
                 );
                 const isPrimary =
-                    desiredWorktree.rootPath === project.canonicalRootPath;
+                    normalizeWorktreePathKey(desiredWorktree.rootPath) ===
+                    projectRootKey;
                 upsertWorktree.run(
                     existingRow?.id ??
                         (isPrimary ? `${projectId}:primary` : randomUUID()),
@@ -1285,6 +1304,87 @@ function isDirectoryPath(projectPath: string): boolean {
         debugBenignError("projects.store.isDirectoryPath", error);
         return false;
     }
+}
+
+function normalizeWorktreePathKey(rootPath: string): string {
+    const resolvedPath = path.resolve(rootPath);
+    return process.platform === "win32"
+        ? resolvedPath.toLowerCase()
+        : resolvedPath;
+}
+
+function createPreferredExistingWorktreeMap({
+    desiredWorktrees,
+    existingRows,
+    primaryWorktreeId,
+    projectRootKey,
+}: {
+    readonly desiredWorktrees: ReadonlyMap<
+        string,
+        {
+            readonly rootPath: string;
+        }
+    >;
+    readonly existingRows: readonly PersistedProjectWorktreeRow[];
+    readonly primaryWorktreeId: string;
+    readonly projectRootKey: string;
+}): Map<string, PersistedProjectWorktreeRow> {
+    const existingByPath = new Map<string, PersistedProjectWorktreeRow>();
+
+    for (const row of existingRows) {
+        const rootKey = normalizeWorktreePathKey(row.root_path);
+        const current = existingByPath.get(rootKey);
+        if (
+            !current ||
+            getExistingWorktreePreferenceScore({
+                desiredRootPath: desiredWorktrees.get(rootKey)?.rootPath ?? null,
+                primaryWorktreeId,
+                projectRootKey,
+                rootKey,
+                row,
+            }) >
+                getExistingWorktreePreferenceScore({
+                    desiredRootPath:
+                        desiredWorktrees.get(rootKey)?.rootPath ?? null,
+                    primaryWorktreeId,
+                    projectRootKey,
+                    rootKey,
+                    row: current,
+                })
+        ) {
+            existingByPath.set(rootKey, row);
+        }
+    }
+
+    return existingByPath;
+}
+
+function getExistingWorktreePreferenceScore({
+    desiredRootPath,
+    primaryWorktreeId,
+    projectRootKey,
+    rootKey,
+    row,
+}: {
+    readonly desiredRootPath: string | null;
+    readonly primaryWorktreeId: string;
+    readonly projectRootKey: string;
+    readonly rootKey: string;
+    readonly row: PersistedProjectWorktreeRow;
+}): number {
+    let score = 0;
+
+    if (rootKey === projectRootKey && row.id === primaryWorktreeId) {
+        score += 100;
+    }
+    if (rootKey === projectRootKey && row.is_primary === 1) {
+        score += 50;
+    }
+    if (desiredRootPath && path.resolve(row.root_path) === desiredRootPath) {
+        score += 10;
+    }
+
+    return score;
 }
 
 function createPlaceholders(count: number): string {


### PR DESCRIPTION
## Summary

Fixes a Windows-specific Git/GitHub sidebar failure where stale worktree identity could leave the GitHub issues and pull requests panel thinking the active project was not a ready Git repository.

## Root Cause

When worktrees were removed or Git returned the same paths with different casing on Windows, the project worktree sync could recreate or retain stale worktree ids. Delayed project watcher invalidations could then propagate ids that no longer existed, causing downstream Git refreshes and GitHub repository detection to lose the active snapshot.

## Changes

- Drop stale project tree invalidations for removed projects or worktrees before broadcasting them.
- Preserve worktree ids on Windows by comparing worktree path identity case-insensitively.
- Clean up legacy duplicate worktree rows that differ only by casing.
- Normalize Git repository path keys case-insensitively on Windows.
- Give `projects.syncProjectWorktrees` more DB worker headroom during Git refreshes.
- Add regression coverage for stale invalidations, valid primary invalidations, Windows casing, and legacy duplicate cleanup.

## Validation

- `pnpm vitest run src/main/projects/service.test.ts`
- `pnpm exec eslint src/main/db/client.ts src/main/ipc/index.ts src/main/projects/service.ts src/main/projects/store.ts src/main/projects/service.test.ts`