### PR TITLE
Fix live Monaco git gutter flicker

### DIFF
--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -2979,12 +2979,7 @@ function trimRetentionRecords<T>(records: T[]): void {
 }
 
 function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
-    if (
-        typeof timer === "object" &&
-        timer !== null &&
-        "unref" in timer &&
-        typeof timer.unref === "function"
-    ) {
+    if (typeof timer.unref === "function") {
         timer.unref();
     }
 }

--- a/src/main/git/client.ts
+++ b/src/main/git/client.ts
@@ -139,6 +139,20 @@ class GitWorkerGateway implements GitWorkerClient {
         });
     }
 
+    async getFileText(
+        inputPath: string,
+        relativePath: string,
+        reference: Parameters<GitGateway["getFileText"]>[2],
+    ) {
+        return await this.#rpc.call<
+            Awaited<ReturnType<GitGateway["getFileText"]>>
+        >("git.getFileText", {
+            inputPath,
+            reference,
+            relativePath,
+        });
+    }
+
     async listHistory(
         inputPath: string,
         options?: Parameters<GitGateway["listHistory"]>[1],

--- a/src/main/git/diff.test.ts
+++ b/src/main/git/diff.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileMock = vi.hoisted(() => vi.fn());
 
@@ -10,7 +10,11 @@ vi.mock("node:child_process", () => ({
     execFile: execFileMock,
 }));
 
-import { getGitFileDiff } from "./diff";
+import { getGitFileDiff, getGitFileText } from "./diff";
+
+beforeEach(() => {
+    execFileMock.mockReset();
+});
 
 describe("getGitFileDiff", () => {
     it("times out and reports a clear error for hung untracked no-index diffs", async () => {
@@ -75,5 +79,62 @@ describe("getGitFileDiff", () => {
             vi.useRealTimers();
             fs.rmSync(rootPath, { force: true, recursive: true });
         }
+    });
+});
+
+describe("getGitFileText", () => {
+    it("reads a text-converted blob with a bounded git show call", async () => {
+        execFileMock.mockImplementation(
+            (
+                _command: string,
+                _args: readonly string[],
+                _options: unknown,
+                callback: (
+                    error: Error | null,
+                    stdout: string,
+                    stderr: string,
+                ) => void,
+            ) => {
+                callback(null, "const value = 1;\n", "");
+            },
+        );
+
+        await expect(
+            getGitFileText("/workspace/repo", "src/app.ts", "index"),
+        ).resolves.toBe("const value = 1;\n");
+
+        expect(execFileMock).toHaveBeenCalledWith(
+            "git",
+            ["show", "--textconv", ":src/app.ts"],
+            expect.objectContaining({
+                cwd: "/workspace/repo",
+                encoding: "utf8",
+                killSignal: "SIGTERM",
+                maxBuffer: 5 * 1024 * 1024,
+                timeout: 10_000,
+            }),
+            expect.any(Function),
+        );
+    });
+
+    it("returns null when the requested blob cannot be read", async () => {
+        execFileMock.mockImplementation(
+            (
+                _command: string,
+                _args: readonly string[],
+                _options: unknown,
+                callback: (
+                    error: Error | null,
+                    stdout: string,
+                    stderr: string,
+                ) => void,
+            ) => {
+                callback(new Error("not found"), "", "");
+            },
+        );
+
+        await expect(
+            getGitFileText("/workspace/repo", "src/missing.ts", "head"),
+        ).resolves.toBeNull();
     });
 });

--- a/src/main/git/diff.ts
+++ b/src/main/git/diff.ts
@@ -14,10 +14,13 @@ import type {
     GitFileDiffLine,
     GitFileDiffOptions,
     GitFileDiffSummary,
+    GitFileTextReference,
 } from "./types";
 
 const execFileAsync = promisify(execFile);
 const GIT_DIFF_MAX_BUFFER_BYTES = 20 * 1024 * 1024;
+const GIT_SHOW_TEXT_MAX_BUFFER_BYTES = 5 * 1024 * 1024;
+const GIT_SHOW_TEXT_TIMEOUT_MS = 10_000;
 const GIT_UNTRACKED_DIFF_TIMEOUT_MS = 30_000;
 
 export async function getGitFileDiff(
@@ -42,6 +45,34 @@ export async function getGitFileDiff(
         summary: parsed.summary,
         hunks: parsed.hunks,
     };
+}
+
+export async function getGitFileText(
+    rootPath: string,
+    relativePath: string,
+    reference: GitFileTextReference,
+): Promise<string | null> {
+    const normalizedPath = normalizeSafeGitPath(relativePath);
+    const objectName =
+        reference === "index" ? `:${normalizedPath}` : `HEAD:${normalizedPath}`;
+
+    try {
+        const result = (await execFileAsync(
+            "git",
+            ["show", "--textconv", objectName],
+            {
+                cwd: rootPath,
+                encoding: "utf8",
+                killSignal: "SIGTERM",
+                maxBuffer: GIT_SHOW_TEXT_MAX_BUFFER_BYTES,
+                timeout: GIT_SHOW_TEXT_TIMEOUT_MS,
+            },
+        )) as string | { readonly stdout: string };
+        return readExecFileStdout(result);
+    } catch (error) {
+        debugBenignError("git.diff.getFileText", error);
+        return null;
+    }
 }
 
 export function parseUnifiedGitDiff(raw: string): {
@@ -232,14 +263,14 @@ async function runGitDiff(
     }
 
     try {
-        const result = await execFileAsync("git", [...args], {
+        const result = (await execFileAsync("git", [...args], {
             cwd: rootPath,
             encoding: "utf8",
             killSignal: "SIGTERM",
             maxBuffer: GIT_DIFF_MAX_BUFFER_BYTES,
             timeout: GIT_UNTRACKED_DIFF_TIMEOUT_MS,
-        });
-        return result.stdout;
+        })) as string | { readonly stdout: string };
+        return readExecFileStdout(result);
     } catch (error) {
         if (isGitDiffTimeoutError(error)) {
             throw new Error(
@@ -258,6 +289,12 @@ async function runGitDiff(
 
         throw error;
     }
+}
+
+function readExecFileStdout(
+    result: string | { readonly stdout: string },
+): string {
+    return typeof result === "string" ? result : result.stdout;
 }
 
 function isGitDiffTimeoutError(error: unknown): boolean {

--- a/src/main/git/service.ts
+++ b/src/main/git/service.ts
@@ -11,6 +11,7 @@ import type {
     GitDiffStatRecord,
     GitFileDiff,
     GitFileDiffOptions,
+    GitFileTextReference,
     GitHistoryListResult,
     GitListBranchesOptions,
     GitListHistoryOptions,
@@ -30,7 +31,7 @@ import {
     listGitWorktrees,
     resolveGitRepository,
 } from "./worktrees";
-import { getGitFileDiff } from "./diff";
+import { getGitFileDiff, getGitFileText } from "./diff";
 import { getGitCommitDetail, listGitHistory } from "./history";
 import { createSafeGitEnvironment } from "./environment";
 import { buildRuntimePathEntries } from "../ai/runtime-env";
@@ -54,6 +55,11 @@ export interface GitGateway {
         relativePath: string,
         options?: GitFileDiffOptions,
     ): Promise<GitFileDiff>;
+    getFileText(
+        inputPath: string,
+        relativePath: string,
+        reference: GitFileTextReference,
+    ): Promise<string | null>;
     listHistory(
         inputPath: string,
         options?: GitListHistoryOptions,
@@ -421,6 +427,23 @@ export class GitService implements GitGateway {
             resolution.canonicalRootPath,
             relativePath,
             options,
+        );
+    }
+
+    async getFileText(
+        inputPath: string,
+        relativePath: string,
+        reference: GitFileTextReference,
+    ): Promise<string | null> {
+        const resolution = await this.resolveRepository(inputPath);
+        if (resolution.state !== "ready" || !resolution.canonicalRootPath) {
+            return null;
+        }
+
+        return getGitFileText(
+            resolution.canonicalRootPath,
+            relativePath,
+            reference,
         );
     }
 

--- a/src/main/git/types.ts
+++ b/src/main/git/types.ts
@@ -158,6 +158,8 @@ export interface GitFileDiffOptions {
     readonly staged?: boolean;
 }
 
+export type GitFileTextReference = "head" | "index";
+
 export interface GitListBranchesOptions {
     readonly scope?: "all" | "local";
 }

--- a/src/main/git/worker.ts
+++ b/src/main/git/worker.ts
@@ -151,6 +151,18 @@ async function dispatchMethod(
                 input.options,
             );
         }
+        case "git.getFileText": {
+            const input = params as {
+                readonly inputPath: string;
+                readonly reference: Parameters<GitService["getFileText"]>[2];
+                readonly relativePath: string;
+            };
+            return await gitService.getFileText(
+                input.inputPath,
+                input.relativePath,
+                input.reference,
+            );
+        }
         case "git.listHistory": {
             const input = params as {
                 readonly inputPath: string;

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -103,6 +103,8 @@ import {
     type GitHubWorkflowRunsResult,
     type GitHistoryListInput,
     type GitHistoryListResult as SharedGitHistoryListResult,
+    type GitOriginalFile,
+    type GitOriginalFileInput,
     type GitPullInput,
     type GitPushInput,
     type GitRemoteSummary,
@@ -257,6 +259,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.listGitHistory);
     ipcMain.removeHandler(IPC_CHANNELS.listGitWorktreeDiff);
     ipcMain.removeHandler(IPC_CHANNELS.getGitDiff);
+    ipcMain.removeHandler(IPC_CHANNELS.getGitOriginalFile);
     ipcMain.removeHandler(IPC_CHANNELS.getGitCommitDetail);
     ipcMain.removeHandler(IPC_CHANNELS.initGitRepository);
     ipcMain.removeHandler(IPC_CHANNELS.stageGitPaths);
@@ -702,6 +705,18 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             input: GitDiffInput,
         ): Promise<SharedGitFileDiff | null> =>
             buildSharedGitDiff(
+                options.projectService,
+                options.gitService,
+                input,
+            ),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.getGitOriginalFile,
+        async (
+            _event,
+            input: GitOriginalFileInput,
+        ): Promise<GitOriginalFile | null> =>
+            buildGitOriginalFile(
                 options.projectService,
                 options.gitService,
                 input,
@@ -2027,6 +2042,131 @@ async function buildSharedGitDiff(
     });
 
     return adaptGitFileDiff(diff, entry, null);
+}
+
+async function buildGitOriginalFile(
+    projectService: ProjectService,
+    gitService: GitGateway,
+    input: GitOriginalFileInput,
+): Promise<GitOriginalFile | null> {
+    const scope = resolveGitScope(projectService, input);
+    const snapshot = await gitService.getRepositorySnapshot(scope.rootPath);
+    if (snapshot.resolution.state !== "ready") {
+        return null;
+    }
+
+    const normalizedPath = normalizeGitPath(input.path);
+    const entry =
+        snapshot.status.entries.find(
+            (candidate) => candidate.relativePath === normalizedPath,
+        ) ?? null;
+    if (!entry) {
+        return null;
+    }
+
+    const requestedScope = normalizeRequestedDiffScope(input.scope);
+    if (
+        requestedScope !== "auto" &&
+        !entry.scopes.includes(requestedScope)
+    ) {
+        return null;
+    }
+
+    const resolvedScope = resolveEffectiveGitDiffScope(entry, requestedScope);
+
+    if (entry.isBinary || resolvedScope === "conflicted") {
+        return {
+            baseText: null,
+            isText: false,
+            kind: mapSharedChangeKind(entry.kind),
+            path: entry.relativePath,
+            previousPath: entry.previousPath,
+            scope: resolvedScope,
+        };
+    }
+
+    const baseText = await resolveGitOriginalFileText(
+        gitService,
+        scope.rootPath,
+        entry,
+        resolvedScope,
+    );
+
+    return {
+        baseText,
+        isText: baseText !== null,
+        kind: mapSharedChangeKind(entry.kind),
+        path: entry.relativePath,
+        previousPath: entry.previousPath,
+        scope: resolvedScope,
+    };
+}
+
+async function resolveGitOriginalFileText(
+    gitService: GitGateway,
+    rootPath: string,
+    entry: MainGitChangeEntry,
+    diffScope: GitDiffScope,
+): Promise<string | null> {
+    if (diffScope === "untracked") {
+        return "";
+    }
+
+    const reference = diffScope === "staged" ? "head" : "index";
+    const basePath = resolveGitOriginalFileBasePath(entry, diffScope);
+    const baseText = await gitService.getFileText(
+        rootPath,
+        basePath,
+        reference,
+    );
+
+    if (baseText !== null) {
+        return baseText;
+    }
+
+    return entry.kind === "added" || entry.kind === "untracked" ? "" : null;
+}
+
+function resolveGitOriginalFileBasePath(
+    entry: MainGitChangeEntry,
+    diffScope: GitDiffScope,
+): string {
+    if (diffScope === "staged") {
+        return entry.previousPath ?? entry.relativePath;
+    }
+
+    if (diffScope === "unstaged" && entry.scopes.includes("staged")) {
+        return entry.relativePath;
+    }
+
+    return entry.previousPath ?? entry.relativePath;
+}
+
+function resolveEffectiveGitDiffScope(
+    entry: MainGitChangeEntry,
+    requestedScope: GitDiffScope | "auto",
+): GitDiffScope {
+    if (requestedScope !== "auto") {
+        return requestedScope;
+    }
+
+    if (entry.scopes.includes("unstaged")) {
+        return "unstaged";
+    }
+
+    if (entry.scopes.includes("untracked")) {
+        return "untracked";
+    }
+
+    if (entry.scopes.includes("staged")) {
+        return "staged";
+    }
+
+    if (entry.scopes.includes("conflicted")) {
+        return "conflicted";
+    }
+
+    return "unstaged";
 }
 
 async function buildSharedGitWorktreeDiff(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -136,6 +136,8 @@ import {
     type GitHubWorkflowRunsResult,
     type GitHistoryListInput,
     type GitHistoryListResult,
+    type GitOriginalFile,
+    type GitOriginalFileInput,
     type GitPullInput,
     type GitPushInput,
     type GitRemoveWorktreeInput,
@@ -891,6 +893,11 @@ const comandoApi: ComandoApi = {
             IPC_CHANNELS.getGitDiff,
             input,
         ) as Promise<GitFileDiff | null>,
+    getGitOriginalFile: (input: GitOriginalFileInput) =>
+        ipcRenderer.invoke(
+            IPC_CHANNELS.getGitOriginalFile,
+            input,
+        ) as Promise<GitOriginalFile | null>,
     listGitWorktreeDiff: (input: GitWorktreeDiffInput) =>
         ipcRenderer.invoke(
             IPC_CHANNELS.listGitWorktreeDiff,

--- a/src/renderer/src/app/editor/markdownLists.test.ts
+++ b/src/renderer/src/app/editor/markdownLists.test.ts
@@ -2,12 +2,65 @@ import { describe, expect, it } from "vitest";
 
 import {
     buildContinuedListPrefix,
+    computeMinimalTextEdit,
     continueMarkdownList,
     indentMarkdownListItems,
     normalizeMarkdownListText,
     outdentMarkdownListItems,
     parseMarkdownListItem,
 } from "./markdownLists";
+
+function applyMinimalEdit(oldText: string, newText: string): string {
+    const edit = computeMinimalTextEdit(oldText, newText);
+    return (
+        oldText.slice(0, edit.rangeStart) +
+        edit.insert +
+        oldText.slice(edit.rangeEnd)
+    );
+}
+
+describe("computeMinimalTextEdit", () => {
+    it("reduces a list continuation to a localized insertion", () => {
+        const oldText = "- one\n- two\n- three\n";
+        const newText = "- one\n- two\n- \n- three\n";
+        const edit = computeMinimalTextEdit(oldText, newText);
+
+        // A pure insertion that does not span the whole document.
+        expect(edit.rangeStart).toBe(edit.rangeEnd);
+        expect(edit.rangeStart).toBeGreaterThan(0);
+        expect(edit.rangeEnd).toBeLessThan(oldText.length);
+        expect(edit.insert).toBe("\n- ");
+        expect(applyMinimalEdit(oldText, newText)).toBe(newText);
+    });
+
+    it("trims the common prefix and suffix around a renumbered marker", () => {
+        const oldText = "1. a\n2. b\n9. c\n";
+        const newText = "1. a\n2. b\n3. c\n";
+        const edit = computeMinimalTextEdit(oldText, newText);
+
+        expect(oldText.slice(edit.rangeStart, edit.rangeEnd)).toBe("9");
+        expect(edit.insert).toBe("3");
+        expect(applyMinimalEdit(oldText, newText)).toBe(newText);
+    });
+
+    it("returns an empty edit when the text is unchanged", () => {
+        const text = "- stable\n";
+        const edit = computeMinimalTextEdit(text, text);
+
+        expect(edit.insert).toBe("");
+        expect(edit.rangeStart).toBe(edit.rangeEnd);
+        expect(applyMinimalEdit(text, text)).toBe(text);
+    });
+
+    it("handles a pure deletion (collapsing an empty item)", () => {
+        const oldText = "- one\n- \n";
+        const newText = "- one\n";
+        const edit = computeMinimalTextEdit(oldText, newText);
+
+        expect(edit.insert).toBe("");
+        expect(applyMinimalEdit(oldText, newText)).toBe(newText);
+    });
+});
 
 describe("markdownLists", () => {
     it("continues nested bullet items with the same indentation", () => {

--- a/src/renderer/src/app/editor/markdownLists.ts
+++ b/src/renderer/src/app/editor/markdownLists.ts
@@ -331,6 +331,52 @@ export function outdentMarkdownListItems(
     );
 }
 
+export interface MinimalTextEdit {
+    readonly insert: string;
+    // `rangeStart`/`rangeEnd` are character offsets into the original text:
+    // replace `oldText.slice(rangeStart, rangeEnd)` with `insert`.
+    readonly rangeEnd: number;
+    readonly rangeStart: number;
+}
+
+// Reduce a full-document rewrite to the smallest contiguous edit by trimming the
+// common prefix and suffix. Applying this localized edit (instead of replacing
+// the whole model) keeps Monaco decorations anchored to the lines they belong to
+// — replacing the entire range drags every tracked decoration to the document
+// end and makes the git gutter flicker on each keystroke.
+export function computeMinimalTextEdit(
+    oldText: string,
+    newText: string,
+): MinimalTextEdit {
+    const oldLength = oldText.length;
+    const newLength = newText.length;
+
+    let prefix = 0;
+    const maxAffix = Math.min(oldLength, newLength);
+    while (
+        prefix < maxAffix &&
+        oldText.charCodeAt(prefix) === newText.charCodeAt(prefix)
+    ) {
+        prefix += 1;
+    }
+
+    let suffix = 0;
+    const maxSuffix = maxAffix - prefix;
+    while (
+        suffix < maxSuffix &&
+        oldText.charCodeAt(oldLength - 1 - suffix) ===
+            newText.charCodeAt(newLength - 1 - suffix)
+    ) {
+        suffix += 1;
+    }
+
+    return {
+        insert: newText.slice(prefix, newLength - suffix),
+        rangeEnd: oldLength - suffix,
+        rangeStart: prefix,
+    };
+}
+
 function buildNormalizedLine(
     originalLine: string,
     item: MarkdownListItem,

--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -14,6 +14,7 @@ import {
 import type {
     AiTrackedFile,
     GitFileDiff,
+    GitOriginalFile,
     GitRepositorySnapshot,
     ProjectFileDocument,
 } from "@shared/ipc";
@@ -79,8 +80,22 @@ const monacoHarness = vi.hoisted(() => {
         readonly dispose: () => void;
     };
 
+    type FakeDecorationRange = {
+        readonly endColumn: number;
+        readonly endLineNumber: number;
+        readonly startColumn: number;
+        readonly startLineNumber: number;
+    };
+
+    type FakeDeltaDecoration = {
+        readonly options: unknown;
+        readonly range: FakeDecorationRange;
+    };
+
     type FakeModel = {
         readonly dispose: () => void;
+        readonly decorations: Map<string, FakeDeltaDecoration>;
+        readonly getDecorationRange: (id: string) => FakeDecorationRange | null;
         readonly getFullModelRange: () => {
             readonly endColumn: number;
             readonly endLineNumber: number;
@@ -115,6 +130,10 @@ const monacoHarness = vi.hoisted(() => {
             readonly initialDecorations: readonly unknown[];
             readonly set: (decorations: readonly unknown[]) => void;
         };
+        readonly deltaDecorations: (
+            oldDecorations: readonly string[],
+            newDecorations: readonly FakeDeltaDecoration[],
+        ) => string[];
         readonly dispose: () => void;
         readonly getContribution: () => null;
         readonly getDomNode: () => HTMLElement;
@@ -133,6 +152,7 @@ const monacoHarness = vi.hoisted(() => {
         readonly onDidDispose: (listener: () => void) => Disposable;
         readonly onDidLayoutChange: () => Disposable;
         readonly onDidScrollChange: () => Disposable;
+        readonly onWillChangeModel: (listener: () => void) => Disposable;
         readonly onMouseLeave: () => Disposable;
         readonly onMouseMove: () => Disposable;
         readonly pushUndoStop: () => void;
@@ -207,8 +227,14 @@ const monacoHarness = vi.hoisted(() => {
         readonly set: ReturnType<typeof vi.fn>;
     }> = [];
     const diffEditors: FakeDiffEditor[] = [];
+    const editorPropSnapshots: Array<{
+        readonly defaultValue: string | undefined;
+        readonly path: string | undefined;
+        readonly value: string | undefined;
+    }> = [];
     let editorCounter = 0;
     let diffEditorCounter = 0;
+    let decorationCounter = 0;
 
     const toLines = (value: string) => value.split("\n");
 
@@ -222,10 +248,12 @@ const monacoHarness = vi.hoisted(() => {
         uri: FakeUri,
     ): FakeModel => {
         const model: FakeModel = {
+            decorations: new Map(),
             dispose: vi.fn(() => {
                 model.disposed = true;
                 models.delete(uri.toString());
             }),
+            getDecorationRange: (id) => model.decorations.get(id)?.range ?? null,
             disposed: false,
             getFullModelRange: () => ({
                 endColumn: toLines(model.value).at(-1)!.length + 1,
@@ -272,9 +300,9 @@ const monacoHarness = vi.hoisted(() => {
             getValue: () => model.value,
             isDisposed: () => model.disposed,
             language,
-            setValue: (nextValue) => {
+            setValue: vi.fn((nextValue: string) => {
                 model.value = nextValue;
-            },
+            }),
             uri: uri.toString(),
             value,
         };
@@ -303,6 +331,7 @@ const monacoHarness = vi.hoisted(() => {
         const domNode = document.createElement("div");
         const disposeListeners = new Set<() => void>();
         const modelChangeListeners = new Set<() => void>();
+        const modelWillChangeListeners = new Set<() => void>();
         const editor: FakeCodeEditor = {
             createDecorationsCollection: vi.fn(
                 (decorations: readonly unknown[] = []) => {
@@ -313,6 +342,30 @@ const monacoHarness = vi.hoisted(() => {
                     };
                     decorationCollections.push(collection);
                     return collection;
+                },
+            ),
+            deltaDecorations: vi.fn(
+                (
+                    oldDecorations: readonly string[],
+                    newDecorations: readonly FakeDeltaDecoration[],
+                ): string[] => {
+                    const model = editor.model;
+                    if (!model) {
+                        return [];
+                    }
+
+                    for (const decorationId of oldDecorations) {
+                        model.decorations.delete(decorationId);
+                    }
+
+                    return newDecorations.map((decoration) => {
+                        const id = `${editor.name}-decoration-${++decorationCounter}`;
+                        model.decorations.set(id, {
+                            options: decoration.options,
+                            range: { ...decoration.range },
+                        });
+                        return id;
+                    });
                 },
             ),
             dispose: () => {
@@ -359,6 +412,14 @@ const monacoHarness = vi.hoisted(() => {
             },
             onDidLayoutChange: () => createDisposable(),
             onDidScrollChange: () => createDisposable(),
+            onWillChangeModel: (listener) => {
+                modelWillChangeListeners.add(listener);
+                return {
+                    dispose: () => {
+                        modelWillChangeListeners.delete(listener);
+                    },
+                };
+            },
             onMouseLeave: () => createDisposable(),
             onMouseMove: () => createDisposable(),
             pushUndoStop: vi.fn(),
@@ -378,6 +439,11 @@ const monacoHarness = vi.hoisted(() => {
             scrollTop: 0,
             setModel: (model: FakeModel | null) => {
                 const previousModel = editor.model;
+                if (previousModel !== model) {
+                    for (const listener of modelWillChangeListeners) {
+                        listener();
+                    }
+                }
                 editor.model = model;
                 if (previousModel !== model) {
                     for (const listener of modelChangeListeners) {
@@ -465,6 +531,7 @@ const monacoHarness = vi.hoisted(() => {
         createDiffEditor,
         decorationCollections,
         diffEditors,
+        editorPropSnapshots,
         models,
         monaco,
         reset: () => {
@@ -473,8 +540,10 @@ const monacoHarness = vi.hoisted(() => {
             codeEditors.length = 0;
             decorationCollections.length = 0;
             diffEditors.length = 0;
+            editorPropSnapshots.length = 0;
             editorCounter = 0;
             diffEditorCounter = 0;
+            decorationCounter = 0;
             monaco.editor.createModel.mockClear();
             monaco.editor.getModel.mockClear();
             monaco.editor.setModelLanguage.mockClear();
@@ -545,6 +614,7 @@ vi.mock("@monaco-editor/react", async () => {
 
     const MockEditor = ({
         beforeMount,
+        defaultValue,
         language,
         onMount,
         options,
@@ -552,6 +622,7 @@ vi.mock("@monaco-editor/react", async () => {
         value,
     }: {
         readonly beforeMount?: () => void;
+        readonly defaultValue?: string;
         readonly language?: string;
         readonly onMount?: (editor: unknown, monaco: unknown) => void;
         readonly options?: unknown;
@@ -563,9 +634,15 @@ vi.mock("@monaco-editor/react", async () => {
         > | null>(null);
         const mountPropsRef = React.useRef({
             beforeMount,
+            defaultValue,
             language,
             onMount,
             options,
+            path,
+            value,
+        });
+        monacoHarness.editorPropSnapshots.push({
+            defaultValue,
             path,
             value,
         });
@@ -580,7 +657,7 @@ vi.mock("@monaco-editor/react", async () => {
             const model =
                 monacoHarness.monaco.editor.getModel(uri) ??
                 monacoHarness.monaco.editor.createModel(
-                    mountProps.value ?? "",
+                    mountProps.defaultValue ?? mountProps.value ?? "",
                     mountProps.language ?? "plaintext",
                     uri,
             );
@@ -596,6 +673,27 @@ vi.mock("@monaco-editor/react", async () => {
                 editorRef.current = null;
             };
         }, []);
+
+        React.useEffect(() => {
+            const editor = editorRef.current;
+            if (!editor || value === undefined) {
+                return;
+            }
+
+            const model = editor.getModel();
+            if (model && model.getValue() !== value) {
+                model.setValue(value);
+            }
+        }, [value]);
+
+        React.useEffect(() => {
+            const editor = editorRef.current;
+            if (!editor || !options) {
+                return;
+            }
+
+            editor.updateOptions(options);
+        }, [options]);
 
         return React.createElement("div", {
             "data-mock-editor": path ?? "",
@@ -805,6 +903,20 @@ function createGitDiff(path = "src/app.ts", newStart = 1): GitFileDiff {
     };
 }
 
+function createGitOriginalFile(
+    path = "src/app.ts",
+    baseText = "const value = 1;\n",
+): GitOriginalFile {
+    return {
+        baseText,
+        isText: true,
+        kind: "modified",
+        path,
+        previousPath: null,
+        scope: "unstaged",
+    };
+}
+
 function createGitSnapshot(
     changedPaths: readonly string[] = ["src/app.ts"],
 ): GitRepositorySnapshot {
@@ -903,6 +1015,14 @@ async function flushEffects() {
     await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
+    });
+}
+
+async function waitForGitGutterLiveDiff() {
+    await act(async () => {
+        await new Promise((resolve) => {
+            window.setTimeout(resolve, 250);
+        });
     });
 }
 
@@ -1010,7 +1130,10 @@ describe("WorkspaceFileEditorHost", () => {
     it("keeps the git gutter decoration collection stable while typing", async () => {
         const tab = createFileTab("file-1");
         const getGitDiff = vi.fn(() => Promise.resolve(createGitDiff()));
-        vi.stubGlobal("comando", { getGitDiff });
+        const getGitOriginalFile = vi.fn(() =>
+            Promise.resolve(createGitOriginalFile()),
+        );
+        vi.stubGlobal("comando", { getGitDiff, getGitOriginalFile });
         mockGitStoreState.current.snapshots = {
             "project-1::primary": createGitSnapshot(),
         };
@@ -1027,6 +1150,10 @@ describe("WorkspaceFileEditorHost", () => {
         await flushEffects();
 
         const editor = monacoHarness.codeEditors[0];
+        expect(editor).toBeDefined();
+        if (!editor) {
+            throw new Error("Expected Monaco editor to mount.");
+        }
         expect(editor?.updateOptions).toHaveBeenCalledWith(
             expect.objectContaining({
                 lineDecorationsWidth: 10,
@@ -1038,10 +1165,20 @@ describe("WorkspaceFileEditorHost", () => {
             projectId: "project-1",
             worktreeId: null,
         });
+        expect(getGitOriginalFile).toHaveBeenCalledWith({
+            path: "src/app.ts",
+            projectId: "project-1",
+            worktreeId: null,
+        });
+        expect(monacoHarness.editorPropSnapshots.at(-1)).toEqual(
+            expect.objectContaining({
+                defaultValue: tab.draftContent,
+                value: undefined,
+            }),
+        );
 
-        expect(monacoHarness.decorationCollections).toHaveLength(1);
-        const gitGutterCollection = monacoHarness.decorationCollections[0];
-        expect(gitGutterCollection?.initialDecorations).toEqual([
+        expect(editor?.createDecorationsCollection).not.toHaveBeenCalled();
+        expect(editor?.deltaDecorations).toHaveBeenCalledWith([], [
             {
                 options: {
                     description: "git-gutter-decoration",
@@ -1058,17 +1195,16 @@ describe("WorkspaceFileEditorHost", () => {
             },
         ]);
 
-        const createCollectionCalls =
-            editor
-                ? vi.mocked(editor.createDecorationsCollection).mock.calls
-                      .length
-                : 0;
-        const setCalls = gitGutterCollection?.set.mock.calls.length ?? 0;
+        vi.mocked(editor.deltaDecorations).mockClear();
         const typedTab = {
             ...tab,
             draftContent: "const value = 2;\nfunction selectedName() {}\n",
             isDirty: true,
         } satisfies RuntimeWorkspaceFileTab;
+        const model = editor?.getModel();
+        const setValueMock = model ? vi.mocked(model.setValue) : null;
+        setValueMock?.mockClear();
+        vi.mocked(editor.updateOptions).mockClear();
 
         act(() => {
             root.render(
@@ -1080,17 +1216,71 @@ describe("WorkspaceFileEditorHost", () => {
         });
         await flushEffects();
 
-        expect(editor?.createDecorationsCollection).toHaveBeenCalledTimes(
-            createCollectionCalls,
+        expect(monacoHarness.editorPropSnapshots.at(-1)).toEqual(
+            expect.objectContaining({
+                defaultValue: typedTab.draftContent,
+                value: undefined,
+            }),
         );
-        expect(gitGutterCollection?.set).toHaveBeenCalledTimes(setCalls);
+        expect(setValueMock).not.toHaveBeenCalled();
+        expect(editor?.updateOptions).not.toHaveBeenCalled();
+        expect(editor?.createDecorationsCollection).not.toHaveBeenCalled();
+        expect(editor?.deltaDecorations).not.toHaveBeenCalled();
+
+        await waitForGitGutterLiveDiff();
+
+        expect(setValueMock).not.toHaveBeenCalled();
+        expect(editor?.updateOptions).not.toHaveBeenCalled();
+        expect(editor?.createDecorationsCollection).not.toHaveBeenCalled();
+        expect(editor?.deltaDecorations).toHaveBeenCalledTimes(1);
+        expect(editor?.deltaDecorations).toHaveBeenCalledWith([], [
+            {
+                options: {
+                    description: "git-gutter-decoration",
+                    isWholeLine: true,
+                    linesDecorationsClassName: "git-diff-glyph git-diff-added",
+                },
+                range: {
+                    endColumn: 1,
+                    endLineNumber: 2,
+                    startColumn: 1,
+                    startLineNumber: 2,
+                },
+            },
+        ]);
+        expect(editor?.getModel()?.decorations.size).toBe(2);
+
+        getGitDiff.mockClear();
+        getGitOriginalFile.mockClear();
+        mockGitStoreState.current.snapshots = {
+            "project-1::primary": {
+                ...createGitSnapshot(),
+                updatedAt: "2026-06-05T00:03:00.000Z",
+            },
+        };
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: typedTab,
+                    fileTabs: [typedTab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(getGitDiff).not.toHaveBeenCalled();
+        expect(getGitOriginalFile).not.toHaveBeenCalled();
     });
 
     it("clears git gutter decorations when switching to a clean file in the same editor", async () => {
         const changedTab = createFileTab("file-1", "src/app.ts");
         const cleanTab = createFileTab("file-2", "src/clean.ts");
         const getGitDiff = vi.fn(() => Promise.resolve(createGitDiff()));
-        vi.stubGlobal("comando", { getGitDiff });
+        const getGitOriginalFile = vi.fn(() =>
+            Promise.resolve(createGitOriginalFile()),
+        );
+        vi.stubGlobal("comando", { getGitDiff, getGitOriginalFile });
         mockGitStoreState.current.snapshots = {
             "project-1::primary": createGitSnapshot(["src/app.ts"]),
         };
@@ -1106,8 +1296,14 @@ describe("WorkspaceFileEditorHost", () => {
         await flushEffects();
         await flushEffects();
 
-        const gitGutterCollection = monacoHarness.decorationCollections[0];
-        expect(gitGutterCollection?.initialDecorations).toHaveLength(1);
+        const editor = monacoHarness.codeEditors[0];
+        expect(editor).toBeDefined();
+        if (!editor) {
+            throw new Error("Expected Monaco editor to mount.");
+        }
+        const changedModel = editor.getModel();
+        expect(changedModel?.decorations.size).toBe(1);
+        const initialDecorationIds = [...(changedModel?.decorations.keys() ?? [])];
 
         act(() => {
             root.render(
@@ -1119,7 +1315,11 @@ describe("WorkspaceFileEditorHost", () => {
         });
         await flushEffects();
 
-        expect(gitGutterCollection?.set).toHaveBeenCalledWith([]);
+        expect(editor.deltaDecorations).toHaveBeenCalledWith(
+            initialDecorationIds,
+            [],
+        );
+        expect(changedModel?.decorations.size).toBe(0);
     });
 
     it("clears stale git gutter decorations before applying the next file diff", async () => {
@@ -1137,7 +1337,18 @@ describe("WorkspaceFileEditorHost", () => {
                         : createGitDiff("src/app.ts", 1),
                 ),
         );
-        vi.stubGlobal("comando", { getGitDiff });
+        const getGitOriginalFile = vi.fn(
+            ({ path }: { readonly path: string }) =>
+                Promise.resolve(
+                    path === "src/other.ts"
+                        ? createGitOriginalFile(
+                              "src/other.ts",
+                              ["one", "two", "old", "four", ""].join("\n"),
+                          )
+                        : createGitOriginalFile("src/app.ts"),
+                ),
+        );
+        vi.stubGlobal("comando", { getGitDiff, getGitOriginalFile });
         mockGitStoreState.current.snapshots = {
             "project-1::primary": createGitSnapshot([
                 "src/app.ts",
@@ -1156,8 +1367,14 @@ describe("WorkspaceFileEditorHost", () => {
         await flushEffects();
         await flushEffects();
 
-        const gitGutterCollection = monacoHarness.decorationCollections[0];
-        expect(gitGutterCollection?.initialDecorations).toHaveLength(1);
+        const editor = monacoHarness.codeEditors[0];
+        expect(editor).toBeDefined();
+        if (!editor) {
+            throw new Error("Expected Monaco editor to mount.");
+        }
+        const firstModel = editor.getModel();
+        expect(firstModel?.decorations.size).toBe(1);
+        const firstDecorationIds = [...(firstModel?.decorations.keys() ?? [])];
 
         act(() => {
             root.render(
@@ -1170,22 +1387,21 @@ describe("WorkspaceFileEditorHost", () => {
         await flushEffects();
         await flushEffects();
 
-        expect(gitGutterCollection?.set.mock.calls).toContainEqual([[]]);
-        expect(gitGutterCollection?.set.mock.calls.at(-1)?.[0]).toEqual([
-            {
-                options: {
-                    description: "git-gutter-decoration",
-                    isWholeLine: true,
-                    linesDecorationsClassName:
-                        "git-diff-glyph git-diff-modified",
-                },
+        expect(editor.deltaDecorations).toHaveBeenCalledWith(
+            firstDecorationIds,
+            [],
+        );
+        expect(firstModel?.decorations.size).toBe(0);
+        expect(editor.getModel()?.decorations.size).toBe(1);
+        expect([...(editor.getModel()?.decorations.values() ?? [])]).toEqual([
+            expect.objectContaining({
                 range: {
                     endColumn: 1,
                     endLineNumber: 3,
                     startColumn: 1,
                     startLineNumber: 3,
                 },
-            },
+            }),
         ]);
     });
 

--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -13,6 +13,8 @@ import {
 
 import type {
     AiTrackedFile,
+    GitFileDiff,
+    GitRepositorySnapshot,
     ProjectFileDocument,
 } from "@shared/ipc";
 import type { RuntimeWorkspaceFileTab } from "@renderer/app/workspace/tree";
@@ -37,11 +39,15 @@ const mockAiStoreState = vi.hoisted(() => ({
     },
 }));
 
-const mockGitStoreState = vi.hoisted(() => ({
-    current: {
-        snapshots: {},
-    },
-}));
+const mockGitStoreState = vi.hoisted(() => {
+    const snapshots: Record<string, GitRepositorySnapshot> = {};
+
+    return {
+        current: {
+            snapshots,
+        },
+    };
+});
 
 const mockProjectsStoreState = vi.hoisted(() => ({
     current: {
@@ -102,8 +108,11 @@ const monacoHarness = vi.hoisted(() => {
     };
 
     type FakeCodeEditor = {
-        readonly createDecorationsCollection: () => {
+        readonly createDecorationsCollection: (
+            decorations?: readonly unknown[],
+        ) => {
             readonly clear: () => void;
+            readonly initialDecorations: readonly unknown[];
             readonly set: (decorations: readonly unknown[]) => void;
         };
         readonly dispose: () => void;
@@ -120,6 +129,7 @@ const monacoHarness = vi.hoisted(() => {
         readonly layout: () => void;
         readonly onDidChangeCursorSelection: () => Disposable;
         readonly onDidChangeHiddenAreas: () => Disposable;
+        readonly onDidChangeModel: (listener: () => void) => Disposable;
         readonly onDidDispose: (listener: () => void) => Disposable;
         readonly onDidLayoutChange: () => Disposable;
         readonly onDidScrollChange: () => Disposable;
@@ -191,6 +201,11 @@ const monacoHarness = vi.hoisted(() => {
     const models = new Map<string, FakeModel>();
     const createdModels: FakeModel[] = [];
     const codeEditors: FakeCodeEditor[] = [];
+    const decorationCollections: Array<{
+        readonly clear: ReturnType<typeof vi.fn>;
+        readonly initialDecorations: readonly unknown[];
+        readonly set: ReturnType<typeof vi.fn>;
+    }> = [];
     const diffEditors: FakeDiffEditor[] = [];
     let editorCounter = 0;
     let diffEditorCounter = 0;
@@ -287,11 +302,19 @@ const monacoHarness = vi.hoisted(() => {
     const createCodeEditor = (name = `editor-${++editorCounter}`) => {
         const domNode = document.createElement("div");
         const disposeListeners = new Set<() => void>();
+        const modelChangeListeners = new Set<() => void>();
         const editor: FakeCodeEditor = {
-            createDecorationsCollection: vi.fn(() => ({
-                clear: vi.fn(),
-                set: vi.fn(),
-            })),
+            createDecorationsCollection: vi.fn(
+                (decorations: readonly unknown[] = []) => {
+                    const collection = {
+                        clear: vi.fn(),
+                        initialDecorations: decorations,
+                        set: vi.fn(),
+                    };
+                    decorationCollections.push(collection);
+                    return collection;
+                },
+            ),
             dispose: () => {
                 if (editor.disposed) {
                     return;
@@ -318,6 +341,14 @@ const monacoHarness = vi.hoisted(() => {
             name,
             onDidChangeCursorSelection: () => createDisposable(),
             onDidChangeHiddenAreas: () => createDisposable(),
+            onDidChangeModel: (listener) => {
+                modelChangeListeners.add(listener);
+                return {
+                    dispose: () => {
+                        modelChangeListeners.delete(listener);
+                    },
+                };
+            },
             onDidDispose: (listener) => {
                 disposeListeners.add(listener);
                 return {
@@ -346,7 +377,13 @@ const monacoHarness = vi.hoisted(() => {
             scrollLeft: 0,
             scrollTop: 0,
             setModel: (model: FakeModel | null) => {
+                const previousModel = editor.model;
                 editor.model = model;
+                if (previousModel !== model) {
+                    for (const listener of modelChangeListeners) {
+                        listener();
+                    }
+                }
             },
             setPosition: vi.fn(
                 (position: {
@@ -426,6 +463,7 @@ const monacoHarness = vi.hoisted(() => {
         createdModels,
         createCodeEditor,
         createDiffEditor,
+        decorationCollections,
         diffEditors,
         models,
         monaco,
@@ -433,6 +471,7 @@ const monacoHarness = vi.hoisted(() => {
             models.clear();
             createdModels.length = 0;
             codeEditors.length = 0;
+            decorationCollections.length = 0;
             diffEditors.length = 0;
             editorCounter = 0;
             diffEditorCounter = 0;
@@ -508,12 +547,14 @@ vi.mock("@monaco-editor/react", async () => {
         beforeMount,
         language,
         onMount,
+        options,
         path,
         value,
     }: {
         readonly beforeMount?: () => void;
         readonly language?: string;
         readonly onMount?: (editor: unknown, monaco: unknown) => void;
+        readonly options?: unknown;
         readonly path?: string;
         readonly value?: string;
     }) => {
@@ -524,6 +565,7 @@ vi.mock("@monaco-editor/react", async () => {
             beforeMount,
             language,
             onMount,
+            options,
             path,
             value,
         });
@@ -541,8 +583,11 @@ vi.mock("@monaco-editor/react", async () => {
                     mountProps.value ?? "",
                     mountProps.language ?? "plaintext",
                     uri,
-                );
+            );
             editor.setModel(model);
+            if (mountProps.options) {
+                editor.updateOptions(mountProps.options);
+            }
             editorRef.current = editor;
             mountProps.onMount?.(editor, monacoHarness.monaco);
 
@@ -727,6 +772,82 @@ function createTrackedFileUpdate(): AiTrackedFile {
     };
 }
 
+function createGitDiff(path = "src/app.ts", newStart = 1): GitFileDiff {
+    return {
+        hunks: [
+            {
+                id: "git-hunk-1",
+                lines: [
+                    {
+                        id: "git-line-1",
+                        text: "const value = 1;",
+                        type: "remove",
+                    },
+                    {
+                        id: "git-line-2",
+                        text: "const value = 2;",
+                        type: "add",
+                    },
+                ],
+                newCount: 1,
+                newStart,
+                oldCount: 1,
+                oldStart: newStart,
+            },
+        ],
+        isText: true,
+        kind: "update",
+        newText: null,
+        oldText: null,
+        path,
+        previousPath: null,
+        reversible: true,
+    };
+}
+
+function createGitSnapshot(
+    changedPaths: readonly string[] = ["src/app.ts"],
+): GitRepositorySnapshot {
+    return {
+        aheadBy: 0,
+        behindBy: 0,
+        branch: null,
+        canonicalRootPath: "/workspace/comando",
+        changedPaths,
+        changes: changedPaths.map((path) => ({
+            additions: 1,
+            deletions: 1,
+            hasChildren: false,
+            isBinary: false,
+            isConflicted: false,
+            isRenamed: false,
+            kind: "modified",
+            path,
+            previousPath: null,
+            scope: "unstaged",
+            worktreeId: null,
+        })),
+        currentWorktreeId: null,
+        defaultTreeViewMode: "tree",
+        headSha: "abc123",
+        projectId: "project-1",
+        remotes: [],
+        repositoryState: "ready",
+        rootPath: "/workspace/comando",
+        selectedRemoteName: null,
+        status: {
+            changedCount: changedPaths.length,
+            conflictedCount: 0,
+            stagedCount: 0,
+            unstagedCount: changedPaths.length,
+            untrackedCount: 0,
+        },
+        syncStatus: "in_sync",
+        updatedAt: "2026-06-05T00:02:00.000Z",
+        worktrees: [],
+    };
+}
+
 function renderHost({
     activeFileTab,
     fileTabs,
@@ -811,6 +932,7 @@ describe("WorkspaceFileEditorHost", () => {
         mockWorkspaceStoreState.current.updateFilePendingOpenLocation.mockClear();
         mockWorkspaceStoreState.current.updateFileViewState.mockClear();
         mockAiStoreState.current.sessions = {};
+        mockGitStoreState.current.snapshots = {};
     });
 
     afterEach(() => {
@@ -883,6 +1005,188 @@ describe("WorkspaceFileEditorHost", () => {
         expect(monacoHarness.codeEditors).toHaveLength(1);
         expect(monacoHarness.codeEditors[0]?.disposed).toBe(false);
         expect(container.querySelector("[aria-hidden='true']")).not.toBeNull();
+    });
+
+    it("keeps the git gutter decoration collection stable while typing", async () => {
+        const tab = createFileTab("file-1");
+        const getGitDiff = vi.fn(() => Promise.resolve(createGitDiff()));
+        vi.stubGlobal("comando", { getGitDiff });
+        mockGitStoreState.current.snapshots = {
+            "project-1::primary": createGitSnapshot(),
+        };
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: tab,
+                    fileTabs: [tab],
+                }),
+            );
+        });
+        await flushEffects();
+        await flushEffects();
+
+        const editor = monacoHarness.codeEditors[0];
+        expect(editor?.updateOptions).toHaveBeenCalledWith(
+            expect.objectContaining({
+                lineDecorationsWidth: 10,
+                lineNumbersMinChars: 4,
+            }),
+        );
+        expect(getGitDiff).toHaveBeenCalledWith({
+            path: "src/app.ts",
+            projectId: "project-1",
+            worktreeId: null,
+        });
+
+        expect(monacoHarness.decorationCollections).toHaveLength(1);
+        const gitGutterCollection = monacoHarness.decorationCollections[0];
+        expect(gitGutterCollection?.initialDecorations).toEqual([
+            {
+                options: {
+                    description: "git-gutter-decoration",
+                    isWholeLine: true,
+                    linesDecorationsClassName:
+                        "git-diff-glyph git-diff-modified",
+                },
+                range: {
+                    endColumn: 1,
+                    endLineNumber: 1,
+                    startColumn: 1,
+                    startLineNumber: 1,
+                },
+            },
+        ]);
+
+        const createCollectionCalls =
+            editor
+                ? vi.mocked(editor.createDecorationsCollection).mock.calls
+                      .length
+                : 0;
+        const setCalls = gitGutterCollection?.set.mock.calls.length ?? 0;
+        const typedTab = {
+            ...tab,
+            draftContent: "const value = 2;\nfunction selectedName() {}\n",
+            isDirty: true,
+        } satisfies RuntimeWorkspaceFileTab;
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: typedTab,
+                    fileTabs: [typedTab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(editor?.createDecorationsCollection).toHaveBeenCalledTimes(
+            createCollectionCalls,
+        );
+        expect(gitGutterCollection?.set).toHaveBeenCalledTimes(setCalls);
+    });
+
+    it("clears git gutter decorations when switching to a clean file in the same editor", async () => {
+        const changedTab = createFileTab("file-1", "src/app.ts");
+        const cleanTab = createFileTab("file-2", "src/clean.ts");
+        const getGitDiff = vi.fn(() => Promise.resolve(createGitDiff()));
+        vi.stubGlobal("comando", { getGitDiff });
+        mockGitStoreState.current.snapshots = {
+            "project-1::primary": createGitSnapshot(["src/app.ts"]),
+        };
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: changedTab,
+                    fileTabs: [changedTab, cleanTab],
+                }),
+            );
+        });
+        await flushEffects();
+        await flushEffects();
+
+        const gitGutterCollection = monacoHarness.decorationCollections[0];
+        expect(gitGutterCollection?.initialDecorations).toHaveLength(1);
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: cleanTab,
+                    fileTabs: [changedTab, cleanTab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(gitGutterCollection?.set).toHaveBeenCalledWith([]);
+    });
+
+    it("clears stale git gutter decorations before applying the next file diff", async () => {
+        const firstTab = createFileTab("file-1", "src/app.ts");
+        const secondTab = createFileTab(
+            "file-2",
+            "src/other.ts",
+            ["one", "two", "three", "four", ""].join("\n"),
+        );
+        const getGitDiff = vi.fn(
+            ({ path }: { readonly path: string }) =>
+                Promise.resolve(
+                    path === "src/other.ts"
+                        ? createGitDiff("src/other.ts", 3)
+                        : createGitDiff("src/app.ts", 1),
+                ),
+        );
+        vi.stubGlobal("comando", { getGitDiff });
+        mockGitStoreState.current.snapshots = {
+            "project-1::primary": createGitSnapshot([
+                "src/app.ts",
+                "src/other.ts",
+            ]),
+        };
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: firstTab,
+                    fileTabs: [firstTab, secondTab],
+                }),
+            );
+        });
+        await flushEffects();
+        await flushEffects();
+
+        const gitGutterCollection = monacoHarness.decorationCollections[0];
+        expect(gitGutterCollection?.initialDecorations).toHaveLength(1);
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: secondTab,
+                    fileTabs: [firstTab, secondTab],
+                }),
+            );
+        });
+        await flushEffects();
+        await flushEffects();
+
+        expect(gitGutterCollection?.set.mock.calls).toContainEqual([[]]);
+        expect(gitGutterCollection?.set.mock.calls.at(-1)?.[0]).toEqual([
+            {
+                options: {
+                    description: "git-gutter-decoration",
+                    isWholeLine: true,
+                    linesDecorationsClassName:
+                        "git-diff-glyph git-diff-modified",
+                },
+                range: {
+                    endColumn: 1,
+                    endLineNumber: 3,
+                    startColumn: 1,
+                    startLineNumber: 3,
+                },
+            },
+        ]);
     });
 
     it("applies a pending file open line before restoring saved view state", async () => {

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -22,7 +22,9 @@ import type {
     AiImageAttachment,
     AiRuntimeId,
     AiTrackedFile,
+    GitChangeEntry,
     GitFileDiff,
+    GitOriginalFile,
     ProjectFileDocument,
 } from "@shared/ipc";
 import {
@@ -60,6 +62,7 @@ import {
 } from "@renderer/app/pointerGuards";
 
 import {
+    computeMinimalTextEdit,
     continueMarkdownList,
     indentMarkdownListItems,
     outdentMarkdownListItems,
@@ -126,6 +129,7 @@ import {
     getGitGutterLineNumbersMinChars,
     hasRenderableGitGutterChange,
 } from "@renderer/components/workspace/gitGutter";
+import { buildLiveGitGutterDiff } from "@renderer/components/workspace/gitGutterLiveDiff";
 import { buildInlineReviewDecorations } from "@renderer/components/workspace/inlineReviewDecorations";
 import { buildInlineReviewDiffEditorOptions } from "@renderer/components/workspace/inlineReviewDiffEditorOptions";
 import {
@@ -226,6 +230,18 @@ const CLAUDE_CODE_TERMINAL_DESCRIPTION =
     "Open the claude CLI in a workspace terminal.";
 const CLAUDE_CODE_NOT_FOUND_MESSAGE =
     "The claude command was not found in Comando's PATH. Your shell may still resolve it.";
+const GIT_GUTTER_LIVE_DIFF_DEBOUNCE_MS = 200;
+
+type GitGutterLiveDiffState =
+    | {
+          readonly diff: GitFileDiff;
+          readonly key: string;
+          readonly status: "ready";
+      }
+    | {
+          readonly key: string;
+          readonly status: "unavailable";
+      };
 
 type QuickCreateSubmenuState = {
     readonly anchorRect: MenuAnchorRect;
@@ -1177,6 +1193,42 @@ function getGitGutterDiffRequestKey(options: {
         options.worktreeId ?? "primary",
         options.relativePath,
     ].join("\u0000");
+}
+
+function getGitGutterChangeSignature(
+    change: GitChangeEntry | null,
+): string | null {
+    if (!change) {
+        return null;
+    }
+
+    return JSON.stringify([
+        change.path,
+        change.previousPath,
+        change.kind,
+        change.scope,
+        change.isBinary,
+        change.isConflicted,
+        change.isRenamed,
+        change.additions,
+        change.deletions,
+    ]);
+}
+
+function mapGitOriginalFileKindToDiffKind(
+    kind: GitOriginalFile["kind"],
+): GitFileDiff["kind"] {
+    switch (kind) {
+        case "added":
+        case "untracked":
+            return "create";
+        case "deleted":
+            return "delete";
+        case "renamed":
+            return "move";
+        default:
+            return "update";
+    }
 }
 
 async function openProjectFileEntriesAtTarget(input: {
@@ -3581,12 +3633,24 @@ function handleMarkdownListEditingShortcut(
     event.stopPropagation();
     event.stopImmediatePropagation();
 
+    // Apply only the minimal changed region. Replacing the full model range
+    // (with forceMoveMarkers) drags every tracked decoration — including the
+    // git gutter markers — to the end of the document, which is what made the
+    // whole gutter flicker on each Enter/Tab in markdown files.
+    const minimalEdit = computeMinimalTextEdit(text, result.text);
+    const editStart = model.getPositionAt(minimalEdit.rangeStart);
+    const editEnd = model.getPositionAt(minimalEdit.rangeEnd);
+
     editor.pushUndoStop();
     editor.executeEdits("markdown-list-continuation", [
         {
-            forceMoveMarkers: true,
-            range: model.getFullModelRange(),
-            text: result.text,
+            range: {
+                endColumn: editEnd.column,
+                endLineNumber: editEnd.lineNumber,
+                startColumn: editStart.column,
+                startLineNumber: editStart.lineNumber,
+            },
+            text: minimalEdit.insert,
         },
     ]);
 
@@ -3811,6 +3875,7 @@ function FileTabView({
         readonly tabId: string;
     } | null>(null);
     const fileTabIdRef = useRef(tab.id);
+    const latestDraftContentRef = useRef(tab.draftContent);
     const gitGutterDecoratorRef = useRef<GitGutterDecorator | null>(null);
     const inlineReviewDecorationsRef =
         useRef<MonacoEditor.IEditorDecorationsCollection | null>(null);
@@ -3852,6 +3917,10 @@ function FileTabView({
             ) ?? null,
         [gitSnapshot?.changes, tab.relativePath],
     );
+    const activeGitChangeSignature = useMemo(
+        () => getGitGutterChangeSignature(activeGitChange),
+        [activeGitChange],
+    );
     const shouldShowGitGutter = hasRenderableGitGutterChange(activeGitChange);
     const gitGutterDiffRequestKey = useMemo(
         () =>
@@ -3867,13 +3936,26 @@ function FileTabView({
         ],
     );
     const [gitGutterDiffState, setGitGutterDiffState] = useState<{
+        readonly base: GitOriginalFile | null;
         readonly diff: GitFileDiff | null;
         readonly key: string;
     } | null>(null);
-    const gitGutterDiff =
+    const [gitGutterLiveDiffState, setGitGutterLiveDiffState] =
+        useState<GitGutterLiveDiffState | null>(null);
+    const gitGutterSource =
         gitGutterDiffState?.key === gitGutterDiffRequestKey
-            ? gitGutterDiffState.diff
+            ? gitGutterDiffState
             : null;
+    const gitGutterLiveState =
+        gitGutterLiveDiffState?.key === gitGutterDiffRequestKey
+            ? gitGutterLiveDiffState
+            : null;
+    const gitGutterDiff =
+        gitGutterLiveState?.status === "ready"
+            ? gitGutterLiveState.diff
+            : gitGutterLiveState?.status === "unavailable"
+              ? null
+              : (gitGutterSource?.diff ?? null);
     const gitGutterLineNumbersMinChars = useMemo(
         () => getGitGutterLineNumbersMinChars(countTextLines(tab.draftContent)),
         [tab.draftContent],
@@ -4813,6 +4895,10 @@ function FileTabView({
     }, [runtime]);
 
     useLayoutEffect(() => {
+        latestDraftContentRef.current = tab.draftContent;
+    }, [tab.draftContent]);
+
+    useLayoutEffect(() => {
         if (
             !document ||
             document.kind === "image" ||
@@ -4832,7 +4918,7 @@ function FileTabView({
                 absolutePath: document.absolutePath,
                 language: monacoLanguageId,
                 monaco,
-                value: tab.draftContent,
+                value: latestDraftContentRef.current,
             }),
         );
 
@@ -4867,7 +4953,6 @@ function FileTabView({
         monacoLanguageId,
         restoreEditorViewStateForTab,
         runWithoutEditorChangeNotification,
-        tab.draftContent,
         tab.id,
         tab.viewState,
     ]);
@@ -5209,6 +5294,7 @@ function FileTabView({
         ) {
             return scheduleEffectStateUpdate(() => {
                 setGitGutterDiffState({
+                    base: null,
                     diff: null,
                     key: gitGutterDiffRequestKey,
                 });
@@ -5216,12 +5302,6 @@ function FileTabView({
         }
 
         const controller = new AbortController();
-        const cancelPendingReset = scheduleEffectStateUpdate(() => {
-            setGitGutterDiffState({
-                diff: null,
-                key: gitGutterDiffRequestKey,
-            });
-        });
 
         const loadGitDiff = async () => {
             try {
@@ -5230,14 +5310,19 @@ function FileTabView({
                     throw new Error("The desktop bridge is not available yet.");
                 }
 
-                const diff = await comandoApi.getGitDiff({
+                const diffInput = {
                     path: tab.relativePath,
                     projectId: tab.projectId,
                     worktreeId: tab.worktreeId ?? null,
-                });
+                };
+                const [diff, base] = await Promise.all([
+                    comandoApi.getGitDiff(diffInput),
+                    comandoApi.getGitOriginalFile(diffInput),
+                ]);
 
                 if (!controller.signal.aborted) {
                     setGitGutterDiffState({
+                        base,
                         diff,
                         key: gitGutterDiffRequestKey,
                     });
@@ -5245,6 +5330,7 @@ function FileTabView({
             } catch {
                 if (!controller.signal.aborted) {
                     setGitGutterDiffState({
+                        base: null,
                         diff: null,
                         key: gitGutterDiffRequestKey,
                     });
@@ -5255,11 +5341,10 @@ function FileTabView({
         void loadGitDiff();
 
         return () => {
-            cancelPendingReset();
             controller.abort();
         };
     }, [
-        activeGitChange,
+        activeGitChangeSignature,
         canEdit,
         document,
         gitGutterDiffRequestKey,
@@ -5267,6 +5352,53 @@ function FileTabView({
         tab.projectId,
         tab.relativePath,
         tab.worktreeId,
+    ]);
+
+    useEffect(() => {
+        const base = gitGutterSource?.base ?? null;
+        if (!base?.isText || base.baseText === null) {
+            return scheduleEffectStateUpdate(() => {
+                setGitGutterLiveDiffState(null);
+            });
+        }
+
+        const baseText = base.baseText;
+        const diffKind =
+            gitGutterSource?.diff?.kind ??
+            mapGitOriginalFileKindToDiffKind(base.kind);
+
+        const timeout = window.setTimeout(() => {
+            const diff = buildLiveGitGutterDiff({
+                baseText,
+                currentText: tab.draftContent,
+                kind: diffKind,
+                path: base.path,
+                previousPath: base.previousPath,
+            });
+
+            if (diff) {
+                setGitGutterLiveDiffState({
+                    diff,
+                    key: gitGutterDiffRequestKey,
+                    status: "ready",
+                });
+                return;
+            }
+
+            setGitGutterLiveDiffState({
+                key: gitGutterDiffRequestKey,
+                status: "unavailable",
+            });
+        }, GIT_GUTTER_LIVE_DIFF_DEBOUNCE_MS);
+
+        return () => {
+            window.clearTimeout(timeout);
+        };
+    }, [
+        gitGutterDiffRequestKey,
+        gitGutterSource?.base,
+        gitGutterSource?.diff?.kind,
+        tab.draftContent,
     ]);
 
     useLayoutEffect(() => {
@@ -5589,6 +5721,63 @@ function FileTabView({
             revision: null,
         };
     }, [clearInlineReviewScrollRestore, inlineReviewTrackedFile]);
+
+    const fileEditorOptions = useMemo(
+        (): MonacoEditor.IStandaloneEditorConstructionOptions => ({
+            automaticLayout: true,
+            fontFamily: editorFontFamily,
+            fontLigatures: true,
+            fontSize: editorSettings.fontSize,
+            glyphMargin: false,
+            lineHeight: editorLineHeightPx,
+            lineDecorationsWidth: GIT_GUTTER_LINE_DECORATIONS_WIDTH,
+            lineNumbers: editorLineNumbers,
+            lineNumbersMinChars: shouldShowGitGutter
+                ? gitGutterLineNumbersMinChars
+                : 4,
+            ...createComandoEditorFeatureOptions(),
+            largeFileOptimizations: true,
+            maxTokenizationLineLength: MONACO_MAX_TOKENIZATION_LINE_LENGTH,
+            minimap: {
+                enabled: editorSettings.minimapEnabled,
+            },
+            overviewRulerBorder: false,
+            overviewRulerLanes: 0,
+            padding: { top: 16, bottom: 16 },
+            quickSuggestions: areSuggestionsEnabled,
+            scrollBeyondLastLine: false,
+            snippetSuggestions: areSuggestionsEnabled ? "inline" : "none",
+            smoothScrolling: true,
+            suggest: {
+                showColors: areSuggestionsEnabled,
+                showFiles: areSuggestionsEnabled,
+                showFolders: areSuggestionsEnabled,
+                showKeywords: areSuggestionsEnabled,
+                showSnippets: areSuggestionsEnabled,
+                showWords: areSuggestionsEnabled,
+            },
+            suggestOnTriggerCharacters: areSuggestionsEnabled,
+            ...semanticHighlightingEditorOptions,
+            wordBasedSuggestions: areSuggestionsEnabled
+                ? "matchingDocuments"
+                : "off",
+            wordWrap:
+                document && shouldEnableDocumentWrapping(document)
+                    ? "on"
+                    : "off",
+        }),
+        [
+            areSuggestionsEnabled,
+            document,
+            editorFontFamily,
+            editorLineHeightPx,
+            editorLineNumbers,
+            editorSettings.fontSize,
+            editorSettings.minimapEnabled,
+            gitGutterLineNumbersMinChars,
+            shouldShowGitGutter,
+        ],
+    );
 
     if (!document) {
         return (
@@ -5990,6 +6179,7 @@ function FileTabView({
                 >
                     <EditorComponent
                         beforeMount={handleEditorBeforeMount}
+                        defaultValue={tab.draftContent}
                         language={monacoLanguageId}
                         onChange={(value: string | undefined) => {
                             if (
@@ -6139,58 +6329,12 @@ function FileTabView({
                             });
                         }}
                         keepCurrentModel
-                        options={{
-                            automaticLayout: true,
-                            fontFamily: editorFontFamily,
-                            fontLigatures: true,
-                            fontSize: editorSettings.fontSize,
-                            glyphMargin: false,
-                            lineHeight: editorLineHeightPx,
-                            lineDecorationsWidth:
-                                GIT_GUTTER_LINE_DECORATIONS_WIDTH,
-                            lineNumbers: editorLineNumbers,
-                            lineNumbersMinChars: shouldShowGitGutter
-                                ? gitGutterLineNumbersMinChars
-                                : 4,
-                            ...createComandoEditorFeatureOptions(),
-                            largeFileOptimizations: true,
-                            maxTokenizationLineLength:
-                                MONACO_MAX_TOKENIZATION_LINE_LENGTH,
-                            minimap: {
-                                enabled: editorSettings.minimapEnabled,
-                            },
-                            overviewRulerBorder: false,
-                            overviewRulerLanes: 0,
-                            padding: { top: 16, bottom: 16 },
-                            quickSuggestions: areSuggestionsEnabled,
-                            scrollBeyondLastLine: false,
-                            snippetSuggestions: areSuggestionsEnabled
-                                ? "inline"
-                                : "none",
-                            smoothScrolling: true,
-                            suggest: {
-                                showColors: areSuggestionsEnabled,
-                                showFiles: areSuggestionsEnabled,
-                                showFolders: areSuggestionsEnabled,
-                                showKeywords: areSuggestionsEnabled,
-                                showSnippets: areSuggestionsEnabled,
-                                showWords: areSuggestionsEnabled,
-                            },
-                            suggestOnTriggerCharacters: areSuggestionsEnabled,
-                            ...semanticHighlightingEditorOptions,
-                            wordBasedSuggestions: areSuggestionsEnabled
-                                ? "matchingDocuments"
-                                : "off",
-                            wordWrap: shouldEnableDocumentWrapping(document)
-                                ? "on"
-                                : "off",
-                        }}
+                        options={fileEditorOptions}
                         saveViewState
                         path={buildWorkspaceFileEditorModelPath(
                             document.absolutePath,
                         )}
                         theme={editorTheme}
-                        value={tab.draftContent}
                     />
                     {editorSettings.vimModeEnabled ? (
                         <div

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -121,8 +121,8 @@ import { ReviewTabView } from "@renderer/components/workspace/ReviewTabView";
 import { WorkspacePaneEmptyState } from "@renderer/components/workspace/WorkspacePaneEmptyState";
 import { persistChatDraftForTab } from "@renderer/components/workspace/chatDraftPersistence";
 import {
-    buildGitGutterDecorations,
-    computeGitGutterMarkers,
+    GIT_GUTTER_LINE_DECORATIONS_WIDTH,
+    GitGutterDecorator,
     getGitGutterLineNumbersMinChars,
     hasRenderableGitGutterChange,
 } from "@renderer/components/workspace/gitGutter";
@@ -1165,6 +1165,18 @@ function getWorkspaceGitContextKey(
     worktreeId: string | null,
 ): string {
     return getGitContextKey(projectId, worktreeId);
+}
+
+function getGitGutterDiffRequestKey(options: {
+    readonly projectId: string;
+    readonly relativePath: string;
+    readonly worktreeId: string | null;
+}): string {
+    return [
+        options.projectId,
+        options.worktreeId ?? "primary",
+        options.relativePath,
+    ].join("\u0000");
 }
 
 async function openProjectFileEntriesAtTarget(input: {
@@ -3799,8 +3811,7 @@ function FileTabView({
         readonly tabId: string;
     } | null>(null);
     const fileTabIdRef = useRef(tab.id);
-    const gitGutterDecorationsRef =
-        useRef<MonacoEditor.IEditorDecorationsCollection | null>(null);
+    const gitGutterDecoratorRef = useRef<GitGutterDecorator | null>(null);
     const inlineReviewDecorationsRef =
         useRef<MonacoEditor.IEditorDecorationsCollection | null>(null);
     const pendingEditorViewStateRef =
@@ -3841,10 +3852,28 @@ function FileTabView({
             ) ?? null,
         [gitSnapshot?.changes, tab.relativePath],
     );
-    const [gitGutterDiff, setGitGutterDiff] = useState<GitFileDiff | null>(
-        null,
-    );
     const shouldShowGitGutter = hasRenderableGitGutterChange(activeGitChange);
+    const gitGutterDiffRequestKey = useMemo(
+        () =>
+            getGitGutterDiffRequestKey({
+                projectId: tab.projectId,
+                relativePath: tab.relativePath,
+                worktreeId: tab.worktreeId ?? null,
+            }),
+        [
+            tab.projectId,
+            tab.relativePath,
+            tab.worktreeId,
+        ],
+    );
+    const [gitGutterDiffState, setGitGutterDiffState] = useState<{
+        readonly diff: GitFileDiff | null;
+        readonly key: string;
+    } | null>(null);
+    const gitGutterDiff =
+        gitGutterDiffState?.key === gitGutterDiffRequestKey
+            ? gitGutterDiffState.diff
+            : null;
     const gitGutterLineNumbersMinChars = useMemo(
         () => getGitGutterLineNumbersMinChars(countTextLines(tab.draftContent)),
         [tab.draftContent],
@@ -5179,13 +5208,19 @@ function FileTabView({
             !shouldShowGitGutter
         ) {
             return scheduleEffectStateUpdate(() => {
-                setGitGutterDiff(null);
+                setGitGutterDiffState({
+                    diff: null,
+                    key: gitGutterDiffRequestKey,
+                });
             });
         }
 
         const controller = new AbortController();
         const cancelPendingReset = scheduleEffectStateUpdate(() => {
-            setGitGutterDiff(null);
+            setGitGutterDiffState({
+                diff: null,
+                key: gitGutterDiffRequestKey,
+            });
         });
 
         const loadGitDiff = async () => {
@@ -5202,11 +5237,17 @@ function FileTabView({
                 });
 
                 if (!controller.signal.aborted) {
-                    setGitGutterDiff(diff);
+                    setGitGutterDiffState({
+                        diff,
+                        key: gitGutterDiffRequestKey,
+                    });
                 }
             } catch {
                 if (!controller.signal.aborted) {
-                    setGitGutterDiff(null);
+                    setGitGutterDiffState({
+                        diff: null,
+                        key: gitGutterDiffRequestKey,
+                    });
                 }
             }
         };
@@ -5221,47 +5262,39 @@ function FileTabView({
         activeGitChange,
         canEdit,
         document,
+        gitGutterDiffRequestKey,
         shouldShowGitGutter,
         tab.projectId,
         tab.relativePath,
         tab.worktreeId,
     ]);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         const editor = editorRef.current;
+        gitGutterDecoratorRef.current?.dispose();
+        gitGutterDecoratorRef.current = null;
+
         if (!editor) {
-            gitGutterDecorationsRef.current?.clear();
-            gitGutterDecorationsRef.current = null;
             return;
         }
 
-        const model = editor.getModel();
-        if (!model) {
-            gitGutterDecorationsRef.current?.clear();
-            gitGutterDecorationsRef.current = null;
-            return;
-        }
+        const decorator = new GitGutterDecorator(editor);
+        gitGutterDecoratorRef.current = decorator;
 
-        const collection =
-            gitGutterDecorationsRef.current ??
-            editor.createDecorationsCollection();
+        return () => {
+            if (gitGutterDecoratorRef.current === decorator) {
+                gitGutterDecoratorRef.current = null;
+            }
+            decorator.dispose();
+        };
+    }, [editorMountVersion]);
 
-        collection.set(
-            gitGutterDiff
-                ? buildGitGutterDecorations(
-                      computeGitGutterMarkers(
-                          gitGutterDiff,
-                          model.getLineCount(),
-                      ),
-                  )
-                : [],
-        );
-        gitGutterDecorationsRef.current = collection;
+    useLayoutEffect(() => {
+        gitGutterDecoratorRef.current?.setDiff(gitGutterDiff);
     }, [
         documentAbsolutePath,
         editorMountVersion,
         gitGutterDiff,
-        tab.draftContent,
         tab.id,
     ]);
 
@@ -5457,7 +5490,7 @@ function FileTabView({
             fontFamily: editorFontFamily,
             fontSize: editorSettings.fontSize,
             lineHeight: editorLineHeightPx,
-            lineDecorationsWidth: 0,
+            lineDecorationsWidth: GIT_GUTTER_LINE_DECORATIONS_WIDTH,
             lineNumbers: editorLineNumbers,
             lineNumbersMinChars: shouldShowGitGutter
                 ? gitGutterLineNumbersMinChars
@@ -6091,7 +6124,8 @@ function FileTabView({
                                 flushScheduledEditorViewStatePersist();
                                 editorRef.current = null;
                                 editorMonacoRef.current = null;
-                                gitGutterDecorationsRef.current = null;
+                                gitGutterDecoratorRef.current?.dispose();
+                                gitGutterDecoratorRef.current = null;
                                 cleanupTokenDebug?.dispose();
                                 scrollListener.dispose();
                                 cursorListener.dispose();
@@ -6112,7 +6146,8 @@ function FileTabView({
                             fontSize: editorSettings.fontSize,
                             glyphMargin: false,
                             lineHeight: editorLineHeightPx,
-                            lineDecorationsWidth: 0,
+                            lineDecorationsWidth:
+                                GIT_GUTTER_LINE_DECORATIONS_WIDTH,
                             lineNumbers: editorLineNumbers,
                             lineNumbersMinChars: shouldShowGitGutter
                                 ? gitGutterLineNumbersMinChars

--- a/src/renderer/src/components/workspace/gitGutter.test.ts
+++ b/src/renderer/src/components/workspace/gitGutter.test.ts
@@ -57,7 +57,12 @@ describe("computeGitGutterMarkers", () => {
         ]);
 
         expect(computeGitGutterMarkers(diff, 12)).toEqual([
-            { lineNumber: 4, tone: "add" },
+            {
+                deletedAtLineEnd: false,
+                endLineNumber: 4,
+                lineNumber: 4,
+                type: "add",
+            },
         ]);
     });
 
@@ -81,7 +86,12 @@ describe("computeGitGutterMarkers", () => {
         ]);
 
         expect(computeGitGutterMarkers(diff, 20)).toEqual([
-            { lineNumber: 8, tone: "modify" },
+            {
+                deletedAtLineEnd: false,
+                endLineNumber: 8,
+                lineNumber: 8,
+                type: "modify",
+            },
         ]);
     });
 
@@ -110,8 +120,18 @@ describe("computeGitGutterMarkers", () => {
         ]);
 
         expect(computeGitGutterMarkers(diff, 30)).toEqual([
-            { lineNumber: 10, tone: "modify" },
-            { lineNumber: 11, tone: "add" },
+            {
+                deletedAtLineEnd: false,
+                endLineNumber: 10,
+                lineNumber: 10,
+                type: "modify",
+            },
+            {
+                deletedAtLineEnd: false,
+                endLineNumber: 11,
+                lineNumber: 11,
+                type: "add",
+            },
         ]);
     });
 
@@ -135,7 +155,12 @@ describe("computeGitGutterMarkers", () => {
         ]);
 
         expect(computeGitGutterMarkers(diff, 18)).toEqual([
-            { lineNumber: 6, tone: "delete-top" },
+            {
+                deletedAtLineEnd: false,
+                endLineNumber: 6,
+                lineNumber: 6,
+                type: "delete",
+            },
         ]);
     });
 
@@ -154,7 +179,12 @@ describe("computeGitGutterMarkers", () => {
         ]);
 
         expect(computeGitGutterMarkers(diff, 13)).toEqual([
-            { lineNumber: 13, tone: "delete-bottom" },
+            {
+                deletedAtLineEnd: true,
+                endLineNumber: 13,
+                lineNumber: 13,
+                type: "delete",
+            },
         ]);
     });
 });
@@ -163,15 +193,26 @@ describe("buildGitGutterDecorations", () => {
     it("renders git markers in the dedicated line decorations lane", () => {
         expect(
             buildGitGutterDecorations([
-                { lineNumber: 8, tone: "modify" },
-                { lineNumber: 13, tone: "delete-bottom" },
+                {
+                    deletedAtLineEnd: false,
+                    endLineNumber: 8,
+                    lineNumber: 8,
+                    type: "modify",
+                },
+                {
+                    deletedAtLineEnd: true,
+                    endLineNumber: 13,
+                    lineNumber: 13,
+                    type: "delete",
+                },
             ]),
         ).toEqual([
             {
                 options: {
+                    description: "git-gutter-decoration",
                     isWholeLine: true,
-                    lineNumberClassName:
-                        "git-gutter-line-number git-gutter-line-number--modify",
+                    linesDecorationsClassName:
+                        "git-diff-glyph git-diff-modified",
                 },
                 range: {
                     endColumn: 1,
@@ -182,27 +223,47 @@ describe("buildGitGutterDecorations", () => {
             },
             {
                 options: {
-                    isWholeLine: true,
-                    lineNumberClassName:
-                        "git-gutter-line-number git-gutter-line-number--delete-bottom",
+                    description: "git-gutter-decoration",
+                    isWholeLine: false,
+                    linesDecorationsClassName:
+                        "git-diff-glyph git-diff-deleted git-diff-deleted-end",
                 },
                 range: {
-                    endColumn: 1,
+                    endColumn: Number.MAX_VALUE,
                     endLineNumber: 13,
-                    startColumn: 1,
+                    startColumn: Number.MAX_VALUE,
                     startLineNumber: 13,
                 },
             },
         ]);
     });
+
+    it("does not attach git marker styles to line-number nodes", () => {
+        const decorations = buildGitGutterDecorations([
+            {
+                deletedAtLineEnd: false,
+                endLineNumber: 4,
+                lineNumber: 4,
+                type: "add",
+            },
+        ]);
+
+        expect(JSON.stringify(decorations)).not.toContain(
+            "lineNumberClassName",
+        );
+        expect(decorations[0]?.options.linesDecorationsClassName).toBe(
+            "git-diff-glyph git-diff-added",
+        );
+    });
 });
 
 describe("getGitGutterLineNumbersMinChars", () => {
-    it("reserves breathing room for the git marker gap", () => {
+    it("keeps line-number width independent from git marker space", () => {
         expect(getGitGutterLineNumbersMinChars(9)).toBe(4);
         expect(getGitGutterLineNumbersMinChars(87)).toBe(4);
-        expect(getGitGutterLineNumbersMinChars(120)).toBe(5);
-        expect(getGitGutterLineNumbersMinChars(2048)).toBe(6);
+        expect(getGitGutterLineNumbersMinChars(120)).toBe(4);
+        expect(getGitGutterLineNumbersMinChars(2048)).toBe(4);
+        expect(getGitGutterLineNumbersMinChars(10000)).toBe(5);
     });
 });
 

--- a/src/renderer/src/components/workspace/gitGutter.test.ts
+++ b/src/renderer/src/components/workspace/gitGutter.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "vitest";
+import type { editor as MonacoEditor, IRange } from "monaco-editor";
+import { describe, expect, it, vi } from "vitest";
 
 import type { GitDiffHunk, GitFileDiff } from "@shared/ipc";
 
 import {
     buildGitGutterDecorations,
     computeGitGutterMarkers,
+    GitGutterDecorator,
     getGitGutterLineNumbersMinChars,
     hasRenderableGitGutterChange,
 } from "./gitGutter";
@@ -38,6 +40,49 @@ function createHunk(
         oldCount: 1,
         oldStart: 1,
         ...overrides,
+    };
+}
+
+function createDecoratorHarness(lineCount = 12) {
+    const decorations = new Map<
+        string,
+        MonacoEditor.IModelDeltaDecoration["range"]
+    >();
+    let decorationId = 0;
+
+    const model = {
+        getDecorationRange: (id: string): IRange | null =>
+            decorations.get(id) ?? null,
+        getLineCount: () => lineCount,
+    };
+    const deltaDecorations = vi.fn(
+        (
+            oldDecorations: readonly string[],
+            newDecorations: readonly MonacoEditor.IModelDeltaDecoration[],
+        ): string[] => {
+            for (const id of oldDecorations) {
+                decorations.delete(id);
+            }
+
+            return newDecorations.map((decoration) => {
+                const id = `decoration-${++decorationId}`;
+                decorations.set(id, decoration.range);
+                return id;
+            });
+        },
+    );
+    const disposable = () => ({ dispose: vi.fn() });
+    const editor = {
+        deltaDecorations,
+        getModel: () => model,
+        onDidChangeModel: disposable,
+        onWillChangeModel: disposable,
+    } as unknown as MonacoEditor.IStandaloneCodeEditor;
+
+    return {
+        decorations,
+        deltaDecorations,
+        decorator: new GitGutterDecorator(editor),
     };
 }
 
@@ -254,6 +299,380 @@ describe("buildGitGutterDecorations", () => {
         expect(decorations[0]?.options.linesDecorationsClassName).toBe(
             "git-diff-glyph git-diff-added",
         );
+    });
+});
+
+describe("GitGutterDecorator", () => {
+    it("corrects a tracked decoration that Monaco moved to the wrong line", () => {
+        const { decorations, decorator, deltaDecorations } =
+            createDecoratorHarness();
+        const diff = createDiff([
+            createHunk(
+                [
+                    {
+                        id: "line-1",
+                        text: "before();",
+                        type: "remove",
+                    },
+                    {
+                        id: "line-2",
+                        text: "after();",
+                        type: "add",
+                    },
+                ],
+                { newCount: 1, newStart: 2, oldCount: 1, oldStart: 2 },
+            ),
+        ]);
+
+        decorator.setDiff(diff);
+
+        const [firstDecorationId] = decorations.keys();
+        expect(firstDecorationId).toBeDefined();
+        expect(decorations.get(firstDecorationId ?? "")).toEqual({
+            endColumn: 1,
+            endLineNumber: 2,
+            startColumn: 1,
+            startLineNumber: 2,
+        });
+
+        decorations.set(firstDecorationId ?? "", {
+            endColumn: 1,
+            endLineNumber: 3,
+            startColumn: 1,
+            startLineNumber: 3,
+        });
+        deltaDecorations.mockClear();
+
+        decorator.setDiff(diff);
+
+        expect(deltaDecorations).toHaveBeenCalledWith(
+            [firstDecorationId],
+            [
+                expect.objectContaining({
+                    range: {
+                        endColumn: 1,
+                        endLineNumber: 2,
+                        startColumn: 1,
+                        startLineNumber: 2,
+                    },
+                }),
+            ],
+        );
+
+        deltaDecorations.mockClear();
+        decorator.setDiff(diff);
+
+        expect(deltaDecorations).not.toHaveBeenCalled();
+    });
+
+    it("keeps adjacent Monaco-moved decorations when a new line is inserted above them", () => {
+        const { decorations, decorator, deltaDecorations } =
+            createDecoratorHarness();
+        const initialDiff = createDiff([
+            createHunk(
+                [
+                    {
+                        id: "line-1",
+                        text: "firstAdded();",
+                        type: "add",
+                    },
+                    {
+                        id: "line-2",
+                        text: "secondAdded();",
+                        type: "add",
+                    },
+                ],
+                { newCount: 2, newStart: 3, oldCount: 0, oldStart: 3 },
+            ),
+        ]);
+
+        decorator.setDiff(initialDiff);
+
+        const [firstDecorationId, secondDecorationId] = decorations.keys();
+        expect(firstDecorationId).toBeDefined();
+        expect(secondDecorationId).toBeDefined();
+
+        decorations.set(firstDecorationId ?? "", {
+            endColumn: 1,
+            endLineNumber: 4,
+            startColumn: 1,
+            startLineNumber: 4,
+        });
+        decorations.set(secondDecorationId ?? "", {
+            endColumn: 1,
+            endLineNumber: 5,
+            startColumn: 1,
+            startLineNumber: 5,
+        });
+
+        const nextDiff = createDiff([
+            createHunk(
+                [
+                    {
+                        id: "line-1",
+                        text: "newAdded();",
+                        type: "add",
+                    },
+                ],
+                { newCount: 1, newStart: 2, oldCount: 0, oldStart: 2 },
+            ),
+            createHunk(
+                [
+                    {
+                        id: "line-2",
+                        text: "firstAdded();",
+                        type: "add",
+                    },
+                    {
+                        id: "line-3",
+                        text: "secondAdded();",
+                        type: "add",
+                    },
+                ],
+                { newCount: 2, newStart: 4, oldCount: 0, oldStart: 3 },
+            ),
+        ]);
+        deltaDecorations.mockClear();
+
+        decorator.setDiff(nextDiff);
+
+        expect(deltaDecorations).toHaveBeenCalledOnce();
+        expect(deltaDecorations).toHaveBeenCalledWith(
+            [],
+            [
+                {
+                    options: {
+                        description: "git-gutter-decoration",
+                        isWholeLine: true,
+                        linesDecorationsClassName:
+                            "git-diff-glyph git-diff-added",
+                    },
+                    range: {
+                        endColumn: 1,
+                        endLineNumber: 2,
+                        startColumn: 1,
+                        startLineNumber: 2,
+                    },
+                },
+            ],
+        );
+        expect(decorations.has(firstDecorationId ?? "")).toBe(true);
+        expect(decorations.has(secondDecorationId ?? "")).toBe(true);
+    });
+
+    it("batches style replacements and new markers into one Monaco transaction", () => {
+        const { decorations, decorator, deltaDecorations } =
+            createDecoratorHarness();
+        const initialDiff = createDiff([
+            createHunk(
+                [
+                    {
+                        id: "line-1",
+                        text: "added();",
+                        type: "add",
+                    },
+                ],
+                { newCount: 1, newStart: 2, oldCount: 0, oldStart: 2 },
+            ),
+            createHunk(
+                [
+                    {
+                        id: "line-2",
+                        text: "keptAdded();",
+                        type: "add",
+                    },
+                ],
+                { newCount: 1, newStart: 5, oldCount: 0, oldStart: 5 },
+            ),
+        ]);
+
+        decorator.setDiff(initialDiff);
+
+        const [replacedDecorationId] = decorations.keys();
+        expect(replacedDecorationId).toBeDefined();
+
+        const nextDiff = createDiff([
+            createHunk(
+                [
+                    {
+                        id: "line-1",
+                        text: "before();",
+                        type: "remove",
+                    },
+                    {
+                        id: "line-2",
+                        text: "after();",
+                        type: "add",
+                    },
+                ],
+                { newCount: 1, newStart: 2, oldCount: 1, oldStart: 2 },
+            ),
+            createHunk(
+                [
+                    {
+                        id: "line-3",
+                        text: "keptAdded();",
+                        type: "add",
+                    },
+                ],
+                { newCount: 1, newStart: 5, oldCount: 0, oldStart: 5 },
+            ),
+            createHunk(
+                [
+                    {
+                        id: "line-4",
+                        text: "newAdded();",
+                        type: "add",
+                    },
+                ],
+                { newCount: 1, newStart: 7, oldCount: 0, oldStart: 7 },
+            ),
+        ]);
+        deltaDecorations.mockClear();
+
+        decorator.setDiff(nextDiff);
+
+        expect(deltaDecorations).toHaveBeenCalledOnce();
+        expect(deltaDecorations).toHaveBeenCalledWith(
+            [replacedDecorationId],
+            [
+                {
+                    options: {
+                        description: "git-gutter-decoration",
+                        isWholeLine: true,
+                        linesDecorationsClassName:
+                            "git-diff-glyph git-diff-modified",
+                    },
+                    range: {
+                        endColumn: 1,
+                        endLineNumber: 2,
+                        startColumn: 1,
+                        startLineNumber: 2,
+                    },
+                },
+                {
+                    options: {
+                        description: "git-gutter-decoration",
+                        isWholeLine: true,
+                        linesDecorationsClassName:
+                            "git-diff-glyph git-diff-added",
+                    },
+                    range: {
+                        endColumn: 1,
+                        endLineNumber: 7,
+                        startColumn: 1,
+                        startLineNumber: 7,
+                    },
+                },
+            ],
+        );
+    });
+
+    it("keeps a marker whose tracked range grew from typing at column 1", () => {
+        const { decorations, decorator, deltaDecorations } =
+            createDecoratorHarness();
+        const diff = createDiff([
+            createHunk(
+                [
+                    {
+                        id: "line-1",
+                        text: "added();",
+                        type: "add",
+                    },
+                ],
+                { newCount: 1, newStart: 4, oldCount: 0, oldStart: 4 },
+            ),
+        ]);
+
+        decorator.setDiff(diff);
+
+        const [decorationId] = decorations.keys();
+        expect(decorationId).toBeDefined();
+
+        // Monaco grows the empty whole-line range when text is typed at the
+        // start of the line. The marker is still an "add" on line 4, so it must
+        // not be torn down and recreated (that is what made the gutter flicker).
+        decorations.set(decorationId ?? "", {
+            endColumn: 6,
+            endLineNumber: 4,
+            startColumn: 1,
+            startLineNumber: 4,
+        });
+        deltaDecorations.mockClear();
+
+        decorator.setDiff(diff);
+
+        expect(deltaDecorations).not.toHaveBeenCalled();
+        expect(decorations.has(decorationId ?? "")).toBe(true);
+    });
+
+    it("preserves every shifted marker when a line is inserted above them", () => {
+        const { decorations, decorator, deltaDecorations } =
+            createDecoratorHarness(20);
+        const initialDiff = createDiff([
+            createHunk(
+                [{ id: "l1", text: "a();", type: "add" }],
+                { newCount: 1, newStart: 5, oldCount: 0, oldStart: 5 },
+            ),
+            createHunk(
+                [{ id: "l2", text: "b();", type: "add" }],
+                { newCount: 1, newStart: 9, oldCount: 0, oldStart: 9 },
+            ),
+            createHunk(
+                [{ id: "l3", text: "c();", type: "add" }],
+                { newCount: 1, newStart: 13, oldCount: 0, oldStart: 13 },
+            ),
+        ]);
+
+        decorator.setDiff(initialDiff);
+
+        const trackedIds = [...decorations.keys()];
+        expect(trackedIds).toHaveLength(3);
+
+        // Monaco shifts every tracked decoration down by one line after the
+        // insert above them.
+        for (const id of trackedIds) {
+            const range = decorations.get(id);
+            if (!range) {
+                continue;
+            }
+            decorations.set(id, {
+                ...range,
+                endLineNumber: range.endLineNumber + 1,
+                startLineNumber: range.startLineNumber + 1,
+            });
+        }
+        deltaDecorations.mockClear();
+
+        const nextDiff = createDiff([
+            createHunk(
+                [{ id: "n", text: "new();", type: "add" }],
+                { newCount: 1, newStart: 2, oldCount: 0, oldStart: 2 },
+            ),
+            createHunk(
+                [{ id: "l1", text: "a();", type: "add" }],
+                { newCount: 1, newStart: 6, oldCount: 0, oldStart: 6 },
+            ),
+            createHunk(
+                [{ id: "l2", text: "b();", type: "add" }],
+                { newCount: 1, newStart: 10, oldCount: 0, oldStart: 10 },
+            ),
+            createHunk(
+                [{ id: "l3", text: "c();", type: "add" }],
+                { newCount: 1, newStart: 14, oldCount: 0, oldStart: 14 },
+            ),
+        ]);
+
+        decorator.setDiff(nextDiff);
+
+        // Only the inserted marker is created; no existing decoration is removed.
+        expect(deltaDecorations).toHaveBeenCalledOnce();
+        const [removedIds, created] = deltaDecorations.mock.calls[0] ?? [];
+        expect(removedIds).toEqual([]);
+        expect(created).toHaveLength(1);
+        for (const id of trackedIds) {
+            expect(decorations.has(id)).toBe(true);
+        }
     });
 });
 

--- a/src/renderer/src/components/workspace/gitGutter.ts
+++ b/src/renderer/src/components/workspace/gitGutter.ts
@@ -1,156 +1,102 @@
 import type { editor as MonacoEditor } from "monaco-editor";
 
-import type { GitChangeEntry, GitDiffHunk, GitFileDiff } from "@shared/ipc";
+import type { GitFileDiff } from "@shared/ipc";
 
-export type GitGutterMarkerTone =
-    | "add"
-    | "delete-bottom"
-    | "delete-top"
-    | "modify";
+import {
+    computeGitGutterMarkers,
+    type GitGutterChangeType,
+    getGitGutterLineNumbersMinChars,
+    hasRenderableGitGutterChange,
+    type GitGutterMarker,
+} from "@renderer/components/workspace/gitGutterModel";
 
-export interface GitGutterMarker {
-    readonly lineNumber: number;
-    readonly tone: GitGutterMarkerTone;
-}
+export {
+    computeGitGutterMarkers,
+    getGitGutterLineNumbersMinChars,
+    hasRenderableGitGutterChange,
+};
 
-export function hasRenderableGitGutterChange(
-    change: Pick<GitChangeEntry, "isBinary"> | null | undefined,
-): boolean {
-    return Boolean(change && !change.isBinary);
-}
+export const GIT_GUTTER_LINE_DECORATIONS_WIDTH = 10;
 
-export function computeGitGutterMarkers(
-    diff: GitFileDiff | null,
-    lineCount: number,
-): readonly GitGutterMarker[] {
-    if (!diff?.isText || lineCount < 1) {
-        return [];
-    }
-
-    const markers: GitGutterMarker[] = [];
-
-    for (const hunk of diff.hunks) {
-        markers.push(...computeHunkMarkers(hunk, lineCount));
-    }
-
-    return dedupeMarkers(markers);
-}
-
-export function getGitGutterLineNumbersMinChars(lineCount: number): number {
-    const digits = String(Math.max(1, lineCount)).length;
-
-    return Math.max(4, digits + 2);
-}
+const gitGutterDecorationClassByType: Record<GitGutterChangeType, string> = {
+    add: "git-diff-added",
+    delete: "git-diff-deleted",
+    modify: "git-diff-modified",
+};
 
 export function buildGitGutterDecorations(
     markers: readonly GitGutterMarker[],
 ): MonacoEditor.IModelDeltaDecoration[] {
-    return markers.map((marker) => ({
-        options: {
-            isWholeLine: true,
-            lineNumberClassName: [
-                "git-gutter-line-number",
-                `git-gutter-line-number--${marker.tone}`,
-            ].join(" "),
-        },
-        range: {
-            endColumn: 1,
-            endLineNumber: marker.lineNumber,
-            startColumn: 1,
-            startLineNumber: marker.lineNumber,
-        },
-    }));
-}
+    return markers.map((marker) => {
+        const isDelete = marker.type === "delete";
+        const startLineNumber = marker.lineNumber;
+        const endLineNumber = isDelete
+            ? marker.lineNumber
+            : marker.endLineNumber;
+        const column = isDelete ? Number.MAX_VALUE : 1;
 
-function computeHunkMarkers(
-    hunk: GitDiffHunk,
-    lineCount: number,
-): readonly GitGutterMarker[] {
-    const markers: GitGutterMarker[] = [];
-    const { lines } = hunk;
-    let index = 0;
-    let nextNewLineNumber = hunk.newStart;
-
-    while (index < lines.length) {
-        const currentLine = lines[index];
-
-        if (currentLine.type === "context") {
-            nextNewLineNumber += 1;
-            index += 1;
-            continue;
-        }
-
-        if (currentLine.type === "add") {
-            while (index < lines.length && lines[index]?.type === "add") {
-                markers.push({
-                    lineNumber: clampLineNumber(nextNewLineNumber, lineCount),
-                    tone: "add",
-                });
-                nextNewLineNumber += 1;
-                index += 1;
-            }
-            continue;
-        }
-
-        const removedStartIndex = index;
-        while (index < lines.length && lines[index]?.type === "remove") {
-            index += 1;
-        }
-        const removedCount = index - removedStartIndex;
-
-        const addedStartIndex = index;
-        const addedLineNumbers: number[] = [];
-        while (index < lines.length && lines[index]?.type === "add") {
-            addedLineNumbers.push(nextNewLineNumber);
-            nextNewLineNumber += 1;
-            index += 1;
-        }
-        const addedCount = index - addedStartIndex;
-
-        if (addedCount > 0) {
-            const modifiedCount = Math.min(removedCount, addedCount);
-
-            for (let offset = 0; offset < addedCount; offset += 1) {
-                markers.push({
-                    lineNumber: clampLineNumber(
-                        addedLineNumbers[offset] ?? nextNewLineNumber,
-                        lineCount,
-                    ),
-                    tone: offset < modifiedCount ? "modify" : "add",
-                });
-            }
-
-            continue;
-        }
-
-        const hasFollowingVisibleLine = index < lines.length;
-
-        markers.push({
-            lineNumber: clampLineNumber(
-                hasFollowingVisibleLine ? nextNewLineNumber : lineCount,
-                lineCount,
-            ),
-            tone: hasFollowingVisibleLine ? "delete-top" : "delete-bottom",
-        });
-    }
-
-    return markers;
-}
-
-function dedupeMarkers(
-    markers: readonly GitGutterMarker[],
-): readonly GitGutterMarker[] {
-    const seen = new Set<string>();
-    return markers.filter((marker) => {
-        const key = `${marker.tone}:${marker.lineNumber}`;
-        if (seen.has(key)) {
-            return false;
-        }
-        seen.add(key);
-        return true;
+        return {
+            options: {
+                description: "git-gutter-decoration",
+                isWholeLine: !isDelete,
+                linesDecorationsClassName: [
+                    "git-diff-glyph",
+                    gitGutterDecorationClassByType[marker.type],
+                    marker.deletedAtLineEnd ? "git-diff-deleted-end" : "",
+                ]
+                    .filter(Boolean)
+                    .join(" "),
+            },
+            range: {
+                endColumn: column,
+                endLineNumber,
+                startColumn: column,
+                startLineNumber,
+            },
+        };
     });
 }
 
-function clampLineNumber(lineNumber: number, lineCount: number): number {
-    return Math.min(Math.max(lineNumber, 1), lineCount);
+export class GitGutterDecorator {
+    private collection: MonacoEditor.IEditorDecorationsCollection | null = null;
+    private readonly modelChangeDisposable: { readonly dispose: () => void };
+
+    constructor(
+        private readonly editor: MonacoEditor.IStandaloneCodeEditor,
+    ) {
+        this.modelChangeDisposable = editor.onDidChangeModel(() => {
+            this.collection?.set([]);
+        });
+    }
+
+    isForEditor(editor: MonacoEditor.IStandaloneCodeEditor): boolean {
+        return this.editor === editor;
+    }
+
+    setDiff(diff: GitFileDiff | null): void {
+        const model = this.editor.getModel();
+
+        if (!model || !diff?.isText) {
+            this.collection?.set([]);
+            return;
+        }
+
+        const decorations = buildGitGutterDecorations(
+            computeGitGutterMarkers(diff, model.getLineCount()),
+        );
+
+        if (!this.collection) {
+            this.collection =
+                this.editor.createDecorationsCollection(decorations);
+            return;
+        }
+
+        this.collection.set(decorations);
+    }
+
+    dispose(): void {
+        this.modelChangeDisposable.dispose();
+        this.collection?.clear();
+        this.collection = null;
+    }
 }

--- a/src/renderer/src/components/workspace/gitGutter.ts
+++ b/src/renderer/src/components/workspace/gitGutter.ts
@@ -58,14 +58,18 @@ export function buildGitGutterDecorations(
 }
 
 export class GitGutterDecorator {
-    private collection: MonacoEditor.IEditorDecorationsCollection | null = null;
+    private decorations: AppliedGitGutterDecoration[] = [];
     private readonly modelChangeDisposable: { readonly dispose: () => void };
+    private readonly modelWillChangeDisposable: { readonly dispose: () => void };
 
     constructor(
         private readonly editor: MonacoEditor.IStandaloneCodeEditor,
     ) {
+        this.modelWillChangeDisposable = editor.onWillChangeModel(() => {
+            this.clearDecorations();
+        });
         this.modelChangeDisposable = editor.onDidChangeModel(() => {
-            this.collection?.set([]);
+            this.decorations = [];
         });
     }
 
@@ -77,26 +81,162 @@ export class GitGutterDecorator {
         const model = this.editor.getModel();
 
         if (!model || !diff?.isText) {
-            this.collection?.set([]);
+            this.clearDecorations();
             return;
         }
 
-        const decorations = buildGitGutterDecorations(
-            computeGitGutterMarkers(diff, model.getLineCount()),
-        );
+        const markers = computeGitGutterMarkers(diff, model.getLineCount());
 
-        if (!this.collection) {
-            this.collection =
-                this.editor.createDecorationsCollection(decorations);
-            return;
-        }
-
-        this.collection.set(decorations);
+        this.decorations = reconcileGitGutterDecorations({
+            editor: this.editor,
+            existingDecorations: this.decorations,
+            nextMarkers: markers,
+        });
     }
 
     dispose(): void {
+        this.modelWillChangeDisposable.dispose();
         this.modelChangeDisposable.dispose();
-        this.collection?.clear();
-        this.collection = null;
+        this.clearDecorations();
     }
+
+    private clearDecorations(): void {
+        if (this.decorations.length > 0) {
+            this.editor.deltaDecorations(
+                this.decorations.map((decoration) => decoration.id),
+                [],
+            );
+        }
+        this.decorations = [];
+    }
+}
+
+interface AppliedGitGutterDecoration {
+    readonly id: string;
+    readonly styleKey: string;
+}
+
+type NextGitGutterDecorationSlot =
+    | {
+          readonly decoration: AppliedGitGutterDecoration;
+          readonly kind: "applied";
+      }
+    | {
+          readonly creationIndex: number;
+          readonly kind: "created";
+      };
+
+// Reconcile the live gutter decorations against the freshly computed markers
+// while preserving the decoration IDs (and therefore the DOM nodes) of markers
+// whose rendered position and style did not change.
+//
+// Matching is done purely by `(current start line, style)`. The start line is
+// read back from Monaco via `getDecorationRange`, so decorations that Monaco
+// already moved to follow text edits line up with the recomputed markers without
+// being recreated. Columns are intentionally ignored: gutter markers are
+// whole-line glyphs and their tracked range can legitimately drift in columns
+// (e.g. typing at column 1 grows the empty range) without the marker changing
+// visually, so a decoration whose line and style are unchanged is left in place
+// rather than torn down and rebuilt.
+function reconcileGitGutterDecorations({
+    editor,
+    existingDecorations,
+    nextMarkers,
+}: {
+    readonly editor: MonacoEditor.IStandaloneCodeEditor;
+    readonly existingDecorations: readonly AppliedGitGutterDecoration[];
+    readonly nextMarkers: readonly GitGutterMarker[];
+}): AppliedGitGutterDecoration[] {
+    const model = editor.getModel();
+    const idsToRemove: string[] = [];
+
+    // Group existing decorations by their current `(line, style)` key. Buckets
+    // tolerate the rare case of several decorations sharing the same key.
+    const reusableByKey = new Map<string, AppliedGitGutterDecoration[]>();
+    for (const decoration of existingDecorations) {
+        const startLineNumber =
+            model?.getDecorationRange(decoration.id)?.startLineNumber ?? null;
+        if (startLineNumber === null) {
+            idsToRemove.push(decoration.id);
+            continue;
+        }
+
+        const key = getGitGutterDecorationKey(
+            startLineNumber,
+            decoration.styleKey,
+        );
+        const bucket = reusableByKey.get(key);
+        if (bucket) {
+            bucket.push(decoration);
+        } else {
+            reusableByKey.set(key, [decoration]);
+        }
+    }
+
+    const nextDecorationSlots: NextGitGutterDecorationSlot[] = [];
+    const pendingCreations: MonacoEditor.IModelDeltaDecoration[] = [];
+    const pendingCreationStyleKeys: string[] = [];
+
+    for (const marker of nextMarkers) {
+        const nextDecoration = buildGitGutterDecorations([marker])[0];
+        if (!nextDecoration) {
+            continue;
+        }
+
+        const styleKey = getGitGutterMarkerStyleKey(marker);
+        const key = getGitGutterDecorationKey(marker.lineNumber, styleKey);
+        const reused = reusableByKey.get(key)?.shift();
+        if (reused) {
+            nextDecorationSlots.push({ decoration: reused, kind: "applied" });
+            continue;
+        }
+
+        nextDecorationSlots.push({
+            creationIndex: pendingCreations.length,
+            kind: "created",
+        });
+        pendingCreations.push(nextDecoration);
+        pendingCreationStyleKeys.push(styleKey);
+    }
+
+    // Existing decorations that no marker reused are now stale.
+    for (const bucket of reusableByKey.values()) {
+        for (const decoration of bucket) {
+            idsToRemove.push(decoration.id);
+        }
+    }
+
+    const createdIds =
+        idsToRemove.length > 0 || pendingCreations.length > 0
+            ? editor.deltaDecorations(idsToRemove, pendingCreations)
+            : [];
+
+    const nextDecorations: AppliedGitGutterDecoration[] = [];
+    for (const slot of nextDecorationSlots) {
+        if (slot.kind === "applied") {
+            nextDecorations.push(slot.decoration);
+            continue;
+        }
+
+        const id = createdIds[slot.creationIndex];
+        const styleKey = pendingCreationStyleKeys[slot.creationIndex];
+        if (!id || styleKey === undefined) {
+            continue;
+        }
+
+        nextDecorations.push({ id, styleKey });
+    }
+
+    return nextDecorations;
+}
+
+function getGitGutterDecorationKey(
+    startLineNumber: number,
+    styleKey: string,
+): string {
+    return `${startLineNumber}:${styleKey}`;
+}
+
+function getGitGutterMarkerStyleKey(marker: GitGutterMarker): string {
+    return [marker.type, marker.deletedAtLineEnd ? "end" : "start"].join(":");
 }

--- a/src/renderer/src/components/workspace/gitGutterLiveDiff.test.ts
+++ b/src/renderer/src/components/workspace/gitGutterLiveDiff.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { computeGitGutterMarkers } from "./gitGutter";
+import { buildLiveGitGutterDiff } from "./gitGutterLiveDiff";
+
+function buildDiff(baseText: string, currentText: string) {
+    const diff = buildLiveGitGutterDiff({
+        baseText,
+        currentText,
+        kind: "update",
+        path: "src/example.ts",
+        previousPath: null,
+    });
+
+    if (!diff) {
+        throw new Error("Expected live diff to be built.");
+    }
+
+    return diff;
+}
+
+describe("buildLiveGitGutterDiff", () => {
+    it("returns an empty diff when the live buffer matches the base text", () => {
+        expect(buildDiff("const value = 1;\n", "const value = 1;\n").hunks)
+            .toEqual([]);
+    });
+
+    it("marks live replacements and additions", () => {
+        const diff = buildDiff(
+            "const value = 1;\nconst same = true;\n",
+            [
+                "const value = 2;",
+                "const same = true;",
+                "const extra = true;",
+                "",
+            ].join("\n"),
+        );
+
+        expect(computeGitGutterMarkers(diff, 4)).toEqual([
+            {
+                deletedAtLineEnd: false,
+                endLineNumber: 1,
+                lineNumber: 1,
+                type: "modify",
+            },
+            {
+                deletedAtLineEnd: false,
+                endLineNumber: 3,
+                lineNumber: 3,
+                type: "add",
+            },
+        ]);
+    });
+
+    it("anchors live deletions to the next surviving line", () => {
+        const diff = buildDiff("alpha\nremove me\nomega\n", "alpha\nomega\n");
+
+        expect(computeGitGutterMarkers(diff, 3)).toEqual([
+            {
+                deletedAtLineEnd: false,
+                endLineNumber: 2,
+                lineNumber: 2,
+                type: "delete",
+            },
+        ]);
+    });
+
+    it("does not mark stable lines between separate live edits", () => {
+        const diff = buildDiff(
+            ["one", "two", "three", "four", "five", ""].join("\n"),
+            ["ONE", "two", "three", "FOUR", "five", ""].join("\n"),
+        );
+
+        expect(computeGitGutterMarkers(diff, 6)).toEqual([
+            {
+                deletedAtLineEnd: false,
+                endLineNumber: 1,
+                lineNumber: 1,
+                type: "modify",
+            },
+            {
+                deletedAtLineEnd: false,
+                endLineNumber: 4,
+                lineNumber: 4,
+                type: "modify",
+            },
+        ]);
+    });
+
+    it("declines to compute very large live diff matrices", () => {
+        const baseText = Array.from(
+            { length: 1_500 },
+            (_, index) => `base ${index}`,
+        ).join("\n");
+        const currentText = Array.from(
+            { length: 1_500 },
+            (_, index) => `current ${index}`,
+        ).join("\n");
+
+        expect(
+            buildLiveGitGutterDiff({
+                baseText,
+                currentText,
+                kind: "update",
+                path: "src/large.ts",
+                previousPath: null,
+            }),
+        ).toBeNull();
+    });
+});

--- a/src/renderer/src/components/workspace/gitGutterLiveDiff.ts
+++ b/src/renderer/src/components/workspace/gitGutterLiveDiff.ts
@@ -1,0 +1,282 @@
+import type { GitFileDiff, GitDiffHunk, GitDiffLine } from "@shared/ipc";
+
+const LIVE_DIFF_CONTEXT_LINES = 3;
+const LIVE_DIFF_MAX_MATRIX_CELLS = 2_000_000;
+
+interface BuildLiveGitGutterDiffInput {
+    readonly baseText: string;
+    readonly currentText: string;
+    readonly kind: GitFileDiff["kind"];
+    readonly path: string;
+    readonly previousPath: string | null;
+}
+
+type DiffOperationType = GitDiffLine["type"];
+
+interface DiffOperation {
+    readonly beforeNewLineNumber: number;
+    readonly beforeOldLineNumber: number;
+    readonly newLineNumber: number | null;
+    readonly oldLineNumber: number | null;
+    readonly text: string;
+    readonly type: DiffOperationType;
+}
+
+export function buildLiveGitGutterDiff({
+    baseText,
+    currentText,
+    kind,
+    path,
+    previousPath,
+}: BuildLiveGitGutterDiffInput): GitFileDiff | null {
+    const operations = computeLineDiffOperations(
+        splitTextForLineDiff(baseText),
+        splitTextForLineDiff(currentText),
+    );
+
+    if (!operations) {
+        return null;
+    }
+
+    return {
+        hunks: buildDiffHunks(operations, path),
+        isText: true,
+        kind,
+        newText: currentText,
+        oldText: baseText,
+        path,
+        previousPath,
+        reversible: true,
+    };
+}
+
+function computeLineDiffOperations(
+    oldLines: readonly string[],
+    newLines: readonly string[],
+): readonly DiffOperation[] | null {
+    let prefixLength = 0;
+    while (
+        prefixLength < oldLines.length &&
+        prefixLength < newLines.length &&
+        oldLines[prefixLength] === newLines[prefixLength]
+    ) {
+        prefixLength += 1;
+    }
+
+    let suffixLength = 0;
+    while (
+        suffixLength < oldLines.length - prefixLength &&
+        suffixLength < newLines.length - prefixLength &&
+        oldLines[oldLines.length - suffixLength - 1] ===
+            newLines[newLines.length - suffixLength - 1]
+    ) {
+        suffixLength += 1;
+    }
+
+    const oldMiddle = oldLines.slice(
+        prefixLength,
+        oldLines.length - suffixLength,
+    );
+    const newMiddle = newLines.slice(
+        prefixLength,
+        newLines.length - suffixLength,
+    );
+    const middleOperations = computeMiddleLineDiffOperations(
+        oldMiddle,
+        newMiddle,
+    );
+
+    if (!middleOperations) {
+        return null;
+    }
+
+    return numberDiffOperations([
+        ...oldLines
+            .slice(0, prefixLength)
+            .map((text) => ({ text, type: "context" as const })),
+        ...middleOperations,
+        ...oldLines
+            .slice(oldLines.length - suffixLength)
+            .map((text) => ({ text, type: "context" as const })),
+    ]);
+}
+
+function computeMiddleLineDiffOperations(
+    oldLines: readonly string[],
+    newLines: readonly string[],
+): ReadonlyArray<Pick<DiffOperation, "text" | "type">> | null {
+    const cellCount = (oldLines.length + 1) * (newLines.length + 1);
+    if (cellCount > LIVE_DIFF_MAX_MATRIX_CELLS) {
+        return null;
+    }
+
+    const width = newLines.length + 1;
+    const table = new Uint32Array(cellCount);
+    const tableIndex = (oldIndex: number, newIndex: number) =>
+        oldIndex * width + newIndex;
+
+    for (let oldIndex = oldLines.length - 1; oldIndex >= 0; oldIndex -= 1) {
+        for (
+            let newIndex = newLines.length - 1;
+            newIndex >= 0;
+            newIndex -= 1
+        ) {
+            table[tableIndex(oldIndex, newIndex)] =
+                oldLines[oldIndex] === newLines[newIndex]
+                    ? table[tableIndex(oldIndex + 1, newIndex + 1)] + 1
+                    : Math.max(
+                          table[tableIndex(oldIndex + 1, newIndex)],
+                          table[tableIndex(oldIndex, newIndex + 1)],
+                      );
+        }
+    }
+
+    const operations: Array<Pick<DiffOperation, "text" | "type">> = [];
+    let oldIndex = 0;
+    let newIndex = 0;
+
+    while (oldIndex < oldLines.length && newIndex < newLines.length) {
+        if (oldLines[oldIndex] === newLines[newIndex]) {
+            operations.push({
+                text: oldLines[oldIndex],
+                type: "context",
+            });
+            oldIndex += 1;
+            newIndex += 1;
+            continue;
+        }
+
+        if (
+            table[tableIndex(oldIndex + 1, newIndex)] >=
+            table[tableIndex(oldIndex, newIndex + 1)]
+        ) {
+            operations.push({
+                text: oldLines[oldIndex],
+                type: "remove",
+            });
+            oldIndex += 1;
+            continue;
+        }
+
+        operations.push({
+            text: newLines[newIndex],
+            type: "add",
+        });
+        newIndex += 1;
+    }
+
+    while (oldIndex < oldLines.length) {
+        operations.push({
+            text: oldLines[oldIndex],
+            type: "remove",
+        });
+        oldIndex += 1;
+    }
+
+    while (newIndex < newLines.length) {
+        operations.push({
+            text: newLines[newIndex],
+            type: "add",
+        });
+        newIndex += 1;
+    }
+
+    return operations;
+}
+
+function numberDiffOperations(
+    operations: ReadonlyArray<Pick<DiffOperation, "text" | "type">>,
+): readonly DiffOperation[] {
+    let oldLineNumber = 1;
+    let newLineNumber = 1;
+
+    return operations.map((operation) => {
+        const numberedOperation: DiffOperation = {
+            beforeNewLineNumber: newLineNumber,
+            beforeOldLineNumber: oldLineNumber,
+            newLineNumber:
+                operation.type === "remove" ? null : newLineNumber,
+            oldLineNumber: operation.type === "add" ? null : oldLineNumber,
+            text: operation.text,
+            type: operation.type,
+        };
+
+        if (operation.type !== "add") {
+            oldLineNumber += 1;
+        }
+
+        if (operation.type !== "remove") {
+            newLineNumber += 1;
+        }
+
+        return numberedOperation;
+    });
+}
+
+function buildDiffHunks(
+    operations: readonly DiffOperation[],
+    path: string,
+): readonly GitDiffHunk[] {
+    const changeIndexes = operations
+        .map((operation, index) =>
+            operation.type === "context" ? null : index,
+        )
+        .filter((index): index is number => index !== null);
+
+    if (changeIndexes.length === 0) {
+        return [];
+    }
+
+    const ranges: Array<{ end: number; start: number }> = [];
+    for (const changeIndex of changeIndexes) {
+        const start = Math.max(0, changeIndex - LIVE_DIFF_CONTEXT_LINES);
+        const end = Math.min(
+            operations.length - 1,
+            changeIndex + LIVE_DIFF_CONTEXT_LINES,
+        );
+        const previous = ranges.at(-1);
+
+        if (previous && start <= previous.end + 1) {
+            previous.end = Math.max(previous.end, end);
+            continue;
+        }
+
+        ranges.push({ end, start });
+    }
+
+    return ranges.map((range, hunkIndex) => {
+        const hunkOperations = operations.slice(range.start, range.end + 1);
+        const firstOperation = hunkOperations[0];
+
+        return {
+            id: `live:${path}:${hunkIndex}`,
+            lines: hunkOperations.map((operation, lineIndex) => ({
+                id: `live:${path}:${hunkIndex}:${lineIndex}`,
+                text: operation.text,
+                type: operation.type,
+            })),
+            newCount: hunkOperations.filter(
+                (operation) => operation.type !== "remove",
+            ).length,
+            newStart: firstOperation?.beforeNewLineNumber ?? 1,
+            oldCount: hunkOperations.filter(
+                (operation) => operation.type !== "add",
+            ).length,
+            oldStart: firstOperation?.beforeOldLineNumber ?? 1,
+        };
+    });
+}
+
+function splitTextForLineDiff(text: string): readonly string[] {
+    const normalizedText = text.replace(/\r\n?/g, "\n");
+    if (normalizedText.length === 0) {
+        return [];
+    }
+
+    const lines = normalizedText.split("\n");
+    if (normalizedText.endsWith("\n")) {
+        lines.pop();
+    }
+
+    return lines;
+}

--- a/src/renderer/src/components/workspace/gitGutterModel.ts
+++ b/src/renderer/src/components/workspace/gitGutterModel.ts
@@ -1,0 +1,148 @@
+import type { GitChangeEntry, GitDiffHunk, GitFileDiff } from "@shared/ipc";
+
+export type GitGutterChangeType = "add" | "delete" | "modify";
+
+export interface GitGutterMarker {
+    readonly deletedAtLineEnd: boolean;
+    readonly endLineNumber: number;
+    readonly lineNumber: number;
+    readonly type: GitGutterChangeType;
+}
+
+export function hasRenderableGitGutterChange(
+    change: Pick<GitChangeEntry, "isBinary"> | null | undefined,
+): boolean {
+    return Boolean(change && !change.isBinary);
+}
+
+export function computeGitGutterMarkers(
+    diff: GitFileDiff | null,
+    lineCount: number,
+): readonly GitGutterMarker[] {
+    if (!diff?.isText || lineCount < 1) {
+        return [];
+    }
+
+    const markers: GitGutterMarker[] = [];
+
+    for (const hunk of diff.hunks) {
+        markers.push(...computeHunkMarkers(hunk, lineCount));
+    }
+
+    return dedupeMarkers(markers);
+}
+
+export function getGitGutterLineNumbersMinChars(lineCount: number): number {
+    const digits = String(Math.max(1, lineCount)).length;
+
+    return Math.max(4, digits);
+}
+
+function computeHunkMarkers(
+    hunk: GitDiffHunk,
+    lineCount: number,
+): readonly GitGutterMarker[] {
+    const markers: GitGutterMarker[] = [];
+    const { lines } = hunk;
+    let index = 0;
+    let nextNewLineNumber = hunk.newStart;
+
+    while (index < lines.length) {
+        const currentLine = lines[index];
+
+        if (currentLine.type === "context") {
+            nextNewLineNumber += 1;
+            index += 1;
+            continue;
+        }
+
+        if (currentLine.type === "add") {
+            while (index < lines.length && lines[index]?.type === "add") {
+                const lineNumber = clampLineNumber(
+                    nextNewLineNumber,
+                    lineCount,
+                );
+                markers.push({
+                    deletedAtLineEnd: false,
+                    endLineNumber: lineNumber,
+                    lineNumber,
+                    type: "add",
+                });
+                nextNewLineNumber += 1;
+                index += 1;
+            }
+            continue;
+        }
+
+        const removedStartIndex = index;
+        while (index < lines.length && lines[index]?.type === "remove") {
+            index += 1;
+        }
+        const removedCount = index - removedStartIndex;
+
+        const addedStartIndex = index;
+        const addedLineNumbers: number[] = [];
+        while (index < lines.length && lines[index]?.type === "add") {
+            addedLineNumbers.push(nextNewLineNumber);
+            nextNewLineNumber += 1;
+            index += 1;
+        }
+        const addedCount = index - addedStartIndex;
+
+        if (addedCount > 0) {
+            const modifiedCount = Math.min(removedCount, addedCount);
+
+            for (let offset = 0; offset < addedCount; offset += 1) {
+                const lineNumber = clampLineNumber(
+                    addedLineNumbers[offset] ?? nextNewLineNumber,
+                    lineCount,
+                );
+                markers.push({
+                    deletedAtLineEnd: false,
+                    endLineNumber: lineNumber,
+                    lineNumber,
+                    type: offset < modifiedCount ? "modify" : "add",
+                });
+            }
+
+            continue;
+        }
+
+        const hasFollowingVisibleLine = index < lines.length;
+        const lineNumber = clampLineNumber(
+            hasFollowingVisibleLine ? nextNewLineNumber : lineCount,
+            lineCount,
+        );
+        markers.push({
+            deletedAtLineEnd: !hasFollowingVisibleLine,
+            endLineNumber: lineNumber,
+            lineNumber,
+            type: "delete",
+        });
+    }
+
+    return markers;
+}
+
+function dedupeMarkers(
+    markers: readonly GitGutterMarker[],
+): readonly GitGutterMarker[] {
+    const seen = new Set<string>();
+    return markers.filter((marker) => {
+        const key = [
+            marker.type,
+            marker.lineNumber,
+            marker.endLineNumber,
+            marker.deletedAtLineEnd ? "end" : "start",
+        ].join(":");
+        if (seen.has(key)) {
+            return false;
+        }
+        seen.add(key);
+        return true;
+    });
+}
+
+function clampLineNumber(lineNumber: number, lineCount: number): number {
+    return Math.min(Math.max(lineNumber, 1), lineCount);
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1639,44 +1639,53 @@ button {
     background: transparent;
 }
 
-.monaco-editor .line-numbers.git-gutter-line-number {
+.monaco-editor .git-diff-glyph {
     box-sizing: border-box;
-    padding-right: 4px;
+    margin-left: 5px;
     pointer-events: none;
-    position: relative !important;
+    z-index: 5;
 }
 
-.monaco-editor .line-numbers.git-gutter-line-number::before {
+.monaco-editor .git-diff-added,
+.monaco-editor .git-diff-modified {
+    border-left-style: solid;
+    border-left-width: 3px;
+}
+
+.monaco-editor .git-diff-added {
+    border-left-color: color-mix(in srgb, var(--diff-add) 88%, transparent);
+}
+
+.monaco-editor .git-diff-modified {
+    border-left-color: color-mix(in srgb, var(--diff-warn) 86%, transparent);
+}
+
+.monaco-editor .git-diff-deleted {
+    position: relative;
+}
+
+.monaco-editor .git-diff-deleted::after {
     content: "";
     position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 2px;
-    width: 2px;
-    border-radius: 0;
-    opacity: 0.9;
+    bottom: -4px;
+    left: 0;
+    box-sizing: border-box;
+    width: 4px;
+    height: 0;
+    z-index: 9;
+    border-top: 4px solid transparent;
+    border-bottom: 4px solid transparent;
+    border-left: 4px solid
+        color-mix(in srgb, var(--diff-remove) 90%, transparent);
     pointer-events: none;
 }
 
-.monaco-editor .line-numbers.git-gutter-line-number--add::before {
-    background: color-mix(in srgb, var(--diff-add) 88%, transparent);
+.monaco-editor .git-diff-deleted.git-diff-deleted-end::after {
+    bottom: 0;
 }
 
-.monaco-editor .line-numbers.git-gutter-line-number--modify::before {
-    background: color-mix(in srgb, var(--diff-warn) 86%, transparent);
-}
-
-.monaco-editor .line-numbers.git-gutter-line-number--delete-top::before,
-.monaco-editor .line-numbers.git-gutter-line-number--delete-bottom::before {
-    background: color-mix(in srgb, var(--diff-remove) 90%, transparent);
-    height: 6px;
-    top: -2px;
-    bottom: auto;
-}
-
-.monaco-editor .line-numbers.git-gutter-line-number--delete-bottom::before {
-    top: auto;
-    bottom: -2px;
+.inline-review-diff .monaco-editor .git-diff-glyph {
+    display: none !important;
 }
 
 .inline-review-diff .monaco-editor .line-numbers.dimmed-line-number {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -49,6 +49,7 @@ export const IPC_CHANNELS = {
     listGitHistory: "git:list-history",
     listGitWorktreeDiff: "git:list-worktree-diff",
     getGitDiff: "git:get-diff",
+    getGitOriginalFile: "git:get-original-file",
     getGitCommitDetail: "git:get-commit-detail",
     initGitRepository: "git:init-repository",
     stageGitPaths: "git:stage-paths",
@@ -906,6 +907,17 @@ export interface GitChangesListInput extends GitRepositoryScopeInput {
 export interface GitDiffInput extends GitRepositoryScopeInput {
     readonly path: string;
     readonly scope?: GitDiffScope | "auto";
+}
+
+export type GitOriginalFileInput = GitDiffInput;
+
+export interface GitOriginalFile {
+    readonly baseText: string | null;
+    readonly isText: boolean;
+    readonly kind: GitChangeKind;
+    readonly path: string;
+    readonly previousPath: string | null;
+    readonly scope: GitDiffScope;
 }
 
 export interface GitWorktreeDiffInput extends GitRepositoryScopeInput {
@@ -2780,6 +2792,9 @@ export interface ComandoApi {
         input: GitWorktreeDiffInput,
     ) => Promise<GitWorktreeDiffResult | null>;
     getGitDiff: (input: GitDiffInput) => Promise<GitFileDiff | null>;
+    getGitOriginalFile: (
+        input: GitOriginalFileInput,
+    ) => Promise<GitOriginalFile | null>;
     getGitCommitDetail: (
         input: GitCommitDetailInput,
     ) => Promise<GitCommitDetail | null>;


### PR DESCRIPTION
## Summary

This PR makes the Monaco git gutter behave like a live editor gutter instead of a saved-file-only indicator, and fixes the flicker that made tracked files feel unstable while typing.

The gutter now:

- Loads both the committed/original file text and the current Git diff.
- Computes a debounced live diff between the original text and the current Monaco draft buffer.
- Updates added/modified/deleted markers as the user types, before the file is saved.
- Reconciles Monaco gutter decorations incrementally instead of replacing the whole decoration collection.
- Keeps the editor uncontrolled from React (`defaultValue` instead of `value`) so typing does not trigger model resets or caret jumps.
- Fixes markdown list editing so it applies a localized edit instead of rewriting the whole model.

There is also a small follow-up commit that removes a redundant timer null check flagged by ESLint.

## Root Cause

There were two overlapping causes, but the markdown one was the real reason the issue was so stubborn in the file used for testing.

### 1. The gutter lifecycle was too coarse

The old gutter implementation used a decoration collection and replaced the full set of Monaco decorations whenever the diff changed. That worked for static saved-file diffs, but it was noisy for live editing:

- markers were recreated instead of reused;
- Monaco already moves decorations as text changes, but we were not taking full advantage of those tracked ranges;
- changing a single line could cause unrelated gutter markers to be torn down and rebuilt.

This made the gutter visually unstable and also made it difficult to distinguish real diff changes from decoration churn.

### 2. Markdown list editing rewrote the whole Monaco model

The bigger root cause for the observed flicker was in the markdown list shortcut path.

When continuing/indenting/outdenting markdown lists, the code generated the new full document text and applied it with:

```ts
editor.executeEdits("markdown-list-continuation", [
  {
    forceMoveMarkers: true,
    range: model.getFullModelRange(),
    text: result.text,
  },
]);
```

That means pressing Enter/Tab in a markdown list replaced the entire Monaco model, even if the actual change was just inserting `\n- ` or renumbering one list marker.

Because `forceMoveMarkers` was enabled on a full-document replacement, Monaco moved every tracked decoration, including every git gutter marker. The gutter then had to correct/recreate markers across the document, which looked like the entire git gutter was blinking even for lines that were not involved in the edit.

This is why fixes focused only on the gutter reconciler improved some cases but did not fully solve the README/markdown reproduction.

## Fix

### Live git gutter source

The renderer now requests the original file text through the Git bridge and keeps it alongside the regular Git diff. Once the base text is available, the editor builds a debounced live diff from:

```text
committed/original text vs current Monaco draft text
```

This makes the gutter update for unsaved edits, closer to VS Code's quick diff behavior.

If live diff computation is unavailable for a file, the gutter falls back safely instead of resetting repeatedly.

### Incremental gutter decoration reconciliation

`GitGutterDecorator` now tracks decoration IDs and reconciles based on each decoration's current Monaco range:

- reusable decorations are matched by current start line and visual style;
- columns are intentionally ignored because gutter markers are whole-line visuals and Monaco can grow empty ranges when typing at column 1;
- stale decorations are removed and new ones are added through a single `deltaDecorations` transaction;
- model changes clear stale decorations before applying the next file's diff.

The important invariant is: if a marker still represents the same line/style after Monaco has shifted it, keep the same decoration ID and DOM node.

### Markdown edits are now localized

The markdown list shortcut no longer replaces the entire document. It computes the smallest contiguous text edit by trimming the common prefix and suffix between the old and new text:

```ts
computeMinimalTextEdit(oldText, newText)
```

Then it applies only that localized range through `executeEdits`.

This keeps Monaco's tracked decorations anchored to the lines they belong to, instead of dragging every marker to the end of the document.

## Why This Solves The Flicker

The previous behavior made unrelated gutter markers participate in every markdown list edit. The fix removes that global edit entirely.

After this PR:

- a markdown list continuation inserts only the new list prefix region;
- Monaco naturally shifts affected ranges;
- the gutter reconciler reuses shifted decorations instead of recreating them;
- unaffected markers are left alone;
- React does not push `value` back into Monaco on every draft change.

So the root problem is no longer merely masked. The operation that invalidated the whole document's tracked marker state has been removed.

## Tests

Validated locally with:

```text
pnpm vitest run src/renderer/src/app/editor/markdownLists.test.ts src/renderer/src/components/workspace/gitGutter.test.ts src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx src/renderer/src/components/workspace/gitGutterLiveDiff.test.ts
pnpm run typecheck
pnpm exec eslint . --ignore-pattern '.personal/**'
```
