### PR TITLE
Jump to file locations from chat references

### DIFF
--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { editor as MonacoEditor } from "monaco-editor";
 
 import type {
     ProjectFileDocument,
@@ -333,6 +334,125 @@ describe("workspace file opening", () => {
         });
         await flushWorkspacePersistenceForTests();
         expect(saveWorkspaceSnapshotMock).toHaveBeenCalled();
+    });
+
+    it("stores file open locations as runtime-only tab intent", async () => {
+        await useWorkspaceStore.getState().openFileTab(
+            "project-1",
+            "src/app.ts",
+            null,
+            undefined,
+            undefined,
+            undefined,
+            {
+                endLine: 14,
+                startLine: 12,
+            },
+        );
+
+        const state = useWorkspaceStore.getState();
+        const openedTab = Object.values(state.tabsById).find(
+            (tab) => tab.kind === "file" && tab.relativePath === "src/app.ts",
+        );
+        expect(openedTab).toMatchObject({
+            kind: "file",
+            pendingOpenLocation: {
+                endLine: 14,
+                startLine: 12,
+            },
+            relativePath: "src/app.ts",
+        });
+
+        await flushWorkspacePersistenceForTests();
+        const persistedSnapshot =
+            saveWorkspaceSnapshotMock.mock.calls.at(-1)?.[0];
+        if (!persistedSnapshot) {
+            throw new Error("Expected workspace snapshot to be persisted.");
+        }
+        const persistedFileTab = persistedSnapshot.tabs.find(
+            (tab) => tab.kind === "file" && tab.relativePath === "src/app.ts",
+        );
+        expect(persistedFileTab).toBeTruthy();
+        expect(persistedFileTab).not.toHaveProperty("pendingOpenLocation");
+    });
+
+    it("updates only the pending location when opening an existing file tab at a line", async () => {
+        const viewState: MonacoEditor.ICodeEditorViewState = {
+            contributionsState: {},
+            cursorState: [],
+            viewState: {
+                firstPosition: {
+                    column: 1,
+                    lineNumber: 1,
+                },
+                firstPositionDeltaTop: 0,
+                scrollLeft: 0,
+            },
+        };
+        const existingTab = createWorkspaceFileTab("file-tab-1", "src/app.ts");
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            rootNode: {
+                activeTabId: "file-tab-1",
+                id: "pane-root",
+                tabIds: ["file-tab-1"],
+                type: "pane",
+            },
+            tabsById: {
+                "file-tab-1": {
+                    ...existingTab,
+                    document: {
+                        absolutePath: "/tmp/src/app.ts",
+                        content: "export const value = 1;\n",
+                        imageDataBase64: null,
+                        isBinary: false,
+                        isTooLarge: false,
+                        kind: "text",
+                        languageId: "typescript",
+                        languageLabel: "TypeScript",
+                        mimeType: "text/typescript",
+                        modifiedAtMs: 1,
+                        name: "app.ts",
+                        projectId: "project-1",
+                        relativePath: "src/app.ts",
+                        sizeBytes: 24,
+                    },
+                    draftContent: "export const value = 1;\n",
+                    pendingOpenLocation: {
+                        endLine: 4,
+                        startLine: 4,
+                    },
+                    savedContent: "export const value = 1;\n",
+                    viewState,
+                },
+            },
+        }));
+
+        await useWorkspaceStore.getState().openFileTab(
+            "project-1",
+            "src/app.ts",
+            null,
+            undefined,
+            "pane-root",
+            undefined,
+            {
+                endLine: 22,
+                startLine: 20,
+            },
+        );
+
+        const state = useWorkspaceStore.getState();
+        const tab = state.tabsById["file-tab-1"];
+        expect(tab).toMatchObject({
+            kind: "file",
+            pendingOpenLocation: {
+                endLine: 22,
+                startLine: 20,
+            },
+            relativePath: "src/app.ts",
+        });
+        expect(tab?.kind === "file" ? tab.viewState : null).toBe(viewState);
+        expect(openProjectFileMock).not.toHaveBeenCalled();
     });
 
     it("opens a singleton project diff tab per project and worktree", async () => {
@@ -746,6 +866,11 @@ describe("workspace file opening", () => {
                 "worktree-1",
                 undefined,
                 "pane-right",
+                undefined,
+                {
+                    endLine: 34,
+                    startLine: 30,
+                },
             );
 
         const state = useWorkspaceStore.getState();
@@ -780,6 +905,10 @@ describe("workspace file opening", () => {
             draftContent: "export const value = 1;\n",
             isDirty: false,
             kind: "file",
+            pendingOpenLocation: {
+                endLine: 34,
+                startLine: 30,
+            },
             projectId: "project-1",
             relativePath: "src/app.ts",
             reviewContext: null,

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -40,6 +40,7 @@ import {
     resizeSplit,
     selectAdjacentPaneTab,
     setFileTabExternalChange,
+    setFileTabPendingOpenLocation,
     setFileTabViewState,
     setFileTabReviewContext,
     selectPaneTab,
@@ -1129,9 +1130,10 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
         targetPaneId?: string | null,
         targetIndex?: number,
-        _openLocation?: RuntimeWorkspaceFileOpenLocation | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => {
         try {
+            const pendingOpenLocation = openLocation ?? null;
             const trackedFiles = collectPendingTrackedFilesFromSessions(
                 useAiStore.getState().sessions,
             );
@@ -1172,30 +1174,34 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 });
 
                 set((state) => ({
-                    ...setFileTabReviewContext(
-                        paneId === resolvedPaneId
-                            ? selectPaneTab(
-                                  state,
-                                  paneId,
-                                  existingTabInResolvedPane.id,
-                              )
-                            : restoreSourcePaneActiveTabAfterMove(
-                                  moveTabToPaneAtIndex(
-                                      state,
-                                      existingTabInResolvedPane.id,
-                                      paneId,
-                                      resolvedPaneId,
-                                      Number.POSITIVE_INFINITY,
-                                  ),
-                                  paneId,
-                                  getSourcePaneFallbackTabIdAfterMove(
+                    ...setFileTabPendingOpenLocation(
+                        setFileTabReviewContext(
+                            paneId === resolvedPaneId
+                                ? selectPaneTab(
                                       state,
                                       paneId,
                                       existingTabInResolvedPane.id,
+                                  )
+                                : restoreSourcePaneActiveTabAfterMove(
+                                      moveTabToPaneAtIndex(
+                                          state,
+                                          existingTabInResolvedPane.id,
+                                          paneId,
+                                          resolvedPaneId,
+                                          Number.POSITIVE_INFINITY,
+                                      ),
+                                      paneId,
+                                      getSourcePaneFallbackTabIdAfterMove(
+                                          state,
+                                          paneId,
+                                          existingTabInResolvedPane.id,
+                                      ),
                                   ),
-                              ),
+                            existingTabInResolvedPane.id,
+                            nextReviewContext,
+                        ),
                         existingTabInResolvedPane.id,
-                        nextReviewContext,
+                        pendingOpenLocation,
                     ),
                     error: null,
                     recentActiveTabIds: recordRecentTabActivation(
@@ -1231,6 +1237,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                     ...sourceTab,
                     createdAt: new Date().toISOString(),
                     id: crypto.randomUUID(),
+                    pendingOpenLocation,
                     reviewContext: nextReviewContext,
                     viewState: sourceTab.viewState ?? null,
                 };
@@ -1270,6 +1277,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 isSaving: false,
                 kind: "file",
                 loadError: null,
+                pendingOpenLocation,
                 reviewContext: resolveFileTabReviewContext({
                     relativePath,
                     requestedReviewContext: reviewContext,

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -318,6 +318,10 @@ interface WorkspaceStore extends WorkspaceTreeState {
     unpinPaneTab: (paneId: string, tabId: string) => Promise<void>;
     updateChatDraft: (tabId: string, draft: string) => Promise<void>;
     updateFileDraft: (tabId: string, draft: string) => void;
+    updateFilePendingOpenLocation: (
+        tabId: string,
+        pendingOpenLocation: RuntimeWorkspaceFileOpenLocation | null,
+    ) => void;
     updateFileViewState: (
         tabId: string,
         viewState: MonacoEditor.ICodeEditorViewState | null,
@@ -1865,6 +1869,16 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     updateFileViewState: (tabId, viewState) => {
         set((state) => ({
             ...setFileTabViewState(state, tabId, viewState),
+        }));
+    },
+
+    updateFilePendingOpenLocation: (tabId, pendingOpenLocation) => {
+        set((state) => ({
+            ...setFileTabPendingOpenLocation(
+                state,
+                tabId,
+                pendingOpenLocation,
+            ),
         }));
     },
 

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -61,6 +61,7 @@ import {
     type RuntimeWorkspaceGitHubPullRequestsTab,
     type MoveDirection,
     type RuntimeWorkspaceGitTab,
+    type RuntimeWorkspaceFileOpenLocation,
     type RuntimeWorkspaceFileReviewContext,
     type RuntimeWorkspaceFileTab,
     type RuntimeWorkspaceReviewTab,
@@ -230,8 +231,10 @@ interface WorkspaceStore extends WorkspaceTreeState {
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
         targetPaneId?: string | null,
         targetIndex?: number,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     openFileTabAtTarget: (input: {
+        readonly openLocation?: RuntimeWorkspaceFileOpenLocation | null;
         readonly projectId: string;
         readonly relativePath: string;
         readonly reviewContext?: RuntimeWorkspaceFileReviewContext | null;
@@ -1126,6 +1129,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
         targetPaneId?: string | null,
         targetIndex?: number,
+        _openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => {
         try {
             const trackedFiles = collectPendingTrackedFilesFromSessions(
@@ -1320,6 +1324,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             input.reviewContext ?? null,
             paneId,
             getWorkspaceOpenTargetInsertIndex(input.target),
+            input.openLocation ?? null,
         );
 
         return paneId;

--- a/src/renderer/src/app/workspace/tree.ts
+++ b/src/renderer/src/app/workspace/tree.ts
@@ -44,6 +44,7 @@ export interface RuntimeWorkspaceFileTab extends WorkspaceFileTab {
     readonly isLoading: boolean;
     readonly isSaving: boolean;
     readonly loadError: string | null;
+    readonly pendingOpenLocation?: RuntimeWorkspaceFileOpenLocation | null;
     readonly reviewContext: RuntimeWorkspaceFileReviewContext | null;
     readonly saveError: string | null;
     readonly savedContent: string;
@@ -970,6 +971,28 @@ export function setFileTabReviewContext(
             [tabId]: {
                 ...tab,
                 reviewContext,
+            },
+        },
+    };
+}
+
+export function setFileTabPendingOpenLocation(
+    state: WorkspaceTreeState,
+    tabId: string,
+    pendingOpenLocation: RuntimeWorkspaceFileOpenLocation | null,
+): WorkspaceTreeState {
+    const tab = state.tabsById[tabId];
+    if (!tab || tab.kind !== "file") {
+        return state;
+    }
+
+    return {
+        ...state,
+        tabsById: {
+            ...state.tabsById,
+            [tabId]: {
+                ...tab,
+                pendingOpenLocation,
             },
         },
     };

--- a/src/renderer/src/app/workspace/tree.ts
+++ b/src/renderer/src/app/workspace/tree.ts
@@ -30,6 +30,11 @@ export interface RuntimeWorkspaceFileReviewContext {
     readonly sessionId: string;
 }
 
+export interface RuntimeWorkspaceFileOpenLocation {
+    readonly endLine?: number | null;
+    readonly startLine: number;
+}
+
 export interface RuntimeWorkspaceFileTab extends WorkspaceFileTab {
     readonly document: ProjectFileDocument | null;
     readonly draftContent: string;

--- a/src/renderer/src/components/workspace/ChatHistoryTabView.test.tsx
+++ b/src/renderer/src/components/workspace/ChatHistoryTabView.test.tsx
@@ -1,6 +1,9 @@
+/** @vitest-environment jsdom */
 import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
     AiHistorySessionSummary,
@@ -9,6 +12,24 @@ import type {
 import type { RuntimeWorkspaceChatHistoryTab } from "@renderer/app/workspace/tree";
 
 import { ChatHistoryTabLayout } from "./ChatHistoryTabView";
+import { resolveProjectFileReference } from "./projectFileReferences";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLDivElement[] = [];
+
+beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+        configurable: true,
+        value: {
+            getItem: vi.fn(() => null),
+            removeItem: vi.fn(),
+            setItem: vi.fn(),
+        },
+    });
+});
 
 const BASE_TAB: RuntimeWorkspaceChatHistoryTab = {
     createdAt: "2026-04-17T10:00:00.000Z",
@@ -151,6 +172,63 @@ function renderLayout(
     );
 }
 
+afterEach(() => {
+    for (const root of mountedRoots.splice(0)) {
+        act(() => {
+            root.unmount();
+        });
+    }
+
+    for (const container of mountedContainers.splice(0)) {
+        container.remove();
+    }
+});
+
+function renderInteractiveLayout(
+    overrides: Partial<Parameters<typeof ChatHistoryTabLayout>[0]> = {},
+): HTMLElement {
+    const selectedSession = overrides.selectedSession ?? null;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const root = createRoot(container);
+    mountedRoots.push(root);
+    mountedContainers.push(container);
+
+    act(() => {
+        root.render(
+            createElement(ChatHistoryTabLayout, {
+                hasMoreMessages: false,
+                handleDelete: vi.fn(async () => {}),
+                handleOpenInChat: vi.fn(async () => {}),
+                handleRefresh: vi.fn(async () => {}),
+                handleRename: vi.fn(() => Promise.resolve()),
+                isBusy: false,
+                isLoadingSessions: false,
+                loadSessionSnapshot: vi.fn(async () => {}),
+                loadTranscriptPage: vi.fn(async () => {}),
+                mutatingSessionId: null,
+                scopeLabel: "Project One",
+                selectedSession,
+                selectedSessionId: selectedSession?.sessionId ?? null,
+                selectedSnapshot: null,
+                selectedSnapshotState: null,
+                selectedSnapshotStatus: null,
+                selectedTranscript: null,
+                sessions: [],
+                sessionsError: null,
+                setSelectedSessionId: vi.fn(),
+                tab: BASE_TAB,
+                transcriptMessages: [],
+                worktreeLabel: "worktree-1",
+                ...overrides,
+            }),
+        );
+    });
+
+    return container;
+}
+
 describe("ChatHistoryTabLayout", () => {
     it("renders the loading state", () => {
         const markup = renderLayout({
@@ -237,6 +315,153 @@ describe("ChatHistoryTabLayout", () => {
         expect(markup).toContain("Assistant returns a concise answer.");
         expect(markup).toContain("open in chat");
         expect(markup).toContain("Load More");
+    });
+
+    it("opens transcript file reference pills with parsed line ranges", () => {
+        const session = createSession();
+        const handleOpenResolvedFileReference = vi.fn();
+        const container = renderInteractiveLayout({
+            canRenderFileReference: () => true,
+            handleOpenResolvedFileReference,
+            resolveFileReference: (reference) =>
+                resolveProjectFileReference(reference, {
+                    projectRoots: ["/Users/test/workspace/comando"],
+                }),
+            selectedSession: session,
+            selectedTranscript: {
+                error: null,
+                isLoading: false,
+                messages: [
+                    {
+                        attachments: [],
+                        content: "See src/app.ts:12-18.",
+                        createdAt: "2026-04-17T10:02:00.000Z",
+                        id: "msg-2",
+                        kind: "assistant",
+                        status: "completed",
+                    },
+                ],
+                totalMessages: 1,
+            },
+            sessions: [session],
+            transcriptMessages: [
+                {
+                    attachments: [],
+                    content: "See src/app.ts:12-18.",
+                    createdAt: "2026-04-17T10:02:00.000Z",
+                    id: "msg-2",
+                    kind: "assistant",
+                    status: "completed",
+                },
+            ],
+        });
+        const pillButton = container.querySelector<HTMLButtonElement>(
+            'button[title="src/app.ts:12-18"]',
+        );
+        expect(pillButton).not.toBeNull();
+
+        act(() => {
+            pillButton?.click();
+        });
+
+        expect(handleOpenResolvedFileReference).toHaveBeenCalledWith({
+            endLine: 18,
+            isAbsolute: false,
+            path: "src/app.ts",
+            relativePath: "src/app.ts",
+            startLine: 12,
+        });
+    });
+
+    it("passes transcript tool location ranges through onOpenFile", () => {
+        const session = createSession();
+        const handleOpenFile = vi.fn(async () => {});
+        const container = renderInteractiveLayout({
+            handleOpenFile,
+            selectedSession: session,
+            selectedSnapshot: createSnapshot({
+                trackedFiles: [],
+                toolActivity: [
+                    {
+                        createdAt: "2026-04-17T10:04:00.000Z",
+                        diffs: [],
+                        exitCode: null,
+                        id: "tool-read",
+                        kind: "read",
+                        locations: [
+                            {
+                                endLine: 11,
+                                line: 10,
+                                path: "src/app.ts",
+                            },
+                        ],
+                        rawInputJson: null,
+                        rawOutputJson: null,
+                        sessionId: "session-1",
+                        status: "completed",
+                        summary: null,
+                        terminalOutput: null,
+                        title: "Read src/app.ts",
+                        updatedAt: "2026-04-17T10:04:01.000Z",
+                    },
+                ],
+            }),
+            selectedTranscript: {
+                error: null,
+                isLoading: false,
+                messages: [
+                    {
+                        attachments: [],
+                        content: "Reading the file.",
+                        createdAt: "2026-04-17T10:03:00.000Z",
+                        id: "msg-1",
+                        kind: "assistant",
+                        status: "completed",
+                    },
+                ],
+                totalMessages: 1,
+            },
+            sessions: [session],
+            toolCardExpansionMode: "expanded",
+            transcriptMessages: [
+                {
+                    attachments: [],
+                    content: "Reading the file.",
+                    createdAt: "2026-04-17T10:03:00.000Z",
+                    id: "msg-1",
+                    kind: "assistant",
+                    status: "completed",
+                },
+            ],
+        });
+        const expandButton = container.querySelector<HTMLButtonElement>(
+            'button[aria-label="Expand details"]',
+        );
+        expect(expandButton).not.toBeNull();
+
+        act(() => {
+            expandButton?.click();
+        });
+
+        const locationButton = Array.from(
+            container.querySelectorAll<HTMLButtonElement>("button"),
+        ).find((button) => button.textContent === "src/app.ts:10-11");
+        expect(locationButton).not.toBeNull();
+
+        act(() => {
+            locationButton?.click();
+        });
+
+        expect(handleOpenFile).toHaveBeenCalledWith(
+            "project-1",
+            "src/app.ts",
+            "worktree-1",
+            undefined,
+            {
+                endLine: 11,
+                startLine: 10,
+            },
+        );
     });
 
     it("renders child agents under their parent without rename actions", () => {

--- a/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
@@ -214,48 +214,6 @@ export function ChatHistoryTabView({ tab }: ChatHistoryTabViewProps) {
         () => buildChatFontFamily(aiChatSettings.chatFontFamily),
         [aiChatSettings.chatFontFamily],
     );
-    const projectFileRoots = useMemo(() => {
-        const activeWorktreeRootPath = tab.worktreeId
-            ? (gitSnapshot?.worktrees.find(
-                  (worktree) => worktree.id === tab.worktreeId,
-              )?.rootPath ?? null)
-            : (gitSnapshot?.worktrees.find((worktree) => worktree.isCurrent)
-                  ?.rootPath ??
-              gitSnapshot?.worktrees.find((worktree) => worktree.isPrimary)
-                  ?.rootPath ??
-              null);
-
-        return collectProjectFileRoots({
-            canonicalProjectRoot: projectSummary?.canonicalRootPath,
-            currentWorktreeRoot: activeWorktreeRootPath,
-            projectRoot: projectSummary?.rootPath,
-            repositoryCanonicalRoot: gitSnapshot?.canonicalRootPath,
-            repositoryRoot: gitSnapshot?.rootPath,
-        });
-    }, [
-        gitSnapshot?.canonicalRootPath,
-        gitSnapshot?.rootPath,
-        gitSnapshot?.worktrees,
-        projectSummary?.canonicalRootPath,
-        projectSummary?.rootPath,
-        tab.worktreeId,
-    ]);
-    const resolveChatFileReference = useCallback(
-        (reference: string): ResolvedProjectFileReference | null => {
-            if (!tab.projectId || projectFileRoots.length === 0) {
-                return null;
-            }
-
-            return resolveProjectFileReference(reference, {
-                projectRoots: projectFileRoots,
-            });
-        },
-        [projectFileRoots, tab.projectId],
-    );
-    const canRenderFileReference = useFileReferenceValidator(
-        tab.projectId ?? null,
-        tab.worktreeId ?? null,
-    );
     const handleOpenFile = useCallback(
         async (
             projectId: string,
@@ -275,24 +233,6 @@ export function ChatHistoryTabView({ tab }: ChatHistoryTabViewProps) {
             );
         },
         [openFileTab],
-    );
-    const handleOpenResolvedFileReference = useCallback(
-        (reference: ResolvedProjectFileReference) => {
-            if (!tab.projectId) {
-                return;
-            }
-
-            void openFileTab(
-                tab.projectId,
-                reference.relativePath,
-                tab.worktreeId ?? null,
-                null,
-                undefined,
-                undefined,
-                getOpenLocationFromResolvedFileReference(reference),
-            );
-        },
-        [openFileTab, tab.projectId, tab.worktreeId],
     );
     const handleOpenImage = useCallback(
         async (attachment: AiImageAttachment) => {
@@ -425,6 +365,68 @@ export function ChatHistoryTabView({ tab }: ChatHistoryTabViewProps) {
     const selectedSession =
         sessions.find((session) => session.sessionId === selectedSessionId) ??
         null;
+    const selectedSessionWorktreeId =
+        selectedSession?.worktreeId ?? tab.worktreeId ?? null;
+    const transcriptProjectFileRoots = useMemo(() => {
+        const activeWorktreeRootPath = selectedSessionWorktreeId
+            ? (gitSnapshot?.worktrees.find(
+                  (worktree) => worktree.id === selectedSessionWorktreeId,
+              )?.rootPath ?? null)
+            : (gitSnapshot?.worktrees.find((worktree) => worktree.isCurrent)
+                  ?.rootPath ??
+              gitSnapshot?.worktrees.find((worktree) => worktree.isPrimary)
+                  ?.rootPath ??
+              null);
+
+        return collectProjectFileRoots({
+            canonicalProjectRoot: projectSummary?.canonicalRootPath,
+            currentWorktreeRoot: activeWorktreeRootPath,
+            projectRoot: projectSummary?.rootPath,
+            repositoryCanonicalRoot: gitSnapshot?.canonicalRootPath,
+            repositoryRoot: gitSnapshot?.rootPath,
+        });
+    }, [
+        gitSnapshot?.canonicalRootPath,
+        gitSnapshot?.rootPath,
+        gitSnapshot?.worktrees,
+        projectSummary?.canonicalRootPath,
+        projectSummary?.rootPath,
+        selectedSessionWorktreeId,
+    ]);
+    const resolveChatFileReference = useCallback(
+        (reference: string): ResolvedProjectFileReference | null => {
+            if (!tab.projectId || transcriptProjectFileRoots.length === 0) {
+                return null;
+            }
+
+            return resolveProjectFileReference(reference, {
+                projectRoots: transcriptProjectFileRoots,
+            });
+        },
+        [tab.projectId, transcriptProjectFileRoots],
+    );
+    const canRenderFileReference = useFileReferenceValidator(
+        tab.projectId ?? null,
+        selectedSessionWorktreeId,
+    );
+    const handleOpenResolvedFileReference = useCallback(
+        (reference: ResolvedProjectFileReference) => {
+            if (!tab.projectId) {
+                return;
+            }
+
+            void openFileTab(
+                tab.projectId,
+                reference.relativePath,
+                selectedSessionWorktreeId,
+                null,
+                undefined,
+                undefined,
+                getOpenLocationFromResolvedFileReference(reference),
+            );
+        },
+        [openFileTab, selectedSessionWorktreeId, tab.projectId],
+    );
     const selectedTranscript = selectedSessionId
         ? (transcriptsBySessionId[selectedSessionId] ?? null)
         : null;

--- a/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
@@ -28,9 +28,14 @@ import { useAiChatSettings } from "@renderer/app/hooks/use-ai-chat-settings";
 import { getGitContextKey } from "@renderer/app/git/context-key";
 import { buildChatFontFamily } from "@renderer/app/settings/theme";
 import { useGitStore } from "@renderer/app/store/git-store";
+import { useFileReferenceValidator } from "@renderer/app/store/projectFileIndexStore";
 import { useProjectsStore } from "@renderer/app/store/projects-store";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
-import type { RuntimeWorkspaceChatHistoryTab } from "@renderer/app/workspace/tree";
+import type {
+    RuntimeWorkspaceChatHistoryTab,
+    RuntimeWorkspaceFileOpenLocation,
+    RuntimeWorkspaceFileReviewContext,
+} from "@renderer/app/workspace/tree";
 
 import {
     IdeActionButton,
@@ -75,6 +80,19 @@ const MIN_HISTORY_SIDEBAR_WIDTH = 200;
 const MAX_HISTORY_SIDEBAR_WIDTH = 520;
 const MIN_HISTORY_DETAIL_PANE_WIDTH = 360;
 
+function getOpenLocationFromResolvedFileReference(
+    reference: ResolvedProjectFileReference,
+): RuntimeWorkspaceFileOpenLocation | null {
+    if (reference.startLine === null) {
+        return null;
+    }
+
+    return {
+        endLine: reference.endLine,
+        startLine: reference.startLine,
+    };
+}
+
 interface ChatHistoryTabViewProps {
     readonly tab: RuntimeWorkspaceChatHistoryTab;
 }
@@ -93,6 +111,10 @@ export interface SessionSnapshotState {
 }
 
 export interface ChatHistoryTabLayoutProps {
+    readonly canRenderFileReference?: (
+        rawReference: string,
+        reference: ResolvedProjectFileReference,
+    ) => boolean;
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
     readonly toolCardExpansionMode?: AiToolCardExpansionMode;
@@ -114,6 +136,8 @@ export interface ChatHistoryTabLayoutProps {
         projectId: string,
         relativePath: string,
         worktreeId?: string | null,
+        reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly handleOpenImage?: (
         attachment: AiImageAttachment,
@@ -228,13 +252,27 @@ export function ChatHistoryTabView({ tab }: ChatHistoryTabViewProps) {
         },
         [projectFileRoots, tab.projectId],
     );
+    const canRenderFileReference = useFileReferenceValidator(
+        tab.projectId ?? null,
+        tab.worktreeId ?? null,
+    );
     const handleOpenFile = useCallback(
         async (
             projectId: string,
             relativePath: string,
             worktreeId?: string | null,
+            reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+            openLocation?: RuntimeWorkspaceFileOpenLocation | null,
         ) => {
-            await openFileTab(projectId, relativePath, worktreeId ?? null);
+            await openFileTab(
+                projectId,
+                relativePath,
+                worktreeId ?? null,
+                reviewContext ?? null,
+                undefined,
+                undefined,
+                openLocation ?? null,
+            );
         },
         [openFileTab],
     );
@@ -248,6 +286,10 @@ export function ChatHistoryTabView({ tab }: ChatHistoryTabViewProps) {
                 tab.projectId,
                 reference.relativePath,
                 tab.worktreeId ?? null,
+                null,
+                undefined,
+                undefined,
+                getOpenLocationFromResolvedFileReference(reference),
             );
         },
         [openFileTab, tab.projectId, tab.worktreeId],
@@ -868,6 +910,7 @@ export function ChatHistoryTabView({ tab }: ChatHistoryTabViewProps) {
             chatFontFamily={chatFontFamily}
             chatFontSize={aiChatSettings.chatFontSize}
             toolCardExpansionMode={aiChatSettings.toolCardExpansionMode}
+            canRenderFileReference={canRenderFileReference}
             handleDelete={handleDelete}
             handleOpenFile={handleOpenFile}
             handleOpenImage={handleOpenImage}
@@ -913,6 +956,7 @@ export function ChatHistoryTabView({ tab }: ChatHistoryTabViewProps) {
 }
 
 export function ChatHistoryTabLayout({
+    canRenderFileReference,
     chatFontFamily,
     chatFontSize,
     toolCardExpansionMode = "collapsed",
@@ -1661,6 +1705,9 @@ export function ChatHistoryTabLayout({
                                         style={{ fontFamily: chatFontFamily }}
                                     >
                                         <HistoryTranscriptTimeline
+                                            canRenderFileReference={
+                                                canRenderFileReference
+                                            }
                                             chatFontFamily={chatFontFamily}
                                             chatFontSize={chatFontSize}
                                             highlightQuery={
@@ -1753,7 +1800,15 @@ export function ChatHistoryTabLayout({
     );
 }
 
-const NOOP_OPEN_FILE = (...args: [string, string, (string | null | undefined)?]) => {
+const NOOP_OPEN_FILE = (
+    ...args: [
+        string,
+        string,
+        (string | null | undefined)?,
+        (RuntimeWorkspaceFileReviewContext | null | undefined)?,
+        (RuntimeWorkspaceFileOpenLocation | null | undefined)?,
+    ]
+) => {
     void args;
     return Promise.resolve();
 };
@@ -1778,6 +1833,10 @@ const NOOP_RESOLVE_FILE_REFERENCE = (
 };
 
 interface HistoryTimelineHandlers {
+    readonly canRenderFileReference?: (
+        rawReference: string,
+        reference: ResolvedProjectFileReference,
+    ) => boolean;
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
     readonly highlightQuery?: string;
@@ -1786,6 +1845,8 @@ interface HistoryTimelineHandlers {
         projectId: string,
         relativePath: string,
         worktreeId?: string | null,
+        reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
     readonly onOpenResolvedFileReference: (
@@ -1798,6 +1859,7 @@ interface HistoryTimelineHandlers {
 }
 
 function HistoryTranscriptTimeline({
+    canRenderFileReference,
     chatFontFamily,
     chatFontSize,
     highlightQuery,
@@ -1812,6 +1874,10 @@ function HistoryTranscriptTimeline({
     transcriptMessages,
     worktreeId,
 }: {
+    readonly canRenderFileReference?: (
+        rawReference: string,
+        reference: ResolvedProjectFileReference,
+    ) => boolean;
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
     readonly highlightQuery?: string;
@@ -1819,6 +1885,8 @@ function HistoryTranscriptTimeline({
         projectId: string,
         relativePath: string,
         worktreeId?: string | null,
+        reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly onOpenImage?: (attachment: AiImageAttachment) => Promise<void>;
     readonly onOpenResolvedFileReference?: (
@@ -1850,6 +1918,7 @@ function HistoryTranscriptTimeline({
 
     const handlers = useMemo<HistoryTimelineHandlers>(
         () => ({
+            canRenderFileReference,
             chatFontFamily,
             chatFontSize,
             highlightQuery,
@@ -1863,6 +1932,7 @@ function HistoryTranscriptTimeline({
                 resolveFileReference ?? NOOP_RESOLVE_FILE_REFERENCE,
         }),
         [
+            canRenderFileReference,
             chatFontFamily,
             chatFontSize,
             highlightQuery,
@@ -1904,6 +1974,7 @@ function HistoryTimelineRow({
     if (row.kind === "message") {
         return (
             <ChatMessageRow
+                canRenderFileReference={handlers.canRenderFileReference}
                 chatFontFamily={handlers.chatFontFamily}
                 chatFontSize={handlers.chatFontSize}
                 highlightQuery={handlers.highlightQuery}

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -610,6 +610,20 @@ export const ChatTabView = memo(function ChatTabView({
                 return;
             }
 
+            if (reference.startLine !== null) {
+                void onOpenFile(
+                    tab.projectId,
+                    reference.relativePath,
+                    tab.worktreeId ?? null,
+                    undefined,
+                    {
+                        endLine: reference.endLine,
+                        startLine: reference.startLine,
+                    },
+                );
+                return;
+            }
+
             void onOpenFile(
                 tab.projectId,
                 reference.relativePath,

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -50,6 +50,7 @@ import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
 import { useRenderProbe } from "@renderer/app/debug/renderProbe";
 import type {
     RuntimeWorkspaceChatTab,
+    RuntimeWorkspaceFileOpenLocation,
     RuntimeWorkspaceFileReviewContext,
 } from "@renderer/app/workspace/tree";
 import type { MeasuredVirtualRange } from "@renderer/components/virtual/MeasuredVirtualList";
@@ -122,6 +123,7 @@ interface ChatTabViewProps {
         relativePath: string,
         worktreeId?: string | null,
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
     readonly onOpenReview: () => Promise<void>;
@@ -2264,6 +2266,7 @@ type ChatTimelineProps = {
         relativePath: string,
         worktreeId?: string | null,
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
     readonly onOpenResolvedFileReference: (
@@ -2502,6 +2505,7 @@ type ChatTimelineHistoryProps = {
         relativePath: string,
         worktreeId?: string | null,
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
     readonly onOpenResolvedFileReference: (
@@ -2639,6 +2643,7 @@ type ChatTimelineLiveTailProps = {
         relativePath: string,
         worktreeId?: string | null,
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
     readonly onOpenResolvedFileReference: (
@@ -2720,6 +2725,7 @@ type ChatTimelineRowViewProps = {
         relativePath: string,
         worktreeId?: string | null,
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly onOpenImage: (attachment: AiImageAttachment) => Promise<void>;
     readonly onOpenResolvedFileReference: (

--- a/src/renderer/src/components/workspace/MarkdownContent.test.ts
+++ b/src/renderer/src/components/workspace/MarkdownContent.test.ts
@@ -1,9 +1,47 @@
+/** @vitest-environment jsdom */
 import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MarkdownContent } from "./MarkdownContent";
 import { resolveProjectFileReference } from "./projectFileReferences";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLDivElement[] = [];
+
+afterEach(() => {
+    for (const root of mountedRoots.splice(0)) {
+        act(() => {
+            root.unmount();
+        });
+    }
+
+    for (const container of mountedContainers.splice(0)) {
+        container.remove();
+    }
+});
+
+function renderInteractiveMarkdownContent(
+    props: Parameters<typeof MarkdownContent>[0],
+): HTMLElement {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const root = createRoot(container);
+    mountedRoots.push(root);
+    mountedContainers.push(container);
+
+    act(() => {
+        root.render(createElement(MarkdownContent, props));
+    });
+
+    return container;
+}
 
 describe("MarkdownContent", () => {
     it("renders diff blocks with DiffLineView", () => {
@@ -202,6 +240,35 @@ describe("MarkdownContent", () => {
         expect(markup).toContain(
             'title="file:///Users/test/workspace/comando/src/app.ts#L9-L14"',
         );
+    });
+
+    it("opens raw diagnostic file reference pills with parsed line ranges", () => {
+        const onOpenFile = vi.fn();
+        const container = renderInteractiveMarkdownContent({
+            canRenderFileReference: () => true,
+            content: "Errors at src/app.ts:12-18.",
+            onOpenFile,
+            resolveFileReference: (reference) =>
+                resolveProjectFileReference(reference, {
+                    projectRoots: ["/Users/test/workspace/comando"],
+                }),
+        });
+        const pillButton = container.querySelector<HTMLButtonElement>(
+            'button[title="src/app.ts:12-18"]',
+        );
+        expect(pillButton).not.toBeNull();
+
+        act(() => {
+            pillButton?.click();
+        });
+
+        expect(onOpenFile).toHaveBeenCalledWith({
+            endLine: 18,
+            isAbsolute: false,
+            path: "src/app.ts",
+            relativePath: "src/app.ts",
+            startLine: 12,
+        });
     });
 
     it("renders markdown project file links as interactive pills", () => {

--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -22,6 +22,7 @@ import type { RuntimeWorkspaceFileTab } from "@renderer/app/workspace/tree";
 
 const mockWorkspaceStoreState = vi.hoisted(() => ({
     current: {
+        updateFilePendingOpenLocation: vi.fn(),
         updateFileViewState: vi.fn(),
     },
 }));
@@ -125,6 +126,13 @@ const monacoHarness = vi.hoisted(() => {
         readonly onMouseLeave: () => Disposable;
         readonly onMouseMove: () => Disposable;
         readonly pushUndoStop: () => void;
+        readonly revealLineInCenter: (lineNumber: number) => void;
+        readonly revealRangeInCenter: (range: {
+            readonly endColumn: number;
+            readonly endLineNumber: number;
+            readonly startColumn: number;
+            readonly startLineNumber: number;
+        }) => void;
         readonly restoreViewState: (viewState: unknown) => void;
         readonly saveViewState: () => {
             readonly contributionsState: readonly unknown[];
@@ -138,6 +146,14 @@ const monacoHarness = vi.hoisted(() => {
         readonly setPosition: (position: {
             readonly column: number;
             readonly lineNumber: number;
+        }) => void;
+        readonly setSelection: (selection: {
+            readonly endColumn: number;
+            readonly endLineNumber: number;
+            readonly selectionStartColumn: number;
+            readonly selectionStartLineNumber: number;
+            readonly startColumn: number;
+            readonly startLineNumber: number;
         }) => void;
         readonly setScrollLeft: (scrollLeft: number) => void;
         readonly setScrollTop: (scrollTop: number) => void;
@@ -315,6 +331,8 @@ const monacoHarness = vi.hoisted(() => {
             onMouseLeave: () => createDisposable(),
             onMouseMove: () => createDisposable(),
             pushUndoStop: vi.fn(),
+            revealLineInCenter: vi.fn(),
+            revealRangeInCenter: vi.fn(),
             restoreViewState: vi.fn(),
             saveViewState: vi.fn(() => ({
                 contributionsState: [],
@@ -338,6 +356,7 @@ const monacoHarness = vi.hoisted(() => {
                     editor.position = position;
                 },
             ),
+            setSelection: vi.fn(),
             setScrollLeft: vi.fn((scrollLeft: number) => {
                 editor.scrollLeft = scrollLeft;
             }),
@@ -789,6 +808,7 @@ describe("WorkspaceFileEditorHost", () => {
         mockEditorRuntime.applyProjectTypeScriptConfigForPath.mockClear();
         mockEditorRuntime.ensureMonacoTextMateForLanguage.mockClear();
         mockEditorRuntime.installMonacoTokenDebugAction.mockClear();
+        mockWorkspaceStoreState.current.updateFilePendingOpenLocation.mockClear();
         mockWorkspaceStoreState.current.updateFileViewState.mockClear();
         mockAiStoreState.current.sessions = {};
     });
@@ -863,6 +883,94 @@ describe("WorkspaceFileEditorHost", () => {
         expect(monacoHarness.codeEditors).toHaveLength(1);
         expect(monacoHarness.codeEditors[0]?.disposed).toBe(false);
         expect(container.querySelector("[aria-hidden='true']")).not.toBeNull();
+    });
+
+    it("applies a pending file open line before restoring saved view state", async () => {
+        const tab = {
+            ...createFileTab(
+                "file-1",
+                "src/app.ts",
+                ["one", "two", "three", ""].join("\n"),
+            ),
+            pendingOpenLocation: {
+                endLine: null,
+                startLine: 99,
+            },
+            viewState: {
+                contributionsState: {},
+                cursorState: [],
+                viewState: {
+                    firstPosition: {
+                        column: 1,
+                        lineNumber: 1,
+                    },
+                    firstPositionDeltaTop: 0,
+                    scrollLeft: 0,
+                },
+            },
+        } satisfies RuntimeWorkspaceFileTab;
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: tab,
+                    fileTabs: [tab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const editor = monacoHarness.codeEditors[0];
+        expect(editor?.setPosition).toHaveBeenCalledWith({
+            column: 1,
+            lineNumber: 4,
+        });
+        expect(editor?.revealLineInCenter).toHaveBeenCalledWith(4);
+        expect(editor?.restoreViewState).not.toHaveBeenCalled();
+        expect(
+            mockWorkspaceStoreState.current.updateFilePendingOpenLocation,
+        ).toHaveBeenCalledWith("file-1", null);
+    });
+
+    it("selects and reveals a pending file open range", async () => {
+        const tab = {
+            ...createFileTab(
+                "file-1",
+                "src/app.ts",
+                ["alpha", "beta", "gamma", ""].join("\n"),
+            ),
+            pendingOpenLocation: {
+                endLine: 3,
+                startLine: 2,
+            },
+        } satisfies RuntimeWorkspaceFileTab;
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: tab,
+                    fileTabs: [tab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const expectedSelection = {
+            endColumn: 6,
+            endLineNumber: 3,
+            selectionStartColumn: 1,
+            selectionStartLineNumber: 2,
+            startColumn: 1,
+            startLineNumber: 2,
+        };
+        const editor = monacoHarness.codeEditors[0];
+        expect(editor?.setSelection).toHaveBeenCalledWith(expectedSelection);
+        expect(editor?.revealRangeInCenter).toHaveBeenCalledWith(
+            expectedSelection,
+        );
+        expect(
+            mockWorkspaceStoreState.current.updateFilePendingOpenLocation,
+        ).toHaveBeenCalledWith("file-1", null);
     });
 
     it("mounts inline review diff models without unmounting the normal file editor", async () => {

--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -973,6 +973,58 @@ describe("WorkspaceFileEditorHost", () => {
         ).toHaveBeenCalledWith("file-1", null);
     });
 
+    it("applies a pending file open location that arrives after mount", async () => {
+        const tab = createFileTab(
+            "file-1",
+            "src/app.ts",
+            ["one", "two", "three", ""].join("\n"),
+        );
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: tab,
+                    fileTabs: [tab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const editor = monacoHarness.codeEditors[0];
+        expect(editor?.setPosition).not.toHaveBeenCalledWith({
+            column: 1,
+            lineNumber: 3,
+        });
+        mockWorkspaceStoreState.current.updateFilePendingOpenLocation.mockClear();
+
+        const tabWithPendingLocation = {
+            ...tab,
+            pendingOpenLocation: {
+                endLine: null,
+                startLine: 3,
+            },
+        } satisfies RuntimeWorkspaceFileTab;
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: tabWithPendingLocation,
+                    fileTabs: [tabWithPendingLocation],
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(editor?.setPosition).toHaveBeenCalledWith({
+            column: 1,
+            lineNumber: 3,
+        });
+        expect(editor?.revealLineInCenter).toHaveBeenCalledWith(3);
+        expect(
+            mockWorkspaceStoreState.current.updateFilePendingOpenLocation,
+        ).toHaveBeenCalledWith("file-1", null);
+    });
+
     it("mounts inline review diff models without unmounting the normal file editor", async () => {
         const fileTab = createFileTab("file-1");
         mockAiStoreState.current.sessions = {

--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -1025,6 +1025,129 @@ describe("WorkspaceFileEditorHost", () => {
         ).toHaveBeenCalledWith("file-1", null);
     });
 
+    it("applies a pending file open range to the inline review modified editor", async () => {
+        const tab = {
+            ...createFileTab("file-1"),
+            pendingOpenLocation: {
+                endLine: 3,
+                startLine: 2,
+            },
+        } satisfies RuntimeWorkspaceFileTab;
+        mockAiStoreState.current.sessions = {
+            "session-1": {
+                snapshot: {
+                    trackedFiles: [createTrackedFileUpdate()],
+                },
+            },
+        };
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: tab,
+                    fileTabs: [tab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const normalEditor = monacoHarness.codeEditors.find((editor) =>
+            editor.name.startsWith("editor-"),
+        );
+        const diffEditor = monacoHarness.diffEditors[0];
+        expect(diffEditor).toBeDefined();
+        if (!diffEditor) {
+            throw new Error("Expected inline review diff editor to mount.");
+        }
+
+        const modifiedEditor = diffEditor.getModifiedEditor();
+        const expectedSelection = {
+            endColumn: modifiedEditor.getModel()?.getLineMaxColumn(3) ?? 1,
+            endLineNumber: 3,
+            selectionStartColumn: 1,
+            selectionStartLineNumber: 2,
+            startColumn: 1,
+            startLineNumber: 2,
+        };
+        expect(modifiedEditor.setSelection).toHaveBeenCalledWith(
+            expectedSelection,
+        );
+        expect(modifiedEditor.revealRangeInCenter).toHaveBeenCalledWith(
+            expectedSelection,
+        );
+        expect(normalEditor?.setSelection).not.toHaveBeenCalled();
+        expect(
+            mockWorkspaceStoreState.current.updateFilePendingOpenLocation,
+        ).toHaveBeenCalledWith("file-1", null);
+    });
+
+    it("applies a pending file open range that arrives after inline review mounts", async () => {
+        const tab = createFileTab("file-1");
+        mockAiStoreState.current.sessions = {
+            "session-1": {
+                snapshot: {
+                    trackedFiles: [createTrackedFileUpdate()],
+                },
+            },
+        };
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: tab,
+                    fileTabs: [tab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const diffEditor = monacoHarness.diffEditors[0];
+        expect(diffEditor).toBeDefined();
+        if (!diffEditor) {
+            throw new Error("Expected inline review diff editor to mount.");
+        }
+        const modifiedEditor = diffEditor.getModifiedEditor();
+        vi.mocked(modifiedEditor.setSelection).mockClear();
+        vi.mocked(modifiedEditor.revealRangeInCenter).mockClear();
+        mockWorkspaceStoreState.current.updateFilePendingOpenLocation.mockClear();
+
+        const tabWithPendingLocation = {
+            ...tab,
+            pendingOpenLocation: {
+                endLine: 3,
+                startLine: 2,
+            },
+        } satisfies RuntimeWorkspaceFileTab;
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: tabWithPendingLocation,
+                    fileTabs: [tabWithPendingLocation],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const expectedSelection = {
+            endColumn: modifiedEditor.getModel()?.getLineMaxColumn(3) ?? 1,
+            endLineNumber: 3,
+            selectionStartColumn: 1,
+            selectionStartLineNumber: 2,
+            startColumn: 1,
+            startLineNumber: 2,
+        };
+        expect(modifiedEditor.setSelection).toHaveBeenCalledWith(
+            expectedSelection,
+        );
+        expect(modifiedEditor.revealRangeInCenter).toHaveBeenCalledWith(
+            expectedSelection,
+        );
+        expect(
+            mockWorkspaceStoreState.current.updateFilePendingOpenLocation,
+        ).toHaveBeenCalledWith("file-1", null);
+    });
+
     it("mounts inline review diff models without unmounting the normal file editor", async () => {
         const fileTab = createFileTab("file-1");
         mockAiStoreState.current.sessions = {

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -506,6 +506,21 @@ function applyEditorOpenLocation(
     return true;
 }
 
+function applyInlineReviewOpenLocation(
+    diffEditor: MonacoEditor.IStandaloneDiffEditor,
+    location: RuntimeWorkspaceFileOpenLocation,
+): boolean {
+    const modifiedEditor = diffEditor.getModifiedEditor();
+    if (!applyEditorOpenLocation(modifiedEditor, location)) {
+        return false;
+    }
+
+    const originalEditor = diffEditor.getOriginalEditor();
+    originalEditor.setScrollLeft(modifiedEditor.getScrollLeft());
+    originalEditor.setScrollTop(modifiedEditor.getScrollTop());
+    return true;
+}
+
 function isMonacoCancellationError(error: unknown): boolean {
     return error instanceof Error && error.message.includes("Canceled");
 }
@@ -4995,6 +5010,29 @@ function FileTabView({
         [clearInlineReviewScrollRestore],
     );
 
+    const consumePendingInlineReviewOpenLocation = useCallback(
+        (diffEditor: MonacoEditor.IStandaloneDiffEditor): boolean => {
+            const pendingOpenLocation = tab.pendingOpenLocation ?? null;
+            if (!pendingOpenLocation) {
+                return false;
+            }
+
+            if (!applyInlineReviewOpenLocation(diffEditor, pendingOpenLocation)) {
+                return false;
+            }
+
+            pendingEditorViewStateTabIdRef.current = tab.id;
+            pendingEditorViewStateRef.current = diffEditor
+                .getModifiedEditor()
+                .saveViewState();
+            inlineReviewScrollStateRef.current =
+                captureDiffEditorScrollState(diffEditor);
+            updateFilePendingOpenLocation(tab.id, null);
+            return true;
+        },
+        [tab.id, tab.pendingOpenLocation, updateFilePendingOpenLocation],
+    );
+
     const applyInlineReviewModels = useCallback(
         (trackedFile: AiTrackedFile | null) => {
             if (
@@ -5007,7 +5045,8 @@ function FileTabView({
                 return;
             }
 
-            const installedModels = diffEditorRef.current.getModel();
+            const diffEditor = diffEditorRef.current;
+            const installedModels = diffEditor.getModel();
             const currentReviewModels = inlineReviewCurrentModelsRef.current;
             if (
                 currentReviewModels.revision ===
@@ -5019,10 +5058,10 @@ function FileTabView({
                 installedModels?.original === currentReviewModels.original &&
                 installedModels?.modified === currentReviewModels.modified
             ) {
+                consumePendingInlineReviewOpenLocation(diffEditor);
                 return;
             }
 
-            const diffEditor = diffEditorRef.current;
             const monaco = inlineReviewMonacoRef.current;
             const previousModels = diffEditor.getModel();
             const currentInlineReviewRestoreState =
@@ -5078,7 +5117,9 @@ function FileTabView({
                     modified: nextModifiedModel,
                     original: nextOriginalModel,
                 };
-                if (currentInlineReviewRestoreState) {
+                if (consumePendingInlineReviewOpenLocation(diffEditor)) {
+                    // Explicit file reference navigation wins over review view state.
+                } else if (currentInlineReviewRestoreState) {
                     restorePortableInlineReviewState(
                         diffEditor,
                         currentInlineReviewRestoreState,
@@ -5125,6 +5166,7 @@ function FileTabView({
             document,
             inlineReviewModelRevision,
             monacoLanguageId,
+            consumePendingInlineReviewOpenLocation,
             restoreInlineReviewScrollState,
             restoreInlineReviewViewState,
             restorePortableInlineReviewState,
@@ -5982,7 +6024,10 @@ function FileTabView({
                                 );
                                 pendingInlineReviewRestoreStateRef.current =
                                     null;
-                            } else if (consumePendingOpenLocation(editor)) {
+                            } else if (
+                                !inlineReviewTrackedFile &&
+                                consumePendingOpenLocation(editor)
+                            ) {
                                 // The explicit location intent wins over saved view state.
                             } else {
                                 const persistedViewState =

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -92,6 +92,7 @@ import {
 import {
     collectPaneNodes,
     findWorkspaceNodeById,
+    type RuntimeWorkspaceFileOpenLocation,
     type RuntimeWorkspaceFileReviewContext,
     type RuntimeWorkspaceFileTab,
     type RuntimeWorkspaceTab,
@@ -1535,6 +1536,7 @@ function WorkspacePaneView({
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
         targetPaneId?: string | null,
         targetIndex?: number,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void> = useWorkspaceStore((state) => state.openFileTab);
     const openChatImageTab = useWorkspaceStore((state) => state.openChatImageTab);
     const openReviewTab = useWorkspaceStore((state) => state.openReviewTab);
@@ -1820,6 +1822,7 @@ function WorkspacePaneView({
             relativePath: string,
             worktreeId?: string | null,
             reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+            openLocation?: RuntimeWorkspaceFileOpenLocation | null,
         ) => {
             await openFileTab(
                 projectId,
@@ -1827,6 +1830,8 @@ function WorkspacePaneView({
                 worktreeId ?? activeTabWorktreeId,
                 reviewContext,
                 paneNodeId,
+                undefined,
+                openLocation,
             );
         },
         [activeTabWorktreeId, openFileTab, paneNodeId],

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -464,6 +464,48 @@ function capturePortableEditorRestoreState(
     };
 }
 
+function applyEditorOpenLocation(
+    editor: MonacoEditor.IStandaloneCodeEditor,
+    location: RuntimeWorkspaceFileOpenLocation,
+): boolean {
+    const model = editor.getModel();
+    if (!model) {
+        return false;
+    }
+
+    const startLine = Math.min(
+        Math.max(location.startLine, 1),
+        model.getLineCount(),
+    );
+    const endLine =
+        location.endLine === null || location.endLine === undefined
+            ? startLine
+            : Math.min(
+                  Math.max(location.endLine, startLine),
+                  model.getLineCount(),
+              );
+
+    editor.layout();
+
+    if (endLine > startLine) {
+        const selection = {
+            endColumn: model.getLineMaxColumn(endLine),
+            endLineNumber: endLine,
+            selectionStartColumn: 1,
+            selectionStartLineNumber: startLine,
+            startColumn: 1,
+            startLineNumber: startLine,
+        };
+        editor.setSelection(selection);
+        editor.revealRangeInCenter(selection);
+        return true;
+    }
+
+    editor.setPosition({ column: 1, lineNumber: startLine });
+    editor.revealLineInCenter(startLine);
+    return true;
+}
+
 function isMonacoCancellationError(error: unknown): boolean {
     return error instanceof Error && error.message.includes("Canceled");
 }
@@ -3691,6 +3733,9 @@ function FileTabView({
     const updateFileViewState = useWorkspaceStore(
         (state) => state.updateFileViewState,
     );
+    const updateFilePendingOpenLocation = useWorkspaceStore(
+        (state) => state.updateFilePendingOpenLocation,
+    );
     const diffEditorRef = useRef<MonacoEditor.IStandaloneDiffEditor | null>(
         null,
     );
@@ -4377,6 +4422,26 @@ function FileTabView({
         [restoreEditorViewState],
     );
 
+    const consumePendingOpenLocation = useCallback(
+        (editor: MonacoEditor.IStandaloneCodeEditor): boolean => {
+            const pendingOpenLocation = tab.pendingOpenLocation ?? null;
+            if (!pendingOpenLocation) {
+                return false;
+            }
+
+            if (!applyEditorOpenLocation(editor, pendingOpenLocation)) {
+                return false;
+            }
+
+            restoredEditorViewStateTabIdRef.current = tab.id;
+            pendingEditorViewStateTabIdRef.current = tab.id;
+            pendingEditorViewStateRef.current = editor.saveViewState();
+            updateFilePendingOpenLocation(tab.id, null);
+            return true;
+        },
+        [tab.id, tab.pendingOpenLocation, updateFilePendingOpenLocation],
+    );
+
     useEffect(() => {
         if (!isVisible) {
             return;
@@ -4403,12 +4468,17 @@ function FileTabView({
             return;
         }
 
+        if (consumePendingOpenLocation(editor)) {
+            return;
+        }
+
         restoreEditorViewStateForTab(
             editor,
             tab.id,
             getPendingEditorViewStateForTab(tab.id, tab.viewState ?? null),
         );
     }, [
+        consumePendingOpenLocation,
         getPendingEditorViewStateForTab,
         inlineReviewTrackedFile,
         isVisible,
@@ -4737,6 +4807,10 @@ function FileTabView({
             return;
         }
 
+        if (consumePendingOpenLocation(editor)) {
+            return;
+        }
+
         restoreEditorViewStateForTab(
             editor,
             tab.id,
@@ -4745,6 +4819,7 @@ function FileTabView({
     }, [
         canEdit,
         acquireFileEditorModel,
+        consumePendingOpenLocation,
         document,
         getPendingEditorViewStateForTab,
         inlineReviewTrackedFile,
@@ -5907,6 +5982,8 @@ function FileTabView({
                                 );
                                 pendingInlineReviewRestoreStateRef.current =
                                     null;
+                            } else if (consumePendingOpenLocation(editor)) {
+                                // The explicit location intent wins over saved view state.
                             } else {
                                 const persistedViewState =
                                     getPendingEditorViewStateForTab(

--- a/src/renderer/src/components/workspace/chat/ChangeReviewPanel.tsx
+++ b/src/renderer/src/components/workspace/chat/ChangeReviewPanel.tsx
@@ -1,7 +1,10 @@
 import { memo, useCallback, useMemo, type CSSProperties } from "react";
 
 import type { AiToolActivity, AiTrackedFile } from "@shared/ipc";
-import type { RuntimeWorkspaceFileReviewContext } from "@renderer/app/workspace/tree";
+import type {
+    RuntimeWorkspaceFileOpenLocation,
+    RuntimeWorkspaceFileReviewContext,
+} from "@renderer/app/workspace/tree";
 
 import { DEFAULT_AI_DIFF_ZOOM } from "@renderer/app/ai/sessionReviewContracts";
 import { useRenderProbe } from "@renderer/app/debug/renderProbe";
@@ -390,6 +393,7 @@ export interface ChangeReviewPanelProps {
         relativePath: string,
         worktreeId?: string | null,
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly projectId: string | null;
     readonly resolveFileReference?: (

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
@@ -543,6 +543,56 @@ describe("ToolActivityItem", () => {
         );
     });
 
+    it("passes raw relative location line ranges when no resolver is available", () => {
+        const onOpenFile = vi.fn(async () => {});
+        const container = renderInteractiveToolActivityItem({
+            activity: createActivity({
+                kind: "read",
+                locations: [
+                    {
+                        endLine: 11,
+                        line: 10,
+                        path: "src/example.ts",
+                    },
+                ],
+                summary: null,
+                title: "Read src/example.ts",
+            }),
+            onOpenFile,
+            projectId: "project-1",
+            trackedFiles: [],
+            worktreeId: null,
+        });
+        const chevronButton = container.querySelector<HTMLButtonElement>(
+            'button[aria-label="Expand details"]',
+        );
+        expect(chevronButton).not.toBeNull();
+
+        act(() => {
+            chevronButton?.click();
+        });
+
+        const locationButton = Array.from(
+            container.querySelectorAll<HTMLButtonElement>("button"),
+        ).find((button) => button.textContent === "src/example.ts:10-11");
+        expect(locationButton).not.toBeNull();
+
+        act(() => {
+            locationButton?.click();
+        });
+
+        expect(onOpenFile).toHaveBeenCalledWith(
+            "project-1",
+            "src/example.ts",
+            null,
+            undefined,
+            {
+                endLine: 11,
+                startLine: 10,
+            },
+        );
+    });
+
     it("activates read title links visually on hover and keyboard focus", () => {
         const container = renderInteractiveToolActivityItem({
             activity: createActivity({

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
@@ -11,7 +11,10 @@ import { useFileReferenceValidator } from "@renderer/app/store/projectFileIndexS
 import { useRenderProbe } from "@renderer/app/debug/renderProbe";
 import { HighlightedCodeText } from "@renderer/app/editor/staticCodeHighlight";
 import { useMarkdownCodeLanguageSupport } from "@renderer/app/editor/useCodeLanguageSupport";
-import type { RuntimeWorkspaceFileReviewContext } from "@renderer/app/workspace/tree";
+import type {
+    RuntimeWorkspaceFileOpenLocation,
+    RuntimeWorkspaceFileReviewContext,
+} from "@renderer/app/workspace/tree";
 
 import { MarkdownContent } from "../MarkdownContent";
 import {
@@ -446,6 +449,7 @@ function openToolFileReference({
         relativePath: string,
         worktreeId?: string | null,
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly onOpenFileReference?: (
         reference: ResolvedProjectFileReference,
@@ -808,6 +812,7 @@ function FileToolMessage({
         relativePath: string,
         worktreeId?: string | null,
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly onOpenFileReference?: (
         reference: ResolvedProjectFileReference,
@@ -1586,6 +1591,7 @@ export const ToolActivityItem = memo(function ToolActivityItem({
         relativePath: string,
         worktreeId?: string | null,
         reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
     ) => Promise<void>;
     readonly onOpenFileReference?: (
         reference: ResolvedProjectFileReference,
@@ -1695,6 +1701,7 @@ function areToolActivityItemPropsEqual(
             relativePath: string,
             worktreeId?: string | null,
             reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+            openLocation?: RuntimeWorkspaceFileOpenLocation | null,
         ) => Promise<void>;
         readonly onOpenFileReference?: (
             reference: ResolvedProjectFileReference,
@@ -1716,6 +1723,7 @@ function areToolActivityItemPropsEqual(
             relativePath: string,
             worktreeId?: string | null,
             reviewContext?: RuntimeWorkspaceFileReviewContext | null,
+            openLocation?: RuntimeWorkspaceFileOpenLocation | null,
         ) => Promise<void>;
         readonly onOpenFileReference?: (
             reference: ResolvedProjectFileReference,

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
@@ -436,6 +436,20 @@ function canOpenToolFileReference({
     return !!parsedReference && !parsedReference.isAbsolute && !!projectId;
 }
 
+function getOpenLocationFromFileReference(reference: {
+    readonly endLine: number | null;
+    readonly startLine: number | null;
+}): RuntimeWorkspaceFileOpenLocation | null {
+    if (reference.startLine === null) {
+        return null;
+    }
+
+    return {
+        endLine: reference.endLine,
+        startLine: reference.startLine,
+    };
+}
+
 function openToolFileReference({
     onOpenFile,
     onOpenFileReference,
@@ -469,17 +483,41 @@ function openToolFileReference({
         }
 
         if (projectId) {
-            void onOpenFile(
-                projectId,
-                resolvedReference.relativePath,
-                worktreeId,
-            );
+            const openLocation =
+                getOpenLocationFromFileReference(resolvedReference);
+            if (openLocation) {
+                void onOpenFile(
+                    projectId,
+                    resolvedReference.relativePath,
+                    worktreeId,
+                    undefined,
+                    openLocation,
+                );
+            } else {
+                void onOpenFile(
+                    projectId,
+                    resolvedReference.relativePath,
+                    worktreeId,
+                );
+            }
         }
         return;
     }
 
     const parsedReference = parseProjectFileReference(target);
     if (!parsedReference || parsedReference.isAbsolute || !projectId) {
+        return;
+    }
+
+    const openLocation = getOpenLocationFromFileReference(parsedReference);
+    if (openLocation) {
+        void onOpenFile(
+            projectId,
+            parsedReference.path,
+            worktreeId,
+            undefined,
+            openLocation,
+        );
         return;
     }
 


### PR DESCRIPTION
## Summary
- add a file open location contract across chat, tool cards, workspace store, and editor host
- preserve line/range metadata from chat file pills and tool activity locations
- store pending open locations as runtime-only tab intent and consume them in Monaco with one-shot navigation
- add coverage for parser-backed pills, tool locations, workspace intent storage, and editor reveal behavior

## Verification
- pnpm test src/renderer/src/components/workspace/projectFileReferences.test.ts src/renderer/src/components/workspace/MarkdownContent.test.ts src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts src/renderer/src/app/store/workspace-store.test.ts src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
- pnpm run typecheck