### PR TITLE
Fix GitHub request timeouts and remote detection

### DIFF
--- a/src/main/git/diff.test.ts
+++ b/src/main/git/diff.test.ts
@@ -26,7 +26,11 @@ describe("getGitFileDiff", () => {
                     _args: readonly string[],
                     options: { readonly timeout?: number },
                     callback: (
-                        error: NodeJS.ErrnoException,
+                        error: Error & {
+                            code?: number | string | null;
+                            killed?: boolean;
+                            signal?: NodeJS.Signals | null;
+                        },
                         stdout: string,
                         stderr: string,
                     ) => void,
@@ -34,8 +38,14 @@ describe("getGitFileDiff", () => {
                     setTimeout(() => {
                         const error = new Error(
                             "Command failed: git diff --no-index",
-                        ) as NodeJS.ErrnoException;
-                        error.code = "ETIMEDOUT";
+                        ) as Error & {
+                            code: string | null;
+                            killed: boolean;
+                            signal: NodeJS.Signals;
+                        };
+                        error.code = null;
+                        error.killed = true;
+                        error.signal = "SIGTERM";
                         callback(error, "", "");
                     }, options.timeout);
                 },

--- a/src/main/git/diff.test.ts
+++ b/src/main/git/diff.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+    execFile: execFileMock,
+}));
+
+import { getGitFileDiff } from "./diff";
+
+describe("getGitFileDiff", () => {
+    it("times out and reports a clear error for hung untracked no-index diffs", async () => {
+        vi.useFakeTimers();
+        const rootPath = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-git-diff-test-"),
+        );
+
+        try {
+            execFileMock.mockImplementation(
+                (
+                    _command: string,
+                    _args: readonly string[],
+                    options: { readonly timeout?: number },
+                    callback: (
+                        error: NodeJS.ErrnoException,
+                        stdout: string,
+                        stderr: string,
+                    ) => void,
+                ) => {
+                    setTimeout(() => {
+                        const error = new Error(
+                            "Command failed: git diff --no-index",
+                        ) as NodeJS.ErrnoException;
+                        error.code = "ETIMEDOUT";
+                        callback(error, "", "");
+                    }, options.timeout);
+                },
+            );
+
+            const diffPromise = getGitFileDiff(rootPath, "new-file.txt", {
+                kind: "untracked",
+                scope: "untracked",
+            });
+            const assertion = expect(diffPromise).rejects.toThrow(
+                "Git diff timed out while reading the untracked file.",
+            );
+
+            await vi.advanceTimersByTimeAsync(30_000);
+
+            await assertion;
+            expect(execFileMock).toHaveBeenCalledWith(
+                "git",
+                expect.arrayContaining(["diff", "--no-index"]),
+                expect.objectContaining({
+                    killSignal: "SIGTERM",
+                    timeout: 30_000,
+                }),
+                expect.any(Function),
+            );
+        } finally {
+            vi.useRealTimers();
+            fs.rmSync(rootPath, { force: true, recursive: true });
+        }
+    });
+});

--- a/src/main/git/diff.ts
+++ b/src/main/git/diff.ts
@@ -18,6 +18,7 @@ import type {
 
 const execFileAsync = promisify(execFile);
 const GIT_DIFF_MAX_BUFFER_BYTES = 20 * 1024 * 1024;
+const GIT_UNTRACKED_DIFF_TIMEOUT_MS = 30_000;
 
 export async function getGitFileDiff(
     rootPath: string,
@@ -234,10 +235,19 @@ async function runGitDiff(
         const result = await execFileAsync("git", [...args], {
             cwd: rootPath,
             encoding: "utf8",
+            killSignal: "SIGTERM",
             maxBuffer: GIT_DIFF_MAX_BUFFER_BYTES,
+            timeout: GIT_UNTRACKED_DIFF_TIMEOUT_MS,
         });
         return result.stdout;
     } catch (error) {
+        if (isGitDiffTimeoutError(error)) {
+            throw new Error(
+                "Git diff timed out while reading the untracked file. The file may be too large or locked.",
+                { cause: error },
+            );
+        }
+
         if (
             isGitExecError(error) &&
             error.code === 1 &&
@@ -248,6 +258,13 @@ async function runGitDiff(
 
         throw error;
     }
+}
+
+function isGitDiffTimeoutError(error: unknown): boolean {
+    return (
+        isGitExecError(error) &&
+        (error.code === "ETIMEDOUT" || error.signal === "SIGTERM")
+    );
 }
 
 async function detectGitChangeKind(
@@ -322,11 +339,16 @@ function normalizeSafeGitPath(filePath: string): string {
 
 function isGitExecError(
     error: unknown,
-): error is Error & { readonly code: number; readonly stdout?: unknown } {
+): error is Error & {
+    readonly code: number | string;
+    readonly signal?: unknown;
+    readonly stdout?: unknown;
+} {
     return (
         error instanceof Error &&
         "code" in error &&
-        typeof (error as { readonly code?: unknown }).code === "number"
+        (typeof (error as { readonly code?: unknown }).code === "number" ||
+            typeof (error as { readonly code?: unknown }).code === "string")
     );
 }
 

--- a/src/main/git/diff.ts
+++ b/src/main/git/diff.ts
@@ -261,9 +261,13 @@ async function runGitDiff(
 }
 
 function isGitDiffTimeoutError(error: unknown): boolean {
+    if (!isGitProcessError(error)) {
+        return false;
+    }
+
     return (
-        isGitExecError(error) &&
-        (error.code === "ETIMEDOUT" || error.signal === "SIGTERM")
+        error.code === "ETIMEDOUT" ||
+        (error.signal === "SIGTERM" && error.killed === true)
     );
 }
 
@@ -341,15 +345,21 @@ function isGitExecError(
     error: unknown,
 ): error is Error & {
     readonly code: number | string;
-    readonly signal?: unknown;
     readonly stdout?: unknown;
 } {
     return (
-        error instanceof Error &&
-        "code" in error &&
-        (typeof (error as { readonly code?: unknown }).code === "number" ||
-            typeof (error as { readonly code?: unknown }).code === "string")
+        isGitProcessError(error) &&
+        (typeof error.code === "number" || typeof error.code === "string")
     );
+}
+
+function isGitProcessError(error: unknown): error is Error & {
+    readonly code?: number | string | null;
+    readonly killed?: unknown;
+    readonly signal?: unknown;
+    readonly stdout?: unknown;
+} {
+    return error instanceof Error;
 }
 
 interface MutableGitFileDiffHunk {

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -48,6 +48,28 @@ describe("GitHubApiClient", () => {
         });
     });
 
+    it("aborts pending REST response bodies after the request timeout", async () => {
+        let requestSignal: AbortSignal | undefined;
+        const fetchMock = vi.fn<GitHubFetch>((_, init) =>
+            Promise.resolve(
+                pendingAbortableBodyResponse(init, (signal) => {
+                    requestSignal = signal;
+                }),
+            ),
+        );
+        const client = new GitHubApiClient({
+            fetch: fetchMock,
+            requestTimeoutMs: 10,
+            token: "ghp_test",
+        });
+
+        await expect(client.listIssues({ repository })).rejects.toMatchObject({
+            code: "timeout",
+            message: "GitHub request timed out.",
+        });
+        expect(requestSignal?.aborted).toBe(true);
+    });
+
     it("aborts pending GraphQL requests after the request timeout", async () => {
         let requestSignal: AbortSignal | undefined;
         const fetchMock = vi
@@ -59,6 +81,39 @@ describe("GitHubApiClient", () => {
                 pendingAbortableResponse(init, (signal) => {
                     requestSignal = signal;
                 }),
+            );
+        const client = new GitHubApiClient({
+            fetch: fetchMock,
+            requestTimeoutMs: 10,
+            token: "ghp_test",
+        });
+
+        await expect(
+            client.setPullRequestDraftState({
+                draft: true,
+                number: 7,
+                repository,
+            }),
+        ).rejects.toMatchObject({
+            code: "timeout",
+            message: "GitHub request timed out.",
+        });
+        expect(requestSignal?.aborted).toBe(true);
+    });
+
+    it("aborts pending GraphQL response bodies after the request timeout", async () => {
+        let requestSignal: AbortSignal | undefined;
+        const fetchMock = vi
+            .fn<GitHubFetch>()
+            .mockResolvedValueOnce(jsonResponse(rawPullRequest()))
+            .mockResolvedValueOnce(jsonResponse([]))
+            .mockResolvedValueOnce(jsonResponse([]))
+            .mockImplementation((_, init) =>
+                Promise.resolve(
+                    pendingAbortableBodyResponse(init, (signal) => {
+                        requestSignal = signal;
+                    }),
+                ),
             );
         const client = new GitHubApiClient({
             fetch: fetchMock,
@@ -90,6 +145,27 @@ function pendingAbortableResponse(
         signal?.addEventListener("abort", () => {
             reject(new DOMException("The operation was aborted.", "AbortError"));
         });
+    });
+}
+
+function pendingAbortableBodyResponse(
+    init: RequestInit | undefined,
+    onSignal: (signal: AbortSignal | undefined) => void,
+): Response {
+    const signal = init?.signal ?? undefined;
+    onSignal(signal);
+    const body = new ReadableStream({
+        start(controller) {
+            signal?.addEventListener("abort", () => {
+                controller.error(
+                    new DOMException("The operation was aborted.", "AbortError"),
+                );
+            });
+        },
+    });
+    return new Response(body, {
+        headers: { "content-type": "application/json" },
+        status: 200,
     });
 }
 

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+    GitHubApiClient,
+    type GitHubFetch,
+} from "@main/github/client";
+
+const repository = {
+    host: "github.com",
+    owner: "octocat",
+    repo: "hello-world",
+};
+
+describe("GitHubApiClient", () => {
+    it("aborts pending REST requests after the request timeout", async () => {
+        let requestSignal: AbortSignal | undefined;
+        const fetchMock = vi.fn<GitHubFetch>((_, init) =>
+            pendingAbortableResponse(init, (signal) => {
+                requestSignal = signal;
+            }),
+        );
+        const client = new GitHubApiClient({
+            fetch: fetchMock,
+            requestTimeoutMs: 10,
+            token: "ghp_test",
+        });
+
+        await expect(client.listIssues({ repository })).rejects.toMatchObject({
+            code: "timeout",
+            message: "GitHub request timed out.",
+        });
+        expect(requestSignal?.aborted).toBe(true);
+    });
+
+    it("maps explicit fetch aborts to timeout errors", async () => {
+        const fetchMock = vi.fn<GitHubFetch>().mockRejectedValue(
+            new DOMException("The operation was aborted.", "AbortError"),
+        );
+        const client = new GitHubApiClient({
+            fetch: fetchMock,
+            requestTimeoutMs: 1_000,
+            token: "ghp_test",
+        });
+
+        await expect(client.listIssues({ repository })).rejects.toMatchObject({
+            code: "timeout",
+            message: "GitHub request timed out.",
+        });
+    });
+
+    it("aborts pending GraphQL requests after the request timeout", async () => {
+        let requestSignal: AbortSignal | undefined;
+        const fetchMock = vi
+            .fn<GitHubFetch>()
+            .mockResolvedValueOnce(jsonResponse(rawPullRequest()))
+            .mockResolvedValueOnce(jsonResponse([]))
+            .mockResolvedValueOnce(jsonResponse([]))
+            .mockImplementation((_, init) =>
+                pendingAbortableResponse(init, (signal) => {
+                    requestSignal = signal;
+                }),
+            );
+        const client = new GitHubApiClient({
+            fetch: fetchMock,
+            requestTimeoutMs: 10,
+            token: "ghp_test",
+        });
+
+        await expect(
+            client.setPullRequestDraftState({
+                draft: true,
+                number: 7,
+                repository,
+            }),
+        ).rejects.toMatchObject({
+            code: "timeout",
+            message: "GitHub request timed out.",
+        });
+        expect(requestSignal?.aborted).toBe(true);
+    });
+});
+
+function pendingAbortableResponse(
+    init: RequestInit | undefined,
+    onSignal: (signal: AbortSignal | undefined) => void,
+): Promise<Response> {
+    const signal = init?.signal ?? undefined;
+    onSignal(signal);
+    return new Promise<Response>((_, reject) => {
+        signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+    });
+}
+
+function jsonResponse(body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+    });
+}
+
+function rawPullRequest() {
+    return {
+        base: rawPullRequestRef("main"),
+        body: "",
+        closed_at: null,
+        comments: 0,
+        created_at: "2026-05-07T00:00:00Z",
+        draft: false,
+        head: rawPullRequestRef("feature/demo"),
+        html_url: "https://github.com/octocat/hello-world/pull/7",
+        id: 7,
+        labels: [],
+        mergeable: true,
+        merged_at: null,
+        node_id: "PR_7",
+        number: 7,
+        state: "open",
+        title: "Pull request",
+        updated_at: "2026-05-07T00:00:00Z",
+        user: rawUser(),
+    };
+}
+
+function rawPullRequestRef(ref: string) {
+    return {
+        label: `octocat:${ref}`,
+        ref,
+        repo: {
+            full_name: "octocat/hello-world",
+            name: "hello-world",
+            owner: rawUser(),
+        },
+        sha: "abc1234",
+    };
+}
+
+function rawUser() {
+    return {
+        avatar_url: "https://avatars.githubusercontent.com/u/1",
+        html_url: "https://github.com/octocat",
+        id: 1,
+        login: "octocat",
+    };
+}

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -76,6 +76,7 @@ import type {
 // Skip per-commit stats enrichment for PRs above this size to avoid
 // flooding the GitHub API with N detail requests for very large PRs.
 const PR_COMMIT_STATS_LIMIT = 50;
+const GITHUB_REQUEST_TIMEOUT_MS = 15_000;
 
 export type GitHubFetch = (
     input: string | URL,
@@ -84,6 +85,7 @@ export type GitHubFetch = (
 
 interface GitHubApiClientOptions {
     readonly fetch?: GitHubFetch;
+    readonly requestTimeoutMs?: number;
     readonly token: string;
 }
 
@@ -389,10 +391,13 @@ export class GitHubApiError extends Error {
 
 export class GitHubApiClient {
     readonly #fetch: GitHubFetch;
+    readonly #requestTimeoutMs: number;
     readonly #token: string;
 
     constructor(options: GitHubApiClientOptions) {
         this.#fetch = options.fetch ?? fetch;
+        this.#requestTimeoutMs =
+            options.requestTimeoutMs ?? GITHUB_REQUEST_TIMEOUT_MS;
         this.#token = options.token;
     }
 
@@ -1207,25 +1212,29 @@ export class GitHubApiClient {
     ): Promise<void> {
         const host = normalizeGitHubHost(hostInput);
         const url = buildGitHubGraphQlUrl(host);
-        const response = await this.#fetch(url, {
-            body: JSON.stringify({ query, variables }),
-            headers: this.#buildHeaders({ contentType: true }),
-            method: "POST",
-        });
-        const data = (await response.json().catch(() => null)) as
-            | RawGraphQlResponse
-            | null;
-        if (!response.ok) {
-            throw buildGitHubApiError(response, data);
-        }
-        if (data?.errors?.length) {
-            throw new GitHubApiError(
-                data.errors
-                    .map((error) => error.message ?? "GraphQL error")
-                    .join("; "),
-                "forbidden",
-                response.status,
-            );
+        try {
+            const response = await this.#fetchWithTimeout(url, {
+                body: JSON.stringify({ query, variables }),
+                headers: this.#buildHeaders({ contentType: true }),
+                method: "POST",
+            });
+            const data = (await response.json().catch(() => null)) as
+                | RawGraphQlResponse
+                | null;
+            if (!response.ok) {
+                throw buildGitHubApiError(response, data);
+            }
+            if (data?.errors?.length) {
+                throw new GitHubApiError(
+                    data.errors
+                        .map((error) => error.message ?? "GraphQL error")
+                        .join("; "),
+                    "forbidden",
+                    response.status,
+                );
+            }
+        } catch (error) {
+            throw normalizeGitHubFetchError(error);
         }
     }
 
@@ -1250,7 +1259,7 @@ export class GitHubApiClient {
         }
 
         try {
-            const response = await this.#fetch(url, {
+            const response = await this.#fetchWithTimeout(url, {
                 body:
                     options.body === undefined
                         ? undefined
@@ -1270,11 +1279,7 @@ export class GitHubApiClient {
             if (error instanceof GitHubApiError) {
                 throw error;
             }
-            throw new GitHubApiError(
-                "GitHub could not be reached.",
-                "network_error",
-                null,
-            );
+            throw normalizeGitHubFetchError(error);
         }
     }
 
@@ -1293,7 +1298,7 @@ export class GitHubApiClient {
         }
 
         try {
-            const response = await this.#fetch(url, {
+            const response = await this.#fetchWithTimeout(url, {
                 body:
                     options.body === undefined
                         ? undefined
@@ -1313,11 +1318,27 @@ export class GitHubApiClient {
             if (error instanceof GitHubApiError) {
                 throw error;
             }
-            throw new GitHubApiError(
-                "GitHub could not be reached.",
-                "network_error",
-                null,
-            );
+            throw normalizeGitHubFetchError(error);
+        }
+    }
+
+    async #fetchWithTimeout(
+        input: string | URL,
+        init: RequestInit,
+    ): Promise<Response> {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => {
+            controller.abort();
+        }, this.#requestTimeoutMs);
+        timeout.unref?.();
+
+        try {
+            return await this.#fetch(input, {
+                ...init,
+                signal: controller.signal,
+            });
+        } finally {
+            clearTimeout(timeout);
         }
     }
 
@@ -1358,6 +1379,31 @@ function buildGitHubApiError(response: Response, body: unknown): GitHubApiError 
     }
 
     return new GitHubApiError(message, "unknown", response.status);
+}
+
+function normalizeGitHubFetchError(error: unknown): GitHubApiError {
+    if (error instanceof GitHubApiError) {
+        return error;
+    }
+
+    if (isAbortError(error)) {
+        return new GitHubApiError("GitHub request timed out.", "timeout", null);
+    }
+
+    return new GitHubApiError(
+        "GitHub could not be reached.",
+        "network_error",
+        null,
+    );
+}
+
+function isAbortError(error: unknown): boolean {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        "name" in error &&
+        error.name === "AbortError"
+    );
 }
 
 function readGitHubErrorMessage(body: unknown): string {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1213,14 +1213,20 @@ export class GitHubApiClient {
         const host = normalizeGitHubHost(hostInput);
         const url = buildGitHubGraphQlUrl(host);
         try {
-            const response = await this.#fetchWithTimeout(url, {
-                body: JSON.stringify({ query, variables }),
-                headers: this.#buildHeaders({ contentType: true }),
-                method: "POST",
-            });
-            const data = (await response.json().catch(() => null)) as
-                | RawGraphQlResponse
-                | null;
+            const { data, response } = await this.#withRequestTimeout(
+                async (signal) => {
+                    const response = await this.#fetch(url, {
+                        body: JSON.stringify({ query, variables }),
+                        headers: this.#buildHeaders({ contentType: true }),
+                        method: "POST",
+                        signal,
+                    });
+                    return {
+                        data: await readJsonResponse<RawGraphQlResponse>(response),
+                        response,
+                    };
+                },
+            );
             if (!response.ok) {
                 throw buildGitHubApiError(response, data);
             }
@@ -1259,17 +1265,25 @@ export class GitHubApiClient {
         }
 
         try {
-            const response = await this.#fetchWithTimeout(url, {
-                body:
-                    options.body === undefined
-                        ? undefined
-                        : JSON.stringify(options.body),
-                headers: this.#buildHeaders({
-                    contentType: options.body !== undefined,
-                }),
-                method: options.method ?? "GET",
-            });
-            const data = (await response.json().catch(() => null)) as T;
+            const { data, response } = await this.#withRequestTimeout(
+                async (signal) => {
+                    const response = await this.#fetch(url, {
+                        body:
+                            options.body === undefined
+                                ? undefined
+                                : JSON.stringify(options.body),
+                        headers: this.#buildHeaders({
+                            contentType: options.body !== undefined,
+                        }),
+                        method: options.method ?? "GET",
+                        signal,
+                    });
+                    return {
+                        data: (await readJsonResponse<T>(response)) as T,
+                        response,
+                    };
+                },
+            );
             if (!response.ok) {
                 throw buildGitHubApiError(response, data);
             }
@@ -1298,17 +1312,25 @@ export class GitHubApiClient {
         }
 
         try {
-            const response = await this.#fetchWithTimeout(url, {
-                body:
-                    options.body === undefined
-                        ? undefined
-                        : JSON.stringify(options.body),
-                headers: this.#buildHeaders({
-                    contentType: options.body !== undefined,
-                }),
-                method: options.method ?? "GET",
-            });
-            const text = await response.text().catch(() => "");
+            const { response, text } = await this.#withRequestTimeout(
+                async (signal) => {
+                    const response = await this.#fetch(url, {
+                        body:
+                            options.body === undefined
+                                ? undefined
+                                : JSON.stringify(options.body),
+                        headers: this.#buildHeaders({
+                            contentType: options.body !== undefined,
+                        }),
+                        method: options.method ?? "GET",
+                        signal,
+                    });
+                    return {
+                        response,
+                        text: await readTextResponse(response),
+                    };
+                },
+            );
             if (!response.ok) {
                 throw buildGitHubApiError(response, text);
             }
@@ -1322,10 +1344,9 @@ export class GitHubApiClient {
         }
     }
 
-    async #fetchWithTimeout(
-        input: string | URL,
-        init: RequestInit,
-    ): Promise<Response> {
+    async #withRequestTimeout<T>(
+        run: (signal: AbortSignal) => Promise<T>,
+    ): Promise<T> {
         const controller = new AbortController();
         const timeout = setTimeout(() => {
             controller.abort();
@@ -1333,10 +1354,7 @@ export class GitHubApiClient {
         timeout.unref?.();
 
         try {
-            return await this.#fetch(input, {
-                ...init,
-                signal: controller.signal,
-            });
+            return await run(controller.signal);
         } finally {
             clearTimeout(timeout);
         }
@@ -1395,6 +1413,28 @@ function normalizeGitHubFetchError(error: unknown): GitHubApiError {
         "network_error",
         null,
     );
+}
+
+async function readJsonResponse<T>(response: Response): Promise<T | null> {
+    try {
+        return (await response.json()) as T;
+    } catch (error) {
+        if (isAbortError(error)) {
+            throw error;
+        }
+        return null;
+    }
+}
+
+async function readTextResponse(response: Response): Promise<string> {
+    try {
+        return await response.text();
+    } catch (error) {
+        if (isAbortError(error)) {
+            throw error;
+        }
+        return "";
+    }
 }
 
 function isAbortError(error: unknown): boolean {

--- a/src/renderer/src/app/git/remote-link.test.ts
+++ b/src/renderer/src/app/git/remote-link.test.ts
@@ -53,6 +53,26 @@ describe("resolveGitHubRepositoryRef", () => {
         });
     });
 
+    it("falls back to a secondary GitHub remote when the default is not GitHub", () => {
+        const ref = resolveGitHubRepositoryRef([
+            createRemote({
+                fetchUrl: "https://gitlab.com/acme/other.git",
+                isDefault: true,
+                name: "upstream",
+            }),
+            createRemote({
+                fetchUrl: "https://github.com/comando/app.git",
+                name: "origin",
+            }),
+        ]);
+
+        expect(ref).toEqual({
+            host: "github.com",
+            owner: "comando",
+            repo: "app",
+        });
+    });
+
     it("returns null for non-GitHub remotes", () => {
         expect(
             resolveGitHubRepositoryRef([

--- a/src/renderer/src/app/git/remote-link.ts
+++ b/src/renderer/src/app/git/remote-link.ts
@@ -57,12 +57,27 @@ export function buildGitRemoteCommitLink(
 export function resolveGitHubRepositoryRef(
     remotes: readonly GitRemoteSummary[],
 ): GitHubRepositoryRef | null {
-    const remote =
-        remotes.find((candidate) => candidate.isDefault) ?? remotes[0] ?? null;
-    if (!remote) {
-        return null;
+    const defaultRemote = remotes.find((candidate) => candidate.isDefault);
+    const candidates = defaultRemote
+        ? [
+              defaultRemote,
+              ...remotes.filter((candidate) => candidate !== defaultRemote),
+          ]
+        : remotes;
+
+    for (const remote of candidates) {
+        const ref = parseGitHubRepositoryRef(remote);
+        if (ref) {
+            return ref;
+        }
     }
 
+    return null;
+}
+
+function parseGitHubRepositoryRef(
+    remote: GitRemoteSummary,
+): GitHubRepositoryRef | null {
     const rawUrl = remote.fetchUrl ?? remote.pushUrl;
     if (!rawUrl) {
         return null;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1058,6 +1058,7 @@ export type GitHubErrorCode =
     | "network_error"
     | "not_found"
     | "rate_limited"
+    | "timeout"
     | "unknown";
 
 export type GitHubIssueState = "closed" | "open";


### PR DESCRIPTION
## Summary

- Add bounded GitHub API requests with abort handling and a distinct timeout error code.
- Improve GitHub remote detection so the panel can use a secondary GitHub remote when the default remote points elsewhere.
- Add local timeout handling for untracked `git diff --no-index` execution, including clearer user-facing errors.
- Cover response body timeout handling and git diff timeout behavior with focused tests.

## Root Cause

GitHub panel requests and untracked file diffs relied on broader process or worker behavior instead of owning their own timeout/cancellation boundaries. Repositories with mixed remotes could also be misdetected because GitHub detection only considered the default or first remote.

## Impact

Issues, PRs, checks, and untracked diffs should recover more predictably under slow networks, hung GitHub responses, corporate proxy/VPN conditions, large files, or locked files. Repos with a non-GitHub default remote plus a GitHub secondary remote should now still enable GitHub features.

## Validation

- `pnpm exec vitest run src/main/github/client.test.ts src/main/github/service.test.ts`
- `pnpm exec vitest run src/renderer/src/app/git/remote-link.test.ts`
- `pnpm exec vitest run src/main/git/diff.test.ts src/main/git/service.test.ts`
- `pnpm run typecheck`
- targeted `eslint` on touched files during the branch work