### PR TITLE
Add Escape shortcut to stop the active agent

### DIFF
--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -101,7 +101,7 @@ import {
     isEditedFileToolActivity,
     ToolActivityItem,
 } from "./chat/ToolActivityItem";
-import { getStopAgentConfirmationMessage } from "./chat/aiSessionLifecycle";
+import { requestStopAgentSession } from "./chat/aiSessionLifecycle";
 import {
     collectProjectFileRoots,
     resolveProjectFileReference,
@@ -1510,16 +1510,10 @@ export const ChatTabView = memo(function ChatTabView({
         void onOpenReview();
     }, [onOpenReview]);
     const handleStopSession = useCallback(() => {
-        const message = getStopAgentConfirmationMessage({
+        requestStopAgentSession({
             sessionId: tab.sessionId,
-            sessions: useAiStore.getState().sessions,
             title: snapshot.title || tab.title || "Chat",
         });
-        if (message && !window.confirm(message)) {
-            return;
-        }
-
-        void useAiStore.getState().cancelSession(tab.sessionId);
     }, [snapshot.title, tab.sessionId, tab.title]);
 
     useEffect(() => {

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -128,6 +128,8 @@ import {
     type WorkspaceFileModelLease,
 } from "@renderer/components/workspace/editorModelPath";
 import { appendSelectionMentionToRegisteredComposer } from "@renderer/components/workspace/chat/composerSelectionBridge";
+import { requestStopAgentSession } from "@renderer/components/workspace/chat/aiSessionLifecycle";
+import { isActiveChatTurnStatus } from "@renderer/components/workspace/chat/chatTurnStatus";
 import { canResolveFileHunks } from "@renderer/components/workspace/review/editedFilesPresentationModel";
 import { createDiffFromTrackedFile } from "@renderer/components/workspace/review/reviewDiff";
 import { closeWorkspaceTabsWithConfirmation } from "@renderer/components/workspace/workspaceCloseGuard";
@@ -1604,6 +1606,34 @@ function WorkspacePaneView({
     );
     const isActivePane = activePaneId === paneNodeId;
     const activeTabWorktreeId = activeTab?.worktreeId ?? null;
+    const activeChatSessionId = activeChatTab?.sessionId ?? null;
+    const activeChatFallbackTitle = activeChatTab?.title ?? "Chat";
+    const activeChatSessionLifecycle = useAiStore(
+        useShallow(
+            useCallback(
+                (state) => {
+                    if (!activeChatSessionId) {
+                        return {
+                            status: null,
+                            title: activeChatFallbackTitle,
+                        };
+                    }
+
+                    const snapshot =
+                        state.sessions[activeChatSessionId]?.snapshot ?? null;
+
+                    return {
+                        status: snapshot?.status ?? null,
+                        title:
+                            snapshot?.title ||
+                            activeChatFallbackTitle ||
+                            "Chat",
+                    };
+                },
+                [activeChatFallbackTitle, activeChatSessionId],
+            ),
+        ),
+    );
 
     useRenderProbe("WorkspacePaneView", {
         activeTabId: activeTab?.id ?? null,
@@ -2110,6 +2140,23 @@ function WorkspacePaneView({
     // Keep the latest handler references in a ref so the keydown listener can
     // be registered a single time per active pane, instead of being torn down
     // and re-attached on every render where any of these callbacks change.
+    const paneActiveAgentStopRef = useRef({
+        sessionId: activeChatSessionId,
+        status: activeChatSessionLifecycle.status,
+        title: activeChatSessionLifecycle.title,
+    });
+    useEffect(() => {
+        paneActiveAgentStopRef.current = {
+            sessionId: activeChatSessionId,
+            status: activeChatSessionLifecycle.status,
+            title: activeChatSessionLifecycle.title,
+        };
+    }, [
+        activeChatSessionId,
+        activeChatSessionLifecycle.status,
+        activeChatSessionLifecycle.title,
+    ]);
+
     const paneShortcutHandlersRef = useRef({
         createTerminalTab,
         defaultProjectId,
@@ -2144,6 +2191,43 @@ function WorkspacePaneView({
         paneNodeId,
         selectAdjacentTab,
     ]);
+
+    useEffect(() => {
+        if (!isActivePane) {
+            return;
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.defaultPrevented || event.key !== "Escape") {
+                return;
+            }
+
+            if (
+                event.altKey ||
+                event.ctrlKey ||
+                event.metaKey ||
+                event.shiftKey
+            ) {
+                return;
+            }
+
+            const { sessionId, status, title } =
+                paneActiveAgentStopRef.current;
+            if (!sessionId || !status || !isActiveChatTurnStatus(status)) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            requestStopAgentSession({
+                sessionId,
+                title,
+            });
+        };
+
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [isActivePane]);
 
     useEffect(() => {
         if (!isActivePane) {

--- a/src/renderer/src/components/workspace/chat/aiSessionLifecycle.ts
+++ b/src/renderer/src/components/workspace/chat/aiSessionLifecycle.ts
@@ -1,5 +1,7 @@
 import type { AiSessionSnapshot } from "@shared/ipc";
 
+import { useAiStore } from "@renderer/app/store/ai-store";
+
 type LifecycleSessionEntry = {
     readonly meta?: {
         readonly title: string;
@@ -51,6 +53,27 @@ export function getStopAgentConfirmationMessage({
         activeChildren.length === 1 ? "child agent" : "child agents";
 
     return `Stop "${title}"? ${activeChildren.length} active ${childLabel}${childSummary} will keep running. This only stops the selected thread.`;
+}
+
+export function requestStopAgentSession({
+    sessionId,
+    title,
+}: {
+    readonly sessionId: string;
+    readonly title: string;
+}): void {
+    const { cancelSession, sessions } = useAiStore.getState();
+    const message = getStopAgentConfirmationMessage({
+        sessionId,
+        sessions,
+        title,
+    });
+
+    if (message && !window.confirm(message)) {
+        return;
+    }
+
+    void cancelSession(sessionId);
 }
 
 function isBusyAiSessionSnapshot(


### PR DESCRIPTION
## Summary

Adds an Escape-key shortcut for stopping the in-progress agent action in the currently active workspace pane.

## Details

- Reuses the same stop-session flow as the existing Stop control, including the child-agent confirmation message.
- Limits the shortcut to the active pane's active chat tab.
- Ignores Escape when another UI already handled it, so composer menus and other local Escape behavior keep priority.
- Only stops sessions in active turn states: starting, streaming, waiting for permission, or waiting for user input.

Closes #26.

## Validation

- `pnpm run typecheck`
- `pnpm exec eslint src/renderer/src/components/workspace/chat/aiSessionLifecycle.ts src/renderer/src/components/workspace/ChatTabView.tsx src/renderer/src/components/workspace/WorkspaceView.tsx`
- `git diff --check`