### PR TITLE
Harden Windows path identity handling

### DIFF
--- a/src/main/ai/review-core.ts
+++ b/src/main/ai/review-core.ts
@@ -45,7 +45,12 @@ import {
     SUPPRESSED_STATUS_TITLES,
     type LiveAcpSession,
 } from "./contracts";
-import { toPosixPath } from "./session-core";
+import {
+    basenameForPathIdentity,
+    resolveSessionScopedPath,
+    type ResolveSessionPathOptions,
+    toPosixPath,
+} from "./session-core";
 import { debugBenignError } from "@main/observability/logging";
 
 const TERMINAL_OUTPUT_MAX_LENGTH = 10_000;
@@ -1564,48 +1569,29 @@ function buildToolSummary(
 export function normalizeTrackedDiffPath(
     liveSession: Pick<LiveAcpSession, "cwd" | "projectRoot">,
     candidatePath: string,
+    options: ResolveSessionPathOptions = {},
 ): string {
     const scopeRoot = liveSession.projectRoot ?? liveSession.cwd;
-    if (isPosixAbsolutePath(scopeRoot) && isPosixAbsolutePath(candidatePath)) {
-        const absolutePath = path.posix.resolve(candidatePath);
-        const normalizedScopeRoot = path.posix.resolve(scopeRoot);
-        if (
-            absolutePath === normalizedScopeRoot ||
-            absolutePath.startsWith(`${normalizedScopeRoot}/`)
-        ) {
-            const relativePath = path.posix.relative(
-                normalizedScopeRoot,
-                absolutePath,
-            );
-            return relativePath.length > 0
-                ? relativePath
-                : path.posix.basename(absolutePath);
-        }
+    const resolvedPath = resolveSessionScopedPath(
+        scopeRoot,
+        candidatePath,
+        options,
+    );
 
-        return absolutePath;
+    if (resolvedPath.insideRoot) {
+        return resolvedPath.relativePath && resolvedPath.relativePath.length > 0
+            ? resolvedPath.relativePath
+            : toPosixPath(
+                  basenameForPathIdentity(
+                      resolvedPath.absolutePath,
+                      { platform: resolvedPath.platform },
+                  ),
+              );
     }
 
-    const absolutePath = path.isAbsolute(candidatePath)
-        ? path.resolve(candidatePath)
-        : path.resolve(scopeRoot, candidatePath);
-
-    if (
-        absolutePath === scopeRoot ||
-        absolutePath.startsWith(`${scopeRoot}${path.sep}`)
-    ) {
-        const relativePath = path.relative(scopeRoot, absolutePath);
-        return relativePath.length > 0
-            ? toPosixPath(relativePath)
-            : toPosixPath(path.basename(absolutePath));
-    }
-
-    return path.isAbsolute(candidatePath)
-        ? absolutePath
+    return resolvedPath.isAbsoluteInput
+        ? resolvedPath.absolutePath
         : toPosixPath(candidatePath);
-}
-
-function isPosixAbsolutePath(candidatePath: string): boolean {
-    return candidatePath.startsWith("/") && !candidatePath.startsWith("//");
 }
 
 export async function readTextIfExists(

--- a/src/main/ai/service.review.test.ts
+++ b/src/main/ai/service.review.test.ts
@@ -392,6 +392,19 @@ describe("AiService tracked file review merging", () => {
         });
     });
 
+    it("normalizes Windows absolute diff paths with different root casing", () => {
+        expect(
+            __testing.normalizeTrackedDiffPath(
+                {
+                    cwd: "C:\\Repo",
+                    projectRoot: "C:\\Repo",
+                },
+                "c:\\repo\\src\\app.ts",
+                { platform: "win32" },
+            ),
+        ).toBe("src/app.ts");
+    });
+
     it("recomputes text hunks instead of trusting external diff metadata", () => {
         const oldText = "alpha\nbeta\ngamma";
         const newText = "alpha\nBETA\ngamma";

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -80,7 +80,9 @@ import {
     getRecentStderrText,
     getRuntimeDisplayName,
     isPathInsideRoot,
+    isSamePath,
     normalizeAdditionalRoots,
+    resolveSessionScopedPath,
     setConfigOptionOnSnapshot,
     setModeOnSnapshot,
     setModelOnSnapshot,
@@ -1443,21 +1445,19 @@ export class AiService {
         },
         candidatePath: string,
     ): string {
-        const absolutePath = path.isAbsolute(candidatePath)
-            ? path.resolve(candidatePath)
-            : path.resolve(scope.scopeRoot, candidatePath);
-        const insidePrimaryScope =
-            absolutePath === scope.scopeRoot ||
-            absolutePath.startsWith(`${scope.scopeRoot}${path.sep}`);
+        const resolvedPath = resolveSessionScopedPath(
+            scope.scopeRoot,
+            candidatePath,
+        );
         const insideAdditionalRoot = scope.additionalRoots.some((rootPath) =>
-            isPathInsideRoot(absolutePath, rootPath),
+            isPathInsideRoot(resolvedPath.absolutePath, rootPath),
         );
 
-        if (!insidePrimaryScope && !insideAdditionalRoot) {
+        if (!resolvedPath.insideRoot && !insideAdditionalRoot) {
             throw new Error("Tracked file path is outside the session scope.");
         }
 
-        return absolutePath;
+        return resolvedPath.absolutePath;
     }
 
     #getLiveSessionRuntimeId(sessionId: string): AiRuntimeId {
@@ -1739,12 +1739,11 @@ export class AiService {
             return normalizeAdditionalRoots(mergedRoots);
         }
 
-        const normalizedProjectRoot = path.resolve(projectRoot);
         return normalizeAdditionalRoots(
             mergedRoots.filter(
                 (rootPath) =>
                     rootPath.trim().length > 0 &&
-                    path.resolve(rootPath) !== normalizedProjectRoot,
+                    !isSamePath(rootPath, projectRoot),
             ),
         );
     }

--- a/src/main/ai/session-core.test.ts
+++ b/src/main/ai/session-core.test.ts
@@ -3,7 +3,13 @@ import { describe, expect, it } from "vitest";
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import type { AiSessionSnapshot } from "@shared/ipc";
 
-import { applySessionCatalogToSnapshot } from "./session-core";
+import {
+    applySessionCatalogToSnapshot,
+    isPathInsideRoot,
+    isSamePath,
+    normalizeAdditionalRoots,
+    resolveSessionScopedPath,
+} from "./session-core";
 
 describe("session-core model reconciliation", () => {
     it("merges runtime models into stale model config options", () => {
@@ -63,6 +69,56 @@ describe("session-core model reconciliation", () => {
                     (option) => option.value === "gpt-5.5",
                 ),
         ).toBe(true);
+    });
+});
+
+describe("session-core path scope identity", () => {
+    it("treats Windows drive-letter casing as the same project scope", () => {
+        expect(
+            isPathInsideRoot("c:\\repo\\src\\file.ts", "C:\\Repo", {
+                platform: "win32",
+            }),
+        ).toBe(true);
+        expect(
+            isSamePath("c:\\repo", "C:\\Repo", { platform: "win32" }),
+        ).toBe(true);
+    });
+
+    it("normalizes equivalent Windows absolute paths to display relatives", () => {
+        expect(
+            resolveSessionScopedPath("C:\\Repo", "c:\\repo\\src\\File.ts", {
+                platform: "win32",
+            }),
+        ).toMatchObject({
+            absolutePath: "c:\\repo\\src\\File.ts",
+            insideRoot: true,
+            isAbsoluteInput: true,
+            relativePath: "src/File.ts",
+        });
+    });
+
+    it("keeps Windows sibling paths outside the project scope", () => {
+        expect(
+            resolveSessionScopedPath(
+                "C:\\Repo",
+                "c:\\repo-other\\src\\File.ts",
+                { platform: "win32" },
+            ),
+        ).toMatchObject({
+            insideRoot: false,
+            isAbsoluteInput: true,
+            relativePath: null,
+        });
+    });
+
+    it("deduplicates additional roots with Windows casing differences", () => {
+        expect(
+            normalizeAdditionalRoots([
+                "C:\\Repo\\Shared",
+                "c:\\repo\\shared",
+                "C:\\Repo\\Other",
+            ], { platform: "win32" }),
+        ).toEqual(["C:\\Repo\\Other", "C:\\Repo\\Shared"]);
     });
 });
 

--- a/src/main/ai/session-core.ts
+++ b/src/main/ai/session-core.ts
@@ -1,6 +1,12 @@
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
+import {
+    isSameOrInsidePath as isSameOrInsidePathIdentity,
+    normalizePathKey,
+    toDisplayRelativePath,
+    type PathIdentityPlatform,
+} from "@shared/path-identity";
 import type {
     ContentBlock,
     SessionConfigOption,
@@ -932,6 +938,7 @@ export function isBusyAiSessionStatus(
 
 export function normalizeAdditionalRoots(
     roots: readonly string[] | undefined,
+    options: ResolveSessionPathOptions = {},
 ): string[] {
     if (!roots || roots.length === 0) {
         return [];
@@ -939,18 +946,20 @@ export function normalizeAdditionalRoots(
 
     const seen = new Set<string>();
     const normalizedRoots: string[] = [];
+    const platform = options.platform ?? getNativePathIdentityPlatform();
 
     for (const rootPath of roots) {
         if (!rootPath.trim()) {
             continue;
         }
 
-        const normalized = path.resolve(rootPath);
-        if (seen.has(normalized)) {
+        const normalized = resolvePathForPlatform(rootPath, platform);
+        const normalizedKey = normalizePathKey(normalized, { platform });
+        if (seen.has(normalizedKey)) {
             continue;
         }
 
-        seen.add(normalized);
+        seen.add(normalizedKey);
         normalizedRoots.push(normalized);
     }
 
@@ -972,16 +981,124 @@ export function sameAdditionalRoots(
 export function isPathInsideRoot(
     candidatePath: string,
     rootPath: string,
+    options: ResolveSessionPathOptions = {},
 ): boolean {
-    const resolvedCandidate = path.resolve(candidatePath);
-    const resolvedRoot = path.resolve(rootPath);
+    const platform = getPathIdentityPlatform(rootPath, candidatePath, options);
+    const resolvedCandidate = resolvePathForPlatform(candidatePath, platform);
+    const resolvedRoot = resolvePathForPlatform(rootPath, platform);
 
+    return isSameOrInsidePathIdentity(resolvedCandidate, resolvedRoot, {
+        platform,
+    });
+}
+
+export function isSamePath(
+    leftPath: string,
+    rightPath: string,
+    options: ResolveSessionPathOptions = {},
+): boolean {
+    const platform = getPathIdentityPlatform(leftPath, rightPath, options);
     return (
-        resolvedCandidate === resolvedRoot ||
-        resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`)
+        normalizePathKey(resolvePathForPlatform(leftPath, platform), {
+            platform,
+        }) ===
+        normalizePathKey(resolvePathForPlatform(rightPath, platform), {
+            platform,
+        })
+    );
+}
+
+export interface ResolveSessionPathOptions {
+    readonly platform?: PathIdentityPlatform;
+}
+
+export interface ResolvedSessionScopedPath {
+    readonly absolutePath: string;
+    readonly insideRoot: boolean;
+    readonly isAbsoluteInput: boolean;
+    readonly platform: PathIdentityPlatform;
+    readonly relativePath: string | null;
+}
+
+export function resolveSessionScopedPath(
+    scopeRoot: string,
+    candidatePath: string,
+    options: ResolveSessionPathOptions = {},
+): ResolvedSessionScopedPath {
+    const platform = getPathIdentityPlatform(scopeRoot, candidatePath, options);
+    const absolutePath = resolvePathForPlatform(
+        candidatePath,
+        platform,
+        scopeRoot,
+    );
+    const resolvedScopeRoot = resolvePathForPlatform(scopeRoot, platform);
+    const insideRoot = isSameOrInsidePathIdentity(
+        absolutePath,
+        resolvedScopeRoot,
+        { platform },
+    );
+
+    return {
+        absolutePath,
+        insideRoot,
+        isAbsoluteInput: getPathApi(platform).isAbsolute(candidatePath),
+        platform,
+        relativePath: insideRoot
+            ? toDisplayRelativePath(absolutePath, resolvedScopeRoot, {
+                  platform,
+              })
+            : null,
+    };
+}
+
+export function basenameForPathIdentity(
+    candidatePath: string,
+    options: ResolveSessionPathOptions = {},
+): string {
+    return getPathApi(options.platform ?? getNativePathIdentityPlatform()).basename(
+        candidatePath,
     );
 }
 
 export function toPosixPath(candidatePath: string): string {
     return candidatePath.split(path.sep).join("/");
+}
+
+function resolvePathForPlatform(
+    candidatePath: string,
+    platform: PathIdentityPlatform,
+    basePath?: string,
+): string {
+    const pathApi = getPathApi(platform);
+    return basePath && !pathApi.isAbsolute(candidatePath)
+        ? pathApi.resolve(basePath, candidatePath)
+        : pathApi.resolve(candidatePath);
+}
+
+function getPathApi(platform: PathIdentityPlatform): typeof path.posix {
+    return platform === "win32" ? path.win32 : path.posix;
+}
+
+function getPathIdentityPlatform(
+    leftPath: string,
+    rightPath: string,
+    options: ResolveSessionPathOptions,
+): PathIdentityPlatform {
+    if (options.platform) {
+        return options.platform;
+    }
+
+    if (isPosixAbsolutePath(leftPath) && isPosixAbsolutePath(rightPath)) {
+        return "posix";
+    }
+
+    return getNativePathIdentityPlatform();
+}
+
+function getNativePathIdentityPlatform(): PathIdentityPlatform {
+    return process.platform === "win32" ? "win32" : "posix";
+}
+
+function isPosixAbsolutePath(candidatePath: string): boolean {
+    return candidatePath.startsWith("/") && !candidatePath.startsWith("//");
 }

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -5220,6 +5220,71 @@ describe("AiWorkerRuntime prepareSession", () => {
         }
     });
 
+    it("keeps tracked files through backslash aliases on non-Windows hosts", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const originalPlatform = process.platform;
+        try {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: "linux",
+            });
+            const runtime = createRuntime();
+            const trackedFile: AiTrackedFile = {
+                hunks: [],
+                identityKey: "src/App.ts",
+                isText: true,
+                kind: "update",
+                newText: "after\n",
+                oldText: "before\n",
+                path: "src\\App.ts",
+                previousPath: null,
+                reviewState: "pending",
+                reversible: true,
+                sessionId: "session-1",
+                toolCallId: "tool-1",
+                updatedAt: "2026-04-15T22:23:13.719838Z",
+                version: 1,
+            };
+            const snapshot = createLaunch({
+                cwd: tempDir,
+                projectRoot: tempDir,
+                title: "Review separator alias test",
+            }).persistedSnapshot;
+
+            const result = await runtime.dispatchMethod("ai.keepTrackedFile", {
+                context: {
+                    additionalRoots: [],
+                    cwd: tempDir,
+                    ownerWindowId: "",
+                    projectRoot: tempDir,
+                    snapshot: {
+                        ...snapshot,
+                        trackedFiles: [trackedFile],
+                    },
+                },
+                input: {
+                    path: "src/App.ts",
+                    sessionId: "session-1",
+                },
+            });
+
+            expect(result).toMatchObject({
+                ownerWindowId: "",
+                snapshot: {
+                    trackedFiles: [],
+                },
+            });
+        } finally {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: originalPlatform,
+            });
+            await fs.rm(tempDir, { force: true, recursive: true });
+        }
+    });
+
     it("rejects tracked files inside additional roots", async () => {
         const tempDir = await fs.mkdtemp(
             path.join(os.tmpdir(), "comando-ai-worker-"),

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -5155,6 +5155,71 @@ describe("AiWorkerRuntime prepareSession", () => {
         });
     });
 
+    it("keeps tracked files through relative Windows casing aliases", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const originalPlatform = process.platform;
+        try {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: "win32",
+            });
+            const runtime = createRuntime();
+            const trackedFile: AiTrackedFile = {
+                hunks: [],
+                identityKey: "src/App.ts",
+                isText: true,
+                kind: "update",
+                newText: "after\n",
+                oldText: "before\n",
+                path: "src/App.ts",
+                previousPath: null,
+                reviewState: "pending",
+                reversible: true,
+                sessionId: "session-1",
+                toolCallId: "tool-1",
+                updatedAt: "2026-04-15T22:23:13.719838Z",
+                version: 1,
+            };
+            const snapshot = createLaunch({
+                cwd: tempDir,
+                projectRoot: tempDir,
+                title: "Review casing test",
+            }).persistedSnapshot;
+
+            const result = await runtime.dispatchMethod("ai.keepTrackedFile", {
+                context: {
+                    additionalRoots: [],
+                    cwd: tempDir,
+                    ownerWindowId: "",
+                    projectRoot: tempDir,
+                    snapshot: {
+                        ...snapshot,
+                        trackedFiles: [trackedFile],
+                    },
+                },
+                input: {
+                    path: "src/app.ts",
+                    sessionId: "session-1",
+                },
+            });
+
+            expect(result).toMatchObject({
+                ownerWindowId: "",
+                snapshot: {
+                    trackedFiles: [],
+                },
+            });
+        } finally {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: originalPlatform,
+            });
+            await fs.rm(tempDir, { force: true, recursive: true });
+        }
+    });
+
     it("rejects tracked files inside additional roots", async () => {
         const tempDir = await fs.mkdtemp(
             path.join(os.tmpdir(), "comando-ai-worker-"),
@@ -5881,6 +5946,78 @@ describe("AiWorkerRuntime prepareSession", () => {
         ).rejects.toThrow("Cannot safely apply this review change");
 
         await expect(fs.readFile(filePath, "utf8")).resolves.toBe(diskText);
+    });
+
+    it("keeps tracked file hunks through relative Windows casing aliases", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const originalPlatform = process.platform;
+        try {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: "win32",
+            });
+            const oldText = "before\n";
+            const newText = "after\n";
+            const hunks = computeDiffHunks(oldText, newText, "src/App.ts");
+            const runtime = createRuntime();
+            const trackedFile: AiTrackedFile = {
+                hunks,
+                identityKey: "src/App.ts",
+                isText: true,
+                kind: "update",
+                newText,
+                oldText,
+                path: "src/App.ts",
+                previousPath: null,
+                reviewState: "pending",
+                reversible: true,
+                sessionId: "session-1",
+                toolCallId: "tool-1",
+                updatedAt: "2026-04-15T22:23:13.719838Z",
+                version: 1,
+            };
+            const snapshot = createLaunch({
+                cwd: tempDir,
+                projectRoot: tempDir,
+                title: "Hunk casing test",
+            }).persistedSnapshot;
+
+            const result = await runtime.dispatchMethod(
+                "ai.keepTrackedFileHunks",
+                {
+                    context: {
+                        additionalRoots: [],
+                        cwd: tempDir,
+                        ownerWindowId: "",
+                        projectRoot: tempDir,
+                        snapshot: {
+                            ...snapshot,
+                            trackedFiles: [trackedFile],
+                        },
+                    },
+                    input: {
+                        hunkIds: [hunks[0]?.id ?? ""],
+                        path: "src/app.ts",
+                        sessionId: "session-1",
+                    },
+                },
+            );
+
+            expect(result).toMatchObject({
+                ownerWindowId: "",
+                snapshot: {
+                    trackedFiles: [],
+                },
+            });
+        } finally {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: originalPlatform,
+            });
+            await fs.rm(tempDir, { force: true, recursive: true });
+        }
     });
 
     it("applies partial hunk rejections inside additional roots", async () => {

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -102,6 +102,7 @@ import {
     hasSelectConfigValue,
     isBusyAiSessionStatus,
     isPathInsideRoot,
+    isSamePath,
     resolveSessionScopedPath,
     resolveSessionTitleOnPrompt,
     sameAdditionalRoots,
@@ -708,7 +709,11 @@ export class AiWorkerRuntime {
             session.snapshot = {
                 ...session.snapshot,
                 trackedFiles: session.snapshot.trackedFiles.filter(
-                    (trackedFile) => trackedFile.path !== params.input.path,
+                    (trackedFile) =>
+                        !matchesTrackedReviewPath(
+                            trackedFile,
+                            params.input.path,
+                        ),
                 ),
                 updatedAt: new Date().toISOString(),
             };
@@ -720,7 +725,8 @@ export class AiWorkerRuntime {
     ): Promise<AiWorkerReviewMutationResult> {
         return await this.#withReviewSession(params.context, async (session) => {
             const trackedFile = session.snapshot.trackedFiles.find(
-                (candidate) => candidate.path === params.input.path,
+                (candidate) =>
+                    matchesTrackedReviewPath(candidate, params.input.path),
             );
             if (!trackedFile) {
                 throw new Error("The file to review was not found.");
@@ -730,7 +736,11 @@ export class AiWorkerRuntime {
             session.snapshot = {
                 ...session.snapshot,
                 trackedFiles: session.snapshot.trackedFiles.filter(
-                    (candidate) => candidate.path !== params.input.path,
+                    (candidate) =>
+                        !matchesTrackedReviewPath(
+                            candidate,
+                            params.input.path,
+                        ),
                 ),
                 updatedAt: new Date().toISOString(),
             };
@@ -742,7 +752,8 @@ export class AiWorkerRuntime {
     ): Promise<AiWorkerReviewMutationResult> {
         return await this.#withReviewSession(params.context, (session) => {
             const trackedFile = session.snapshot.trackedFiles.find(
-                (candidate) => candidate.path === params.input.path,
+                (candidate) =>
+                    matchesTrackedReviewPath(candidate, params.input.path),
             );
             if (!trackedFile) {
                 throw new Error("The file to review was not found.");
@@ -770,7 +781,8 @@ export class AiWorkerRuntime {
     ): Promise<AiWorkerReviewMutationResult> {
         return await this.#withReviewSession(params.context, async (session) => {
             const trackedFile = session.snapshot.trackedFiles.find(
-                (candidate) => candidate.path === params.input.path,
+                (candidate) =>
+                    matchesTrackedReviewPath(candidate, params.input.path),
             );
             if (!trackedFile) {
                 throw new Error("The file to review was not found.");
@@ -5441,6 +5453,18 @@ function normalizeTerminalExitCode(exitCode: number | null): number | null {
     }
 
     return Math.floor(exitCode);
+}
+
+function matchesTrackedReviewPath(
+    trackedFile: AiTrackedFile,
+    candidatePath: string,
+): boolean {
+    return (
+        isSamePath(trackedFile.path, candidatePath) ||
+        (trackedFile.previousPath
+            ? isSamePath(trackedFile.previousPath, candidatePath)
+            : false)
+    );
 }
 
 function appendTerminalOutput(

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -102,6 +102,7 @@ import {
     hasSelectConfigValue,
     isBusyAiSessionStatus,
     isPathInsideRoot,
+    resolveSessionScopedPath,
     resolveSessionTitleOnPrompt,
     sameAdditionalRoots,
     serializeComposerPartsForDisplay,
@@ -111,7 +112,6 @@ import {
     setTitleOnSnapshot,
     shouldFlushLiveSessionImmediately,
     summarizeUserInputAnswers,
-    toPosixPath,
 } from "./session-core";
 import {
     isImageGenerationToolUpdate,
@@ -4335,33 +4335,29 @@ export class AiWorkerRuntime {
         readonly relativePath: string | null;
     } {
         const scopeRoot = liveSession.projectRoot ?? liveSession.cwd;
-        const absolutePath = path.isAbsolute(candidatePath)
-            ? path.resolve(candidatePath)
-            : path.resolve(scopeRoot, candidatePath);
-        const insidePrimaryScope =
-            absolutePath === scopeRoot ||
-            absolutePath.startsWith(`${scopeRoot}${path.sep}`);
+        const resolvedPath = resolveSessionScopedPath(scopeRoot, candidatePath);
         const insideAdditionalRoot =
             options.allowAdditionalRoots === true &&
             liveSession.additionalRoots.some((rootPath) =>
-                isPathInsideRoot(absolutePath, rootPath),
+                isPathInsideRoot(resolvedPath.absolutePath, rootPath),
             );
 
-        if (!insidePrimaryScope && !insideAdditionalRoot) {
+        if (!resolvedPath.insideRoot && !insideAdditionalRoot) {
             throw new Error(
                 `${getRuntimeDisplayName(liveSession.runtimeId)} attempted to access a path outside the project.`,
             );
         }
 
         const relativePath =
-            insidePrimaryScope &&
-            absolutePath.startsWith(`${scopeRoot}${path.sep}`)
-                ? toPosixPath(path.relative(scopeRoot, absolutePath))
+            resolvedPath.insideRoot &&
+            resolvedPath.relativePath !== null &&
+            resolvedPath.relativePath.length > 0
+                ? resolvedPath.relativePath
                 : null;
 
         return {
-            absolutePath,
-            displayPath: relativePath ?? absolutePath,
+            absolutePath: resolvedPath.absolutePath,
+            displayPath: relativePath ?? resolvedPath.absolutePath,
             relativePath,
         };
     }

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -49,6 +49,10 @@ import {
 import { SessionBusyError } from "@shared/ai-errors";
 import { isDefaultChatTitle } from "@shared/chatTitle";
 import { buildAiSessionDomainEvents } from "@shared/ai-session-events";
+import {
+    normalizePathKey,
+    type PathIdentityPlatform,
+} from "@shared/path-identity";
 
 import { debugBenignError } from "@main/observability/logging";
 
@@ -102,7 +106,6 @@ import {
     hasSelectConfigValue,
     isBusyAiSessionStatus,
     isPathInsideRoot,
-    isSamePath,
     resolveSessionScopedPath,
     resolveSessionTitleOnPrompt,
     sameAdditionalRoots,
@@ -5460,11 +5463,46 @@ function matchesTrackedReviewPath(
     candidatePath: string,
 ): boolean {
     return (
-        isSamePath(trackedFile.path, candidatePath) ||
+        areTrackedReviewPathsEquivalent(trackedFile.path, candidatePath) ||
         (trackedFile.previousPath
-            ? isSamePath(trackedFile.previousPath, candidatePath)
+            ? areTrackedReviewPathsEquivalent(
+                  trackedFile.previousPath,
+                  candidatePath,
+              )
             : false)
     );
+}
+
+function areTrackedReviewPathsEquivalent(
+    leftPath: string,
+    rightPath: string,
+): boolean {
+    const platform = resolveTrackedReviewPathPlatform(leftPath, rightPath);
+    return (
+        normalizePathKey(leftPath, { platform }) ===
+        normalizePathKey(rightPath, { platform })
+    );
+}
+
+function resolveTrackedReviewPathPlatform(
+    leftPath: string,
+    rightPath: string,
+): PathIdentityPlatform {
+    return isWindowsShapedPath(leftPath) || isWindowsShapedPath(rightPath)
+        ? "win32"
+        : getNativePathIdentityPlatform();
+}
+
+function isWindowsShapedPath(candidatePath: string): boolean {
+    return (
+        /^(?:[a-zA-Z]:[\\/]|[\\/]{2}[^\\/]+[\\/][^\\/]+)/.test(
+            candidatePath,
+        ) || candidatePath.includes("\\")
+    );
+}
+
+function getNativePathIdentityPlatform(): PathIdentityPlatform {
+    return process.platform === "win32" ? "win32" : "posix";
 }
 
 function appendTerminalOutput(

--- a/src/main/git/service.ts
+++ b/src/main/git/service.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { simpleGit } from "simple-git";
 import type { GitRemoteSummary } from "@shared/ipc";
+import { normalizePathKey } from "@shared/path-identity";
 
 import type {
     GitBranchSummary,
@@ -173,14 +174,15 @@ export class GitService implements GitGateway {
         inputPath: string,
     ): Promise<GitRepositoryResolution> {
         const normalizedPath = path.resolve(inputPath);
-        const cachedResolution = this.#resolutionCache.get(normalizedPath);
+        const cacheKey = normalizeGitCachePathKey(normalizedPath);
+        const cachedResolution = this.#resolutionCache.get(cacheKey);
         if (cachedResolution) {
             return cachedResolution;
         }
 
         const resolution = await resolveGitRepository(normalizedPath);
         if (this.#cacheSnapshots) {
-            this.#resolutionCache.set(normalizedPath, resolution);
+            this.#resolutionCache.set(cacheKey, resolution);
         }
 
         return resolution;
@@ -190,14 +192,15 @@ export class GitService implements GitGateway {
         inputPath: string,
     ): Promise<GitRepositorySnapshot> {
         const normalizedPath = path.resolve(inputPath);
-        const cacheState = this.#snapshotCache.has(normalizedPath)
+        const cacheKey = normalizeGitCachePathKey(normalizedPath);
+        const cacheState = this.#snapshotCache.has(cacheKey)
             ? "hit"
             : "miss";
 
         return mainProcessPerformance.measureAsync(
             "git.getRepositorySnapshot",
             async () => {
-                const cachedSnapshot = this.#snapshotCache.get(normalizedPath);
+                const cachedSnapshot = this.#snapshotCache.get(cacheKey);
                 if (cachedSnapshot) {
                     return cachedSnapshot;
                 }
@@ -226,7 +229,7 @@ export class GitService implements GitGateway {
                     } satisfies GitRepositorySnapshot;
 
                     if (this.#cacheSnapshots) {
-                        this.#snapshotCache.set(normalizedPath, snapshot);
+                        this.#snapshotCache.set(cacheKey, snapshot);
                     }
 
                     return snapshot;
@@ -254,7 +257,7 @@ export class GitService implements GitGateway {
                 } satisfies GitRepositorySnapshot;
 
                 if (this.#cacheSnapshots) {
-                    this.#snapshotCache.set(normalizedPath, snapshot);
+                    this.#snapshotCache.set(cacheKey, snapshot);
                 }
 
                 return snapshot;
@@ -816,8 +819,9 @@ export class GitService implements GitGateway {
         }
 
         const normalizedPath = path.resolve(inputPath);
-        this.#snapshotCache.delete(normalizedPath);
-        this.#resolutionCache.delete(normalizedPath);
+        const cacheKey = normalizeGitCachePathKey(normalizedPath);
+        this.#snapshotCache.delete(cacheKey);
+        this.#resolutionCache.delete(cacheKey);
     }
 
     clear(): void {
@@ -875,6 +879,16 @@ async function readGitConfig(
 
 function normalizeGitPaths(paths: readonly string[]): string[] {
     return paths.map((filePath) => filePath.split(path.sep).join("/"));
+}
+
+function normalizeGitCachePathKey(inputPath: string): string {
+    return normalizePathKey(path.resolve(inputPath), {
+        platform: getNativePathIdentityPlatform(),
+    });
+}
+
+function getNativePathIdentityPlatform(): "posix" | "win32" {
+    return process.platform === "win32" ? "win32" : "posix";
 }
 
 function extractRemoteName(trackingBranchName: string | null): string | null {

--- a/src/main/git/worktrees.ts
+++ b/src/main/git/worktrees.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { simpleGit } from "simple-git";
+import { normalizePathKey } from "@shared/path-identity";
 
 import { debugBenignError } from "@main/observability/logging";
 
@@ -134,25 +135,27 @@ export async function listGitWorktrees(
     const git = simpleGit(rootPath);
     const output = await git.raw(["worktree", "list", "--porcelain"]);
     const entries = parseWorktreePorcelain(output);
+    const canonicalRootKey = normalizeWorktreePathKey(canonicalRootPath);
 
     return entries
-        .map((entry) => ({
-            branchName: entry.branchRef
-                ? normalizeBranchName(entry.branchRef)
-                : null,
-            branchRef: entry.branchRef,
-            canonicalPath: path.resolve(entry.path),
-            detached: entry.detached,
-            headCommit: entry.headCommit,
-            isCurrent:
-                path.resolve(entry.path) === path.resolve(canonicalRootPath),
-            isMain:
-                path.resolve(entry.path) === path.resolve(canonicalRootPath),
-            locked: entry.locked,
-            lockReason: entry.lockReason,
-            path: entry.path,
-            prunable: entry.prunable,
-        }))
+        .map((entry) => {
+            const entryRootKey = normalizeWorktreePathKey(entry.path);
+            return {
+                branchName: entry.branchRef
+                    ? normalizeBranchName(entry.branchRef)
+                    : null,
+                branchRef: entry.branchRef,
+                canonicalPath: path.resolve(entry.path),
+                detached: entry.detached,
+                headCommit: entry.headCommit,
+                isCurrent: entryRootKey === canonicalRootKey,
+                isMain: entryRootKey === canonicalRootKey,
+                locked: entry.locked,
+                lockReason: entry.lockReason,
+                path: entry.path,
+                prunable: entry.prunable,
+            };
+        })
         .sort((left, right) => {
             if (left.isCurrent !== right.isCurrent) {
                 return left.isCurrent ? -1 : 1;
@@ -160,6 +163,16 @@ export async function listGitWorktrees(
 
             return left.canonicalPath.localeCompare(right.canonicalPath);
         });
+}
+
+function normalizeWorktreePathKey(rootPath: string): string {
+    return normalizePathKey(path.resolve(rootPath), {
+        platform: getNativePathIdentityPlatform(),
+    });
+}
+
+function getNativePathIdentityPlatform(): "posix" | "win32" {
+    return process.platform === "win32" ? "win32" : "posix";
 }
 
 export async function buildBranchWorktreeMap(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -152,6 +152,7 @@ import {
     type WriteTerminalInput,
     type WorkspaceSnapshot,
 } from "@shared/ipc";
+import { normalizePathKey as normalizeSharedPathKey } from "@shared/path-identity";
 
 import {
     BrowserWindow,
@@ -880,8 +881,8 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
 
             const createdWorktree = sharedSnapshot.worktrees.find(
                 (worktree) =>
-                    path.resolve(worktree.rootPath) ===
-                    path.resolve(input.path),
+                    normalizePathKey(worktree.rootPath) ===
+                    normalizePathKey(input.path),
             );
             if (!createdWorktree) {
                 throw new Error(
@@ -2700,10 +2701,13 @@ function stripRemotePrefix(referenceName: string): string {
 }
 
 function normalizePathKey(filePath: string): string {
-    const normalizedPath = path.resolve(filePath).split(path.sep).join("/");
-    return process.platform === "win32"
-        ? normalizedPath.toLowerCase()
-        : normalizedPath;
+    return normalizeSharedPathKey(path.resolve(filePath), {
+        platform: getNativePathIdentityPlatform(),
+    });
+}
+
+function getNativePathIdentityPlatform(): "posix" | "win32" {
+    return process.platform === "win32" ? "win32" : "posix";
 }
 
 function normalizeGitPath(filePath: string): string {

--- a/src/main/projects/runtime.ts
+++ b/src/main/projects/runtime.ts
@@ -18,6 +18,7 @@ import {
     scoreProjectSearchCandidate,
     type ProjectSearchCandidate,
 } from "@shared/project-search";
+import { normalizePathKey } from "@shared/path-identity";
 
 import { debugBenignError } from "../observability/logging";
 import { shouldIgnoreEntry } from "./ignore";
@@ -414,7 +415,7 @@ export class ProjectRuntime {
         input: ProjectRuntimeScopeInput,
         relativePaths: readonly string[],
     ): void {
-        this.#gitSnapshots.delete(normalizeRootPath(input.rootPath));
+        this.#gitSnapshots.delete(normalizeRootPathKey(input.rootPath));
         this.#invalidateProjectSearchIndex(input.rootPath);
         this.#scheduleInvalidation(
             input.projectId,
@@ -442,15 +443,16 @@ export class ProjectRuntime {
     }
 
     async #getGitSnapshot(rootPath: string): Promise<GitSnapshot> {
-        const normalizedRootPath = normalizeRootPath(rootPath);
-        const cachedSnapshot = this.#gitSnapshots.get(normalizedRootPath);
+        const resolvedRootPath = resolveRootPath(rootPath);
+        const rootPathKey = normalizeRootPathKey(resolvedRootPath);
+        const cachedSnapshot = this.#gitSnapshots.get(rootPathKey);
         if (cachedSnapshot) {
             return cachedSnapshot;
         }
 
         try {
             const status =
-                await createBackgroundSafeGit(normalizedRootPath).status();
+                await createBackgroundSafeGit(resolvedRootPath).status();
             const exactBadges = new Map<string, GitStatusBadge>();
 
             for (const filePath of status.modified) {
@@ -478,7 +480,7 @@ export class ProjectRuntime {
                 exactBadges,
             } satisfies GitSnapshot;
 
-            this.#gitSnapshots.set(normalizedRootPath, snapshot);
+            this.#gitSnapshots.set(rootPathKey, snapshot);
             return snapshot;
         } catch (error) {
             debugBenignError("projects.runtime.computeGitSnapshot", error);
@@ -487,7 +489,7 @@ export class ProjectRuntime {
                 exactBadges: new Map<string, GitStatusBadge>(),
             } satisfies GitSnapshot;
 
-            this.#gitSnapshots.set(normalizedRootPath, emptySnapshot);
+            this.#gitSnapshots.set(rootPathKey, emptySnapshot);
             return emptySnapshot;
         }
     }
@@ -514,7 +516,7 @@ export class ProjectRuntime {
                         normalizeProjectWatchRelativePath(relativePath);
 
                     this.#gitSnapshots.delete(
-                        normalizeRootPath(context.rootPath),
+                        normalizeRootPathKey(context.rootPath),
                     );
                     this.#invalidateProjectSearchIndex(context.rootPath);
                     this.#scheduleInvalidation(
@@ -576,8 +578,9 @@ export class ProjectRuntime {
         readonly cacheState: "hit" | "miss";
         readonly entries: readonly IndexedProjectEntry[];
     } {
-        const normalizedRootPath = normalizeRootPath(rootPath);
-        const cachedIndex = this.#searchIndexes.get(normalizedRootPath);
+        const resolvedRootPath = resolveRootPath(rootPath);
+        const rootPathKey = normalizeRootPathKey(resolvedRootPath);
+        const cachedIndex = this.#searchIndexes.get(rootPathKey);
         if (cachedIndex) {
             return {
                 cacheState: "hit",
@@ -585,8 +588,8 @@ export class ProjectRuntime {
             };
         }
 
-        const entries = buildProjectSearchIndex(normalizedRootPath);
-        this.#searchIndexes.set(normalizedRootPath, entries);
+        const entries = buildProjectSearchIndex(resolvedRootPath);
+        this.#searchIndexes.set(rootPathKey, entries);
         return {
             cacheState: "miss",
             entries,
@@ -594,7 +597,7 @@ export class ProjectRuntime {
     }
 
     #invalidateProjectSearchIndex(rootPath: string): void {
-        this.#searchIndexes.delete(normalizeRootPath(rootPath));
+        this.#searchIndexes.delete(normalizeRootPathKey(rootPath));
     }
 
     #closeRegisteredRoot(rootKey: string): void {
@@ -606,9 +609,9 @@ export class ProjectRuntime {
         }
 
         if (context) {
-            const normalizedRootPath = normalizeRootPath(context.rootPath);
-            this.#gitSnapshots.delete(normalizedRootPath);
-            this.#searchIndexes.delete(normalizedRootPath);
+            const rootPathKey = normalizeRootPathKey(context.rootPath);
+            this.#gitSnapshots.delete(rootPathKey);
+            this.#searchIndexes.delete(rootPathKey);
         }
 
         this.#registeredRoots.delete(rootKey);
@@ -659,7 +662,8 @@ function buildRegisteredRoots(
 function buildProjectSearchIndex(
     rootPath: string,
 ): readonly IndexedProjectEntry[] {
-    const queue = [normalizeRootPath(rootPath)];
+    const resolvedRootPath = resolveRootPath(rootPath);
+    const queue = [resolvedRootPath];
     const pendingEntries: {
         readonly extension: string | null;
         readonly kind: ProjectTreeNode["kind"];
@@ -689,7 +693,7 @@ function buildProjectSearchIndex(
             (entry) => !shouldIgnoreEntry(entry.name, entry.isDirectory()),
         );
         const currentRelativePath = normalizeRelativePath(
-            path.relative(rootPath, currentDirectory),
+            path.relative(resolvedRootPath, currentDirectory),
         );
 
         if (currentRelativePath !== ".") {
@@ -702,7 +706,7 @@ function buildProjectSearchIndex(
         for (const entry of visibleEntries) {
             const absolutePath = path.join(currentDirectory, entry.name);
             const relativePath = normalizeRelativePath(
-                path.relative(rootPath, absolutePath),
+                path.relative(resolvedRootPath, absolutePath),
             );
             const kind = entry.isDirectory() ? "directory" : "file";
 
@@ -829,15 +833,25 @@ function createProjectTreeNodeFromIndexEntry(
 }
 
 function buildRegisteredRootKey(projectId: string, rootPath: string): string {
-    return `${projectId}:${normalizeRootPath(rootPath)}`;
+    return `${projectId}:${normalizeRootPathKey(rootPath)}`;
 }
 
 function normalizeGitPath(filePath: string): string {
     return filePath.split(path.sep).join("/");
 }
 
-function normalizeRootPath(rootPath: string): string {
+function resolveRootPath(rootPath: string): string {
     return path.resolve(rootPath);
+}
+
+function normalizeRootPathKey(rootPath: string): string {
+    return normalizePathKey(resolveRootPath(rootPath), {
+        platform: getNativePathIdentityPlatform(),
+    });
+}
+
+function getNativePathIdentityPlatform(): "posix" | "win32" {
+    return process.platform === "win32" ? "win32" : "posix";
 }
 
 function normalizeWorktreeId(worktreeId: string | null): string | null {

--- a/src/main/projects/service.ts
+++ b/src/main/projects/service.ts
@@ -22,6 +22,7 @@ import type {
     SearchProjectEntriesInput,
 } from "@shared/ipc";
 import { normalizeProjectSearchQuery } from "@shared/project-search";
+import { normalizePathKey } from "@shared/path-identity";
 
 import { mainProcessPerformance } from "../observability/performance";
 import { debugBenignError } from "../observability/logging";
@@ -141,7 +142,7 @@ export class ProjectService {
         );
         rootPaths.push(this.#getProjectById(projectId).rootPath);
         for (const rootPath of rootPaths) {
-            this.#indexedRoots.delete(normalizeRootPath(rootPath));
+            this.#indexedRoots.delete(normalizeRootPathKey(rootPath));
         }
 
         const project = await this.#store.relocateProject(
@@ -149,7 +150,7 @@ export class ProjectService {
             projectPath,
         );
         await this.#worker.removeProject(projectId);
-        this.#indexedRoots.delete(normalizeRootPath(project.rootPath));
+        this.#indexedRoots.delete(normalizeRootPathKey(project.rootPath));
         this.#markWorkerRegistryDirty();
         await this.#ensureWorkerRegistry();
         this.#onProjectTouched?.(project.rootPath);
@@ -172,7 +173,7 @@ export class ProjectService {
         );
         rootPaths.push(this.#getProjectById(projectId).rootPath);
         for (const rootPath of rootPaths) {
-            this.#indexedRoots.delete(normalizeRootPath(rootPath));
+            this.#indexedRoots.delete(normalizeRootPathKey(rootPath));
         }
 
         this.#markWorkerRegistryDirty();
@@ -230,14 +231,14 @@ export class ProjectService {
             input.projectId,
             input.worktreeId ?? null,
         );
-        const normalizedRootPath = normalizeRootPath(project.rootPath);
+        const rootPathKey = normalizeRootPathKey(project.rootPath);
         const listEntries = async () =>
             await this.#worker.listProjectEntries({
                 projectId: input.projectId,
                 rootPath: project.rootPath,
                 worktreeId: project.worktreeId,
             });
-        const response = this.#indexedRoots.has(normalizedRootPath)
+        const response = this.#indexedRoots.has(rootPathKey)
             ? await this.#trackFilesystemAccess(project.rootPath, listEntries)
             : await mainProcessPerformance.measureAsync(
                   "projects.buildSearchIndex",
@@ -248,13 +249,13 @@ export class ProjectService {
                       ),
                   {
                       projectId: input.projectId,
-                      rootPath: normalizedRootPath,
+                      rootPath: resolveRootPath(project.rootPath),
                       transport: "worker",
                       worktreeId: input.worktreeId ?? "primary",
                   },
               );
 
-        this.#indexedRoots.add(normalizedRootPath);
+        this.#indexedRoots.add(rootPathKey);
         return [...response.nodes];
     }
 
@@ -293,7 +294,7 @@ export class ProjectService {
             input.projectId,
             input.worktreeId ?? null,
         );
-        const normalizedRootPath = normalizeRootPath(project.rootPath);
+        const rootPathKey = normalizeRootPathKey(project.rootPath);
         const search = async () =>
             await this.#worker.searchProjectEntries({
                 limit: input.limit,
@@ -302,7 +303,7 @@ export class ProjectService {
                 rootPath: project.rootPath,
                 worktreeId: project.worktreeId,
             });
-        const response = this.#indexedRoots.has(normalizedRootPath)
+        const response = this.#indexedRoots.has(rootPathKey)
             ? await this.#trackFilesystemAccess(project.rootPath, search)
             : await mainProcessPerformance.measureAsync(
                   "projects.buildSearchIndex",
@@ -313,13 +314,13 @@ export class ProjectService {
                       ),
                   {
                       projectId: input.projectId,
-                      rootPath: normalizedRootPath,
+                      rootPath: resolveRootPath(project.rootPath),
                       transport: "worker",
                       worktreeId: input.worktreeId ?? "primary",
                   },
               );
 
-        this.#indexedRoots.add(normalizedRootPath);
+        this.#indexedRoots.add(rootPathKey);
         return [...response.nodes];
     }
 
@@ -531,12 +532,12 @@ export class ProjectService {
 
         for (const existingWorktree of existingWorktrees) {
             this.#indexedRoots.delete(
-                normalizeRootPath(existingWorktree.rootPath),
+                normalizeRootPathKey(existingWorktree.rootPath),
             );
         }
         for (const syncedWorktree of syncedWorktrees) {
             this.#indexedRoots.delete(
-                normalizeRootPath(syncedWorktree.rootPath),
+                normalizeRootPathKey(syncedWorktree.rootPath),
             );
         }
 
@@ -575,7 +576,7 @@ export class ProjectService {
                 payload.projectId,
                 payload.worktreeId ?? null,
             );
-            this.#indexedRoots.delete(normalizeRootPath(project.rootPath));
+            this.#indexedRoots.delete(normalizeRootPathKey(project.rootPath));
         } catch (error) {
             // Watchers can flush after a project or worktree has already been
             // removed. Dropping the stale event prevents downstream refreshes
@@ -731,8 +732,18 @@ export class ProjectService {
     }
 }
 
-function normalizeRootPath(rootPath: string): string {
+function resolveRootPath(rootPath: string): string {
     return path.resolve(rootPath);
+}
+
+function normalizeRootPathKey(rootPath: string): string {
+    return normalizePathKey(resolveRootPath(rootPath), {
+        platform: getNativePathIdentityPlatform(),
+    });
+}
+
+function getNativePathIdentityPlatform(): "posix" | "win32" {
+    return process.platform === "win32" ? "win32" : "posix";
 }
 
 export { shouldIgnoreProjectWatchPath };

--- a/src/main/projects/store.ts
+++ b/src/main/projects/store.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import type Database from "better-sqlite3";
 
 import type { ProjectAppDataSummary, ProjectSummary } from "@shared/ipc";
+import { normalizePathKey } from "@shared/path-identity";
 
 import type { Awaitable } from "../db/awaitable";
 import { debugBenignError } from "../observability/logging";
@@ -1307,10 +1308,13 @@ function isDirectoryPath(projectPath: string): boolean {
 }
 
 function normalizeWorktreePathKey(rootPath: string): string {
-    const resolvedPath = path.resolve(rootPath);
-    return process.platform === "win32"
-        ? resolvedPath.toLowerCase()
-        : resolvedPath;
+    return normalizePathKey(path.resolve(rootPath), {
+        platform: getNativePathIdentityPlatform(),
+    });
+}
+
+function getNativePathIdentityPlatform(): "posix" | "win32" {
+    return process.platform === "win32" ? "win32" : "posix";
 }
 
 function createPreferredExistingWorktreeMap({
@@ -1380,7 +1384,11 @@ function getExistingWorktreePreferenceScore({
     if (rootKey === projectRootKey && row.is_primary === 1) {
         score += 50;
     }
-    if (desiredRootPath && path.resolve(row.root_path) === desiredRootPath) {
+    if (
+        desiredRootPath &&
+        normalizeWorktreePathKey(row.root_path) ===
+            normalizeWorktreePathKey(desiredRootPath)
+    ) {
         score += 10;
     }
 

--- a/src/main/projects/tree.test.ts
+++ b/src/main/projects/tree.test.ts
@@ -12,6 +12,7 @@ import {
     listProjectTreeChildren,
     readProjectFile,
     renameProjectEntry,
+    resolveProjectPath,
     writeProjectFile,
 } from "./tree";
 
@@ -63,6 +64,22 @@ describe("project tree helpers", () => {
         });
 
         expect(nodes).toEqual([]);
+    });
+
+    it("resolves file operation paths inside the project root", () => {
+        const rootPath = createProjectFixture();
+
+        expect(resolveProjectPath(rootPath, "src/../README.md")).toBe(
+            path.join(rootPath, "README.md"),
+        );
+    });
+
+    it("rejects file operation paths outside the project root", () => {
+        const rootPath = createProjectFixture();
+
+        expect(() => resolveProjectPath(rootPath, "../outside.txt")).toThrow(
+            /outside of the project root/i,
+        );
     });
 
     it("reads text files and preserves the relative path metadata", async () => {

--- a/src/main/projects/tree.ts
+++ b/src/main/projects/tree.ts
@@ -10,6 +10,7 @@ import type {
 } from "@shared/ipc";
 import { resolveEditorLanguage } from "@shared/editor-language";
 import { INLINE_EDITOR_MAX_BYTES } from "@shared/editor-performance";
+import { isSameOrInsidePath, normalizePathKey } from "@shared/path-identity";
 
 import { debugBenignError } from "../observability/logging";
 import { shouldIgnoreEntry } from "./ignore";
@@ -468,13 +469,18 @@ export function resolveProjectPath(
 
     const candidatePath = path.resolve(resolvedRoot, relativePath);
     if (
-        candidatePath !== resolvedRoot &&
-        !candidatePath.startsWith(`${resolvedRoot}${path.sep}`)
+        !isSameOrInsidePath(candidatePath, resolvedRoot, {
+            platform: getNativePathIdentityPlatform(),
+        })
     ) {
         throw new Error("The requested path is outside of the project root.");
     }
 
     return candidatePath;
+}
+
+function getNativePathIdentityPlatform(): "posix" | "win32" {
+    return process.platform === "win32" ? "win32" : "posix";
 }
 
 function directoryHasVisibleChildren(directoryPath: string): boolean {
@@ -724,22 +730,24 @@ function compactCopySourceEntriesByAbsoluteAncestor(
 }
 
 function isSameOrChildPath(candidatePath: string, parentPath: string): boolean {
-    const candidate = normalizeComparableAbsolutePath(candidatePath);
-    const parent = normalizeComparableAbsolutePath(parentPath);
-    return candidate === parent || isChildPath(candidate, parent);
+    return isSameOrInsidePath(candidatePath, parentPath, {
+        platform: getNativePathIdentityPlatform(),
+    });
 }
 
 function isChildPath(candidatePath: string, parentPath: string): boolean {
-    const candidate = normalizeComparableAbsolutePath(candidatePath);
-    const parent = normalizeComparableAbsolutePath(parentPath);
-    return candidate.startsWith(`${parent}/`);
+    const platform = getNativePathIdentityPlatform();
+    return (
+        normalizeComparableAbsolutePath(candidatePath) !==
+            normalizeComparableAbsolutePath(parentPath) &&
+        isSameOrInsidePath(candidatePath, parentPath, { platform })
+    );
 }
 
 function normalizeComparableAbsolutePath(candidatePath: string): string {
-    const normalizedPath = path.resolve(candidatePath).replaceAll("\\", "/");
-    return process.platform === "win32"
-        ? normalizedPath.toLowerCase()
-        : normalizedPath;
+    return normalizePathKey(path.resolve(candidatePath), {
+        platform: getNativePathIdentityPlatform(),
+    });
 }
 
 function resolveCopyDestinationName(

--- a/src/renderer/src/app/ai/trackedFilePath.test.ts
+++ b/src/renderer/src/app/ai/trackedFilePath.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { AppBootstrapSnapshot } from "@shared/ipc";
+
+import { useAppStore } from "@renderer/app/store/app-store";
+import { areTrackedFilePathsEquivalent } from "./trackedFilePath";
+
+afterEach(() => {
+    useAppStore.setState({
+        bootstrap: null,
+        error: null,
+        status: "idle",
+    });
+});
+
+describe("trackedFilePath", () => {
+    it("matches relative forward-slash casing aliases on Windows", () => {
+        setRendererPlatform("win32");
+
+        expect(
+            areTrackedFilePathsEquivalent("src/App.ts", "src/app.ts"),
+        ).toBe(true);
+    });
+
+    it("keeps relative forward-slash casing distinct on Linux", () => {
+        setRendererPlatform("linux");
+
+        expect(
+            areTrackedFilePathsEquivalent("src/App.ts", "src/app.ts"),
+        ).toBe(false);
+    });
+
+    it("still treats explicit Windows-shaped paths as Windows aliases", () => {
+        setRendererPlatform("linux");
+
+        expect(
+            areTrackedFilePathsEquivalent(
+                "C:\\Repo\\src\\App.ts",
+                "c:\\repo\\src\\app.ts",
+            ),
+        ).toBe(true);
+    });
+});
+
+function setRendererPlatform(platform: string): void {
+    useAppStore.setState({
+        bootstrap: createBootstrap(platform),
+        error: null,
+        status: "ready",
+    });
+}
+
+function createBootstrap(platform: string): AppBootstrapSnapshot {
+    return {
+        app: {
+            bundleId: "test.bundle",
+            channel: "dev",
+            iconPaths: {
+                macos: "macos.icon",
+                png: "app.png",
+                windows: "windows.ico",
+            },
+            id: "test.app",
+            name: "Test App",
+            productName: "Test App",
+            windowTitle: "Test App",
+        },
+        database: {
+            appliedMigrations: [],
+            databaseFile: ":memory:",
+        },
+        platform,
+        startedAt: "2026-06-08T00:00:00.000Z",
+        versions: {
+            chrome: "0",
+            electron: "0",
+            node: "0",
+        },
+        windowEffects: {
+            windowsAcrylic: false,
+        },
+    };
+}

--- a/src/renderer/src/app/ai/trackedFilePath.ts
+++ b/src/renderer/src/app/ai/trackedFilePath.ts
@@ -4,6 +4,8 @@ import {
     type PathIdentityPlatform,
 } from "@shared/path-identity";
 
+import { useAppStore } from "@renderer/app/store/app-store";
+
 export interface TrackedFilePathMatchOptions {
     readonly platform?: PathIdentityPlatform;
 }
@@ -27,20 +29,14 @@ export function areTrackedFilePathsEquivalent(
         return false;
     }
 
-    const platform =
-        options.platform ?? inferTrackedFilePathPlatform(leftPath, rightPath);
-    if (
+    const platform = resolveTrackedFilePathPlatform(
+        leftPath,
+        rightPath,
+        options,
+    );
+    return (
         normalizePathKey(leftPath, { platform }) ===
         normalizePathKey(rightPath, { platform })
-    ) {
-        return true;
-    }
-
-    return (
-        !options.platform &&
-        platform !== "win32" &&
-        normalizePathKey(leftPath, { platform: "win32" }) ===
-            normalizePathKey(rightPath, { platform: "win32" })
     );
 }
 
@@ -60,6 +56,28 @@ function inferTrackedFilePathPlatform(
             /^(?:[a-zA-Z]:[\\/]|[\\/]{2}[^\\/]+[\\/][^\\/]+)/.test(path) ||
             path.includes("\\"),
     )
+        ? "win32"
+        : "posix";
+}
+
+function resolveTrackedFilePathPlatform(
+    leftPath: string,
+    rightPath: string,
+    options: TrackedFilePathMatchOptions,
+): PathIdentityPlatform {
+    if (options.platform) {
+        return options.platform;
+    }
+
+    const inferredPathPlatform = inferTrackedFilePathPlatform(
+        leftPath,
+        rightPath,
+    );
+    if (inferredPathPlatform === "win32") {
+        return "win32";
+    }
+
+    return useAppStore.getState().bootstrap?.platform === "win32"
         ? "win32"
         : "posix";
 }

--- a/src/renderer/src/app/ai/trackedFilePath.ts
+++ b/src/renderer/src/app/ai/trackedFilePath.ts
@@ -1,0 +1,56 @@
+import type { AiTrackedFile } from "@shared/ipc";
+import {
+    normalizePathKey,
+    type PathIdentityPlatform,
+} from "@shared/path-identity";
+
+export interface TrackedFilePathMatchOptions {
+    readonly platform?: PathIdentityPlatform;
+}
+
+export function matchesTrackedFilePath(
+    trackedFile: AiTrackedFile,
+    candidatePath: string,
+    options: TrackedFilePathMatchOptions = {},
+): boolean {
+    return getTrackedFilePathAliases(trackedFile).some((path) =>
+        areTrackedFilePathsEquivalent(path, candidatePath, options),
+    );
+}
+
+export function areTrackedFilePathsEquivalent(
+    leftPath: string | null | undefined,
+    rightPath: string | null | undefined,
+    options: TrackedFilePathMatchOptions = {},
+): boolean {
+    if (!leftPath || !rightPath) {
+        return false;
+    }
+
+    const platform =
+        options.platform ?? inferTrackedFilePathPlatform(leftPath, rightPath);
+    return (
+        normalizePathKey(leftPath, { platform }) ===
+        normalizePathKey(rightPath, { platform })
+    );
+}
+
+export function getTrackedFilePathAliases(
+    trackedFile: AiTrackedFile,
+): readonly string[] {
+    return trackedFile.previousPath
+        ? [trackedFile.path, trackedFile.previousPath]
+        : [trackedFile.path];
+}
+
+function inferTrackedFilePathPlatform(
+    ...paths: readonly string[]
+): PathIdentityPlatform {
+    return paths.some(
+        (path) =>
+            /^(?:[a-zA-Z]:[\\/]|[\\/]{2}[^\\/]+[\\/][^\\/]+)/.test(path) ||
+            path.includes("\\"),
+    )
+        ? "win32"
+        : "posix";
+}

--- a/src/renderer/src/app/ai/trackedFilePath.ts
+++ b/src/renderer/src/app/ai/trackedFilePath.ts
@@ -29,9 +29,18 @@ export function areTrackedFilePathsEquivalent(
 
     const platform =
         options.platform ?? inferTrackedFilePathPlatform(leftPath, rightPath);
-    return (
+    if (
         normalizePathKey(leftPath, { platform }) ===
         normalizePathKey(rightPath, { platform })
+    ) {
+        return true;
+    }
+
+    return (
+        !options.platform &&
+        platform !== "win32" &&
+        normalizePathKey(leftPath, { platform: "win32" }) ===
+            normalizePathKey(rightPath, { platform: "win32" })
     );
 }
 

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -9,12 +9,14 @@ import type {
     AiSessionUpdate,
     AiToolActivity,
     AiTrackedFile,
+    AppBootstrapSnapshot,
     WorkspaceChatTab,
 } from "@shared/ipc";
 
 import { AI_SESSION_BUSY_MESSAGE } from "@shared/ai-errors";
 
 import { getSessionReviewPreferencesStorageKey } from "@renderer/app/ai/sessionReviewPreferences";
+import { useAppStore } from "./app-store";
 import { useAiStore } from "./ai-store";
 
 // Electron's ipcRenderer.invoke wraps handler errors with a prefix before
@@ -201,6 +203,14 @@ function createDeferred<T>() {
     return { promise, resolve };
 }
 
+function setRendererPlatform(platform: string): void {
+    useAppStore.setState({
+        bootstrap: { platform } as AppBootstrapSnapshot,
+        error: null,
+        status: "ready",
+    });
+}
+
 describe("ai-store queue", () => {
     beforeEach(() => {
         const storage = new Map<string, string>();
@@ -225,6 +235,11 @@ describe("ai-store queue", () => {
             runtimeStatusById: {},
             sessions: {},
         }));
+        useAppStore.setState({
+            bootstrap: null,
+            error: null,
+            status: "idle",
+        });
         vi.restoreAllMocks();
     });
 
@@ -696,6 +711,8 @@ describe("ai-store queue", () => {
     });
 
     it("optimistically removes tracked files through relative Windows casing aliases", async () => {
+        setRendererPlatform("win32");
+
         const rejectAiTrackedFile = vi.fn().mockResolvedValue(undefined);
         Object.defineProperty(globalThis, "window", {
             configurable: true,

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -8,6 +8,7 @@ import type {
     AiSessionSnapshot,
     AiSessionUpdate,
     AiToolActivity,
+    AiTrackedFile,
     WorkspaceChatTab,
 } from "@shared/ipc";
 
@@ -63,6 +64,39 @@ function createSnapshot(
         trackedFiles: [],
         updatedAt: "2026-04-14T00:00:00.000Z",
         worktreeId: TAB.worktreeId ?? null,
+        ...overrides,
+    };
+}
+
+function createTrackedFile(
+    overrides: Partial<AiTrackedFile> = {},
+): AiTrackedFile {
+    return {
+        hunks: [
+            {
+                id: "hunk-1",
+                lines: [
+                    { id: "line-1", text: "before", type: "remove" },
+                    { id: "line-2", text: "after", type: "add" },
+                ],
+                newCount: 1,
+                newStart: 1,
+                oldCount: 1,
+                oldStart: 1,
+            },
+        ],
+        identityKey: "tracked-1",
+        isText: true,
+        kind: "update",
+        newText: "after\n",
+        oldText: "before\n",
+        path: "src/app.ts",
+        previousPath: null,
+        reviewState: "pending",
+        reversible: true,
+        sessionId: TAB.sessionId,
+        toolCallId: "tool-1",
+        updatedAt: "2026-04-14T00:00:00.000Z",
         ...overrides,
     };
 }
@@ -623,6 +657,81 @@ describe("ai-store queue", () => {
                 updatedAt: "2026-04-14T00:00:03.000Z",
             }),
         );
+    });
+
+    it("optimistically removes tracked files through normalized path aliases", async () => {
+        const keepAiTrackedFile = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    keepAiTrackedFile,
+                },
+            },
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                trackedFiles: [
+                    createTrackedFile({
+                        path: "src\\app.ts",
+                    }),
+                ],
+            }),
+        );
+
+        await useAiStore.getState().keepTrackedFile({
+            path: "src/app.ts",
+            sessionId: TAB.sessionId,
+        });
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot
+                ?.trackedFiles,
+        ).toEqual([]);
+        expect(keepAiTrackedFile).toHaveBeenCalledWith({
+            path: "src/app.ts",
+            sessionId: TAB.sessionId,
+        });
+    });
+
+    it("optimistically updates tracked file hunks through Windows casing aliases", async () => {
+        const keepAiTrackedFileHunks = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    keepAiTrackedFileHunks,
+                },
+            },
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                trackedFiles: [
+                    createTrackedFile({
+                        path: "C:\\Repo\\src\\App.ts",
+                    }),
+                ],
+            }),
+        );
+        const hunkId = "C:\\Repo\\src\\App.ts:1:1:0";
+
+        await useAiStore.getState().keepTrackedFileHunks({
+            hunkIds: [hunkId],
+            path: "c:\\repo\\src\\app.ts",
+            sessionId: TAB.sessionId,
+        });
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot
+                ?.trackedFiles,
+        ).toEqual([]);
+        expect(keepAiTrackedFileHunks).toHaveBeenCalledWith({
+            hunkIds: [hunkId],
+            path: "c:\\repo\\src\\app.ts",
+            sessionId: TAB.sessionId,
+        });
     });
 
     it("creates a minimal session for orphan patches with runtime metadata", () => {

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -695,6 +695,42 @@ describe("ai-store queue", () => {
         });
     });
 
+    it("optimistically removes tracked files through relative Windows casing aliases", async () => {
+        const rejectAiTrackedFile = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    rejectAiTrackedFile,
+                },
+            },
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                trackedFiles: [
+                    createTrackedFile({
+                        path: "src/App.ts",
+                    }),
+                ],
+            }),
+        );
+
+        await useAiStore.getState().rejectTrackedFile({
+            path: "src/app.ts",
+            sessionId: TAB.sessionId,
+        });
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot
+                ?.trackedFiles,
+        ).toEqual([]);
+        expect(rejectAiTrackedFile).toHaveBeenCalledWith({
+            path: "src/app.ts",
+            sessionId: TAB.sessionId,
+        });
+    });
+
     it("optimistically updates tracked file hunks through Windows casing aliases", async () => {
         const keepAiTrackedFileHunks = vi.fn().mockResolvedValue(undefined);
         Object.defineProperty(globalThis, "window", {

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -65,6 +65,7 @@ import {
     writeAiSessionTranscriptToSnapshot,
     type AiSessionTranscriptModel,
 } from "@renderer/app/ai/transcriptModel";
+import { matchesTrackedFilePath } from "@renderer/app/ai/trackedFilePath";
 import { collectExternalComposerRoots } from "@renderer/components/workspace/chat/composerParts";
 import type {
     RuntimeWorkspaceChatTab,
@@ -3488,7 +3489,7 @@ function removeTrackedFileFromSnapshot(
     return {
         ...snapshot,
         trackedFiles: snapshot.trackedFiles.filter(
-            (trackedFile) => trackedFile.path !== path,
+            (trackedFile) => !matchesTrackedFilePath(trackedFile, path),
         ),
         updatedAt: new Date().toISOString(),
     };
@@ -3500,7 +3501,7 @@ function resolveTrackedFileHunksInSnapshot(
     decision: "keep" | "reject",
 ): AiSessionSnapshot {
     const nextTrackedFiles = snapshot.trackedFiles.flatMap((trackedFile) => {
-        if (trackedFile.path !== input.path) {
+        if (!matchesTrackedFilePath(trackedFile, input.path)) {
             return [trackedFile];
         }
 

--- a/src/renderer/src/app/workspace/pending-review.test.ts
+++ b/src/renderer/src/app/workspace/pending-review.test.ts
@@ -117,6 +117,25 @@ describe("pending review helpers", () => {
         });
     });
 
+    it("matches relative forward-slash paths with Windows casing aliases", () => {
+        const trackedFiles = [
+            createTrackedFile({
+                path: "src/App.ts",
+                sessionId: "session-relative-casing",
+            }),
+        ];
+
+        expect(
+            findBestPendingTrackedFile({
+                paths: ["src/app.ts"],
+                trackedFiles,
+            }),
+        )?.toMatchObject({
+            path: "src/App.ts",
+            sessionId: "session-relative-casing",
+        });
+    });
+
     it("prefers inline-review capable updates over newer non-inline matches", () => {
         const trackedFiles = [
             createTrackedFile({

--- a/src/renderer/src/app/workspace/pending-review.test.ts
+++ b/src/renderer/src/app/workspace/pending-review.test.ts
@@ -1,12 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import type { AiTrackedFile } from "@shared/ipc";
+import type { AiTrackedFile, AppBootstrapSnapshot } from "@shared/ipc";
+import { useAppStore } from "@renderer/app/store/app-store";
 
 import {
     collectPendingTrackedFilesFromSessions,
     findBestPendingTrackedFile,
     resolveFileTabReviewContext,
 } from "./pending-review";
+
+afterEach(() => {
+    useAppStore.setState({
+        bootstrap: null,
+        error: null,
+        status: "idle",
+    });
+});
+
+function setRendererPlatform(platform: string): void {
+    useAppStore.setState({
+        bootstrap: { platform } as AppBootstrapSnapshot,
+        error: null,
+        status: "ready",
+    });
+}
 
 function createTrackedFile(
     overrides: Partial<AiTrackedFile> &
@@ -118,6 +135,8 @@ describe("pending review helpers", () => {
     });
 
     it("matches relative forward-slash paths with Windows casing aliases", () => {
+        setRendererPlatform("win32");
+
         const trackedFiles = [
             createTrackedFile({
                 path: "src/App.ts",

--- a/src/renderer/src/app/workspace/pending-review.test.ts
+++ b/src/renderer/src/app/workspace/pending-review.test.ts
@@ -79,6 +79,44 @@ describe("pending review helpers", () => {
         });
     });
 
+    it("matches pending tracked files across Windows separator aliases", () => {
+        const trackedFiles = [
+            createTrackedFile({
+                path: "src\\editor.ts",
+                sessionId: "session-windows-separators",
+            }),
+        ];
+
+        expect(
+            resolveFileTabReviewContext({
+                relativePath: "src/editor.ts",
+                trackedFiles,
+            }),
+        ).toEqual({
+            path: "src\\editor.ts",
+            sessionId: "session-windows-separators",
+        });
+    });
+
+    it("matches Windows absolute tracked files with equivalent casing", () => {
+        const trackedFiles = [
+            createTrackedFile({
+                path: "C:\\Repo\\src\\Editor.ts",
+                sessionId: "session-windows-casing",
+            }),
+        ];
+
+        expect(
+            findBestPendingTrackedFile({
+                paths: ["c:\\repo\\src\\editor.ts"],
+                trackedFiles,
+            }),
+        )?.toMatchObject({
+            path: "C:\\Repo\\src\\Editor.ts",
+            sessionId: "session-windows-casing",
+        });
+    });
+
     it("prefers inline-review capable updates over newer non-inline matches", () => {
         const trackedFiles = [
             createTrackedFile({

--- a/src/renderer/src/app/workspace/pending-review.ts
+++ b/src/renderer/src/app/workspace/pending-review.ts
@@ -1,5 +1,9 @@
 import type { AiTrackedFile } from "@shared/ipc";
 
+import {
+    areTrackedFilePathsEquivalent,
+    matchesTrackedFilePath as matchesTrackedFilePathAlias,
+} from "@renderer/app/ai/trackedFilePath";
 import type { RuntimeWorkspaceFileReviewContext } from "./tree";
 
 type SessionWithTrackedFiles = {
@@ -39,7 +43,7 @@ export function matchesTrackedFilePath(
     trackedFile: AiTrackedFile,
     path: string,
 ): boolean {
-    return trackedFile.path === path || trackedFile.previousPath === path;
+    return matchesTrackedFilePathAlias(trackedFile, path);
 }
 
 export function isInlineReviewSupported(
@@ -153,11 +157,19 @@ function getTrackedFilePriority(
         score += 4;
     }
 
-    if (candidatePaths.some((path) => trackedFile.path === path)) {
+    if (
+        candidatePaths.some((path) =>
+            areTrackedFilePathsEquivalent(trackedFile.path, path),
+        )
+    ) {
         score += 2;
     }
 
-    if (candidatePaths.some((path) => trackedFile.previousPath === path)) {
+    if (
+        candidatePaths.some((path) =>
+            areTrackedFilePathsEquivalent(trackedFile.previousPath, path),
+        )
+    ) {
         score += 1;
     }
 

--- a/src/renderer/src/components/workspace/chat/ChangeReviewPanel.test.ts
+++ b/src/renderer/src/components/workspace/chat/ChangeReviewPanel.test.ts
@@ -223,6 +223,42 @@ describe("ChangeReviewPanel", () => {
         expect(markup).toContain("Open");
     });
 
+    it("keeps the open action available for UNC tracked paths", () => {
+        const uncPath = "\\\\Server\\Share\\Comando\\src\\app.ts";
+        const markup = renderToStaticMarkup(
+            createElement(ChangeReviewPanel, {
+                activity: createActivity({
+                    diffs: [
+                        {
+                            ...createActivity().diffs[0],
+                            path: uncPath,
+                        },
+                    ],
+                }),
+                defaultExpanded: true,
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                resolveFileReference: (reference) =>
+                    reference === uncPath
+                        ? {
+                              endLine: null,
+                              isAbsolute: true,
+                              path: reference,
+                              relativePath: "src/app.ts",
+                              startLine: null,
+                          }
+                        : null,
+                trackedFiles: [
+                    createTrackedFile({
+                        path: uncPath,
+                    }),
+                ],
+            }),
+        );
+
+        expect(markup).toContain("Open");
+    });
+
     it("keeps wrapping enabled for markdown review cards", () => {
         const markup = renderToStaticMarkup(
             createElement(ChangeReviewPanel, {

--- a/src/renderer/src/components/workspace/chat/ChangeReviewPanel.tsx
+++ b/src/renderer/src/components/workspace/chat/ChangeReviewPanel.tsx
@@ -124,7 +124,11 @@ function getBadgeLabel(item: ChangeReviewItem): string {
 }
 
 function looksAbsolutePath(path: string): boolean {
-    return path.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(path);
+    return (
+        path.startsWith("/") ||
+        /^[a-zA-Z]:[\\/]/.test(path) ||
+        path.startsWith("\\\\")
+    );
 }
 
 function canOpenItem(

--- a/src/renderer/src/components/workspace/chat/toolActivityReviewModel.test.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityReviewModel.test.ts
@@ -99,6 +99,29 @@ describe("toolActivityReviewModel", () => {
         ).toEqual(["tracked-1"]);
     });
 
+    it("uses normalized path fallback for Windows separator aliases", () => {
+        const activity = createActivity({
+            id: "tool-without-link",
+            locations: [
+                {
+                    endLine: null,
+                    line: null,
+                    path: "src/app.ts",
+                },
+            ],
+        });
+        const trackedFile = createTrackedFile({
+            path: "src\\app.ts",
+            toolCallId: null,
+        });
+
+        expect(
+            deriveTrackedFilesForToolActivity(activity, [trackedFile]).map(
+                (candidate) => candidate.identityKey,
+            ),
+        ).toEqual(["tracked-1"]);
+    });
+
     it("does not use path fallback for tracked files owned by another tool call", () => {
         const activity = createActivity({
             diffs: [
@@ -210,6 +233,30 @@ describe("toolActivityReviewModel", () => {
         expect(items[0]?.file?.identityKey).toBe("tracked-1");
         expect(items[1]?.file?.identityKey).toBe("tracked-2");
         expect(items[1]?.diff.path).toBe("src/secondary.ts");
+    });
+
+    it("matches diffs to tracked files with Windows casing aliases", () => {
+        const activity = createActivity({
+            diffs: [
+                {
+                    hunks: [],
+                    isText: true,
+                    kind: "update",
+                    newText: "next",
+                    oldText: "prev",
+                    path: "c:\\repo\\src\\app.ts",
+                    previousPath: null,
+                    reversible: true,
+                },
+            ],
+        });
+        const trackedFile = createTrackedFile({
+            path: "C:\\Repo\\src\\App.ts",
+        });
+
+        const [item] = deriveChangeReviewItems(activity, [trackedFile]);
+
+        expect(item?.file?.identityKey).toBe("tracked-1");
     });
 
     it("prefers the matched tracked file diff for chat review rendering", () => {

--- a/src/renderer/src/components/workspace/chat/toolActivityReviewModel.test.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityReviewModel.test.ts
@@ -1,13 +1,34 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import type { AiToolActivity, AiTrackedFile } from "@shared/ipc";
+import type {
+    AiToolActivity,
+    AiTrackedFile,
+    AppBootstrapSnapshot,
+} from "@shared/ipc";
 
+import { useAppStore } from "@renderer/app/store/app-store";
 import {
     deriveChangeReviewItems,
     deriveChangeReviewSummary,
     deriveToolActivityReviewEntries,
     deriveTrackedFilesForToolActivity,
 } from "./toolActivityReviewModel";
+
+afterEach(() => {
+    useAppStore.setState({
+        bootstrap: null,
+        error: null,
+        status: "idle",
+    });
+});
+
+function setRendererPlatform(platform: string): void {
+    useAppStore.setState({
+        bootstrap: { platform } as AppBootstrapSnapshot,
+        error: null,
+        status: "ready",
+    });
+}
 
 function createActivity(
     overrides: Partial<AiToolActivity> = {},
@@ -260,6 +281,8 @@ describe("toolActivityReviewModel", () => {
     });
 
     it("matches relative forward-slash diffs with Windows casing aliases", () => {
+        setRendererPlatform("win32");
+
         const activity = createActivity({
             diffs: [
                 {

--- a/src/renderer/src/components/workspace/chat/toolActivityReviewModel.test.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityReviewModel.test.ts
@@ -259,6 +259,30 @@ describe("toolActivityReviewModel", () => {
         expect(item?.file?.identityKey).toBe("tracked-1");
     });
 
+    it("matches relative forward-slash diffs with Windows casing aliases", () => {
+        const activity = createActivity({
+            diffs: [
+                {
+                    hunks: [],
+                    isText: true,
+                    kind: "update",
+                    newText: "next",
+                    oldText: "prev",
+                    path: "src/app.ts",
+                    previousPath: null,
+                    reversible: true,
+                },
+            ],
+        });
+        const trackedFile = createTrackedFile({
+            path: "src/App.ts",
+        });
+
+        const [item] = deriveChangeReviewItems(activity, [trackedFile]);
+
+        expect(item?.file?.identityKey).toBe("tracked-1");
+    });
+
     it("prefers the matched tracked file diff for chat review rendering", () => {
         const activity = createActivity({
             diffs: [

--- a/src/renderer/src/components/workspace/chat/toolActivityReviewModel.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityReviewModel.ts
@@ -1,5 +1,9 @@
 import type { AiFileDiff, AiToolActivity, AiTrackedFile } from "@shared/ipc";
 
+import {
+    areTrackedFilePathsEquivalent,
+    matchesTrackedFilePath,
+} from "@renderer/app/ai/trackedFilePath";
 import type {
     ReviewFileStats,
     ReviewFileTone,
@@ -88,8 +92,7 @@ export function deriveTrackedFilesForToolActivity(
         const pathMatches = trackedFiles.filter(
             (trackedFile) =>
                 trackedFile.toolCallId === null &&
-                (trackedFile.path === candidatePath ||
-                    trackedFile.previousPath === candidatePath),
+                matchesTrackedFilePath(trackedFile, candidatePath),
         );
 
         if (pathMatches.length === 1) {
@@ -290,23 +293,43 @@ function scoreTrackedFileMatch(
     trackedFile: AiTrackedFile,
 ): number {
     if (
-        trackedFile.path === diff.path &&
-        (trackedFile.previousPath ?? null) === (diff.previousPath ?? null)
+        areTrackedFilePathsEquivalent(trackedFile.path, diff.path) &&
+        areOptionalTrackedFilePathsEquivalent(
+            trackedFile.previousPath,
+            diff.previousPath,
+        )
     ) {
         return 4;
     }
 
-    if (trackedFile.path === diff.path) {
+    if (areTrackedFilePathsEquivalent(trackedFile.path, diff.path)) {
         return 3;
     }
 
-    if (diff.previousPath && trackedFile.previousPath === diff.previousPath) {
+    if (
+        diff.previousPath &&
+        areTrackedFilePathsEquivalent(trackedFile.previousPath, diff.previousPath)
+    ) {
         return 2;
     }
 
-    if (diff.previousPath && trackedFile.path === diff.previousPath) {
+    if (
+        diff.previousPath &&
+        areTrackedFilePathsEquivalent(trackedFile.path, diff.previousPath)
+    ) {
         return 1;
     }
 
     return -1;
+}
+
+function areOptionalTrackedFilePathsEquivalent(
+    leftPath: string | null | undefined,
+    rightPath: string | null | undefined,
+): boolean {
+    if (!leftPath && !rightPath) {
+        return true;
+    }
+
+    return areTrackedFilePathsEquivalent(leftPath, rightPath);
 }

--- a/src/renderer/src/components/workspace/projectFileReferences.test.ts
+++ b/src/renderer/src/components/workspace/projectFileReferences.test.ts
@@ -71,6 +71,23 @@ describe("projectFileReferences", () => {
         });
     });
 
+    it("resolves UNC absolute paths without collapsing the server root", () => {
+        expect(
+            resolveProjectFileReference(
+                "\\\\Server\\Share\\Comando\\src\\app.ts",
+                {
+                    projectRoots: ["\\\\server\\share\\comando"],
+                },
+            ),
+        ).toEqual({
+            endLine: null,
+            isAbsolute: true,
+            path: "//Server/Share/Comando/src/app.ts",
+            relativePath: "src/app.ts",
+            startLine: null,
+        });
+    });
+
     it("keeps relative paths ready to open in tabs", () => {
         expect(
             resolveProjectFileReference("./src/app.ts", { projectRoots: [] }),

--- a/src/renderer/src/components/workspace/projectFileReferences.ts
+++ b/src/renderer/src/components/workspace/projectFileReferences.ts
@@ -308,10 +308,12 @@ function safeDecodeURIComponent(value: string): string {
 }
 
 function normalizeAbsolutePath(path: string): string | null {
-    const normalized = path
-        .replace(/\\/g, "/")
-        .replace(/\/{2,}/g, "/")
-        .replace(/\/+$/, "");
+    const separated = path.replace(/\\/g, "/");
+    const normalized = (
+        separated.startsWith("//")
+            ? `//${separated.slice(2).replace(/\/{2,}/g, "/")}`
+            : separated.replace(/\/{2,}/g, "/")
+    ).replace(/\/+$/, "");
 
     if (!normalized) {
         return null;
@@ -383,7 +385,7 @@ function stripRootPrefix(path: string, root: string): string | null {
 }
 
 function toComparableAbsolutePath(path: string): string {
-    if (WINDOWS_DRIVE_RE.test(path)) {
+    if (WINDOWS_DRIVE_RE.test(path) || path.startsWith("//")) {
         return path.toLowerCase();
     }
 

--- a/src/shared/path-identity.test.ts
+++ b/src/shared/path-identity.test.ts
@@ -1,0 +1,140 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+    isSameOrInsidePath,
+    normalizePathKey,
+    toDisplayRelativePath,
+} from "./path-identity";
+
+describe("normalizePathKey", () => {
+    it("normalizes Windows drive letters, dot segments, separators, and casing", () => {
+        const filePath = path.win32.join(
+            "C:\\Workspace",
+            "Comando",
+            "src",
+            "..",
+            "README.md",
+        );
+
+        expect(normalizePathKey(filePath, { platform: "win32" })).toBe(
+            "c:/workspace/comando/readme.md",
+        );
+    });
+
+    it("normalizes mixed Windows separators", () => {
+        expect(
+            normalizePathKey("C:/Workspace\\Comando/./src\\File.ts", {
+                platform: "win32",
+            }),
+        ).toBe("c:/workspace/comando/src/file.ts");
+    });
+
+    it("keeps UNC roots intact while normalizing casing", () => {
+        expect(
+            normalizePathKey("\\\\Server\\Share\\Comando\\SRC\\File.ts", {
+                platform: "win32",
+            }),
+        ).toBe("//server/share/comando/src/file.ts");
+    });
+
+    it("normalizes extended Windows UNC paths", () => {
+        expect(
+            normalizePathKey("\\\\?\\UNC\\Server\\Share\\Comando\\File.ts", {
+                platform: "win32",
+            }),
+        ).toBe("//server/share/comando/file.ts");
+    });
+
+    it("keeps POSIX casing significant", () => {
+        expect(
+            normalizePathKey("/Users/example/Comando/SRC/../File.ts", {
+                platform: "posix",
+            }),
+        ).toBe("/Users/example/Comando/File.ts");
+    });
+});
+
+describe("isSameOrInsidePath", () => {
+    it("treats Windows paths with different casing as the same location", () => {
+        expect(
+            isSameOrInsidePath("C:\\Workspace\\Comando", "c:/workspace/comando", {
+                platform: "win32",
+            }),
+        ).toBe(true);
+    });
+
+    it("matches Windows descendants with mixed separators and casing", () => {
+        expect(
+            isSameOrInsidePath(
+                "C:/WORKSPACE\\Comando\\src\\File.ts",
+                "c:\\workspace\\comando",
+                { platform: "win32" },
+            ),
+        ).toBe(true);
+    });
+
+    it("does not treat Windows siblings as descendants", () => {
+        expect(
+            isSameOrInsidePath(
+                "C:\\Workspace\\Comando-other\\src\\File.ts",
+                "C:\\Workspace\\Comando",
+                { platform: "win32" },
+            ),
+        ).toBe(false);
+    });
+
+    it("keeps POSIX containment case-sensitive", () => {
+        expect(
+            isSameOrInsidePath(
+                "/Users/example/Comando/src",
+                "/users/example/comando",
+                {
+                    platform: "posix",
+                },
+            ),
+        ).toBe(false);
+    });
+});
+
+describe("toDisplayRelativePath", () => {
+    it("returns a Windows relative display path while preserving candidate casing", () => {
+        expect(
+            toDisplayRelativePath(
+                "C:\\WORKSPACE\\Comando\\Src\\File.ts",
+                "c:/workspace/comando",
+                { platform: "win32" },
+            ),
+        ).toBe("Src/File.ts");
+    });
+
+    it("returns an empty string for the same Windows path", () => {
+        expect(
+            toDisplayRelativePath(
+                "C:\\Workspace\\Comando",
+                "c:/workspace/comando",
+                { platform: "win32" },
+            ),
+        ).toBe("");
+    });
+
+    it("supports UNC relative paths", () => {
+        expect(
+            toDisplayRelativePath(
+                "\\\\SERVER\\Share\\Comando\\src\\File.ts",
+                "\\\\server\\share\\comando",
+                { platform: "win32" },
+            ),
+        ).toBe("src/File.ts");
+    });
+
+    it("falls back to a normalized display path when outside the container", () => {
+        expect(
+            toDisplayRelativePath(
+                "C:\\Workspace\\Other\\File.ts",
+                "C:\\Workspace\\Comando",
+                { platform: "win32" },
+            ),
+        ).toBe("C:/Workspace/Other/File.ts");
+    });
+});

--- a/src/shared/path-identity.test.ts
+++ b/src/shared/path-identity.test.ts
@@ -90,6 +90,30 @@ describe("isSameOrInsidePath", () => {
         ).toBe(false);
     });
 
+    it("rejects Windows paths that escape the project root through parent segments", () => {
+        expect(
+            isSameOrInsidePath(
+                "c:\\repo\\..\\outside\\secret.txt",
+                "C:\\Repo",
+                { platform: "win32" },
+            ),
+        ).toBe(false);
+    });
+
+    it("produces the same Windows cache key for root paths with different casing", () => {
+        expect(
+            normalizePathKey("C:\\Repo\\Feature", { platform: "win32" }),
+        ).toBe(normalizePathKey("c:\\repo\\feature", { platform: "win32" }));
+    });
+
+    it("matches worktree paths returned by Git with different casing", () => {
+        expect(
+            isSameOrInsidePath("C:\\Repo\\Worktree", "c:\\repo\\worktree", {
+                platform: "win32",
+            }),
+        ).toBe(true);
+    });
+
     it("keeps POSIX containment case-sensitive", () => {
         expect(
             isSameOrInsidePath(

--- a/src/shared/path-identity.test.ts
+++ b/src/shared/path-identity.test.ts
@@ -30,6 +30,12 @@ describe("normalizePathKey", () => {
         ).toBe("c:/workspace/comando/src/file.ts");
     });
 
+    it("infers Windows semantics from relative backslash paths", () => {
+        expect(normalizePathKey("src\\Feature\\File.ts")).toBe(
+            "src/feature/file.ts",
+        );
+    });
+
     it("keeps UNC roots intact while normalizing casing", () => {
         expect(
             normalizePathKey("\\\\Server\\Share\\Comando\\SRC\\File.ts", {

--- a/src/shared/path-identity.ts
+++ b/src/shared/path-identity.ts
@@ -251,7 +251,8 @@ function inferPathPlatform(
     ...paths: readonly string[]
 ): PathIdentityPlatform {
     return paths.some((pathText) =>
-        /^(?:[a-zA-Z]:[\\/]|[\\/]{2}[^\\/]+[\\/][^\\/]+)/.test(pathText),
+        /^(?:[a-zA-Z]:[\\/]|[\\/]{2}[^\\/]+[\\/][^\\/]+)/.test(pathText) ||
+        pathText.includes("\\"),
     )
         ? "win32"
         : "posix";

--- a/src/shared/path-identity.ts
+++ b/src/shared/path-identity.ts
@@ -1,0 +1,258 @@
+export type PathIdentityPlatform = "posix" | "win32";
+
+export interface PathIdentityOptions {
+    readonly platform?: PathIdentityPlatform;
+    readonly basePath?: string;
+}
+
+interface NormalizedPathParts {
+    readonly root: string;
+    readonly segments: readonly string[];
+}
+
+export function normalizePathKey(
+    filePath: string,
+    options: PathIdentityOptions = {},
+): string {
+    const platform = options.platform ?? inferPathPlatform(filePath);
+    const parts = normalizePathParts(filePath, platform, options.basePath);
+    return formatPathKey(parts, platform);
+}
+
+export function isSameOrInsidePath(
+    candidatePath: string,
+    containerPath: string,
+    options: PathIdentityOptions = {},
+): boolean {
+    const platform =
+        options.platform ?? inferPathPlatform(candidatePath, containerPath);
+    const candidateKey = normalizePathKey(candidatePath, {
+        ...options,
+        platform,
+    });
+    const containerKey = normalizePathKey(containerPath, {
+        ...options,
+        platform,
+    });
+
+    if (candidateKey === containerKey) {
+        return true;
+    }
+
+    const containerPrefix = containerKey.endsWith("/")
+        ? containerKey
+        : `${containerKey}/`;
+    return candidateKey.startsWith(containerPrefix);
+}
+
+export function toDisplayRelativePath(
+    candidatePath: string,
+    containerPath: string,
+    options: PathIdentityOptions = {},
+): string {
+    const platform =
+        options.platform ?? inferPathPlatform(candidatePath, containerPath);
+    const candidateParts = normalizePathParts(
+        candidatePath,
+        platform,
+        options.basePath,
+    );
+    const containerParts = normalizePathParts(
+        containerPath,
+        platform,
+        options.basePath,
+    );
+
+    if (!hasSameRoot(candidateParts, containerParts, platform)) {
+        return formatDisplayPath(candidateParts);
+    }
+
+    if (
+        candidateParts.segments.length < containerParts.segments.length ||
+        !containerParts.segments.every((segment, index) =>
+            isSameSegment(segment, candidateParts.segments[index], platform),
+        )
+    ) {
+        return formatDisplayPath(candidateParts);
+    }
+
+    return candidateParts.segments
+        .slice(containerParts.segments.length)
+        .join("/");
+}
+
+function normalizePathParts(
+    filePath: string,
+    platform: PathIdentityPlatform,
+    basePath?: string,
+): NormalizedPathParts {
+    const pathText = normalizeInputPath(filePath, platform);
+    const resolvedPath =
+        basePath && !isAbsolutePath(pathText, platform)
+            ? joinPathText(normalizeInputPath(basePath, platform), pathText)
+            : pathText;
+    const { root, rest } = splitRoot(resolvedPath, platform);
+    const segments = normalizeSegments(rest.split("/"), Boolean(root));
+
+    return { root, segments };
+}
+
+function normalizeInputPath(
+    filePath: string,
+    platform: PathIdentityPlatform,
+): string {
+    const normalized =
+        platform === "win32" ? stripExtendedWindowsPrefix(filePath) : filePath;
+    const separated =
+        platform === "win32" ? normalized.replace(/\\/g, "/") : normalized;
+
+    if (platform === "win32" && separated.startsWith("//")) {
+        return `//${separated.slice(2).replace(/\/+/g, "/")}`;
+    }
+
+    return separated.replace(/\/+/g, "/");
+}
+
+function stripExtendedWindowsPrefix(filePath: string): string {
+    const pathText = filePath.replace(/\\/g, "/");
+    if (pathText.startsWith("//?/UNC/")) {
+        return `//${pathText.slice("//?/UNC/".length)}`;
+    }
+
+    if (pathText.startsWith("//?/")) {
+        return pathText.slice("//?/".length);
+    }
+
+    return filePath;
+}
+
+function splitRoot(
+    pathText: string,
+    platform: PathIdentityPlatform,
+): { root: string; rest: string } {
+    if (platform === "win32") {
+        const uncMatch = pathText.match(/^\/\/([^/]+)\/([^/]+)(?:\/(.*))?$/);
+        if (uncMatch) {
+            return {
+                root: `//${uncMatch[1]}/${uncMatch[2]}`,
+                rest: uncMatch[3] ?? "",
+            };
+        }
+
+        const driveMatch = pathText.match(/^([a-zA-Z]:)(?:\/(.*))?$/);
+        if (driveMatch) {
+            return { root: `${driveMatch[1]}/`, rest: driveMatch[2] ?? "" };
+        }
+    }
+
+    if (pathText.startsWith("/")) {
+        return { root: "/", rest: pathText.slice(1) };
+    }
+
+    return { root: "", rest: pathText };
+}
+
+function normalizeSegments(
+    segments: readonly string[],
+    isRooted: boolean,
+): string[] {
+    const normalized: string[] = [];
+
+    for (const segment of segments) {
+        if (!segment || segment === ".") {
+            continue;
+        }
+
+        if (segment === "..") {
+            if (normalized.length > 0) {
+                normalized.pop();
+            } else if (!isRooted) {
+                normalized.push(segment);
+            }
+            continue;
+        }
+
+        normalized.push(segment);
+    }
+
+    return normalized;
+}
+
+function formatPathKey(
+    parts: NormalizedPathParts,
+    platform: PathIdentityPlatform,
+): string {
+    const displayPath = formatDisplayPath(parts);
+    return platform === "win32" ? displayPath.toLowerCase() : displayPath;
+}
+
+function formatDisplayPath(parts: NormalizedPathParts): string {
+    if (!parts.root) {
+        return parts.segments.join("/");
+    }
+
+    if (parts.root === "/") {
+        return parts.segments.length > 0 ? `/${parts.segments.join("/")}` : "/";
+    }
+
+    if (parts.root.endsWith("/")) {
+        return `${parts.root}${parts.segments.join("/")}`.replace(/\/$/, "/");
+    }
+
+    return parts.segments.length > 0
+        ? `${parts.root}/${parts.segments.join("/")}`
+        : parts.root;
+}
+
+function hasSameRoot(
+    left: NormalizedPathParts,
+    right: NormalizedPathParts,
+    platform: PathIdentityPlatform,
+): boolean {
+    return platform === "win32"
+        ? left.root.toLowerCase() === right.root.toLowerCase()
+        : left.root === right.root;
+}
+
+function isSameSegment(
+    left: string,
+    right: string | undefined,
+    platform: PathIdentityPlatform,
+): boolean {
+    if (right === undefined) {
+        return false;
+    }
+
+    return platform === "win32"
+        ? left.toLowerCase() === right.toLowerCase()
+        : left === right;
+}
+
+function isAbsolutePath(
+    pathText: string,
+    platform: PathIdentityPlatform,
+): boolean {
+    if (platform === "win32") {
+        return /^([a-zA-Z]:\/|\/\/[^/]+\/[^/]+)/.test(pathText);
+    }
+
+    return pathText.startsWith("/");
+}
+
+function joinPathText(basePath: string, relativePath: string): string {
+    if (!basePath) {
+        return relativePath;
+    }
+
+    return `${basePath.replace(/\/+$/, "")}/${relativePath.replace(/^\/+/, "")}`;
+}
+
+function inferPathPlatform(
+    ...paths: readonly string[]
+): PathIdentityPlatform {
+    return paths.some((pathText) =>
+        /^(?:[a-zA-Z]:[\\/]|[\\/]{2}[^\\/]+[\\/][^\\/]+)/.test(pathText),
+    )
+        ? "win32"
+        : "posix";
+}


### PR DESCRIPTION
## Summary

This PR hardens path identity handling across Windows-sensitive surfaces:

- adds shared path identity helpers for POSIX vs Windows normalization
- normalizes AI review, tracked file, inline review, and chat review path matching
- normalizes project tree and Git cache root keys so casing/separator aliases do not split the same repo/worktree
- keeps renderer relative path casing behavior platform-aware, so Windows aliases still match while Linux/macOS keep case-sensitive relative paths distinct

## Root Cause

Several systems compared paths as raw strings or used local one-off normalization. On Windows, equivalent paths can arrive with different casing or separators, which caused missed tracked-file matches, duplicated cache identities, stale review state, and Git/worktree flows that could look disconnected from the active project.

## Validation

- `pnpm vitest run src/shared/path-identity.test.ts src/main/ai/session-core.test.ts src/main/ai/service.review.test.ts src/main/ai/worker-runtime.test.ts src/renderer/src/app/ai/trackedFilePath.test.ts src/renderer/src/app/workspace/pending-review.test.ts src/renderer/src/components/workspace/chat/toolActivityReviewModel.test.ts src/renderer/src/app/store/ai-store.test.ts src/renderer/src/components/workspace/projectFileReferences.test.ts src/renderer/src/components/workspace/chat/ChangeReviewPanel.test.ts src/renderer/src/components/workspace/ReviewTabView.test.ts src/main/projects/tree.test.ts src/main/projects/service.test.ts src/main/git/service.test.ts`
- `pnpm run typecheck`
- `pnpm exec eslint src/renderer/src/app/ai/trackedFilePath.ts src/renderer/src/app/ai/trackedFilePath.test.ts src/renderer/src/app/workspace/pending-review.test.ts src/renderer/src/components/workspace/chat/toolActivityReviewModel.test.ts src/renderer/src/app/store/ai-store.test.ts`
- `git diff --check`