### PR TITLE
Fix GitHub sidebar drag lifecycle

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.test.ts
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type {
     GitBranchSummary,
@@ -19,8 +23,28 @@ import {
     getProjectSnapshot,
     reconcileSidebarGitHubSelection,
     resolveSidebarGitHubItemClickSelection,
+    SidebarGitHubDraggableRow,
     shouldOpenSidebarGitHubItemClick,
 } from "./SidebarGitHubPanel";
+import {
+    SIDEBAR_GITHUB_DRAG_EVENT,
+    type SidebarGitHubDragDetail,
+} from "./sidebarGitHubDragEvents";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+afterEach(() => {
+    for (const root of mountedRoots.splice(0)) {
+        act(() => {
+            root.unmount();
+        });
+    }
+    for (const container of mountedContainers.splice(0)) {
+        container.remove();
+    }
+    vi.restoreAllMocks();
+});
 
 function createBranch(
     overrides: Partial<GitBranchSummary> = {},
@@ -412,6 +436,117 @@ describe("SidebarGitHubPanel selection helpers", () => {
                 shiftKey: false,
             }),
         ).toBe(false);
+    });
+});
+
+describe("SidebarGitHubDraggableRow", () => {
+    it("keeps an active drag alive across rerenders with new drag item arrays", () => {
+        const releasePointerCapture = vi.fn();
+        const setPointerCapture = vi.fn();
+        const events: SidebarGitHubDragDetail[] = [];
+        const handleDrag = (event: Event) => {
+            events.push(
+                (event as CustomEvent<SidebarGitHubDragDetail>).detail,
+            );
+        };
+        window.addEventListener(SIDEBAR_GITHUB_DRAG_EVENT, handleDrag);
+
+        const container = document.createElement("div");
+        document.body.append(container);
+        mountedContainers.push(container);
+        const root = createRoot(container);
+        mountedRoots.push(root);
+
+        const renderRow = (title: string) => {
+            act(() => {
+                root.render(
+                    createElement(
+                        SidebarGitHubDraggableRow,
+                        {
+                            children: createElement("span", null, title),
+                            dragItems: [{ number: 7, title }],
+                            itemKind: "issue",
+                            meta: "#7 - 1 comment",
+                            number: 7,
+                            onOpen: () => undefined,
+                            projectId: "project-1",
+                            repoRef,
+                            selected: false,
+                            title,
+                            worktreeId: "project-1:primary",
+                        },
+                    ),
+                );
+            });
+        };
+
+        try {
+            renderRow("First title");
+            const row = container.querySelector<HTMLElement>("[role='button']");
+            expect(row).not.toBeNull();
+            if (!row) {
+                throw new Error("Expected draggable row to render.");
+            }
+
+            row.setPointerCapture = setPointerCapture;
+            row.releasePointerCapture = releasePointerCapture;
+
+            act(() => {
+                row.dispatchEvent(
+                    new PointerEvent("pointerdown", {
+                        bubbles: true,
+                        button: 0,
+                        buttons: 1,
+                        clientX: 10,
+                        clientY: 10,
+                        pointerId: 4,
+                    }),
+                );
+                row.dispatchEvent(
+                    new PointerEvent("pointermove", {
+                        bubbles: true,
+                        buttons: 1,
+                        clientX: 26,
+                        clientY: 10,
+                        pointerId: 4,
+                    }),
+                );
+            });
+
+            renderRow("Second title");
+
+            act(() => {
+                window.dispatchEvent(
+                    new PointerEvent("pointerup", {
+                        bubbles: true,
+                        button: 0,
+                        buttons: 0,
+                        clientX: 32,
+                        clientY: 10,
+                        pointerId: 4,
+                    }),
+                );
+            });
+
+            expect(events.map((event) => event.phase)).toEqual([
+                "start",
+                "end",
+            ]);
+            expect(events[0]).toMatchObject({
+                items: [{ number: 7, title: "First title" }],
+                number: 7,
+                title: "First title",
+            });
+            expect(events[1]).toMatchObject({
+                items: [{ number: 7, title: "First title" }],
+                number: 7,
+                title: "First title",
+            });
+            expect(setPointerCapture).toHaveBeenCalledWith(4);
+            expect(releasePointerCapture).toHaveBeenCalledWith(4);
+        } finally {
+            window.removeEventListener(SIDEBAR_GITHUB_DRAG_EVENT, handleDrag);
+        }
     });
 });
 

--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
@@ -6,7 +6,6 @@ import {
     useRef,
     useState,
     type MouseEvent as ReactMouseEvent,
-    type PointerEvent as ReactPointerEvent,
     type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
@@ -85,6 +84,24 @@ type SidebarGitHubDragPreview = {
     readonly title: string;
     readonly x: number;
     readonly y: number;
+};
+
+type SidebarGitHubDragSnapshot = {
+    readonly itemKind: SidebarGitHubDragItemKind;
+    readonly items: readonly SidebarGitHubDragItem[];
+    readonly number: number;
+    readonly previewKindLabel: string;
+    readonly previewMeta: string;
+    readonly previewTitle: string;
+    readonly projectId: string | null;
+    readonly ref: GitHubRepositoryRef;
+    readonly title: string;
+    readonly worktreeId: string | null;
+};
+
+type SidebarGitHubPointerPoint = {
+    readonly clientX: number;
+    readonly clientY: number;
 };
 
 type SidebarGitHubContextMenuPayload = {
@@ -745,6 +762,10 @@ export function SidebarGitHubPanel({
         },
         [selectedItemNumbers, visibleItemNumbers],
     );
+    const handleItemPointerDown = useCallback(() => {
+        setGitHubContextMenu(null);
+        setLabelPicker(null);
+    }, []);
     const getIssueDragItems = useCallback(
         (issue: GitHubIssueSummary): readonly SidebarGitHubDragItem[] =>
             getSidebarGitHubDragItems({
@@ -1011,6 +1032,7 @@ export function SidebarGitHubPanel({
                                         )
                                     }
                                     onOpen={() => openIssueTab(issue.number)}
+                                    onPointerDown={handleItemPointerDown}
                                     onRowClick={(event) =>
                                         handleItemClickSelection(
                                             event,
@@ -1053,6 +1075,7 @@ export function SidebarGitHubPanel({
                                             worktreeId,
                                         })
                                     }
+                                    onPointerDown={handleItemPointerDown}
                                     onRowClick={(event) =>
                                         handleItemClickSelection(
                                             event,
@@ -1109,6 +1132,7 @@ function SidebarGitHubIssueRow({
     issue,
     onContextMenu,
     onOpen,
+    onPointerDown,
     onRowClick,
     projectId,
     repoRef,
@@ -1119,6 +1143,7 @@ function SidebarGitHubIssueRow({
     readonly issue: GitHubIssueSummary;
     readonly onContextMenu: (event: ReactMouseEvent<HTMLElement>) => void;
     readonly onOpen: () => void;
+    readonly onPointerDown: () => void;
     readonly onRowClick: (event: ReactMouseEvent<HTMLElement>) => void;
     readonly projectId: string | null;
     readonly repoRef: GitHubRepositoryRef;
@@ -1141,6 +1166,7 @@ function SidebarGitHubIssueRow({
             number={issue.number}
             onContextMenu={onContextMenu}
             onOpen={onOpen}
+            onPointerDown={onPointerDown}
             onRowClick={onRowClick}
             projectId={projectId}
             repoRef={repoRef}
@@ -1202,6 +1228,7 @@ function SidebarGitHubPullRequestRow({
     dragItems,
     onContextMenu,
     onOpen,
+    onPointerDown,
     onRowClick,
     projectId,
     pullRequest,
@@ -1213,6 +1240,7 @@ function SidebarGitHubPullRequestRow({
     readonly dragItems: readonly SidebarGitHubDragItem[];
     readonly onContextMenu: (event: ReactMouseEvent<HTMLElement>) => void;
     readonly onOpen: () => void;
+    readonly onPointerDown: () => void;
     readonly onRowClick: (event: ReactMouseEvent<HTMLElement>) => void;
     readonly projectId: string | null;
     readonly pullRequest: GitHubPullRequestSummary;
@@ -1233,6 +1261,7 @@ function SidebarGitHubPullRequestRow({
             number={pullRequest.number}
             onContextMenu={onContextMenu}
             onOpen={onOpen}
+            onPointerDown={onPointerDown}
             onRowClick={onRowClick}
             projectId={projectId}
             repoRef={repoRef}
@@ -1488,6 +1517,7 @@ function SidebarGitHubDraggableRow({
     number,
     onContextMenu,
     onOpen,
+    onPointerDown,
     onRowClick,
     projectId,
     repoRef,
@@ -1502,6 +1532,7 @@ function SidebarGitHubDraggableRow({
     readonly number: number;
     readonly onContextMenu?: (event: ReactMouseEvent<HTMLElement>) => void;
     readonly onOpen: () => void;
+    readonly onPointerDown?: () => void;
     readonly onRowClick?: (event: ReactMouseEvent<HTMLElement>) => void;
     readonly projectId: string | null;
     readonly repoRef: GitHubRepositoryRef;
@@ -1510,7 +1541,9 @@ function SidebarGitHubDraggableRow({
     readonly worktreeId: string | null;
 }) {
     const dragStateRef = useRef<{
+        readonly captureElement: HTMLElement | null;
         readonly pointerId: number;
+        readonly snapshot: SidebarGitHubDragSnapshot;
         readonly startX: number;
         readonly startY: number;
         active: boolean;
@@ -1529,36 +1562,40 @@ function SidebarGitHubDraggableRow({
 
     const emitDrag = useCallback(
         (
+            snapshot: SidebarGitHubDragSnapshot,
             phase: "cancel" | "end" | "move" | "start",
-            event?: Pick<ReactPointerEvent<HTMLElement>, "clientX" | "clientY">,
+            event?: SidebarGitHubPointerPoint,
         ) => {
             emitSidebarGitHubDrag({
-                itemKind,
-                items: dragItems,
-                number,
+                itemKind: snapshot.itemKind,
+                items: snapshot.items,
+                number: snapshot.number,
                 phase,
-                projectId,
-                ref: repoRef,
-                title,
-                worktreeId,
+                projectId: snapshot.projectId,
+                ref: snapshot.ref,
+                title: snapshot.title,
+                worktreeId: snapshot.worktreeId,
                 x: event?.clientX ?? 0,
                 y: event?.clientY ?? 0,
             });
         },
-        [dragItems, itemKind, number, projectId, repoRef, title, worktreeId],
+        [],
     );
 
     const updateDragPreview = useCallback(
-        (event: Pick<ReactPointerEvent<HTMLElement>, "clientX" | "clientY">) => {
+        (
+            snapshot: SidebarGitHubDragSnapshot,
+            event: SidebarGitHubPointerPoint,
+        ) => {
             setDragPreview({
-                kindLabel: previewKindLabel,
-                meta: previewMeta,
-                title: previewTitle,
+                kindLabel: snapshot.previewKindLabel,
+                meta: snapshot.previewMeta,
+                title: snapshot.previewTitle,
                 x: event.clientX,
                 y: event.clientY,
             });
         },
-        [previewKindLabel, previewMeta, previewTitle],
+        [],
     );
 
     const clearDragState = useCallback(
@@ -1569,10 +1606,7 @@ function SidebarGitHubDraggableRow({
             releaseTarget,
         }: {
             readonly emitCancel: boolean;
-            readonly event?: Pick<
-                ReactPointerEvent<HTMLElement>,
-                "clientX" | "clientY"
-            >;
+            readonly event?: SidebarGitHubPointerPoint;
             readonly pointerId?: number;
             readonly releaseTarget?: EventTarget | null;
         }) => {
@@ -1585,15 +1619,16 @@ function SidebarGitHubDraggableRow({
             setIsPointerTracking(false);
             setDragPreview(null);
 
-            if (
-                releaseTarget instanceof HTMLElement &&
-                pointerId !== undefined
-            ) {
-                releaseTarget.releasePointerCapture?.(pointerId);
+            const captureElement =
+                releaseTarget instanceof HTMLElement
+                    ? releaseTarget
+                    : dragState.captureElement;
+            if (captureElement && pointerId !== undefined) {
+                captureElement.releasePointerCapture?.(pointerId);
             }
 
             if (emitCancel && shouldEmitSidebarDragCancel(dragState.active)) {
-                emitDrag("cancel", event);
+                emitDrag(dragState.snapshot, "cancel", event);
             }
         },
         [emitDrag],
@@ -1607,6 +1642,39 @@ function SidebarGitHubDraggableRow({
         const handleWindowBlur = () => {
             clearDragState({ emitCancel: true });
         };
+        const handlePointerCancel = (event: PointerEvent) => {
+            const dragState = dragStateRef.current;
+            if (!dragState || dragState.pointerId !== event.pointerId) {
+                return;
+            }
+
+            clearDragState({
+                emitCancel: true,
+                event,
+                pointerId: event.pointerId,
+            });
+        };
+        const handlePointerUp = (event: PointerEvent) => {
+            const dragState = dragStateRef.current;
+            if (!dragState || dragState.pointerId !== event.pointerId) {
+                return;
+            }
+
+            dragStateRef.current = null;
+            setIsPointerTracking(false);
+            dragState.captureElement?.releasePointerCapture?.(event.pointerId);
+            if (!dragState.active) {
+                setDragPreview(null);
+                return;
+            }
+
+            setDragPreview(null);
+            suppressClickRef.current = true;
+            window.requestAnimationFrame(() => {
+                suppressClickRef.current = false;
+            });
+            emitDrag(dragState.snapshot, "end", event);
+        };
         const handleVisibilityChange = () => {
             if (document.visibilityState !== "hidden") {
                 return;
@@ -1616,17 +1684,21 @@ function SidebarGitHubDraggableRow({
         };
 
         window.addEventListener("blur", handleWindowBlur);
+        window.addEventListener("pointercancel", handlePointerCancel);
+        window.addEventListener("pointerup", handlePointerUp);
         document.addEventListener("visibilitychange", handleVisibilityChange);
 
         return () => {
             window.removeEventListener("blur", handleWindowBlur);
+            window.removeEventListener("pointercancel", handlePointerCancel);
+            window.removeEventListener("pointerup", handlePointerUp);
             document.removeEventListener(
                 "visibilitychange",
                 handleVisibilityChange,
             );
             clearDragState({ emitCancel: true });
         };
-    }, [clearDragState, isPointerTracking]);
+    }, [clearDragState, emitDrag, isPointerTracking]);
 
     return (
         <>
@@ -1687,9 +1759,23 @@ function SidebarGitHubDraggableRow({
                         return;
                     }
 
+                    onPointerDown?.();
                     dragStateRef.current = {
                         active: false,
+                        captureElement: event.currentTarget,
                         pointerId: event.pointerId,
+                        snapshot: {
+                            itemKind,
+                            items: dragItems,
+                            number,
+                            previewKindLabel,
+                            previewMeta,
+                            previewTitle,
+                            projectId,
+                            ref: repoRef,
+                            title,
+                            worktreeId,
+                        },
                         startX: event.clientX,
                         startY: event.clientY,
                     };
@@ -1722,11 +1808,11 @@ function SidebarGitHubDraggableRow({
                         }
 
                         dragState.active = true;
-                        updateDragPreview(event);
-                        emitDrag("start", event);
+                        updateDragPreview(dragState.snapshot, event);
+                        emitDrag(dragState.snapshot, "start", event);
                     } else {
-                        updateDragPreview(event);
-                        emitDrag("move", event);
+                        updateDragPreview(dragState.snapshot, event);
+                        emitDrag(dragState.snapshot, "move", event);
                     }
 
                     event.preventDefault();
@@ -1752,7 +1838,7 @@ function SidebarGitHubDraggableRow({
                     window.requestAnimationFrame(() => {
                         suppressClickRef.current = false;
                     });
-                    emitDrag("end", event);
+                    emitDrag(dragState.snapshot, "end", event);
                 }}
                 role="button"
                 tabIndex={0}

--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
@@ -1509,7 +1509,7 @@ function SidebarGitHubLabelPicker({
     );
 }
 
-function SidebarGitHubDraggableRow({
+export function SidebarGitHubDraggableRow({
     children,
     dragItems,
     itemKind,


### PR DESCRIPTION
## Summary

Fixes an intermittent GitHub issue/PR drag failure in the sidebar multipane flow. QA confirmed the fix locally.

## Root Cause

The multi-select GitHub sidebar work introduced `dragItems` arrays that are recreated on render. During a drag, the initial `start` event can trigger sidebar/overlay state updates and rerender the row. Because the drag callbacks depended on the live `dragItems` prop, that rerender could tear down the tracking effect and cancel the active drag, making the UI feel like something remained selected or blocked.

## Changes

- Capture a stable drag snapshot on `pointerdown` and use it for all `start`/`move`/`end`/`cancel` events.
- Add global `pointerup` and `pointercancel` handling while GitHub sidebar drag tracking is active.
- Clear GitHub context/label overlays when starting item interaction.
- Add DOM coverage for `pointerdown -> drag start -> rerender with new drag item arrays -> pointerup`, asserting the drag emits `start` and `end` with the original snapshot.

## Validation

- QA verified the drag now works.
- `pnpm vitest run src/renderer/src/components/sidebar/SidebarGitHubPanel.test.ts`
- `pnpm run typecheck`
- `pnpm exec eslint src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx src/renderer/src/components/sidebar/SidebarGitHubPanel.test.ts`