### PR TITLE
Harden Windows command launching

### DIFF
--- a/scripts/ai/_shared.mjs
+++ b/scripts/ai/_shared.mjs
@@ -176,6 +176,7 @@ export function prepareCommandForSpawnSync(
         args: [
             "/d",
             "/s",
+            "/v:off",
             "/c",
             buildWindowsBatchCommandLine(command, args),
         ],
@@ -198,9 +199,26 @@ function buildWindowsBatchCommandLine(command, args) {
 }
 
 function quoteWindowsCmdArgument(value) {
-    const escapedValue = String(value)
-        .replace(/"/g, '\\"')
-        .replace(/([&|<>()^%!])/g, "^$1");
+    let escapedValue = "";
+    let backslashCount = 0;
+
+    for (const character of String(value)) {
+        if (character === "\\") {
+            backslashCount += 1;
+            continue;
+        }
+
+        if (character === '"') {
+            escapedValue += `${"\\".repeat(backslashCount * 2 + 1)}"`;
+            backslashCount = 0;
+            continue;
+        }
+
+        escapedValue += `${"\\".repeat(backslashCount)}${character}`;
+        backslashCount = 0;
+    }
+
+    escapedValue += "\\".repeat(backslashCount * 2);
 
     return `"${escapedValue}"`;
 }

--- a/scripts/ai/_shared.mjs
+++ b/scripts/ai/_shared.mjs
@@ -180,7 +180,7 @@ export function prepareCommandForSpawnSync(
             buildWindowsBatchCommandLine(command, args),
         ],
         command: launchOptions.comSpec ?? process.env.ComSpec ?? "cmd.exe",
-        options,
+        options: withWindowsVerbatimArguments(options),
     };
 }
 
@@ -203,4 +203,11 @@ function quoteWindowsCmdArgument(value) {
         .replace(/([&|<>()^%!])/g, "^$1");
 
     return `"${escapedValue}"`;
+}
+
+function withWindowsVerbatimArguments(options) {
+    return {
+        ...options,
+        windowsVerbatimArguments: true,
+    };
 }

--- a/scripts/ai/_shared.mjs
+++ b/scripts/ai/_shared.mjs
@@ -214,6 +214,12 @@ function quoteWindowsCmdArgument(value) {
             continue;
         }
 
+        if (character === "%") {
+            escapedValue += `${"\\".repeat(backslashCount)}"^%"`;
+            backslashCount = 0;
+            continue;
+        }
+
         escapedValue += `${"\\".repeat(backslashCount)}${character}`;
         backslashCount = 0;
     }

--- a/scripts/ai/_shared.mjs
+++ b/scripts/ai/_shared.mjs
@@ -155,3 +155,52 @@ export function resolveFromPath(command) {
 
     return null;
 }
+
+export function prepareCommandForSpawnSync(
+    command,
+    args = [],
+    options = {},
+    launchOptions = {},
+) {
+    const platform = launchOptions.platform ?? process.platform;
+
+    if (platform !== "win32" || !isWindowsBatchCommand(command)) {
+        return {
+            args: [...args],
+            command,
+            options,
+        };
+    }
+
+    return {
+        args: [
+            "/d",
+            "/s",
+            "/c",
+            buildWindowsBatchCommandLine(command, args),
+        ],
+        command: launchOptions.comSpec ?? process.env.ComSpec ?? "cmd.exe",
+        options,
+    };
+}
+
+export function isWindowsBatchCommand(command) {
+    const extension = path.win32.extname(command).toLowerCase();
+    return extension === ".cmd" || extension === ".bat";
+}
+
+function buildWindowsBatchCommandLine(command, args) {
+    const innerCommandLine = [command, ...args]
+        .map(quoteWindowsCmdArgument)
+        .join(" ");
+
+    return `"${innerCommandLine}"`;
+}
+
+function quoteWindowsCmdArgument(value) {
+    const escapedValue = String(value)
+        .replace(/"/g, '\\"')
+        .replace(/([&|<>()^%!])/g, "^$1");
+
+    return `"${escapedValue}"`;
+}

--- a/scripts/ai/_shared.test.mjs
+++ b/scripts/ai/_shared.test.mjs
@@ -32,8 +32,9 @@ describe("script command launch helpers", () => {
                 args: [
                     "/d",
                     "/s",
+                    "/v:off",
                     "/c",
-                    `""${command}" "run" "build ^& package" "^%TEMP^%""`,
+                    `""${command}" "run" "build & package" "%TEMP%""`,
                 ],
                 command: "C:\\Windows\\System32\\cmd.exe",
                 options: {
@@ -61,7 +62,7 @@ describe("script command launch helpers", () => {
         });
     });
 
-    it("escapes cmd metacharacters before launching a batch command", () => {
+    it("quotes cmd metacharacters before launching a batch command", () => {
         // Keep this mirrored with src/main/shell/command-launch.test.ts so runtime and packaging quoting stay aligned.
         const prepared = prepareCommandForSpawnSync(
             "C:\\Tools\\run.cmd",
@@ -70,8 +71,8 @@ describe("script command launch helpers", () => {
             { platform: "win32" },
         );
 
-        expect(prepared.args[3]).toBe(
-            '""C:\\Tools\\run.cmd" "A^&B" "^(group^)" "100^%" "has^^caret" "say \\"hi\\"""',
+        expect(prepared.args[4]).toBe(
+            '""C:\\Tools\\run.cmd" "A&B" "(group)" "100%" "has^caret" "say \\"hi\\"""',
         );
         expect(prepared.options.windowsVerbatimArguments).toBe(true);
     });

--- a/scripts/ai/_shared.test.mjs
+++ b/scripts/ai/_shared.test.mjs
@@ -61,6 +61,21 @@ describe("script command launch helpers", () => {
         });
     });
 
+    it("escapes cmd metacharacters before launching a batch command", () => {
+        // Keep this mirrored with src/main/shell/command-launch.test.ts so runtime and packaging quoting stay aligned.
+        const prepared = prepareCommandForSpawnSync(
+            "C:\\Tools\\run.cmd",
+            ["A&B", "(group)", "100%", "has^caret", "say \"hi\""],
+            undefined,
+            { platform: "win32" },
+        );
+
+        expect(prepared.args[3]).toBe(
+            '""C:\\Tools\\run.cmd" "A^&B" "^(group^)" "100^%" "has^^caret" "say \\"hi\\"""',
+        );
+        expect(prepared.options.windowsVerbatimArguments).toBe(true);
+    });
+
     it("does not wrap batch commands outside Windows", () => {
         const prepared = prepareCommandForSpawnSync(
             "C:\\Program Files\\nodejs\\pnpm.cmd",

--- a/scripts/ai/_shared.test.mjs
+++ b/scripts/ai/_shared.test.mjs
@@ -36,9 +36,13 @@ describe("script command launch helpers", () => {
                     `""${command}" "run" "build ^& package" "^%TEMP^%""`,
                 ],
                 command: "C:\\Windows\\System32\\cmd.exe",
-                options,
+                options: {
+                    ...options,
+                    windowsVerbatimArguments: true,
+                },
             });
-            expect(prepared.options).toBe(options);
+            expect(prepared.options).not.toBe(options);
+            expect(options.windowsVerbatimArguments).toBeUndefined();
         },
     );
 

--- a/scripts/ai/_shared.test.mjs
+++ b/scripts/ai/_shared.test.mjs
@@ -34,7 +34,7 @@ describe("script command launch helpers", () => {
                     "/s",
                     "/v:off",
                     "/c",
-                    `""${command}" "run" "build & package" "%TEMP%""`,
+                    `""${command}" "run" "build & package" ""^%"TEMP"^%"""`,
                 ],
                 command: "C:\\Windows\\System32\\cmd.exe",
                 options: {
@@ -72,7 +72,7 @@ describe("script command launch helpers", () => {
         );
 
         expect(prepared.args[4]).toBe(
-            '""C:\\Tools\\run.cmd" "A&B" "(group)" "100%" "has^caret" "say \\"hi\\"""',
+            '""C:\\Tools\\run.cmd" "A&B" "(group)" "100"^%"" "has^caret" "say \\"hi\\"""',
         );
         expect(prepared.options.windowsVerbatimArguments).toBe(true);
     });

--- a/scripts/ai/_shared.test.mjs
+++ b/scripts/ai/_shared.test.mjs
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    isWindowsBatchCommand,
+    prepareCommandForSpawnSync,
+} from "./_shared.mjs";
+
+describe("script command launch helpers", () => {
+    it.each(["pnpm.cmd", "npm.cmd"])(
+        "wraps %s paths with spaces through cmd.exe",
+        (commandName) => {
+            const command = `C:\\Program Files\\nodejs\\${commandName}`;
+            const options = {
+                cwd: "C:\\Workspaces\\Project With Spaces",
+                env: {
+                    PATH: "C:\\Program Files\\nodejs",
+                },
+                stdio: "inherit",
+            };
+
+            const prepared = prepareCommandForSpawnSync(
+                command,
+                ["run", "build & package", "%TEMP%"],
+                options,
+                {
+                    comSpec: "C:\\Windows\\System32\\cmd.exe",
+                    platform: "win32",
+                },
+            );
+
+            expect(prepared).toEqual({
+                args: [
+                    "/d",
+                    "/s",
+                    "/c",
+                    `""${command}" "run" "build ^& package" "^%TEMP^%""`,
+                ],
+                command: "C:\\Windows\\System32\\cmd.exe",
+                options,
+            });
+            expect(prepared.options).toBe(options);
+        },
+    );
+
+    it("does not wrap Windows non-batch executables", () => {
+        const prepared = prepareCommandForSpawnSync(
+            "C:\\Program Files\\nodejs\\node.exe",
+            ["script.js"],
+            undefined,
+            { platform: "win32" },
+        );
+
+        expect(prepared).toEqual({
+            args: ["script.js"],
+            command: "C:\\Program Files\\nodejs\\node.exe",
+            options: {},
+        });
+    });
+
+    it("does not wrap batch commands outside Windows", () => {
+        const prepared = prepareCommandForSpawnSync(
+            "C:\\Program Files\\nodejs\\pnpm.cmd",
+            ["run", "build"],
+            { cwd: "/repo" },
+            { platform: "darwin" },
+        );
+
+        expect(prepared).toEqual({
+            args: ["run", "build"],
+            command: "C:\\Program Files\\nodejs\\pnpm.cmd",
+            options: { cwd: "/repo" },
+        });
+    });
+
+    it("detects Windows batch command extensions", () => {
+        expect(isWindowsBatchCommand("C:\\Tools\\run.cmd")).toBe(true);
+        expect(isWindowsBatchCommand("C:\\Tools\\run.BAT")).toBe(true);
+        expect(isWindowsBatchCommand("C:\\Tools\\node.exe")).toBe(false);
+        expect(isWindowsBatchCommand("pnpm")).toBe(false);
+    });
+});

--- a/scripts/build-windows-acp-bundles.mjs
+++ b/scripts/build-windows-acp-bundles.mjs
@@ -11,6 +11,7 @@ import {
     ensureDir,
     isExecutableFile,
     isFile,
+    prepareCommandForSpawnSync,
     relativeToRepo,
     repoRoot,
     resetDir,
@@ -301,9 +302,12 @@ function capture(command, args, options = {}) {
         stdio: ["ignore", "pipe", "inherit"],
         ...options,
     };
-    const result = isCmdShim(command)
-        ? spawnSync(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", command, ...args], spawnOptions)
-        : spawnSync(command, args, spawnOptions);
+    const prepared = prepareCommandForSpawnSync(command, args, spawnOptions);
+    const result = spawnSync(
+        prepared.command,
+        prepared.args,
+        prepared.options,
+    );
 
     if (result.error) {
         throw result.error;
@@ -326,9 +330,12 @@ function run(command, args, options = {}) {
         stdio: "inherit",
         ...options,
     };
-    const result = isCmdShim(command)
-        ? spawnSync(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", command, ...args], spawnOptions)
-        : spawnSync(command, args, spawnOptions);
+    const prepared = prepareCommandForSpawnSync(command, args, spawnOptions);
+    const result = spawnSync(
+        prepared.command,
+        prepared.args,
+        prepared.options,
+    );
 
     if (result.error) {
         throw result.error;
@@ -337,10 +344,6 @@ function run(command, args, options = {}) {
     if (result.status !== 0) {
         process.exit(result.status ?? 1);
     }
-}
-
-function isCmdShim(command) {
-    return /\.cmd$|\.bat$/i.test(command);
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/package-macos-app.mjs
+++ b/scripts/package-macos-app.mjs
@@ -11,6 +11,7 @@ import {
     ensureDir,
     isExecutableFile,
     isFile,
+    prepareCommandForSpawnSync,
     relativeToRepo,
     repoRoot,
     resolveFromPath,
@@ -1290,7 +1291,7 @@ function run(command, args, options = {}) {
     ]
         .filter(Boolean)
         .join(path.delimiter);
-    const result = spawnSync(command, args, {
+    const prepared = prepareCommandForSpawnSync(command, args, {
         cwd: repoRoot,
         env: {
             ...process.env,
@@ -1300,6 +1301,11 @@ function run(command, args, options = {}) {
         stdio: "inherit",
         ...spawnOptions,
     });
+    const result = spawnSync(
+        prepared.command,
+        prepared.args,
+        prepared.options,
+    );
 
     if (result.error) {
         throw result.error;

--- a/scripts/package-windows-app.mjs
+++ b/scripts/package-windows-app.mjs
@@ -11,6 +11,7 @@ import {
     ensureDir,
     isExecutableFile,
     isFile,
+    prepareCommandForSpawnSync,
     relativeToRepo,
     repoRoot,
     resolveFromPath,
@@ -459,9 +460,12 @@ function run(command, args, options = {}) {
         stdio: "inherit",
         ...options,
     };
-    const result = isCmdShim(command)
-        ? spawnSync(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", command, ...args], spawnOptions)
-        : spawnSync(command, args, spawnOptions);
+    const prepared = prepareCommandForSpawnSync(command, args, spawnOptions);
+    const result = spawnSync(
+        prepared.command,
+        prepared.args,
+        prepared.options,
+    );
 
     if (result.error) {
         throw result.error;
@@ -500,8 +504,4 @@ function resolvePythonBinary() {
     }
 
     return null;
-}
-
-function isCmdShim(command) {
-    return /\.cmd$|\.bat$/i.test(command);
 }

--- a/src/main/ai/auth/terminal-login.test.ts
+++ b/src/main/ai/auth/terminal-login.test.ts
@@ -22,8 +22,11 @@ describe("terminal login helpers", () => {
         expect(quoteWindowsArg("C:\\Program Files\\Comando")).toBe(
             '"C:\\Program Files\\Comando"',
         );
-        expect(quoteWindowsArg('say "hello"')).toBe('"say \\"hello\\""');
-        expect(quoteWindowsArg("A&B")).toBe('"A&B"');
+        expect(quoteWindowsArg('say "hello"')).toBe('"say ^"hello^""');
+        expect(quoteWindowsArg("A&B")).toBe('"A^&B"');
+        expect(quoteWindowsArg("%TEMP%\\Comando^!")).toBe(
+            '"%%TEMP%%\\Comando^^^!"',
+        );
     });
 
     it("builds POSIX login scripts with a unique provider prefix", () => {
@@ -46,10 +49,14 @@ describe("terminal login helpers", () => {
         }
     });
 
-    it("builds Windows login scripts without exposing unquoted paths", () => {
+    it("builds Windows login scripts without exposing unsafe paths", () => {
         const scriptPath = buildWindowsLoginScript({
-            commandParts: ["C:\\Program Files\\Claude\\claude.exe", "login"],
-            cwd: "C:\\Users\\Me\\Project & Stuff",
+            commandParts: [
+                "C:\\Program Files\\Claude\\claude.exe",
+                "login",
+                'say "hello" & wait',
+            ],
+            cwd: "C:\\Users\\Me\\%TEMP% Project & Stuff!",
             scriptPrefix: "comando-test-login",
         });
 
@@ -57,7 +64,7 @@ describe("terminal login helpers", () => {
             expect(scriptPath).toContain("comando-test-login-");
             expect(scriptPath).toMatch(/\.cmd$/);
             expect(fs.readFileSync(scriptPath, "utf8")).toContain(
-                'cd /d "C:\\Users\\Me\\Project & Stuff"\r\n"C:\\Program Files\\Claude\\claude.exe" "login"',
+                'cd /d "C:\\Users\\Me\\%%TEMP%% Project ^& Stuff^!"\r\n"C:\\Program Files\\Claude\\claude.exe" "login" "say ^"hello^" ^& wait"',
             );
         } finally {
             fs.rmSync(scriptPath, {

--- a/src/main/ai/auth/terminal-login.ts
+++ b/src/main/ai/auth/terminal-login.ts
@@ -99,7 +99,16 @@ export function quoteShellArg(value: string): string {
 }
 
 export function quoteWindowsArg(value: string): string {
-    return `"${value.replace(/"/g, '\\"')}"`;
+    return `"${escapeWindowsBatchArgument(value)}"`;
+}
+
+function escapeWindowsBatchArgument(value: string): string {
+    return value
+        .replace(/%/g, "%%")
+        .replace(/\^/g, "^^")
+        .replace(/!/g, "^!")
+        .replace(/"/g, '^"')
+        .replace(/([&|<>()])/g, "^$1");
 }
 
 function spawnDetached(

--- a/src/main/ai/grok/setup.test.ts
+++ b/src/main/ai/grok/setup.test.ts
@@ -132,7 +132,10 @@ describe("Grok setup", () => {
         );
 
         try {
-            const binaryPath = writeExecutable(tempDir, "grok");
+            const binaryPath = writeExecutable(
+                tempDir,
+                platformExecutableName("grok"),
+            );
             process.env.PATH = tempDir;
 
             const fromSettings = resolveGrokRuntime({
@@ -180,6 +183,7 @@ describe("Grok setup", () => {
                 [
                     "/d",
                     "/s",
+                    "/v:off",
                     "/c",
                     `""${binaryPath}" "--no-auto-update" "agent" "stdio""`,
                 ],
@@ -205,7 +209,10 @@ describe("Grok setup", () => {
         try {
             const userBinDir = path.join(tempDir, ".grok", "bin");
             fs.mkdirSync(userBinDir, { recursive: true });
-            const binaryPath = writeExecutable(userBinDir, "grok");
+            const binaryPath = writeExecutable(
+                userBinDir,
+                platformExecutableName("grok"),
+            );
             process.env.HOME = tempDir;
             delete process.env.USERPROFILE;
             process.env.PATH = "";
@@ -227,7 +234,15 @@ describe("Grok setup", () => {
 
         try {
             const nonExecutablePath = path.join(tempDir, "grok");
-            fs.writeFileSync(nonExecutablePath, "#!/bin/sh\nexit 0\n", "utf8");
+            if (process.platform === "win32") {
+                fs.mkdirSync(nonExecutablePath);
+            } else {
+                fs.writeFileSync(
+                    nonExecutablePath,
+                    "#!/bin/sh\nexit 0\n",
+                    "utf8",
+                );
+            }
             process.env.HOME = tempDir;
             delete process.env.USERPROFILE;
             process.env.PATH = "";
@@ -492,6 +507,10 @@ function writeExecutable(directory: string, name: string): string {
     fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
     fs.chmodSync(binaryPath, 0o755);
     return binaryPath;
+}
+
+function platformExecutableName(command: string): string {
+    return process.platform === "win32" ? `${command}.CMD` : command;
 }
 
 function writeGrokAuthStore(homeDir: string): void {

--- a/src/main/ai/grok/setup.test.ts
+++ b/src/main/ai/grok/setup.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { GrokRuntimeSettings } from "@shared/ipc";
 import type { SecretStoreGateway } from "../secret-store";
@@ -15,8 +16,32 @@ import {
     isGrokAuthenticationError,
     loadGrokSecretBundle,
     markGrokAuthInvalidated,
+    probeGrokCachedTokenAuth,
     resolveGrokRuntime,
 } from "./setup";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+const initializeMock = vi.hoisted(() =>
+    vi.fn(() =>
+        Promise.resolve({
+            authMethods: [{ id: "cached_token" }],
+        }),
+    ),
+);
+const authenticateMock = vi.hoisted(() => vi.fn(() => Promise.resolve({})));
+
+vi.mock("node:child_process", () => ({
+    spawn: spawnMock,
+}));
+
+vi.mock("@agentclientprotocol/sdk", () => ({
+    ClientSideConnection: class MockClientSideConnection {
+        initialize = initializeMock;
+        authenticate = authenticateMock;
+    },
+    PROTOCOL_VERSION: "test-protocol-version",
+    ndJsonStream: vi.fn(() => ({})),
+}));
 
 const originalGrokEnv = process.env.COMANDO_GROK_ACP_BIN;
 const originalHome = process.env.HOME;
@@ -27,6 +52,14 @@ const originalXaiApiKey = process.env.XAI_API_KEY;
 beforeEach(() => {
     delete process.env.COMANDO_GROK_ACP_BIN;
     delete process.env.XAI_API_KEY;
+    initializeMock.mockClear();
+    initializeMock.mockResolvedValue({
+        authMethods: [{ id: "cached_token" }],
+    });
+    authenticateMock.mockClear();
+    authenticateMock.mockResolvedValue({});
+    spawnMock.mockClear();
+    spawnMock.mockImplementation(createMockChildProcess);
 });
 
 afterEach(() => {
@@ -113,6 +146,53 @@ describe("Grok setup", () => {
             expect(fromPath.program).toBe(binaryPath);
             expect(fromPath.status.source).toBe("path");
         } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("probes Windows .cmd Grok runtimes through cmd.exe", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-cmd-probe-"),
+        );
+        const originalPlatform = process.platform;
+
+        try {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: "win32",
+            });
+            const binaryPath = writeExecutable(tempDir, "grok.cmd");
+            process.env.PATH = "";
+
+            await expect(
+                probeGrokCachedTokenAuth(
+                    createEmptyGrokSettings({ binaryPath }),
+                    null,
+                    {
+                        cwd: tempDir,
+                        timeoutMs: 100,
+                    },
+                ),
+            ).resolves.toBe(true);
+
+            expect(spawnMock).toHaveBeenCalledWith(
+                "cmd.exe",
+                [
+                    "/d",
+                    "/s",
+                    "/c",
+                    `""${binaryPath}" "--no-auto-update" "agent" "stdio""`,
+                ],
+                expect.objectContaining({
+                    cwd: tempDir,
+                    stdio: ["pipe", "pipe", "pipe"],
+                }),
+            );
+        } finally {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: originalPlatform,
+            });
             fs.rmSync(tempDir, { force: true, recursive: true });
         }
     });
@@ -395,6 +475,15 @@ function createSecretStore(
         saveSecret: (namespace, secretId, value) => {
             secrets.set(`${namespace}:${secretId}`, value);
         },
+    };
+}
+
+function createMockChildProcess() {
+    return {
+        kill: vi.fn(() => true),
+        stderr: new PassThrough(),
+        stdin: new PassThrough(),
+        stdout: new PassThrough(),
     };
 }
 

--- a/src/main/ai/grok/setup.ts
+++ b/src/main/ai/grok/setup.ts
@@ -29,6 +29,7 @@ import {
     buildRuntimeSpawnEnv,
     resolveExecutableFromRuntimePath,
 } from "../runtime-env";
+import { prepareCommandForSpawn } from "../../shell/command-launch";
 
 const GROK_PROGRAM_NAME = "grok";
 const GROK_ACP_ARGS = ["--no-auto-update", "agent", "stdio"] as const;
@@ -346,14 +347,19 @@ export async function probeGrokCachedTokenAuth(
         return false;
     }
 
-    const child = spawn(resolved.program, [...resolved.args], {
+    const runtimeSpawn = prepareCommandForSpawn(resolved.program, resolved.args, {
         cwd: options.cwd ?? undefined,
         env: buildRuntimeSpawnEnv(
             applyGrokAuthEnv(process.env, settings, secretStore),
             resolved.program,
         ),
-        stdio: ["pipe", "pipe", "pipe"],
+        stdio: ["pipe", "pipe", "pipe"] as ["pipe", "pipe", "pipe"],
     });
+    const child = spawn(
+        runtimeSpawn.command,
+        runtimeSpawn.args,
+        runtimeSpawn.options,
+    );
     const client: Client = {
         readTextFile: () => {
             throw new Error("Grok auth probe does not support file reads.");

--- a/src/main/ai/service.codex.test.ts
+++ b/src/main/ai/service.codex.test.ts
@@ -1,4 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
     AiRuntimeStatus,
@@ -7,6 +13,44 @@ import type {
 } from "@shared/ipc";
 
 import { AiService } from "./service";
+
+const initializeMock = vi.hoisted(() =>
+    vi.fn(() =>
+        Promise.resolve({
+            authMethods: [{ id: "codex-api-key" }, { id: "chatgpt" }],
+        }),
+    ),
+);
+const authenticateMock = vi.hoisted(() => vi.fn(() => Promise.resolve({})));
+const logoutMock = vi.hoisted(() => vi.fn(() => Promise.resolve({})));
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agentclientprotocol/sdk", () => ({
+    ClientSideConnection: class MockClientSideConnection {
+        initialize = initializeMock;
+        authenticate = authenticateMock;
+        unstable_logout = logoutMock;
+    },
+    PROTOCOL_VERSION: "test-protocol-version",
+    ndJsonStream: vi.fn(() => ({})),
+}));
+
+vi.mock("node:child_process", () => ({
+    spawn: spawnMock,
+}));
+
+beforeEach(() => {
+    initializeMock.mockReset();
+    initializeMock.mockResolvedValue({
+        authMethods: [{ id: "codex-api-key" }, { id: "chatgpt" }],
+    });
+    authenticateMock.mockReset();
+    authenticateMock.mockResolvedValue({});
+    logoutMock.mockReset();
+    logoutMock.mockResolvedValue({});
+    spawnMock.mockReset();
+    spawnMock.mockImplementation(createMockChildProcess);
+});
 
 describe("AiService Codex branch", () => {
     it("stores Codex settings, persists only one API key, and emits runtime status", async () => {
@@ -533,6 +577,88 @@ describe("AiService Codex branch", () => {
         expect(saveCodexRuntimeSettings).not.toHaveBeenCalled();
     });
 
+    it("rejects Codex runtime auth when the child process fails to spawn", async () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-codex-auth-spawn-"),
+        );
+        const executablePath = path.join(tempDir, "codex-acp");
+        fs.writeFileSync(executablePath, "#!/bin/sh\nexit 0\n", "utf8");
+        fs.chmodSync(executablePath, 0o755);
+        const child = createMockChildProcess();
+        spawnMock.mockReturnValueOnce(child);
+        initializeMock.mockImplementationOnce(
+            () => new Promise(() => undefined),
+        );
+        const service = new AiService({
+            onRuntimeStatus: vi.fn(),
+            onSessionSnapshot: vi.fn(),
+            persistence: {
+                loadLatestRuntimeCatalog: vi.fn(() => null),
+                loadSessionSnapshot: vi.fn(() => null),
+                saveSessionSnapshot: vi.fn(),
+            } as never,
+            projectService: {
+                getProjectRootPath: vi.fn(() => tempDir),
+            } as never,
+            secretStore: {
+                loadSecret: vi.fn(() => null),
+                saveSecret: vi.fn(),
+            },
+            settingsService: {
+                loadClaudeRuntimeSettings: vi.fn(() => ({
+                    authInvalidatedAtMs: null,
+                    authMethod: null,
+                    binaryPath: null,
+                    gatewayBaseUrl: null,
+                    hasGatewayAuthToken: false,
+                    hasGatewayCustomHeaders: false,
+                })),
+                loadCodexRuntimeSettings: vi.fn(() => ({
+                    authMethod: null,
+                    binaryPath: executablePath,
+                    hasCodexApiKey: false,
+                    hasOpenAiApiKey: false,
+                })),
+                loadGeminiRuntimeSettings: vi.fn(() => ({
+                    authInvalidatedAtMs: null,
+                    authMethod: null,
+                    binaryPath: null,
+                    googleCloudLocation: null,
+                    googleCloudProject: null,
+                    hasGeminiApiKey: false,
+                    hasGoogleApiKey: false,
+                })),
+                loadKiloRuntimeSettings: vi.fn(() => ({
+                    authInvalidatedAtMs: null,
+                    binaryPath: null,
+                })),
+                saveClaudeRuntimeSettings: vi.fn(),
+                saveCodexRuntimeSettings: vi.fn(),
+                saveGeminiRuntimeSettings: vi.fn(),
+                saveKiloRuntimeSettings: vi.fn(),
+            } as never,
+        });
+
+        const result = service.launchRuntimeAuth({
+            methodId: "codex-api-key",
+            projectId: null,
+            runtimeId: "codex",
+        });
+        queueMicrotask(() => {
+            child.emit("error", new Error("spawn ENOENT"));
+        });
+
+        try {
+            await expect(result).rejects.toThrow("spawn ENOENT");
+            expect(child.kill).toHaveBeenCalled();
+            expect(child.stdin.destroyed).toBe(true);
+            expect(child.stdout.destroyed).toBe(true);
+            expect(child.stderr.destroyed).toBe(true);
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
     it("clears the opposing key when changing Codex preferred method", async () => {
         let savedSettings: CodexRuntimeSettings | null = null;
         const secretValues = new Map<string, string>([
@@ -1023,3 +1149,28 @@ describe("AiService Codex branch", () => {
         expect(saveSessionSnapshot).toHaveBeenCalled();
     });
 });
+
+function createMockChildProcess() {
+    const emitter = new EventEmitter();
+    const child = {
+        emit: (event: string, ...args: unknown[]) => emitter.emit(event, ...args),
+        kill: vi.fn(() => true),
+        off: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+            emitter.off(event, listener);
+            return child;
+        }),
+        on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+            emitter.on(event, listener);
+            return child;
+        }),
+        once: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+            emitter.once(event, listener);
+            return child;
+        }),
+        stderr: new PassThrough(),
+        stdin: new PassThrough(),
+        stdout: new PassThrough(),
+    };
+
+    return child;
+}

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -56,6 +56,7 @@ import type {
     SecretStoreGateway,
 } from "@main/ai/secret-store";
 import { debugBenignError } from "@main/observability/logging";
+import { prepareCommandForSpawn } from "@main/shell/command-launch";
 
 import {
     createEmptyAiSessionSnapshot,
@@ -2178,14 +2179,23 @@ export class AiService {
             );
         }
 
-        const child = spawn(
+        const runtimeSpawn = prepareCommandForSpawn(
             resolvedRuntime.executable,
-            [...resolvedRuntime.args],
+            resolvedRuntime.args,
             {
                 cwd,
                 env: resolvedRuntime.env,
-                stdio: ["pipe", "pipe", "pipe"],
+                stdio: ["pipe", "pipe", "pipe"] as [
+                    "pipe",
+                    "pipe",
+                    "pipe",
+                ],
             },
+        );
+        const child = spawn(
+            runtimeSpawn.command,
+            runtimeSpawn.args,
+            runtimeSpawn.options,
         );
         const stderrChunks: string[] = [];
         const stderrHandler = (chunk: Buffer | string) => {
@@ -2197,6 +2207,17 @@ export class AiService {
             }
         };
         child.stderr.on("data", stderrHandler);
+        let removeSpawnErrorHandler = () => {};
+        const spawnErrorPromise = new Promise<never>((_, reject) => {
+            const spawnErrorHandler = (error: Error) => {
+                debugBenignError("ai.service.runtimeAuth.process", error);
+                reject(error);
+            };
+            child.once("error", spawnErrorHandler);
+            removeSpawnErrorHandler = () => {
+                child.off("error", spawnErrorHandler);
+            };
+        });
 
         const client: Client = {
             readTextFile: () => {
@@ -2219,7 +2240,7 @@ export class AiService {
         const connection = new ClientSideConnection(() => client, stream);
 
         try {
-            await action(connection);
+            await Promise.race([action(connection), spawnErrorPromise]);
         } catch (error) {
             const stderrText = getRecentStderrText(stderrChunks);
 
@@ -2235,6 +2256,7 @@ export class AiService {
                 },
             );
         } finally {
+            removeSpawnErrorHandler();
             child.stderr.off("data", stderrHandler);
             child.kill();
             child.stdin.destroy();

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -325,6 +325,129 @@ describe("AiWorkerRuntime prepareSession", () => {
         ).toBe(true);
     });
 
+    it("launches Windows batch ACP runtimes through cmd.exe", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const originalPlatform = process.platform;
+        const cases: Array<{
+            readonly args: readonly string[];
+            readonly executable: string;
+            readonly runtimeId: AiRuntimeStatus["runtimeId"];
+        }> = [
+            {
+                args: [],
+                executable:
+                    "C:\\Program Files\\Comando Test\\codex-acp.cmd",
+                runtimeId: "codex",
+            },
+            {
+                args: ["--acp"],
+                executable: "C:\\Program Files\\Comando Test\\gemini.cmd",
+                runtimeId: "gemini",
+            },
+            {
+                args: ["acp"],
+                executable: "C:\\Program Files\\Comando Test\\kilo.cmd",
+                runtimeId: "kilo",
+            },
+            {
+                args: ["acp"],
+                executable: "C:\\Program Files\\Comando Test\\opencode.cmd",
+                runtimeId: "opencode",
+            },
+            {
+                args: ["--no-auto-update", "agent", "stdio"],
+                executable: "C:\\Program Files\\Comando Test\\grok.cmd",
+                runtimeId: "grok",
+            },
+        ];
+
+        try {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: "win32",
+            });
+
+            for (const input of cases) {
+                spawnMock.mockClear();
+                spawnedChildren = [];
+                const runtime = createRuntime();
+                const command = [input.executable, ...input.args].join(" ");
+                const readyStatus: AiRuntimeStatus = {
+                    authMethod:
+                        input.runtimeId === "codex" ? "chatgpt" : null,
+                    authMethods: [],
+                    authReady: true,
+                    checkedAt: "2026-04-15T00:00:00.000Z",
+                    command,
+                    hasCustomBinaryPath: true,
+                    hasGatewayConfig: false,
+                    hasGatewayUrl: false,
+                    message: null,
+                    onboardingRequired: false,
+                    runtimeId: input.runtimeId,
+                    source: "settings",
+                    state: "ready",
+                };
+                const launch = createLaunch({
+                    cwd: tempDir,
+                    projectRoot: tempDir,
+                    resolvedRuntime: {
+                        args: input.args,
+                        command,
+                        env: process.env,
+                        executable: input.executable,
+                        status: readyStatus,
+                    },
+                    title: `${input.runtimeId} batch launch`,
+                });
+
+                await runtime.dispatchMethod("ai.prepareSession", {
+                    input: {
+                        ...launch.input,
+                        runtimeId: input.runtimeId,
+                    },
+                    launch: {
+                        ...launch,
+                        input: {
+                            ...launch.input,
+                            runtimeId: input.runtimeId,
+                        },
+                        persistedSnapshot: {
+                            ...launch.persistedSnapshot,
+                            runtimeId: input.runtimeId,
+                        },
+                    },
+                });
+
+                expect(spawnMock).toHaveBeenCalledWith(
+                    "cmd.exe",
+                    [
+                        "/d",
+                        "/s",
+                        "/c",
+                        [
+                            `""${input.executable}"`,
+                            ...input.args.map((arg) => `"${arg}"`),
+                        ].join(" ") + '"',
+                    ],
+                    expect.objectContaining({
+                        cwd: tempDir,
+                        env: process.env,
+                        stdio: ["pipe", "pipe", "pipe"],
+                    }),
+                );
+            }
+        } finally {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: originalPlatform,
+            });
+            await fs.rm(tempDir, { force: true, recursive: true });
+        }
+    });
+
     it("authenticates Grok with the xAI API key ACP method before opening a session", async () => {
         initializeMock.mockResolvedValueOnce({
             authMethods: [{ id: "xai.api_key" }, { id: "cached_token" }],

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -5054,6 +5054,97 @@ describe("AiWorkerRuntime prepareSession", () => {
         });
     });
 
+    it("launches approved ACP terminal commands resolved by Windows PATHEXT", async () => {
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-"),
+        );
+        const binDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), "comando-ai-worker-bin-"),
+        );
+        const executablePath = path.join(binDir, "pnpm.CMD");
+        const originalPlatform = process.platform;
+        const emittedEvents: AiWorkerEventMessage[] = [];
+
+        try {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: "win32",
+            });
+            await fs.writeFile(executablePath, "", "utf8");
+            const runtime = new AiWorkerRuntime({
+                emitEvent: (event) => {
+                    emittedEvents.push(event);
+                },
+            });
+            const launch = createLaunch({
+                cwd: tempDir,
+                projectRoot: tempDir,
+                title: "Terminal Windows PATHEXT test",
+            });
+
+            await runtime.dispatchMethod("ai.prepareSession", {
+                input: launch.input,
+                launch,
+            });
+
+            const client = latestClientFactory?.();
+            expect(client).toBeDefined();
+            const createPromise = client!.createTerminal({
+                args: ["test"],
+                command: "pnpm",
+                cwd: tempDir,
+                env: [
+                    {
+                        name: "PATH",
+                        value: binDir,
+                    },
+                    {
+                        name: "PATHEXT",
+                        value: ".CMD;.EXE",
+                    },
+                ],
+                outputByteLimit: 1024,
+                sessionId: "runtime-session-1",
+            });
+
+            await Promise.resolve();
+            const pendingPermission = getLatestPendingPermission(emittedEvents);
+            expect(pendingPermission).not.toBeNull();
+            expect(pendingPermission!.description).toContain(
+                "Command: pnpm test",
+            );
+            const allowOption = pendingPermission!.options.find(
+                (option) => option.kind === "allow_once",
+            );
+            expect(allowOption).toBeDefined();
+            await runtime.dispatchMethod("ai.respondPermission", {
+                input: {
+                    optionId: allowOption!.optionId,
+                    requestId: pendingPermission!.requestId,
+                    sessionId: "session-1",
+                },
+            });
+
+            await createPromise;
+
+            expect(spawnMock).toHaveBeenLastCalledWith(
+                "cmd.exe",
+                ["/d", "/s", "/c", `""${executablePath}" "test""`],
+                expect.objectContaining({
+                    cwd: tempDir,
+                    stdio: ["ignore", "pipe", "pipe"],
+                }),
+            );
+        } finally {
+            Object.defineProperty(process, "platform", {
+                configurable: true,
+                value: originalPlatform,
+            });
+            await fs.rm(tempDir, { force: true, recursive: true });
+            await fs.rm(binDir, { force: true, recursive: true });
+        }
+    });
+
     it("normalizes negative ACP terminal exit codes to null", async () => {
         const tempDir = await fs.mkdtemp(
             path.join(os.tmpdir(), "comando-ai-worker-"),

--- a/src/main/ai/worker-runtime.test.ts
+++ b/src/main/ai/worker-runtime.test.ts
@@ -426,6 +426,7 @@ describe("AiWorkerRuntime prepareSession", () => {
                     [
                         "/d",
                         "/s",
+                        "/v:off",
                         "/c",
                         [
                             `""${input.executable}"`,
@@ -5129,7 +5130,13 @@ describe("AiWorkerRuntime prepareSession", () => {
 
             expect(spawnMock).toHaveBeenLastCalledWith(
                 "cmd.exe",
-                ["/d", "/s", "/c", `""${executablePath}" "test""`],
+                [
+                    "/d",
+                    "/s",
+                    "/v:off",
+                    "/c",
+                    `""${executablePath}" "test""`,
+                ],
                 expect.objectContaining({
                     cwd: tempDir,
                     stdio: ["ignore", "pipe", "pipe"],

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -55,6 +55,7 @@ import {
 } from "@shared/path-identity";
 
 import { debugBenignError } from "@main/observability/logging";
+import { prepareCommandForSpawn } from "@main/shell/command-launch";
 
 import {
     AI_SESSION_STREAMING_FLUSH_MS,
@@ -1181,14 +1182,23 @@ export class AiWorkerRuntime {
             });
         }
 
-        const child = spawn(
+        const runtimeSpawn = prepareCommandForSpawn(
             launch.resolvedRuntime.executable,
-            [...launch.resolvedRuntime.args],
+            launch.resolvedRuntime.args,
             {
                 cwd: launch.cwd,
                 env: launch.resolvedRuntime.env,
-                stdio: ["pipe", "pipe", "pipe"],
+                stdio: ["pipe", "pipe", "pipe"] as [
+                    "pipe",
+                    "pipe",
+                    "pipe",
+                ],
             },
+        );
+        const child = spawn(
+            runtimeSpawn.command,
+            runtimeSpawn.args,
+            runtimeSpawn.options,
         );
         const liveConnection = {} as LiveAcpConnection;
         const liveSession = {} as LiveAcpSession;

--- a/src/main/ai/worker-runtime.ts
+++ b/src/main/ai/worker-runtime.ts
@@ -2959,11 +2959,28 @@ export class AiWorkerRuntime {
             throw new Error("The terminal command was not approved.");
         }
 
-        const child = spawn(command, args, {
-            cwd,
-            env: buildTerminalEnv(params.env ?? []),
-            stdio: ["ignore", "pipe", "pipe"],
-        });
+        const terminalEnv = buildTerminalEnv(params.env ?? []);
+        const terminalSpawn = prepareCommandForSpawn(
+            command,
+            args,
+            {
+                cwd,
+                env: terminalEnv,
+                stdio: ["ignore", "pipe", "pipe"] as [
+                    "ignore",
+                    "pipe",
+                    "pipe",
+                ],
+            },
+            {
+                env: terminalEnv,
+            },
+        );
+        const child = spawn(
+            terminalSpawn.command,
+            terminalSpawn.args,
+            terminalSpawn.options,
+        );
         const terminal: LiveAcpTerminal = {
             child,
             commandLine,

--- a/src/main/shell/command-launch.test.ts
+++ b/src/main/shell/command-launch.test.ts
@@ -1,12 +1,23 @@
 import type { SpawnOptions } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
     isWindowsBatchCommand,
     prepareCommandForExecFile,
     prepareCommandForSpawn,
 } from "./command-launch";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+        fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+});
 
 describe("command launch helpers", () => {
     it("wraps Windows .cmd files through cmd.exe", () => {
@@ -104,6 +115,56 @@ describe("command launch helpers", () => {
         });
     });
 
+    it("wraps bare Windows commands resolved through PATHEXT", () => {
+        const binDir = createTempDir();
+        const executablePath = writeExecutable(binDir, "pnpm.CMD");
+
+        const prepared = prepareCommandForSpawn(
+            "pnpm",
+            ["test"],
+            undefined,
+            {
+                env: {
+                    PATHEXT: ".EXE;.CMD",
+                },
+                pathEntries: [binDir],
+                platform: "win32",
+            },
+        );
+
+        expect(prepared).toEqual({
+            args: ["/d", "/s", "/c", `""${executablePath}" "test""`],
+            command: "cmd.exe",
+            options: undefined,
+            wrappedByWindowsShell: true,
+        });
+    });
+
+    it("keeps bare Windows commands unchanged when PATHEXT resolves a non-batch executable", () => {
+        const binDir = createTempDir();
+        writeExecutable(binDir, "node.EXE");
+
+        const prepared = prepareCommandForSpawn(
+            "node",
+            ["script.js"],
+            undefined,
+            {
+                env: {
+                    PATHEXT: ".EXE;.CMD",
+                },
+                pathEntries: [binDir],
+                platform: "win32",
+            },
+        );
+
+        expect(prepared).toEqual({
+            args: ["script.js"],
+            command: "node",
+            options: undefined,
+            wrappedByWindowsShell: false,
+        });
+    });
+
     it("does not wrap batch-looking commands on POSIX platforms", () => {
         const prepared = prepareCommandForSpawn(
             "C:\\Program Files\\nodejs\\pnpm.cmd",
@@ -127,3 +188,18 @@ describe("command launch helpers", () => {
         expect(isWindowsBatchCommand("pnpm")).toBe(false);
     });
 });
+
+function createTempDir(): string {
+    const tempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "comando-command-launch-"),
+    );
+    tempDirs.push(tempDir);
+    return tempDir;
+}
+
+function writeExecutable(directory: string, name: string): string {
+    const executablePath = path.join(directory, name);
+    fs.writeFileSync(executablePath, "", { mode: 0o755 });
+    fs.chmodSync(executablePath, 0o755);
+    return executablePath;
+}

--- a/src/main/shell/command-launch.test.ts
+++ b/src/main/shell/command-launch.test.ts
@@ -36,7 +36,7 @@ describe("command launch helpers", () => {
                 '""C:\\Program Files\\nodejs\\pnpm.cmd" "run" "test suite""',
             ],
             command: "cmd.exe",
-            options: undefined,
+            options: { windowsVerbatimArguments: true },
             wrappedByWindowsShell: true,
         });
     });
@@ -56,7 +56,10 @@ describe("command launch helpers", () => {
             "/c",
             '""C:\\Tools\\setup.BAT" "--flag""',
         ]);
-        expect(prepared.options).toEqual({ cwd: "C:\\Workspaces\\Project" });
+        expect(prepared.options).toEqual({
+            cwd: "C:\\Workspaces\\Project",
+            windowsVerbatimArguments: true,
+        });
         expect(prepared.wrappedByWindowsShell).toBe(true);
     });
 
@@ -90,13 +93,15 @@ describe("command launch helpers", () => {
             { platform: "win32" },
         );
 
-        expect(prepared.options).toBe(options);
+        expect(prepared.options).not.toBe(options);
         expect(prepared.options.cwd).toBe(
             "C:\\Workspaces\\Project With Spaces",
         );
         expect(prepared.options.env).toBe(options.env);
         expect(prepared.options.signal).toBe(controller.signal);
         expect(prepared.options.stdio).toBe(stdio);
+        expect(prepared.options.windowsVerbatimArguments).toBe(true);
+        expect(options.windowsVerbatimArguments).toBeUndefined();
     });
 
     it("does not wrap non-batch commands on Windows", () => {
@@ -135,7 +140,7 @@ describe("command launch helpers", () => {
         expect(prepared).toEqual({
             args: ["/d", "/s", "/c", `""${executablePath}" "test""`],
             command: "cmd.exe",
-            options: undefined,
+            options: { windowsVerbatimArguments: true },
             wrappedByWindowsShell: true,
         });
     });
@@ -160,7 +165,7 @@ describe("command launch helpers", () => {
         expect(prepared).toEqual({
             args: ["/d", "/s", "/c", `""${executablePath}" "test""`],
             command: "cmd.exe",
-            options: undefined,
+            options: { windowsVerbatimArguments: true },
             wrappedByWindowsShell: true,
         });
     });

--- a/src/main/shell/command-launch.test.ts
+++ b/src/main/shell/command-launch.test.ts
@@ -1,0 +1,129 @@
+import type { SpawnOptions } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+import {
+    isWindowsBatchCommand,
+    prepareCommandForExecFile,
+    prepareCommandForSpawn,
+} from "./command-launch";
+
+describe("command launch helpers", () => {
+    it("wraps Windows .cmd files through cmd.exe", () => {
+        const prepared = prepareCommandForSpawn(
+            "C:\\Program Files\\nodejs\\pnpm.cmd",
+            ["run", "test suite"],
+            undefined,
+            { platform: "win32" },
+        );
+
+        expect(prepared).toEqual({
+            args: [
+                "/d",
+                "/s",
+                "/c",
+                '""C:\\Program Files\\nodejs\\pnpm.cmd" "run" "test suite""',
+            ],
+            command: "cmd.exe",
+            options: undefined,
+            wrappedByWindowsShell: true,
+        });
+    });
+
+    it("wraps Windows .bat files case-insensitively for execFile", () => {
+        const prepared = prepareCommandForExecFile(
+            "C:\\Tools\\setup.BAT",
+            ["--flag"],
+            { cwd: "C:\\Workspaces\\Project" },
+            { platform: "win32" },
+        );
+
+        expect(prepared.command).toBe("cmd.exe");
+        expect(prepared.args).toEqual([
+            "/d",
+            "/s",
+            "/c",
+            '""C:\\Tools\\setup.BAT" "--flag""',
+        ]);
+        expect(prepared.options).toEqual({ cwd: "C:\\Workspaces\\Project" });
+        expect(prepared.wrappedByWindowsShell).toBe(true);
+    });
+
+    it("escapes cmd metacharacters before launching a batch command", () => {
+        const prepared = prepareCommandForSpawn(
+            "C:\\Tools\\run.cmd",
+            ["A&B", "(group)", "100%", "has^caret", "say \"hi\""],
+            undefined,
+            { platform: "win32" },
+        );
+
+        expect(prepared.args[3]).toBe(
+            '""C:\\Tools\\run.cmd" "A^&B" "^(group^)" "100^%" "has^^caret" "say \\"hi\\"""',
+        );
+    });
+
+    it("preserves spawn options without mutating them", () => {
+        const controller = new AbortController();
+        const stdio: SpawnOptions["stdio"] = ["ignore", "pipe", "pipe"];
+        const options: SpawnOptions = {
+            cwd: "C:\\Workspaces\\Project With Spaces",
+            env: { PATH: "C:\\Tools", TEST_VALUE: "1" },
+            signal: controller.signal,
+            stdio,
+        };
+
+        const prepared = prepareCommandForSpawn(
+            "C:\\Tools\\runner.cmd",
+            ["--watch"],
+            options,
+            { platform: "win32" },
+        );
+
+        expect(prepared.options).toBe(options);
+        expect(prepared.options.cwd).toBe(
+            "C:\\Workspaces\\Project With Spaces",
+        );
+        expect(prepared.options.env).toBe(options.env);
+        expect(prepared.options.signal).toBe(controller.signal);
+        expect(prepared.options.stdio).toBe(stdio);
+    });
+
+    it("does not wrap non-batch commands on Windows", () => {
+        const prepared = prepareCommandForSpawn(
+            "C:\\Program Files\\nodejs\\node.exe",
+            ["script.js"],
+            undefined,
+            { platform: "win32" },
+        );
+
+        expect(prepared).toEqual({
+            args: ["script.js"],
+            command: "C:\\Program Files\\nodejs\\node.exe",
+            options: undefined,
+            wrappedByWindowsShell: false,
+        });
+    });
+
+    it("does not wrap batch-looking commands on POSIX platforms", () => {
+        const prepared = prepareCommandForSpawn(
+            "C:\\Program Files\\nodejs\\pnpm.cmd",
+            ["test"],
+            undefined,
+            { platform: "darwin" },
+        );
+
+        expect(prepared).toEqual({
+            args: ["test"],
+            command: "C:\\Program Files\\nodejs\\pnpm.cmd",
+            options: undefined,
+            wrappedByWindowsShell: false,
+        });
+    });
+
+    it("detects Windows batch command extensions", () => {
+        expect(isWindowsBatchCommand("C:\\Tools\\run.cmd")).toBe(true);
+        expect(isWindowsBatchCommand("C:\\Tools\\run.BAT")).toBe(true);
+        expect(isWindowsBatchCommand("C:\\Tools\\run.exe")).toBe(false);
+        expect(isWindowsBatchCommand("pnpm")).toBe(false);
+    });
+});

--- a/src/main/shell/command-launch.test.ts
+++ b/src/main/shell/command-launch.test.ts
@@ -64,6 +64,7 @@ describe("command launch helpers", () => {
     });
 
     it("escapes cmd metacharacters before launching a batch command", () => {
+        // Keep this mirrored with scripts/ai/_shared.test.mjs so runtime and packaging quoting stay aligned.
         const prepared = prepareCommandForSpawn(
             "C:\\Tools\\run.cmd",
             ["A&B", "(group)", "100%", "has^caret", "say \"hi\""],

--- a/src/main/shell/command-launch.test.ts
+++ b/src/main/shell/command-launch.test.ts
@@ -75,7 +75,7 @@ describe("command launch helpers", () => {
         );
 
         expect(prepared.args[4]).toBe(
-            '""C:\\Tools\\run.cmd" "A&B" "(group)" "100%" "has^caret" "say \\"hi\\"""',
+            '""C:\\Tools\\run.cmd" "A&B" "(group)" "100"^%"" "has^caret" "say \\"hi\\"""',
         );
     });
 
@@ -105,9 +105,8 @@ describe("command launch helpers", () => {
             const expectedReceivedArgs = [
                 "space value",
                 "A&B",
-                // Percent environment references are expanded by cmd.exe before the batch file receives argv.
-                expandedTempPath,
-                expandedComSpec,
+                "%TEMP%",
+                "%COMSPEC%",
                 "bang!value",
                 "caret^value",
                 'say "hi"',

--- a/src/main/shell/command-launch.test.ts
+++ b/src/main/shell/command-launch.test.ts
@@ -1,4 +1,4 @@
-import type { SpawnOptions } from "node:child_process";
+import { spawn, type SpawnOptions } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -32,6 +32,7 @@ describe("command launch helpers", () => {
             args: [
                 "/d",
                 "/s",
+                "/v:off",
                 "/c",
                 '""C:\\Program Files\\nodejs\\pnpm.cmd" "run" "test suite""',
             ],
@@ -53,6 +54,7 @@ describe("command launch helpers", () => {
         expect(prepared.args).toEqual([
             "/d",
             "/s",
+            "/v:off",
             "/c",
             '""C:\\Tools\\setup.BAT" "--flag""',
         ]);
@@ -63,7 +65,7 @@ describe("command launch helpers", () => {
         expect(prepared.wrappedByWindowsShell).toBe(true);
     });
 
-    it("escapes cmd metacharacters before launching a batch command", () => {
+    it("quotes cmd metacharacters before launching a batch command", () => {
         // Keep this mirrored with scripts/ai/_shared.test.mjs so runtime and packaging quoting stay aligned.
         const prepared = prepareCommandForSpawn(
             "C:\\Tools\\run.cmd",
@@ -72,10 +74,107 @@ describe("command launch helpers", () => {
             { platform: "win32" },
         );
 
-        expect(prepared.args[3]).toBe(
-            '""C:\\Tools\\run.cmd" "A^&B" "^(group^)" "100^%" "has^^caret" "say \\"hi\\"""',
+        expect(prepared.args[4]).toBe(
+            '""C:\\Tools\\run.cmd" "A&B" "(group)" "100%" "has^caret" "say \\"hi\\"""',
         );
     });
+
+    it.skipIf(process.platform !== "win32")(
+        "launches a real .cmd file with cmd metacharacter arguments",
+        async () => {
+            const tempDir = createTempDir();
+            const commandPath = path.join(tempDir, "launch target.cmd");
+            const captureScriptPath = path.join(tempDir, "capture-args.mjs");
+            const captureOutputPath = path.join(tempDir, "captured-args.json");
+            const expandedTempPath = path.join(tempDir, "Temp Value");
+            const expandedComSpec =
+                process.env.ComSpec ??
+                process.env.COMSPEC ??
+                "C:\\Windows\\System32\\cmd.exe";
+            const inputArgs = [
+                "space value",
+                "A&B",
+                "%TEMP%",
+                "%COMSPEC%",
+                "bang!value",
+                "caret^value",
+                'say "hi"',
+                "(group)",
+                "C:\\Path With Spaces\\",
+            ];
+            const expectedReceivedArgs = [
+                "space value",
+                "A&B",
+                // Percent environment references are expanded by cmd.exe before the batch file receives argv.
+                expandedTempPath,
+                expandedComSpec,
+                "bang!value",
+                "caret^value",
+                'say "hi"',
+                "(group)",
+                "C:\\Path With Spaces\\",
+            ];
+
+            fs.mkdirSync(expandedTempPath);
+            fs.writeFileSync(
+                captureScriptPath,
+                [
+                    'import fs from "node:fs";',
+                    "fs.writeFileSync(",
+                    "    process.env.COMANDO_CAPTURE_OUTPUT,",
+                    "    JSON.stringify(process.argv.slice(2)),",
+                    '    "utf8",',
+                    ");",
+                ].join("\n"),
+                "utf8",
+            );
+            fs.writeFileSync(
+                commandPath,
+                [
+                    "@echo off",
+                    "setlocal DisableDelayedExpansion",
+                    '"%COMANDO_TEST_NODE%" "%~dp0capture-args.mjs" %*',
+                    "exit /b %ERRORLEVEL%",
+                ].join("\r\n"),
+                "utf8",
+            );
+
+            const prepared = prepareCommandForSpawn(
+                commandPath,
+                inputArgs,
+                {
+                    cwd: tempDir,
+                    env: {
+                        ...process.env,
+                        COMANDO_CAPTURE_OUTPUT: captureOutputPath,
+                        COMANDO_TEST_NODE: process.execPath,
+                        ComSpec: expandedComSpec,
+                        TEMP: expandedTempPath,
+                    },
+                    stdio: ["ignore", "pipe", "pipe"],
+                },
+            );
+
+            expect(prepared.wrappedByWindowsShell).toBe(true);
+
+            const result = await runPreparedCommand(prepared);
+            if (result.code !== 0) {
+                throw new Error(
+                    [
+                        `Expected command to exit 0, got ${result.code}.`,
+                        result.stdout,
+                        result.stderr,
+                    ]
+                        .filter(Boolean)
+                        .join("\n"),
+                );
+            }
+
+            expect(
+                JSON.parse(fs.readFileSync(captureOutputPath, "utf8")),
+            ).toEqual(expectedReceivedArgs);
+        },
+    );
 
     it("preserves spawn options without mutating them", () => {
         const controller = new AbortController();
@@ -139,7 +238,13 @@ describe("command launch helpers", () => {
         );
 
         expect(prepared).toEqual({
-            args: ["/d", "/s", "/c", `""${executablePath}" "test""`],
+            args: [
+                "/d",
+                "/s",
+                "/v:off",
+                "/c",
+                `""${executablePath}" "test""`,
+            ],
             command: "cmd.exe",
             options: { windowsVerbatimArguments: true },
             wrappedByWindowsShell: true,
@@ -164,7 +269,13 @@ describe("command launch helpers", () => {
         );
 
         expect(prepared).toEqual({
-            args: ["/d", "/s", "/c", `""${executablePath}" "test""`],
+            args: [
+                "/d",
+                "/s",
+                "/v:off",
+                "/c",
+                `""${executablePath}" "test""`,
+            ],
             command: "cmd.exe",
             options: { windowsVerbatimArguments: true },
             wrappedByWindowsShell: true,
@@ -233,4 +344,35 @@ function writeExecutable(directory: string, name: string): string {
     fs.writeFileSync(executablePath, "", { mode: 0o755 });
     fs.chmodSync(executablePath, 0o755);
     return executablePath;
+}
+
+function runPreparedCommand(
+    prepared: ReturnType<typeof prepareCommandForSpawn<SpawnOptions>>,
+): Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+    readonly stderr: string;
+    readonly stdout: string;
+}> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(prepared.command, prepared.args, prepared.options);
+        const stdout: Buffer[] = [];
+        const stderr: Buffer[] = [];
+
+        child.stdout?.on("data", (chunk: Buffer) => {
+            stdout.push(chunk);
+        });
+        child.stderr?.on("data", (chunk: Buffer) => {
+            stderr.push(chunk);
+        });
+        child.on("error", reject);
+        child.on("close", (code, signal) => {
+            resolve({
+                code,
+                signal,
+                stderr: Buffer.concat(stderr).toString("utf8"),
+                stdout: Buffer.concat(stdout).toString("utf8"),
+            });
+        });
+    });
 }

--- a/src/main/shell/command-launch.test.ts
+++ b/src/main/shell/command-launch.test.ts
@@ -140,6 +140,31 @@ describe("command launch helpers", () => {
         });
     });
 
+    it("resolves Windows PATH and PATHEXT case-insensitively", () => {
+        const binDir = createTempDir();
+        const executablePath = writeExecutable(binDir, "pnpm.CMD");
+
+        const prepared = prepareCommandForSpawn(
+            "pnpm",
+            ["test"],
+            undefined,
+            {
+                env: {
+                    Path: binDir,
+                    PathExt: ".EXE;.CMD",
+                },
+                platform: "win32",
+            },
+        );
+
+        expect(prepared).toEqual({
+            args: ["/d", "/s", "/c", `""${executablePath}" "test""`],
+            command: "cmd.exe",
+            options: undefined,
+            wrappedByWindowsShell: true,
+        });
+    });
+
     it("keeps bare Windows commands unchanged when PATHEXT resolves a non-batch executable", () => {
         const binDir = createTempDir();
         writeExecutable(binDir, "node.EXE");

--- a/src/main/shell/command-launch.ts
+++ b/src/main/shell/command-launch.ts
@@ -128,8 +128,11 @@ function resolveWindowsPathExtCommand(
 ): string | null {
     const env = launchOptions.env ?? process.env;
     const pathEntries =
-        launchOptions.pathEntries ?? splitWindowsPathEntries(env.PATH);
-    const extensions = getWindowsPathExtensions(env.PATHEXT);
+        launchOptions.pathEntries ??
+        splitWindowsPathEntries(getWindowsEnvironmentValue(env, "PATH"));
+    const extensions = getWindowsPathExtensions(
+        getWindowsEnvironmentValue(env, "PATHEXT"),
+    );
     const searchEntries = hasPathDirectory(command) ? [""] : pathEntries;
 
     for (const entry of searchEntries) {
@@ -167,6 +170,18 @@ function getWindowsPathExtensions(value: string | undefined): string[] {
         .split(";")
         .map((entry) => entry.trim())
         .filter(Boolean);
+}
+
+function getWindowsEnvironmentValue(
+    env: NodeJS.ProcessEnv,
+    name: string,
+): string | undefined {
+    return (
+        env[name] ??
+        Object.entries(env).find(
+            ([key]) => key.toLowerCase() === name.toLowerCase(),
+        )?.[1]
+    );
 }
 
 function isFile(candidatePath: string): boolean {

--- a/src/main/shell/command-launch.ts
+++ b/src/main/shell/command-launch.ts
@@ -6,6 +6,16 @@ import type {
 } from "node:child_process";
 
 type CommandLaunchOptions = SpawnOptions | ExecFileOptions;
+type WindowsShellOptions<
+    TOptions extends CommandLaunchOptions | undefined,
+> = (TOptions extends undefined
+    ? CommandLaunchOptions
+    : Omit<TOptions, "windowsVerbatimArguments">) & {
+    readonly windowsVerbatimArguments: true;
+};
+type PreparedLaunchOptions<
+    TOptions extends CommandLaunchOptions | undefined,
+> = TOptions | WindowsShellOptions<TOptions>;
 
 export interface PrepareCommandLaunchOptions {
     readonly env?: NodeJS.ProcessEnv;
@@ -20,7 +30,7 @@ export interface PreparedCommandLaunch<
 > {
     readonly command: string;
     readonly args: string[];
-    readonly options: TOptions;
+    readonly options: PreparedLaunchOptions<TOptions>;
     readonly wrappedByWindowsShell: boolean;
 }
 
@@ -98,9 +108,18 @@ function prepareCommandLaunch<
             buildWindowsBatchCommandLine(resolvedCommand, args),
         ],
         command: "cmd.exe",
-        options,
+        options: withWindowsVerbatimArguments(options),
         wrappedByWindowsShell: true,
     };
+}
+
+function withWindowsVerbatimArguments<
+    TOptions extends CommandLaunchOptions | undefined,
+>(options: TOptions): WindowsShellOptions<TOptions> {
+    return {
+        ...(options ?? {}),
+        windowsVerbatimArguments: true,
+    } as WindowsShellOptions<TOptions>;
 }
 
 function resolveWindowsBatchCommand(

--- a/src/main/shell/command-launch.ts
+++ b/src/main/shell/command-launch.ts
@@ -104,6 +104,7 @@ function prepareCommandLaunch<
         args: [
             "/d",
             "/s",
+            "/v:off",
             "/c",
             buildWindowsBatchCommandLine(resolvedCommand, args),
         ],
@@ -223,9 +224,26 @@ function buildWindowsBatchCommandLine(
 }
 
 function quoteWindowsCmdArgument(value: string): string {
-    const escapedValue = value
-        .replace(/"/g, '\\"')
-        .replace(/([&|<>()^%!])/g, "^$1");
+    let escapedValue = "";
+    let backslashCount = 0;
+
+    for (const character of value) {
+        if (character === "\\") {
+            backslashCount += 1;
+            continue;
+        }
+
+        if (character === '"') {
+            escapedValue += `${"\\".repeat(backslashCount * 2 + 1)}"`;
+            backslashCount = 0;
+            continue;
+        }
+
+        escapedValue += `${"\\".repeat(backslashCount)}${character}`;
+        backslashCount = 0;
+    }
+
+    escapedValue += "\\".repeat(backslashCount * 2);
 
     return `"${escapedValue}"`;
 }

--- a/src/main/shell/command-launch.ts
+++ b/src/main/shell/command-launch.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type {
     ExecFileOptions,
@@ -7,6 +8,8 @@ import type {
 type CommandLaunchOptions = SpawnOptions | ExecFileOptions;
 
 export interface PrepareCommandLaunchOptions {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly pathEntries?: readonly string[];
     readonly platform?: NodeJS.Platform;
 }
 
@@ -77,7 +80,8 @@ function prepareCommandLaunch<
     launchOptions: PrepareCommandLaunchOptions,
 ): PreparedCommandLaunch<TOptions> {
     const platform = launchOptions.platform ?? process.platform;
-    if (platform !== "win32" || !isWindowsBatchCommand(command)) {
+    const resolvedCommand = resolveWindowsBatchCommand(command, launchOptions);
+    if (platform !== "win32" || !resolvedCommand) {
         return {
             args: [...args],
             command,
@@ -87,11 +91,90 @@ function prepareCommandLaunch<
     }
 
     return {
-        args: ["/d", "/s", "/c", buildWindowsBatchCommandLine(command, args)],
+        args: [
+            "/d",
+            "/s",
+            "/c",
+            buildWindowsBatchCommandLine(resolvedCommand, args),
+        ],
         command: "cmd.exe",
         options,
         wrappedByWindowsShell: true,
     };
+}
+
+function resolveWindowsBatchCommand(
+    command: string,
+    launchOptions: PrepareCommandLaunchOptions,
+): string | null {
+    const platform = launchOptions.platform ?? process.platform;
+    if (platform !== "win32") {
+        return null;
+    }
+
+    if (isWindowsBatchCommand(command)) {
+        return command;
+    }
+
+    const resolvedCommand = resolveWindowsPathExtCommand(command, launchOptions);
+    return resolvedCommand && isWindowsBatchCommand(resolvedCommand)
+        ? resolvedCommand
+        : null;
+}
+
+function resolveWindowsPathExtCommand(
+    command: string,
+    launchOptions: PrepareCommandLaunchOptions,
+): string | null {
+    const env = launchOptions.env ?? process.env;
+    const pathEntries =
+        launchOptions.pathEntries ?? splitWindowsPathEntries(env.PATH);
+    const extensions = getWindowsPathExtensions(env.PATHEXT);
+    const searchEntries = hasPathDirectory(command) ? [""] : pathEntries;
+
+    for (const entry of searchEntries) {
+        for (const extension of extensions) {
+            if (path.win32.extname(command)) {
+                continue;
+            }
+            const candidate = entry
+                ? path.join(entry, `${command}${extension}`)
+                : `${command}${extension}`;
+            if (isFile(candidate)) {
+                return candidate;
+            }
+        }
+    }
+
+    return null;
+}
+
+function hasPathDirectory(command: string): boolean {
+    return (
+        path.isAbsolute(command) ||
+        path.win32.isAbsolute(command) ||
+        command.includes("/") ||
+        command.includes("\\")
+    );
+}
+
+function splitWindowsPathEntries(value: string | undefined): string[] {
+    return value?.split(";").filter(Boolean) ?? [];
+}
+
+function getWindowsPathExtensions(value: string | undefined): string[] {
+    return (value ?? ".EXE;.CMD;.BAT;.COM")
+        .split(";")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+}
+
+function isFile(candidatePath: string): boolean {
+    try {
+        return fs.statSync(candidatePath).isFile();
+    } catch {
+        return false;
+    }
 }
 
 function buildWindowsBatchCommandLine(

--- a/src/main/shell/command-launch.ts
+++ b/src/main/shell/command-launch.ts
@@ -21,12 +21,12 @@ export interface PreparedCommandLaunch<
     readonly wrappedByWindowsShell: boolean;
 }
 
-export function prepareCommandForSpawn(
+export function prepareCommandForSpawn<TOptions extends SpawnOptions>(
     command: string,
     args: readonly string[],
-    options: SpawnOptions,
+    options: TOptions,
     launchOptions?: PrepareCommandLaunchOptions,
-): PreparedCommandLaunch<SpawnOptions>;
+): PreparedCommandLaunch<TOptions>;
 export function prepareCommandForSpawn(
     command: string,
     args?: readonly string[],
@@ -42,12 +42,12 @@ export function prepareCommandForSpawn(
     return prepareCommandLaunch(command, args, options, launchOptions);
 }
 
-export function prepareCommandForExecFile(
+export function prepareCommandForExecFile<TOptions extends ExecFileOptions>(
     command: string,
     args: readonly string[],
-    options: ExecFileOptions,
+    options: TOptions,
     launchOptions?: PrepareCommandLaunchOptions,
-): PreparedCommandLaunch<ExecFileOptions>;
+): PreparedCommandLaunch<TOptions>;
 export function prepareCommandForExecFile(
     command: string,
     args?: readonly string[],

--- a/src/main/shell/command-launch.ts
+++ b/src/main/shell/command-launch.ts
@@ -1,0 +1,114 @@
+import path from "node:path";
+import type {
+    ExecFileOptions,
+    SpawnOptions,
+} from "node:child_process";
+
+type CommandLaunchOptions = SpawnOptions | ExecFileOptions;
+
+export interface PrepareCommandLaunchOptions {
+    readonly platform?: NodeJS.Platform;
+}
+
+export interface PreparedCommandLaunch<
+    TOptions extends CommandLaunchOptions | undefined =
+        | CommandLaunchOptions
+        | undefined,
+> {
+    readonly command: string;
+    readonly args: string[];
+    readonly options: TOptions;
+    readonly wrappedByWindowsShell: boolean;
+}
+
+export function prepareCommandForSpawn(
+    command: string,
+    args: readonly string[],
+    options: SpawnOptions,
+    launchOptions?: PrepareCommandLaunchOptions,
+): PreparedCommandLaunch<SpawnOptions>;
+export function prepareCommandForSpawn(
+    command: string,
+    args?: readonly string[],
+    options?: undefined,
+    launchOptions?: PrepareCommandLaunchOptions,
+): PreparedCommandLaunch<undefined>;
+export function prepareCommandForSpawn(
+    command: string,
+    args: readonly string[] = [],
+    options?: SpawnOptions,
+    launchOptions: PrepareCommandLaunchOptions = {},
+): PreparedCommandLaunch<SpawnOptions | undefined> {
+    return prepareCommandLaunch(command, args, options, launchOptions);
+}
+
+export function prepareCommandForExecFile(
+    command: string,
+    args: readonly string[],
+    options: ExecFileOptions,
+    launchOptions?: PrepareCommandLaunchOptions,
+): PreparedCommandLaunch<ExecFileOptions>;
+export function prepareCommandForExecFile(
+    command: string,
+    args?: readonly string[],
+    options?: undefined,
+    launchOptions?: PrepareCommandLaunchOptions,
+): PreparedCommandLaunch<undefined>;
+export function prepareCommandForExecFile(
+    command: string,
+    args: readonly string[] = [],
+    options?: ExecFileOptions,
+    launchOptions: PrepareCommandLaunchOptions = {},
+): PreparedCommandLaunch<ExecFileOptions | undefined> {
+    return prepareCommandLaunch(command, args, options, launchOptions);
+}
+
+export function isWindowsBatchCommand(command: string): boolean {
+    const extension = path.win32.extname(command).toLowerCase();
+    return extension === ".cmd" || extension === ".bat";
+}
+
+function prepareCommandLaunch<
+    TOptions extends CommandLaunchOptions | undefined,
+>(
+    command: string,
+    args: readonly string[],
+    options: TOptions,
+    launchOptions: PrepareCommandLaunchOptions,
+): PreparedCommandLaunch<TOptions> {
+    const platform = launchOptions.platform ?? process.platform;
+    if (platform !== "win32" || !isWindowsBatchCommand(command)) {
+        return {
+            args: [...args],
+            command,
+            options,
+            wrappedByWindowsShell: false,
+        };
+    }
+
+    return {
+        args: ["/d", "/s", "/c", buildWindowsBatchCommandLine(command, args)],
+        command: "cmd.exe",
+        options,
+        wrappedByWindowsShell: true,
+    };
+}
+
+function buildWindowsBatchCommandLine(
+    command: string,
+    args: readonly string[],
+): string {
+    const innerCommandLine = [command, ...args]
+        .map(quoteWindowsCmdArgument)
+        .join(" ");
+
+    return `"${innerCommandLine}"`;
+}
+
+function quoteWindowsCmdArgument(value: string): string {
+    const escapedValue = value
+        .replace(/"/g, '\\"')
+        .replace(/([&|<>()^%!])/g, "^$1");
+
+    return `"${escapedValue}"`;
+}

--- a/src/main/shell/command-launch.ts
+++ b/src/main/shell/command-launch.ts
@@ -239,6 +239,12 @@ function quoteWindowsCmdArgument(value: string): string {
             continue;
         }
 
+        if (character === "%") {
+            escapedValue += `${"\\".repeat(backslashCount)}"^%"`;
+            backslashCount = 0;
+            continue;
+        }
+
         escapedValue += `${"\\".repeat(backslashCount)}${character}`;
         backslashCount = 0;
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,6 @@ export default defineConfig({
     },
     test: {
         environment: "node",
-        include: ["src/**/*.test.{ts,tsx}"],
+        include: ["src/**/*.test.{ts,tsx}", "scripts/**/*.test.mjs"],
     },
 });


### PR DESCRIPTION
## Summary
- add a shared command launch helper for Windows batch shims and PATHEXT resolution
- route AI runtimes, ACP terminal commands, auth flows, and packaging scripts through the Windows-safe launch path
- harden Windows login quoting and spawn error handling
- cover runtime/script quoting parity, env casing, PATHEXT, and auth spawn failures

## Verification
- pnpm vitest run src/main/shell/command-launch.test.ts scripts/ai/_shared.test.mjs
- pnpm run typecheck
- pnpm test
- node --check scripts/ai/_shared.mjs scripts/package-windows-app.mjs scripts/build-windows-acp-bundles.mjs scripts/package-macos-app.mjs