### PR TITLE
Fix Windows test suite portability

### DIFF
--- a/src/main/ai/claude/setup.test.ts
+++ b/src/main/ai/claude/setup.test.ts
@@ -177,22 +177,15 @@ describe("Claude setup", () => {
         }
     });
 
-    it("resolves Claude with generic packaged embedded Node and vendor entry", () => {
+    it("resolves Claude with packaged embedded Node and vendor entry", () => {
         const tempRoot = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-claude-packaged-generic-"),
         );
         const packagedResourcesPath = path.join(tempRoot, "packaged");
 
         try {
-            const packagedNode = writeTestExecutable(
-                path.join(
-                    packagedResourcesPath,
-                    "ai",
-                    "embedded",
-                    "node",
-                    "bin",
-                ),
-                getNodeExecutableName(),
+            const packagedNode = writePackagedClaudeNodeFixture(
+                packagedResourcesPath,
             );
             const packagedEntry = path.join(
                 packagedResourcesPath,
@@ -744,4 +737,26 @@ function createFakeSecretStore(
 
 function getNodeExecutableName(): string {
     return process.platform === "win32" ? "node.exe" : "node";
+}
+
+function writePackagedClaudeNodeFixture(packagedResourcesPath: string): string {
+    const nodeDirectory =
+        process.platform === "darwin"
+            ? path.join(
+                  packagedResourcesPath,
+                  "ai",
+                  "embedded",
+                  "node",
+                  `darwin-${process.arch}`,
+                  "bin",
+              )
+            : path.join(
+                  packagedResourcesPath,
+                  "ai",
+                  "embedded",
+                  "node",
+                  "bin",
+              );
+
+    return writeTestExecutable(nodeDirectory, getNodeExecutableName());
 }

--- a/src/main/ai/claude/setup.test.ts
+++ b/src/main/ai/claude/setup.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { writeTestExecutable } from "@main/testing/executable-fixture";
+
 import {
     applyClaudeAuthEnv,
     buildClaudeSecretPatches,
@@ -119,14 +121,16 @@ describe("Claude setup", () => {
         );
 
         try {
-            const embeddedNode = path.join(
-                tempRoot,
-                "resources",
-                "ai",
-                "embedded",
-                "node",
-                "bin",
-                "node",
+            const embeddedNode = writeTestExecutable(
+                path.join(
+                    tempRoot,
+                    "resources",
+                    "ai",
+                    "embedded",
+                    "node",
+                    "bin",
+                ),
+                getNodeExecutableName(),
             );
             const embeddedEntry = path.join(
                 tempRoot,
@@ -138,20 +142,16 @@ describe("Claude setup", () => {
                 "index.js",
             );
 
-            fs.mkdirSync(path.dirname(embeddedNode), { recursive: true });
             fs.mkdirSync(path.dirname(embeddedEntry), { recursive: true });
             fs.mkdirSync(path.join(tempRoot, "resources", "ai"), {
                 recursive: true,
             });
-            fs.writeFileSync(embeddedNode, "#!/bin/sh\nexit 0\n", "utf8");
             fs.writeFileSync(embeddedEntry, "console.log('ok')\n", "utf8");
             fs.writeFileSync(
                 path.join(tempRoot, "package.json"),
                 '{"name":"comando-test"}\n',
                 "utf8",
             );
-            fs.chmodSync(embeddedNode, 0o755);
-
             const resolved = resolveClaudeRuntime(
                 createEmptyClaudeSettings(),
                 createFakeSecretStore(),
@@ -186,14 +186,16 @@ describe("Claude setup", () => {
         );
 
         try {
-            const embeddedNode = path.join(
-                tempRoot,
-                "resources",
-                "ai",
-                "embedded",
-                "node",
-                "bin",
-                "node",
+            writeTestExecutable(
+                path.join(
+                    tempRoot,
+                    "resources",
+                    "ai",
+                    "embedded",
+                    "node",
+                    "bin",
+                ),
+                getNodeExecutableName(),
             );
             const embeddedEntry = path.join(
                 tempRoot,
@@ -206,12 +208,9 @@ describe("Claude setup", () => {
             );
             const authFile = path.join(tempHome, ".claude.json");
 
-            fs.mkdirSync(path.dirname(embeddedNode), { recursive: true });
             fs.mkdirSync(path.dirname(embeddedEntry), { recursive: true });
-            fs.writeFileSync(embeddedNode, "#!/bin/sh\nexit 0\n", "utf8");
             fs.writeFileSync(embeddedEntry, "console.log('ok')\n", "utf8");
             fs.writeFileSync(authFile, '{"session":true}', "utf8");
-            fs.chmodSync(embeddedNode, 0o755);
 
             process.env.HOME = tempHome;
             delete process.env.USERPROFILE;
@@ -250,14 +249,16 @@ describe("Claude setup", () => {
         );
 
         try {
-            const embeddedNode = path.join(
-                tempRoot,
-                "resources",
-                "ai",
-                "embedded",
-                "node",
-                "bin",
-                "node",
+            writeTestExecutable(
+                path.join(
+                    tempRoot,
+                    "resources",
+                    "ai",
+                    "embedded",
+                    "node",
+                    "bin",
+                ),
+                getNodeExecutableName(),
             );
             const embeddedEntry = path.join(
                 tempRoot,
@@ -270,12 +271,9 @@ describe("Claude setup", () => {
             );
             const authFile = path.join(tempHome, ".claude.json");
 
-            fs.mkdirSync(path.dirname(embeddedNode), { recursive: true });
             fs.mkdirSync(path.dirname(embeddedEntry), { recursive: true });
-            fs.writeFileSync(embeddedNode, "#!/bin/sh\nexit 0\n", "utf8");
             fs.writeFileSync(embeddedEntry, "console.log('ok')\n", "utf8");
             fs.writeFileSync(authFile, '{"session":true}', "utf8");
-            fs.chmodSync(embeddedNode, 0o755);
 
             process.env.HOME = tempHome;
             delete process.env.USERPROFILE;
@@ -382,7 +380,9 @@ describe("Claude setup", () => {
         expect(status.authCredentialSource).toBe("environment");
     });
 
-    it("prefers packaged macOS architecture-specific Node when available", () => {
+    it.runIf(process.platform === "darwin")(
+        "prefers packaged macOS architecture-specific Node when available",
+        () => {
         const tempRoot = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-claude-packaged-"),
         );
@@ -430,7 +430,8 @@ describe("Claude setup", () => {
         } finally {
             fs.rmSync(tempRoot, { force: true, recursive: true });
         }
-    });
+        },
+    );
 
     it("injects Claude gateway and secrets without overwriting external values", () => {
         const secretStore = createFakeSecretStore({
@@ -690,4 +691,8 @@ function createFakeSecretStore(
             secrets.set(key, normalized);
         },
     };
+}
+
+function getNodeExecutableName(): string {
+    return process.platform === "win32" ? "node.exe" : "node";
 }

--- a/src/main/ai/claude/setup.test.ts
+++ b/src/main/ai/claude/setup.test.ts
@@ -177,6 +177,55 @@ describe("Claude setup", () => {
         }
     });
 
+    it("resolves Claude with generic packaged embedded Node and vendor entry", () => {
+        const tempRoot = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-claude-packaged-generic-"),
+        );
+        const packagedResourcesPath = path.join(tempRoot, "packaged");
+
+        try {
+            const packagedNode = writeTestExecutable(
+                path.join(
+                    packagedResourcesPath,
+                    "ai",
+                    "embedded",
+                    "node",
+                    "bin",
+                ),
+                getNodeExecutableName(),
+            );
+            const packagedEntry = path.join(
+                packagedResourcesPath,
+                "ai",
+                "embedded",
+                "claude-agent-acp",
+                "dist",
+                "index.js",
+            );
+
+            fs.mkdirSync(path.dirname(packagedEntry), { recursive: true });
+            fs.writeFileSync(packagedEntry, "console.log('ok')\n", "utf8");
+
+            const resolved = resolveClaudeRuntime(
+                createEmptyClaudeSettings(),
+                createFakeSecretStore(),
+                {
+                    allowPathFallback: false,
+                    appRoot: tempRoot,
+                    debugMode: false,
+                    packagedResourcesPath,
+                },
+            );
+
+            expect(resolved.program).toBe(packagedNode);
+            expect(resolved.args).toEqual([packagedEntry]);
+            expect(resolved.status.source).toBe("bundled");
+            expect(resolved.status.state).toBe("ready");
+        } finally {
+            fs.rmSync(tempRoot, { force: true, recursive: true });
+        }
+    });
+
     it("detects Claude auth from ~/.claude.json while respecting saved config", () => {
         const tempRoot = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-claude-auth-"),

--- a/src/main/ai/claude/setup.ts
+++ b/src/main/ai/claude/setup.ts
@@ -873,7 +873,9 @@ function resolveClaudeBinary(
     const configuredPath = settings.binaryPath?.trim() ?? "";
     const appRoot = options.appRoot ?? getAppRoot(options.currentFilePath);
     const packagedResourcesPath =
-        options.packagedResourcesPath ?? getPackagedResourcesPath();
+        options.packagedResourcesPath === undefined
+            ? getPackagedResourcesPath()
+            : options.packagedResourcesPath;
     const debugMode =
         options.debugMode ?? process.env.NODE_ENV !== "production";
     const bundledPath = getBundledClaudeCandidate(

--- a/src/main/ai/environment-diagnostics.test.ts
+++ b/src/main/ai/environment-diagnostics.test.ts
@@ -78,33 +78,33 @@ describe("AI environment diagnostics", () => {
             expect(diagnostics.checkedAt).toBe("2026-05-19T12:00:00.000Z");
             expect(diagnostics.path.inherited).toBe(binDir);
             expect(diagnostics.path.inheritedEntries).toEqual([binDir]);
-            expect(
-                diagnostics.executables.find(
-                    (entry) => entry.command === "codex-acp",
-                ),
-            ).toMatchObject({
-                path: codexPath,
+            const codexExecutable = diagnostics.executables.find(
+                (entry) => entry.command === "codex-acp",
+            );
+            expect(codexExecutable).toMatchObject({
                 source: "path",
                 state: "ready",
             });
-            expect(
-                diagnostics.runtimePathOverrides.find(
-                    (entry) => entry.name === "COMANDO_GEMINI_ACP_BIN",
-                ),
-            ).toMatchObject({
-                pathOrCommand: geminiPath,
+            expectPathToBe(codexExecutable?.path, codexPath);
+
+            const geminiOverride = diagnostics.runtimePathOverrides.find(
+                (entry) => entry.name === "COMANDO_GEMINI_ACP_BIN",
+            );
+            expect(geminiOverride).toMatchObject({
                 present: true,
                 runtimeId: "gemini",
             });
-            expect(
-                diagnostics.runtimePathOverrides.find(
-                    (entry) => entry.name === "COMANDO_GROK_ACP_BIN",
-                ),
-            ).toMatchObject({
-                pathOrCommand: grokPath,
+            expectPathToBe(geminiOverride?.pathOrCommand, geminiPath);
+
+            const grokOverride = diagnostics.runtimePathOverrides.find(
+                (entry) => entry.name === "COMANDO_GROK_ACP_BIN",
+            );
+            expect(grokOverride).toMatchObject({
                 present: true,
                 runtimeId: "grok",
             });
+            expectPathToBe(grokOverride?.pathOrCommand, grokPath);
+
             expect(
                 diagnostics.credentialEnvironment.find(
                     (entry) => entry.name === "CODEX_API_KEY",
@@ -113,50 +113,49 @@ describe("AI environment diagnostics", () => {
                 present: true,
                 runtimeId: "codex",
             });
-            expect(
-                diagnostics.runtimes.find(
-                    (runtime) => runtime.runtimeId === "codex",
-                ),
-            ).toMatchObject({
+            const codexRuntime = diagnostics.runtimes.find(
+                (runtime) => runtime.runtimeId === "codex",
+            );
+            expect(codexRuntime).toMatchObject({
                 authCredentialSource: "environment",
                 authMethod: "codex-api-key",
                 authReady: true,
-                command: codexPath,
-                executablePath: codexPath,
                 source: "env",
                 state: "ready",
             });
-            expect(
-                diagnostics.runtimes.find(
-                    (runtime) => runtime.runtimeId === "gemini",
-                ),
-            ).toMatchObject({
+            expectPathCommandToBe(codexRuntime?.command, codexPath);
+            expectPathToBe(codexRuntime?.executablePath, codexPath);
+
+            const geminiRuntime = diagnostics.runtimes.find(
+                (runtime) => runtime.runtimeId === "gemini",
+            );
+            expect(geminiRuntime).toMatchObject({
                 authCredentialSource: "environment",
                 authMethod: "use_gemini",
                 authReady: true,
-                command: `${geminiPath} --acp`,
-                executablePath: geminiPath,
                 source: "env",
                 state: "ready",
             });
+            expectPathCommandToBe(geminiRuntime?.command, `${geminiPath} --acp`);
+            expectPathToBe(geminiRuntime?.executablePath, geminiPath);
             expect(
-                diagnostics.runtimes.find(
-                    (runtime) => runtime.runtimeId === "gemini",
-                )?.preferredPathEntries[0],
+                geminiRuntime?.preferredPathEntries[0],
             ).toBe(binDir);
-            expect(
-                diagnostics.runtimes.find(
-                    (runtime) => runtime.runtimeId === "grok",
-                ),
-            ).toMatchObject({
+            const grokRuntime = diagnostics.runtimes.find(
+                (runtime) => runtime.runtimeId === "grok",
+            );
+            expect(grokRuntime).toMatchObject({
                 authCredentialSource: "environment",
                 authMethod: "xai-api-key",
                 authReady: true,
-                command: `${grokPath} --no-auto-update agent stdio`,
-                executablePath: grokPath,
                 source: "env",
                 state: "ready",
             });
+            expectPathCommandToBe(
+                grokRuntime?.command,
+                `${grokPath} --no-auto-update agent stdio`,
+            );
+            expectPathToBe(grokRuntime?.executablePath, grokPath);
             expect(
                 diagnostics.credentialEnvironment.find(
                     (entry) =>
@@ -167,19 +166,18 @@ describe("AI environment diagnostics", () => {
                 present: true,
                 runtimeId: "grok",
             });
-            expect(
-                diagnostics.runtimes.find(
-                    (runtime) => runtime.runtimeId === "opencode",
-                ),
-            ).toMatchObject({
+            const openCodeRuntime = diagnostics.runtimes.find(
+                (runtime) => runtime.runtimeId === "opencode",
+            );
+            expect(openCodeRuntime).toMatchObject({
                 authCredentialSource: "environment",
                 authMethod: "opencode-login",
                 authReady: true,
-                command: `${opencodePath} acp`,
-                executablePath: opencodePath,
                 source: "env",
                 state: "ready",
             });
+            expectPathCommandToBe(openCodeRuntime?.command, `${opencodePath} acp`);
+            expectPathToBe(openCodeRuntime?.executablePath, opencodePath);
             expect(
                 diagnostics.credentialEnvironment.find(
                     (entry) =>
@@ -242,20 +240,26 @@ describe("AI environment diagnostics", () => {
                 ),
             ).toMatchObject({
                 message: null,
-                path: grokPath,
                 source: "path",
                 state: "ready",
             });
-            expect(
-                diagnostics.runtimes.find(
-                    (runtime) => runtime.runtimeId === "grok",
-                ),
-            ).toMatchObject({
-                command: `${grokPath} --no-auto-update agent stdio`,
-                executablePath: grokPath,
+            const grokExecutable = diagnostics.executables.find(
+                (entry) => entry.command === "grok",
+            );
+            expectPathToBe(grokExecutable?.path, grokPath);
+
+            const grokRuntime = diagnostics.runtimes.find(
+                (runtime) => runtime.runtimeId === "grok",
+            );
+            expect(grokRuntime).toMatchObject({
                 source: "path",
                 state: "ready",
             });
+            expectPathCommandToBe(
+                grokRuntime?.command,
+                `${grokPath} --no-auto-update agent stdio`,
+            );
+            expectPathToBe(grokRuntime?.executablePath, grokPath);
         } finally {
             fs.rmSync(tempDir, { force: true, recursive: true });
         }
@@ -395,5 +399,29 @@ function createSecretStore(
             values[`${namespace}:${secretId}`] ?? null,
         saveSecret: () => undefined,
     };
+}
+
+function expectPathToBe(
+    actual: string | null | undefined,
+    expected: string,
+): void {
+    expect(normalizePathForComparison(actual)).toBe(
+        normalizePathForComparison(expected),
+    );
+}
+
+function expectPathCommandToBe(
+    actual: string | null | undefined,
+    expected: string,
+): void {
+    expect(normalizePathForComparison(actual)).toBe(
+        normalizePathForComparison(expected),
+    );
+}
+
+function normalizePathForComparison(value: string | null | undefined): string {
+    const normalized = path.normalize(value ?? "");
+
+    return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 

--- a/src/main/ai/environment-diagnostics.test.ts
+++ b/src/main/ai/environment-diagnostics.test.ts
@@ -424,4 +424,3 @@ function normalizePathForComparison(value: string | null | undefined): string {
 
     return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
-

--- a/src/main/ai/environment-diagnostics.test.ts
+++ b/src/main/ai/environment-diagnostics.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from "vitest";
 
 import type { AiSettingsSnapshot } from "@shared/ipc";
 
+import { writeTestExecutable } from "@main/testing/executable-fixture";
+
 import type { SecretStoreGateway } from "./secret-store";
 import { createAiEnvironmentDiagnostics } from "./environment-diagnostics";
 
@@ -22,12 +24,15 @@ describe("AI environment diagnostics", () => {
             fs.mkdirSync(homeDir, { recursive: true });
             fs.mkdirSync(binDir, { recursive: true });
 
-            const claudePath = writeExecutable(binDir, "claude-agent-acp");
-            const codexPath = writeExecutable(binDir, "codex-acp");
-            const geminiPath = writeExecutable(binDir, "gemini");
-            const grokPath = writeExecutable(binDir, "grok");
-            const kiloPath = writeExecutable(binDir, "kilo");
-            const opencodePath = writeExecutable(binDir, "opencode");
+            const claudePath = writeTestExecutable(
+                binDir,
+                "claude-agent-acp",
+            );
+            const codexPath = writeTestExecutable(binDir, "codex-acp");
+            const geminiPath = writeTestExecutable(binDir, "gemini");
+            const grokPath = writeTestExecutable(binDir, "grok");
+            const kiloPath = writeTestExecutable(binDir, "kilo");
+            const opencodePath = writeTestExecutable(binDir, "opencode");
             const diagnostics = createAiEnvironmentDiagnostics({
                 env: {
                     CODEX_API_KEY: "codex-secret-value",
@@ -212,7 +217,7 @@ describe("AI environment diagnostics", () => {
             const homeDir = path.join(tempDir, "home");
             const grokBinDir = path.join(homeDir, ".grok", "bin");
             fs.mkdirSync(grokBinDir, { recursive: true });
-            const grokPath = writeExecutable(grokBinDir, "grok");
+            const grokPath = writeTestExecutable(grokBinDir, "grok");
 
             const diagnostics = createAiEnvironmentDiagnostics({
                 env: {
@@ -392,16 +397,3 @@ function createSecretStore(
     };
 }
 
-function writeExecutable(directory: string, name: string): string {
-    const executableName = process.platform === "win32" ? `${name}.cmd` : name;
-    const executablePath = path.join(directory, executableName);
-    const content =
-        process.platform === "win32"
-            ? "@echo off\r\nexit /b 0\r\n"
-            : "#!/bin/sh\nexit 0\n";
-
-    fs.writeFileSync(executablePath, content, "utf8");
-    fs.chmodSync(executablePath, 0o755);
-
-    return executablePath;
-}

--- a/src/main/ai/gemini/setup.test.ts
+++ b/src/main/ai/gemini/setup.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { SecretStoreService } from "../secret-store";
+import { writeTestExecutable } from "@main/testing/executable-fixture";
 import {
     applyGeminiAuthEnv,
     detectGeminiAuthMethod,
@@ -73,9 +74,7 @@ describe("Gemini setup", () => {
         );
 
         try {
-            const binaryPath = path.join(tempDir, "custom-gemini");
-            fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(binaryPath, 0o755);
+            const binaryPath = writeTestExecutable(tempDir, "custom-gemini");
             process.env.COMANDO_GEMINI_ACP_BIN = binaryPath;
             process.env.PATH = "";
 
@@ -100,9 +99,7 @@ describe("Gemini setup", () => {
         );
 
         try {
-            const binaryPath = path.join(tempDir, "gemini");
-            fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(binaryPath, 0o755);
+            const binaryPath = writeTestExecutable(tempDir, "gemini");
             process.env.PATH = tempDir;
 
             const fromSettings = resolveGeminiRuntime(
@@ -167,13 +164,12 @@ describe("Gemini setup", () => {
         );
 
         try {
-            const binaryPath = path.join(tempDir, "gemini");
+            const binaryPath = writeTestExecutable(tempDir, "gemini");
             const tempHome = path.join(tempDir, "home");
             const settingsDir = path.join(tempHome, ".gemini");
             const settingsPath = path.join(settingsDir, "settings.json");
 
             fs.mkdirSync(settingsDir, { recursive: true });
-            fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
             fs.writeFileSync(
                 settingsPath,
                 JSON.stringify({
@@ -185,8 +181,6 @@ describe("Gemini setup", () => {
                 }),
                 "utf8",
             );
-            fs.chmodSync(binaryPath, 0o755);
-
             process.env.HOME = tempHome;
             delete process.env.USERPROFILE;
             process.env.COMANDO_GEMINI_ACP_BIN = binaryPath;

--- a/src/main/ai/kilo/setup.test.ts
+++ b/src/main/ai/kilo/setup.test.ts
@@ -6,6 +6,8 @@ import { pathToFileURL } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { writeTestExecutable } from "@main/testing/executable-fixture";
+
 import {
     applyKiloAuthEnv,
     buildKiloSecretPatches,
@@ -87,9 +89,7 @@ describe("Kilo setup", () => {
         );
 
         try {
-            const binaryPath = path.join(tempDir, "custom-kilo");
-            fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(binaryPath, 0o755);
+            const binaryPath = writeTestExecutable(tempDir, "custom-kilo");
             process.env.COMANDO_KILO_ACP_BIN = binaryPath;
             process.env.PATH = "";
 
@@ -111,9 +111,7 @@ describe("Kilo setup", () => {
         );
 
         try {
-            const binaryPath = path.join(tempDir, "kilo");
-            fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(binaryPath, 0o755);
+            const binaryPath = writeTestExecutable(tempDir, "kilo");
             process.env.PATH = tempDir;
 
             const fromSettings = resolveKiloRuntime({
@@ -215,14 +213,12 @@ describe("Kilo setup", () => {
         );
 
         try {
-            const binaryPath = path.join(tempDir, "kilo");
+            const binaryPath = writeTestExecutable(tempDir, "kilo");
             const dataDir = path.join(tempDir, "xdg");
             const secretStore = createSecretStore({
                 "ai.kilo:kilo_api_key": "stored-kilo-key",
             });
 
-            fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(binaryPath, 0o755);
             writeActiveKiloLegacyAuthStore(dataDir);
 
             process.env.COMANDO_KILO_ACP_BIN = binaryPath;
@@ -301,13 +297,11 @@ describe("Kilo setup", () => {
         );
 
         try {
-            const binaryPath = path.join(tempDir, "kilo");
+            const binaryPath = writeTestExecutable(tempDir, "kilo");
             const authDir = path.join(tempDir, ".local", "share", "kilo");
             const authPath = path.join(authDir, "auth.json");
 
             fs.mkdirSync(authDir, { recursive: true });
-            fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(binaryPath, 0o755);
             fs.writeFileSync(
                 authPath,
                 JSON.stringify({
@@ -322,6 +316,7 @@ describe("Kilo setup", () => {
             );
 
             process.env.HOME = tempDir;
+            delete process.env.LOCALAPPDATA;
             delete process.env.USERPROFILE;
             delete process.env.XDG_DATA_HOME;
             process.env.COMANDO_KILO_ACP_BIN = binaryPath;
@@ -351,7 +346,7 @@ describe("Kilo setup", () => {
                         import fs from "node:fs";
                         import os from "node:os";
                         import path from "node:path";
-                        import { execFileSync } from "node:child_process";
+                        import { DatabaseSync } from "node:sqlite";
                         import { readKiloSqliteAuthStoreStatus } from ${JSON.stringify(pathToFileURL(path.resolve("src/main/ai/kilo/setup.ts")).href)};
 
                         const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "comando-kilo-auth-db-child-"));
@@ -361,46 +356,46 @@ describe("Kilo setup", () => {
                         const now = Date.now();
 
                         fs.mkdirSync(kiloDir, { recursive: true });
-                        execFileSync("sqlite3", [databasePath], {
-                            input: \`
-                                CREATE TABLE account (
-                                    id TEXT PRIMARY KEY,
-                                    email TEXT NOT NULL,
-                                    url TEXT NOT NULL,
-                                    access_token TEXT NOT NULL,
-                                    refresh_token TEXT NOT NULL,
-                                    token_expiry INTEGER,
-                                    time_created INTEGER NOT NULL,
-                                    time_updated INTEGER NOT NULL
-                                );
-                                CREATE TABLE account_state (
-                                    id INTEGER PRIMARY KEY NOT NULL,
-                                    active_account_id TEXT,
-                                    active_org_id TEXT
-                                );
-                                INSERT INTO account (
-                                    id,
-                                    email,
-                                    url,
-                                    access_token,
-                                    refresh_token,
-                                    token_expiry,
-                                    time_created,
-                                    time_updated
-                                ) VALUES (
-                                    'acc-1',
-                                    'user@example.com',
-                                    'https://kilo.example',
-                                    'access-token',
-                                    'refresh-token',
-                                    \${now + 60_000},
-                                    \${now},
-                                    \${now}
-                                );
-                                INSERT INTO account_state (id, active_account_id, active_org_id)
-                                VALUES (1, 'acc-1', NULL);
-                            \`,
-                        });
+                        const database = new DatabaseSync(databasePath);
+                        database.exec(\`
+                            CREATE TABLE account (
+                                id TEXT PRIMARY KEY,
+                                email TEXT NOT NULL,
+                                url TEXT NOT NULL,
+                                access_token TEXT NOT NULL,
+                                refresh_token TEXT NOT NULL,
+                                token_expiry INTEGER,
+                                time_created INTEGER NOT NULL,
+                                time_updated INTEGER NOT NULL
+                            );
+                            CREATE TABLE account_state (
+                                id INTEGER PRIMARY KEY NOT NULL,
+                                active_account_id TEXT,
+                                active_org_id TEXT
+                            );
+                            INSERT INTO account (
+                                id,
+                                email,
+                                url,
+                                access_token,
+                                refresh_token,
+                                token_expiry,
+                                time_created,
+                                time_updated
+                            ) VALUES (
+                                'acc-1',
+                                'user@example.com',
+                                'https://kilo.example',
+                                'access-token',
+                                'refresh-token',
+                                \${now + 60_000},
+                                \${now},
+                                \${now}
+                            );
+                            INSERT INTO account_state (id, active_account_id, active_org_id)
+                            VALUES (1, 'acc-1', NULL);
+                        \`);
+                        database.close();
 
                         const status = readKiloSqliteAuthStoreStatus(databasePath);
                         process.stdout.write(JSON.stringify(status));
@@ -426,9 +421,7 @@ describe("Kilo setup", () => {
         );
 
         try {
-            const binaryPath = path.join(tempDir, "kilo");
-            fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(binaryPath, 0o755);
+            const binaryPath = writeTestExecutable(tempDir, "kilo");
             process.env.COMANDO_KILO_ACP_BIN = binaryPath;
             process.env.PATH = "";
             process.env.XDG_DATA_HOME = path.join(tempDir, "empty-xdg");

--- a/src/main/ai/opencode/setup.test.ts
+++ b/src/main/ai/opencode/setup.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { OpenCodeRuntimeSettings } from "@shared/ipc";
 
+import { writeTestExecutable } from "@main/testing/executable-fixture";
+
 import {
     applyOpenCodeAuthEnv,
     getOpenCodeRuntimeStatus,
@@ -47,7 +49,10 @@ describe("OpenCode setup", () => {
         );
 
         try {
-            const binaryPath = writeExecutable(tempDir, "custom-opencode");
+            const binaryPath = writeTestExecutable(
+                tempDir,
+                "custom-opencode",
+            );
             process.env.COMANDO_OPENCODE_ACP_BIN = binaryPath;
             process.env.PATH = "";
 
@@ -71,7 +76,7 @@ describe("OpenCode setup", () => {
         );
 
         try {
-            const binaryPath = writeExecutable(tempDir, "opencode");
+            const binaryPath = writeTestExecutable(tempDir, "opencode");
             process.env.PATH = tempDir;
 
             const fromSettings = resolveOpenCodeRuntime(
@@ -101,7 +106,7 @@ describe("OpenCode setup", () => {
         try {
             const userBinDir = path.join(tempDir, ".opencode", "bin");
             fs.mkdirSync(userBinDir, { recursive: true });
-            const binaryPath = writeExecutable(userBinDir, "opencode");
+            const binaryPath = writeTestExecutable(userBinDir, "opencode");
             process.env.HOME = tempDir;
             delete process.env.USERPROFILE;
             process.env.PATH = "";
@@ -189,7 +194,7 @@ describe("OpenCode setup", () => {
         );
 
         try {
-            const binaryPath = writeExecutable(tempDir, "opencode");
+            const binaryPath = writeTestExecutable(tempDir, "opencode");
             process.env.XDG_DATA_HOME = path.join(tempDir, "xdg");
             const status = getOpenCodeRuntimeStatus(
                 createOpenCodeSettings({
@@ -212,7 +217,7 @@ describe("OpenCode setup", () => {
         );
 
         try {
-            const binaryPath = writeExecutable(tempDir, "opencode");
+            const binaryPath = writeTestExecutable(tempDir, "opencode");
             process.env.XDG_DATA_HOME = path.join(tempDir, "xdg");
             const status = getOpenCodeRuntimeStatus(
                 createOpenCodeSettings({
@@ -306,13 +311,6 @@ function createOpenCodeSettings(
         binaryPath: null,
         ...overrides,
     };
-}
-
-function writeExecutable(dir: string, name: string): string {
-    const binaryPath = path.join(dir, name);
-    fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
-    fs.chmodSync(binaryPath, 0o755);
-    return binaryPath;
 }
 
 function writeOpenCodeAuthFile(dataDir: string): string {

--- a/src/main/ai/resolver/runtime-resolver.test.ts
+++ b/src/main/ai/resolver/runtime-resolver.test.ts
@@ -164,6 +164,42 @@ describe("resolveCodexRuntime", () => {
         }
     });
 
+    it("uses the generic packaged bundled binary when repo bundle is absent", () => {
+        const tempRoot = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-codex-packaged-generic-"),
+        );
+        const packagedResourcesPath = path.join(tempRoot, "packaged");
+
+        try {
+            delete process.env.COMANDO_CODEX_ACP_BIN;
+            process.env.PATH = "";
+
+            const packagedBinary = writeTestExecutable(
+                path.join(packagedResourcesPath, "ai", "binaries"),
+                getCodexBundledExecutableName(),
+            );
+
+            const resolved = resolveCodexRuntime(
+                {
+                    authMethod: null,
+                    binaryPath: null,
+                    hasCodexApiKey: false,
+                    hasOpenAiApiKey: false,
+                },
+                {
+                    allowPathFallback: false,
+                    appRoot: tempRoot,
+                    packagedResourcesPath,
+                },
+            );
+
+            expect(resolved.executable).toBe(packagedBinary);
+            expect(resolved.status.source).toBe("bundled");
+        } finally {
+            fs.rmSync(tempRoot, { force: true, recursive: true });
+        }
+    });
+
     it.runIf(process.platform === "darwin")(
         "uses the packaged architecture-specific bundled binary on macOS",
         () => {

--- a/src/main/ai/resolver/runtime-resolver.test.ts
+++ b/src/main/ai/resolver/runtime-resolver.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { writeTestExecutable } from "@main/testing/executable-fixture";
+
 import { resolveCodexRuntime } from "./runtime-resolver";
 
 const originalPath = process.env.PATH;
@@ -31,9 +33,7 @@ describe("resolveCodexRuntime", () => {
 
         try {
             delete process.env.COMANDO_CODEX_ACP_BIN;
-            const executablePath = path.join(tempDir, "codex-acp");
-            fs.writeFileSync(executablePath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(executablePath, 0o755);
+            const executablePath = writeTestExecutable(tempDir, "codex-acp");
             process.env.PATH = tempDir;
 
             const resolved = resolveCodexRuntime(
@@ -76,7 +76,7 @@ describe("resolveCodexRuntime", () => {
                 "resources",
                 "ai",
                 "binaries",
-                "codex-acp",
+                getCodexBundledExecutableName(),
             );
             const vendorPath = path.join(
                 tempRoot,
@@ -84,18 +84,20 @@ describe("resolveCodexRuntime", () => {
                 "codex-acp",
                 "target",
                 "release",
-                "codex-acp",
+                getCodexBundledExecutableName(),
             );
-            const pathExecutable = path.join(tempPathDir, "codex-acp");
+            writeTestExecutable(tempPathDir, "codex-acp");
 
             fs.mkdirSync(path.dirname(bundledPath), { recursive: true });
             fs.mkdirSync(path.dirname(vendorPath), { recursive: true });
-            fs.writeFileSync(bundledPath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.writeFileSync(vendorPath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.writeFileSync(pathExecutable, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(bundledPath, 0o755);
-            fs.chmodSync(vendorPath, 0o755);
-            fs.chmodSync(pathExecutable, 0o755);
+            writeTestExecutable(
+                path.dirname(bundledPath),
+                path.basename(bundledPath),
+            );
+            writeTestExecutable(
+                path.dirname(vendorPath),
+                path.basename(vendorPath),
+            );
             process.env.PATH = tempPathDir;
 
             const resolved = resolveCodexRuntime(
@@ -132,11 +134,13 @@ describe("resolveCodexRuntime", () => {
                 "codex-acp",
                 "target",
                 "release",
-                "codex-acp",
+                getCodexBundledExecutableName(),
             );
             fs.mkdirSync(path.dirname(vendorPath), { recursive: true });
-            fs.writeFileSync(vendorPath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(vendorPath, 0o755);
+            writeTestExecutable(
+                path.dirname(vendorPath),
+                path.basename(vendorPath),
+            );
             process.env.PATH = "";
 
             const resolved = resolveCodexRuntime(
@@ -160,7 +164,9 @@ describe("resolveCodexRuntime", () => {
         }
     });
 
-    it("uses the packaged architecture-specific bundled binary on macOS", () => {
+    it.runIf(process.platform === "darwin")(
+        "uses the packaged architecture-specific bundled binary on macOS",
+        () => {
         const tempRoot = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-codex-packaged-"),
         );
@@ -175,7 +181,7 @@ describe("resolveCodexRuntime", () => {
                 "ai",
                 "binaries",
                 `darwin-${process.arch}`,
-                "codex-acp",
+                getCodexBundledExecutableName(),
             );
             fs.mkdirSync(path.dirname(packagedBinary), { recursive: true });
             fs.writeFileSync(packagedBinary, "#!/bin/sh\nexit 0\n", "utf8");
@@ -209,9 +215,10 @@ describe("resolveCodexRuntime", () => {
 
         try {
             delete process.env.COMANDO_CODEX_ACP_BIN;
-            const executablePath = path.join(tempDir, "codex");
-            fs.writeFileSync(executablePath, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(executablePath, 0o755);
+            const executablePath = writeTestExecutable(
+                tempDir,
+                process.platform === "win32" ? "codex.EXE" : "codex",
+            );
             process.env.PATH = tempDir;
 
             const resolved = resolveCodexRuntime(
@@ -240,5 +247,10 @@ describe("resolveCodexRuntime", () => {
                 recursive: true,
             });
         }
-    });
+        },
+    );
 });
+
+function getCodexBundledExecutableName(): string {
+    return process.platform === "win32" ? "codex-acp.exe" : "codex-acp";
+}

--- a/src/main/ai/resolver/runtime-resolver.test.ts
+++ b/src/main/ai/resolver/runtime-resolver.test.ts
@@ -167,46 +167,53 @@ describe("resolveCodexRuntime", () => {
     it.runIf(process.platform === "darwin")(
         "uses the packaged architecture-specific bundled binary on macOS",
         () => {
-        const tempRoot = fs.mkdtempSync(
-            path.join(os.tmpdir(), "comando-codex-packaged-"),
-        );
-        const packagedResourcesPath = path.join(tempRoot, "packaged");
-
-        try {
-            delete process.env.COMANDO_CODEX_ACP_BIN;
-            process.env.PATH = "";
-
-            const packagedBinary = path.join(
-                packagedResourcesPath,
-                "ai",
-                "binaries",
-                `darwin-${process.arch}`,
-                getCodexBundledExecutableName(),
+            const tempRoot = fs.mkdtempSync(
+                path.join(os.tmpdir(), "comando-codex-packaged-"),
             );
-            fs.mkdirSync(path.dirname(packagedBinary), { recursive: true });
-            fs.writeFileSync(packagedBinary, "#!/bin/sh\nexit 0\n", "utf8");
-            fs.chmodSync(packagedBinary, 0o755);
+            const packagedResourcesPath = path.join(tempRoot, "packaged");
 
-            const resolved = resolveCodexRuntime(
-                {
-                    authMethod: null,
-                    binaryPath: null,
-                    hasCodexApiKey: false,
-                    hasOpenAiApiKey: false,
-                },
-                {
-                    allowPathFallback: false,
-                    appRoot: tempRoot,
+            try {
+                delete process.env.COMANDO_CODEX_ACP_BIN;
+                process.env.PATH = "";
+
+                const packagedBinary = path.join(
                     packagedResourcesPath,
-                },
-            );
+                    "ai",
+                    "binaries",
+                    `darwin-${process.arch}`,
+                    getCodexBundledExecutableName(),
+                );
+                fs.mkdirSync(path.dirname(packagedBinary), {
+                    recursive: true,
+                });
+                fs.writeFileSync(
+                    packagedBinary,
+                    "#!/bin/sh\nexit 0\n",
+                    "utf8",
+                );
+                fs.chmodSync(packagedBinary, 0o755);
 
-            expect(resolved.executable).toBe(packagedBinary);
-            expect(resolved.status.source).toBe("bundled");
-        } finally {
-            fs.rmSync(tempRoot, { force: true, recursive: true });
-        }
-    });
+                const resolved = resolveCodexRuntime(
+                    {
+                        authMethod: null,
+                        binaryPath: null,
+                        hasCodexApiKey: false,
+                        hasOpenAiApiKey: false,
+                    },
+                    {
+                        allowPathFallback: false,
+                        appRoot: tempRoot,
+                        packagedResourcesPath,
+                    },
+                );
+
+                expect(resolved.executable).toBe(packagedBinary);
+                expect(resolved.status.source).toBe("bundled");
+            } finally {
+                fs.rmSync(tempRoot, { force: true, recursive: true });
+            }
+        },
+    );
 
     it("marks codex as incompatible when only modern CLI exists", () => {
         const tempDir = fs.mkdtempSync(

--- a/src/main/ai/resolver/runtime-resolver.ts
+++ b/src/main/ai/resolver/runtime-resolver.ts
@@ -33,7 +33,9 @@ export function resolveCodexRuntime(
     const envPath = process.env.COMANDO_CODEX_ACP_BIN?.trim() ?? "";
     const appRoot = options.appRoot ?? getAppRoot();
     const packagedResourcesPath =
-        options.packagedResourcesPath ?? getPackagedResourcesPath();
+        options.packagedResourcesPath === undefined
+            ? getPackagedResourcesPath()
+            : options.packagedResourcesPath;
 
     if (envPath) {
         return resolveCandidate(envPath, "env");

--- a/src/main/file-preview-protocol.test.ts
+++ b/src/main/file-preview-protocol.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { resolveCodexGeneratedImagePreviewPath } from "./file-preview-protocol";
 
+const canCreateFileSymlink = canCreateSymlink();
+
 describe("resolveCodexGeneratedImagePreviewPath", () => {
     let tempDir: string;
     let generatedImagesRoot: string;
@@ -44,18 +46,21 @@ describe("resolveCodexGeneratedImagePreviewPath", () => {
         });
     });
 
-    it("blocks symlinks that escape the authorized root", async () => {
-        const outsidePath = path.join(tempDir, "outside.png");
-        const symlinkPath = path.join(generatedImagesRoot, "linked.png");
-        fs.writeFileSync(outsidePath, "png");
-        fs.symlinkSync(outsidePath, symlinkPath);
+    it.skipIf(!canCreateFileSymlink)(
+        "blocks symlinks that escape the authorized root",
+        async () => {
+            const outsidePath = path.join(tempDir, "outside.png");
+            const symlinkPath = path.join(generatedImagesRoot, "linked.png");
+            fs.writeFileSync(outsidePath, "png");
+            fs.symlinkSync(outsidePath, symlinkPath, "file");
 
-        await expect(resolvePath(symlinkPath)).resolves.toMatchObject({
-            filePath: null,
-            mimeType: null,
-            status: 404,
-        });
-    });
+            await expect(resolvePath(symlinkPath)).resolves.toMatchObject({
+                filePath: null,
+                mimeType: null,
+                status: 404,
+            });
+        },
+    );
 
     it("returns 415 for non-image files inside an authorized root", async () => {
         const textPath = path.join(generatedImagesRoot, "notes.txt");
@@ -84,4 +89,22 @@ function encodeBase64Url(value: string): string {
         .replace(/\+/g, "-")
         .replace(/\//g, "_")
         .replace(/=+$/g, "");
+}
+
+function canCreateSymlink(): boolean {
+    const tempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "comando-preview-symlink-check-"),
+    );
+    const targetPath = path.join(tempDir, "target.png");
+    const symlinkPath = path.join(tempDir, "linked.png");
+
+    try {
+        fs.writeFileSync(targetPath, "png");
+        fs.symlinkSync(targetPath, symlinkPath, "file");
+        return true;
+    } catch {
+        return false;
+    } finally {
+        fs.rmSync(tempDir, { force: true, recursive: true });
+    }
 }

--- a/src/main/git/environment.ts
+++ b/src/main/git/environment.ts
@@ -1,0 +1,15 @@
+export function createSafeGitEnvironment(
+    overrides: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        ...overrides,
+    };
+
+    // simple-git blocks pager variables for safety, and programmatic calls
+    // should never need interactive paging.
+    delete env.GIT_PAGER;
+    delete env.PAGER;
+
+    return env;
+}

--- a/src/main/git/history.ts
+++ b/src/main/git/history.ts
@@ -9,6 +9,7 @@ import type {
     GitHistoryListResult,
     GitListHistoryOptions,
 } from "./types";
+import { createSafeGitEnvironment } from "./environment";
 
 const FIELD_SEPARATOR = "\u001f";
 const RECORD_SEPARATOR = "\u001e";
@@ -380,8 +381,9 @@ function parseCommitDiffFile(
 }
 
 function createBackgroundSafeGit(rootPath: string) {
-    return simpleGit(rootPath).env({
-        ...process.env,
-        GIT_OPTIONAL_LOCKS: "0",
-    });
+    return simpleGit(rootPath).env(
+        createSafeGitEnvironment({
+            GIT_OPTIONAL_LOCKS: "0",
+        }),
+    );
 }

--- a/src/main/git/history.ts
+++ b/src/main/git/history.ts
@@ -380,5 +380,8 @@ function parseCommitDiffFile(
 }
 
 function createBackgroundSafeGit(rootPath: string) {
-    return simpleGit(rootPath).env({ GIT_OPTIONAL_LOCKS: "0" });
+    return simpleGit(rootPath).env({
+        ...process.env,
+        GIT_OPTIONAL_LOCKS: "0",
+    });
 }

--- a/src/main/git/service.test.ts
+++ b/src/main/git/service.test.ts
@@ -577,11 +577,26 @@ describe("GitService", () => {
     it("runs preflight checks before committing", async () => {
         const rootPath = createGitRepositoryFixture();
         const isolatedHome = createGitRepositoryFixture();
-        const previousHome = process.env.HOME;
-        const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+        const previousEnv = snapshotEnv([
+            "GIT_AUTHOR_EMAIL",
+            "GIT_AUTHOR_NAME",
+            "GIT_COMMITTER_EMAIL",
+            "GIT_COMMITTER_NAME",
+            "GIT_CONFIG_NOSYSTEM",
+            "HOME",
+            "USERPROFILE",
+            "XDG_CONFIG_HOME",
+        ]);
 
         process.env.HOME = isolatedHome;
+        process.env.USERPROFILE = isolatedHome;
         process.env.XDG_CONFIG_HOME = path.join(isolatedHome, ".config");
+        process.env.GIT_CONFIG_NOSYSTEM = "1";
+        delete process.env.GIT_AUTHOR_EMAIL;
+        delete process.env.GIT_AUTHOR_NAME;
+        delete process.env.GIT_COMMITTER_EMAIL;
+        delete process.env.GIT_COMMITTER_NAME;
+        fs.writeFileSync(path.join(isolatedHome, ".gitconfig"), "", "utf8");
 
         try {
             git(rootPath, ["init", "-b", "main"]);
@@ -610,8 +625,7 @@ describe("GitService", () => {
                 service.commit(rootPath, "without staging"),
             ).rejects.toThrow("Stage at least one change before committing.");
         } finally {
-            process.env.HOME = previousHome;
-            process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
+            restoreEnv(previousEnv);
         }
     });
 });
@@ -641,5 +655,21 @@ function git(cwd: string, args: readonly string[]): void {
                 .filter(Boolean)
                 .join("\n"),
         );
+    }
+}
+
+function snapshotEnv(
+    names: readonly string[],
+): ReadonlyMap<string, string | undefined> {
+    return new Map(names.map((name) => [name, process.env[name]]));
+}
+
+function restoreEnv(snapshot: ReadonlyMap<string, string | undefined>): void {
+    for (const [name, value] of snapshot) {
+        if (typeof value === "string") {
+            process.env[name] = value;
+        } else {
+            delete process.env[name];
+        }
     }
 }

--- a/src/main/git/service.ts
+++ b/src/main/git/service.ts
@@ -936,7 +936,7 @@ function collectNumstatRecords(
 }
 
 function createBackgroundSafeGit(rootPath: string) {
-    return createGit(rootPath).env({ GIT_OPTIONAL_LOCKS: "0" });
+    return createGit(rootPath).env("GIT_OPTIONAL_LOCKS", "0");
 }
 
 function createGit(rootPath: string) {
@@ -951,6 +951,7 @@ function createGit(rootPath: string) {
     }
 
     return simpleGit(rootPath).env({
+        ...process.env,
         PATH: pathEntries.join(path.delimiter),
     });
 }

--- a/src/main/git/service.ts
+++ b/src/main/git/service.ts
@@ -32,6 +32,7 @@ import {
 } from "./worktrees";
 import { getGitFileDiff } from "./diff";
 import { getGitCommitDetail, listGitHistory } from "./history";
+import { createSafeGitEnvironment } from "./environment";
 import { buildRuntimePathEntries } from "../ai/runtime-env";
 
 export interface GitServiceOptions {
@@ -950,8 +951,9 @@ function createGit(rootPath: string) {
         return simpleGit(rootPath);
     }
 
-    return simpleGit(rootPath).env({
-        ...process.env,
-        PATH: pathEntries.join(path.delimiter),
-    });
+    return simpleGit(rootPath).env(
+        createSafeGitEnvironment({
+            PATH: pathEntries.join(path.delimiter),
+        }),
+    );
 }

--- a/src/main/projects/runtime.ts
+++ b/src/main/projects/runtime.ts
@@ -947,7 +947,10 @@ function mergeProjectInvalidationRelativePaths(
 }
 
 function createBackgroundSafeGit(rootPath: string) {
-    return simpleGit(rootPath).env({ GIT_OPTIONAL_LOCKS: "0" });
+    return simpleGit(rootPath).env({
+        ...process.env,
+        GIT_OPTIONAL_LOCKS: "0",
+    });
 }
 
 function getDirectoryBadge(

--- a/src/main/projects/runtime.ts
+++ b/src/main/projects/runtime.ts
@@ -21,6 +21,7 @@ import {
 import { normalizePathKey } from "@shared/path-identity";
 
 import { debugBenignError } from "../observability/logging";
+import { createSafeGitEnvironment } from "../git/environment";
 import { shouldIgnoreEntry } from "./ignore";
 import {
     copyExternalProjectEntries,
@@ -947,10 +948,11 @@ function mergeProjectInvalidationRelativePaths(
 }
 
 function createBackgroundSafeGit(rootPath: string) {
-    return simpleGit(rootPath).env({
-        ...process.env,
-        GIT_OPTIONAL_LOCKS: "0",
-    });
+    return simpleGit(rootPath).env(
+        createSafeGitEnvironment({
+            GIT_OPTIONAL_LOCKS: "0",
+        }),
+    );
 }
 
 function getDirectoryBadge(

--- a/src/main/shell/command-availability.test.ts
+++ b/src/main/shell/command-availability.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { writeTestExecutable } from "@main/testing/executable-fixture";
+
 import { checkCommandAvailability } from "./command-availability";
 
 const tempDirs: string[] = [];
@@ -17,7 +19,7 @@ afterEach(() => {
 describe("checkCommandAvailability", () => {
     it("finds an allowed executable in PATH entries without running it", () => {
         const binDir = createTempDir();
-        const executablePath = writeExecutable(
+        const executablePath = writeTestExecutable(
             binDir,
             "claude",
             [
@@ -40,7 +42,7 @@ describe("checkCommandAvailability", () => {
 
     it("rejects unsafe or non-allowed command names", () => {
         const binDir = createTempDir();
-        writeExecutable(binDir, "claude");
+        writeTestExecutable(binDir, "claude");
 
         for (const name of [
             "claude code",
@@ -63,7 +65,7 @@ describe("checkCommandAvailability", () => {
 
     it("respects PATHEXT when resolving on Windows", () => {
         const binDir = createTempDir();
-        const executablePath = writeExecutable(binDir, "claude.CMD");
+        const executablePath = writeTestExecutable(binDir, "claude.CMD");
 
         expect(
             checkCommandAvailability(
@@ -89,13 +91,3 @@ function createTempDir(): string {
     return tempDir;
 }
 
-function writeExecutable(
-    directory: string,
-    name: string,
-    content = "",
-): string {
-    const executablePath = path.join(directory, name);
-    fs.writeFileSync(executablePath, content, { mode: 0o755 });
-    fs.chmodSync(executablePath, 0o755);
-    return executablePath;
-}

--- a/src/main/shell/command-availability.test.ts
+++ b/src/main/shell/command-availability.test.ts
@@ -90,4 +90,3 @@ function createTempDir(): string {
     tempDirs.push(tempDir);
     return tempDir;
 }
-

--- a/src/main/testing/executable-fixture.ts
+++ b/src/main/testing/executable-fixture.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export function getTestExecutableName(name: string): string {
+    if (process.platform !== "win32" || path.extname(name)) {
+        return name;
+    }
+
+    return `${name}.CMD`;
+}
+
+export function writeTestExecutable(
+    directory: string,
+    name: string,
+    content = getDefaultExecutableContent(),
+): string {
+    const executablePath = path.join(directory, getTestExecutableName(name));
+
+    fs.mkdirSync(directory, { recursive: true });
+    fs.writeFileSync(executablePath, content, {
+        encoding: "utf8",
+        mode: 0o755,
+    });
+    fs.chmodSync(executablePath, 0o755);
+
+    return executablePath;
+}
+
+function getDefaultExecutableContent(): string {
+    return process.platform === "win32"
+        ? "@echo off\r\nexit /b 0\r\n"
+        : "#!/bin/sh\nexit 0\n";
+}


### PR DESCRIPTION
## Summary
- Make Windows-hostile tests portable with executable fixtures, symlink capability checks, and case-insensitive diagnostic path assertions on Windows.
- Allow tests to explicitly disable packaged runtime lookup with `packagedResourcesPath: null`, while preserving default production behavior when the option is omitted.
- Isolate Git identity tests and preserve environment variables for Git commands that customize PATH or disable optional locks.
- Add coverage for generic packaged runtime resource lookup for Codex and Claude.

## Verification
- `pnpm test` passed previously on Windows with `193 passed`, `1617 passed | 6 skipped`.
- `pnpm run typecheck` and focused ESLint passed before the original commits.
- `pnpm exec vitest run src/main/ai/resolver/runtime-resolver.test.ts src/main/ai/claude/setup.test.ts`
- `pnpm exec eslint src/main/ai/resolver/runtime-resolver.test.ts src/main/ai/claude/setup.test.ts`
- `pnpm exec eslint src/main/git/history.ts src/main/projects/runtime.ts`
- `pnpm exec tsc --noEmit -p tsconfig.node.json --pretty false`
- `pnpm exec vitest run src/main/git/service.test.ts`
- `pnpm exec vitest run src/main/projects/service.test.ts src/main/projects/tree.test.ts`