### PR TITLE
Fix Claude context usage updates

### DIFF
--- a/vendor/Claude-agent-acp-upstream/src/acp-agent.ts
+++ b/vendor/Claude-agent-acp-upstream/src/acp-agent.ts
@@ -125,6 +125,8 @@ type UsageSnapshot = {
   cache_creation_input_tokens: number;
 };
 
+type ContextWindowSizeSource = "default" | "heuristic" | "modelUsage";
+
 const ZERO_USAGE = Object.freeze({
   input_tokens: 0,
   output_tokens: 0,
@@ -190,6 +192,10 @@ type Session = {
    *  DEFAULT_CONTEXT_WINDOW, refreshed from each result's modelUsage, and
    *  invalidated when the user switches the session's model. */
   contextWindowSize: number;
+  /** Describes whether `contextWindowSize` is still the generic default or was
+   *  learned from model metadata. Streaming usage updates are only safe once the
+   *  size is no longer the default placeholder. */
+  contextWindowSizeSource: ContextWindowSizeSource;
   /** Accumulated task list for the session, keyed by task ID. Task IDs are
    *  per-session, so this state must not be shared across sessions. */
   taskState: TaskState;
@@ -1149,6 +1155,7 @@ export class ClaudeAcpAgent implements Agent {
             // leave the next prompt's mid-stream updates reporting 200k.
             if (matchingModelUsage) {
               session.contextWindowSize = matchingModelUsage.contextWindow;
+              session.contextWindowSizeSource = "modelUsage";
             }
 
             // Task-notification followups are autonomous work triggered by a
@@ -1300,6 +1307,7 @@ export class ClaudeAcpAgent implements Agent {
                     const inferred = inferContextWindowFromModel(model);
                     if (inferred !== null) {
                       session.contextWindowSize = inferred;
+                      session.contextWindowSizeSource = "heuristic";
                     }
                   }
                 }
@@ -1323,14 +1331,20 @@ export class ClaudeAcpAgent implements Agent {
               const nextUsage = totalTokens(lastAssistantUsage);
               if (nextUsage !== lastAssistantTotalUsage) {
                 lastAssistantTotalUsage = nextUsage;
-                await this.client.sessionUpdate({
-                  sessionId: params.sessionId,
-                  update: {
-                    sessionUpdate: "usage_update",
-                    used: nextUsage,
-                    size: session.contextWindowSize,
-                  },
-                });
+                // Do not publish live context usage while the window is still
+                // the generic 200k placeholder. The final `result.modelUsage`
+                // update below supplies the real window, and publishing the
+                // placeholder here makes 1M sessions look artificially full.
+                if (session.contextWindowSizeSource !== "default") {
+                  await this.client.sessionUpdate({
+                    sessionId: params.sessionId,
+                    update: {
+                      sessionUpdate: "usage_update",
+                      used: nextUsage,
+                      size: session.contextWindowSize,
+                    },
+                  });
+                }
               }
             }
             for (const notification of streamEventToAcpNotifications(
@@ -2088,7 +2102,10 @@ export class ClaudeAcpAgent implements Agent {
         // to the new model's heuristic so mid-stream updates between now and
         // the next `result` reflect the user's selection instead of the old
         // model's window.
-        session.contextWindowSize = inferContextWindowFromModel(value) ?? DEFAULT_CONTEXT_WINDOW;
+        const inferredContextWindowSize = inferContextWindowFromModel(value);
+        session.contextWindowSize = inferredContextWindowSize ?? DEFAULT_CONTEXT_WINDOW;
+        session.contextWindowSizeSource =
+          inferredContextWindowSize === null ? "default" : "heuristic";
       }
       session.models = { ...session.models, currentModelId: value };
 
@@ -2546,6 +2563,7 @@ export class ClaudeAcpAgent implements Agent {
         effortLevel: initialEffort.currentValue as Settings["effortLevel"],
       });
     }
+    const inferredContextWindowSize = inferContextWindowFromModel(models.currentModelId);
     this.sessions[sessionId] = {
       query: q,
       input: input,
@@ -2568,8 +2586,8 @@ export class ClaudeAcpAgent implements Agent {
       nextPendingOrder: 0,
       abortController,
       emitRawSDKMessages: sessionMeta?.claudeCode?.emitRawSDKMessages ?? false,
-      contextWindowSize:
-        inferContextWindowFromModel(models.currentModelId) ?? DEFAULT_CONTEXT_WINDOW,
+      contextWindowSize: inferredContextWindowSize ?? DEFAULT_CONTEXT_WINDOW,
+      contextWindowSizeSource: inferredContextWindowSize === null ? "default" : "heuristic",
       taskState,
       toolUseCache: {},
       messageIdToUuid: new Map(),

--- a/vendor/Claude-agent-acp-upstream/src/tests/acp-agent.test.ts
+++ b/vendor/Claude-agent-acp-upstream/src/tests/acp-agent.test.ts
@@ -2485,6 +2485,48 @@ describe("usage_update computation", () => {
     expect(usageUpdates[1].update.cost).toBeDefined();
   });
 
+  it("does not publish a default-window streaming usage update before modelUsage is known", async () => {
+    const { agent, updates } = createMockAgentWithCapture();
+    injectSession(agent, [
+      createStreamEvent("message_start", {
+        model: "claude-opus-4-20250514",
+        usage: {
+          input_tokens: 100000,
+          output_tokens: 10000,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      }),
+      createResultMessageWithModel({
+        modelUsage: {
+          "claude-opus-4-20250514": {
+            inputTokens: 100000,
+            outputTokens: 10000,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 1000000,
+            maxOutputTokens: 16384,
+          },
+        },
+      }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
+
+    const usageUpdates = updates.filter((u: any) => u.update?.sessionUpdate === "usage_update");
+    const unsafeStreamingUpdates = usageUpdates.filter(
+      (u: any) => u.update.cost === undefined && u.update.size === 200000,
+    );
+    expect(unsafeStreamingUpdates).toHaveLength(0);
+
+    const finalUsageUpdate = usageUpdates.find((u: any) => u.update.cost !== undefined);
+    expect(finalUsageUpdate?.update.used).toBe(110000);
+    expect(finalUsageUpdate?.update.size).toBe(1000000);
+  });
+
   it("stream_event message_delta patches previous snapshot", async () => {
     const { agent, updates } = createMockAgentWithCapture();
     injectSession(agent, [
@@ -2527,6 +2569,51 @@ describe("usage_update computation", () => {
     expect(usageUpdates[1].update.cost).toBeUndefined();
     expect(usageUpdates[2].update.used).toBe(1800);
     expect(usageUpdates[2].update.cost).toBeDefined();
+  });
+
+  it("does not publish default-window streaming usage updates while deltas are still provisional", async () => {
+    const { agent, updates } = createMockAgentWithCapture();
+    injectSession(agent, [
+      createStreamEvent("message_start", {
+        model: "claude-opus-4-20250514",
+        usage: {
+          input_tokens: 90000,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      }),
+      createStreamEvent("message_delta", {
+        usage: { output_tokens: 20000 },
+      }),
+      createResultMessageWithModel({
+        modelUsage: {
+          "claude-opus-4-20250514": {
+            inputTokens: 90000,
+            outputTokens: 20000,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 1000000,
+            maxOutputTokens: 16384,
+          },
+        },
+      }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
+
+    const usageUpdates = updates.filter((u: any) => u.update?.sessionUpdate === "usage_update");
+    const unsafeStreamingUpdates = usageUpdates.filter(
+      (u: any) => u.update.cost === undefined && u.update.size === 200000,
+    );
+    expect(unsafeStreamingUpdates).toHaveLength(0);
+
+    const finalUsageUpdate = usageUpdates.find((u: any) => u.update.cost !== undefined);
+    expect(finalUsageUpdate?.update.used).toBe(110000);
+    expect(finalUsageUpdate?.update.size).toBe(1000000);
   });
 
   it("mid-stream size is inferred from a 1M model name before the first result", async () => {

--- a/vendor/Claude-agent-acp-upstream/src/tests/acp-agent.test.ts
+++ b/vendor/Claude-agent-acp-upstream/src/tests/acp-agent.test.ts
@@ -1614,6 +1614,7 @@ describe("stop reason propagation", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowSizeSource: "default",
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
@@ -1760,6 +1761,7 @@ describe("stop reason propagation", () => {
       nextPendingOrder: 0,
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowSizeSource: "default",
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
@@ -1921,6 +1923,7 @@ describe("session/close", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowSizeSource: "default",
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
@@ -2007,6 +2010,7 @@ describe("session/delete", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowSizeSource: "default",
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
@@ -2110,6 +2114,7 @@ describe("getOrCreateSession param change detection", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowSizeSource: "default",
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
@@ -2347,6 +2352,7 @@ describe("usage_update computation", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowSizeSource: "default",
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
@@ -2381,7 +2387,6 @@ describe("usage_update computation", () => {
       }),
       { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
-
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
 
     const usageUpdate = updates.find((u: any) => u.update?.sessionUpdate === "usage_update");
@@ -2427,7 +2432,6 @@ describe("usage_update computation", () => {
       }),
       { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
-
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
 
     const usageUpdates = updates.filter((u: any) => u.update?.sessionUpdate === "usage_update");
@@ -2442,7 +2446,7 @@ describe("usage_update computation", () => {
     }
   });
 
-  it("stream_event message_start emits usage_update before result", async () => {
+  it("stream_event message_start waits for result when only the default window is known", async () => {
     const { agent, updates } = createMockAgentWithCapture();
     injectSession(agent, [
       createStreamEvent("message_start", {
@@ -2470,19 +2474,13 @@ describe("usage_update computation", () => {
       }),
       { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
-
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
 
     const usageUpdates = updates.filter((u: any) => u.update?.sessionUpdate === "usage_update");
-    expect(usageUpdates).toHaveLength(2);
+    expect(usageUpdates).toHaveLength(1);
     expect(usageUpdates[0].update.used).toBe(1800);
-    // First prompt of a session has no prior result to learn the window from,
-    // so the mid-stream update falls back to the default context window.
-    expect(usageUpdates[0].update.size).toBe(200000);
-    expect(usageUpdates[0].update.cost).toBeUndefined();
-    expect(usageUpdates[1].update.used).toBe(1800);
-    expect(usageUpdates[1].update.size).toBe(1000000);
-    expect(usageUpdates[1].update.cost).toBeDefined();
+    expect(usageUpdates[0].update.size).toBe(1000000);
+    expect(usageUpdates[0].update.cost).toBeDefined();
   });
 
   it("does not publish a default-window streaming usage update before modelUsage is known", async () => {
@@ -2527,7 +2525,7 @@ describe("usage_update computation", () => {
     expect(finalUsageUpdate?.update.size).toBe(1000000);
   });
 
-  it("stream_event message_delta patches previous snapshot", async () => {
+  it("stream_event message_delta patches previous snapshot for the final result", async () => {
     const { agent, updates } = createMockAgentWithCapture();
     injectSession(agent, [
       createStreamEvent("message_start", {
@@ -2562,13 +2560,10 @@ describe("usage_update computation", () => {
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
 
     const usageUpdates = updates.filter((u: any) => u.update?.sessionUpdate === "usage_update");
-    expect(usageUpdates).toHaveLength(3);
-    expect(usageUpdates[0].update.used).toBe(1300);
-    expect(usageUpdates[0].update.cost).toBeUndefined();
-    expect(usageUpdates[1].update.used).toBe(1800);
-    expect(usageUpdates[1].update.cost).toBeUndefined();
-    expect(usageUpdates[2].update.used).toBe(1800);
-    expect(usageUpdates[2].update.cost).toBeDefined();
+    expect(usageUpdates).toHaveLength(1);
+    expect(usageUpdates[0].update.used).toBe(1800);
+    expect(usageUpdates[0].update.size).toBe(1000000);
+    expect(usageUpdates[0].update.cost).toBeDefined();
   });
 
   it("does not publish default-window streaming usage updates while deltas are still provisional", async () => {
@@ -2689,6 +2684,8 @@ describe("usage_update computation", () => {
       }),
       { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
+    agent.sessions["test-session"].contextWindowSize = 1000000;
+    agent.sessions["test-session"].contextWindowSizeSource = "modelUsage";
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
 
@@ -2733,6 +2730,7 @@ describe("usage_update computation", () => {
     ]);
     // Simulate a prior prompt having learned the 1M window for this model.
     agent.sessions["test-session"].contextWindowSize = 1000000;
+    agent.sessions["test-session"].contextWindowSizeSource = "modelUsage";
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
 
@@ -2775,6 +2773,7 @@ describe("usage_update computation", () => {
     ]);
     const session = agent.sessions["test-session"];
     expect(session.contextWindowSize).toBe(200000);
+    expect(session.contextWindowSizeSource).toBe("default");
 
     await (agent as any).applyConfigOptionValue(
       "test-session",
@@ -2783,6 +2782,7 @@ describe("usage_update computation", () => {
       "claude-opus-4-6-1m",
     );
     expect(session.contextWindowSize).toBe(1000000);
+    expect(session.contextWindowSizeSource).toBe("heuristic");
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
 
@@ -2863,6 +2863,7 @@ describe("usage_update computation", () => {
     ]);
     const session = agent.sessions["test-session"];
     session.contextWindowSize = 1000000;
+    session.contextWindowSizeSource = "modelUsage";
     session.models = { ...session.models, currentModelId: "claude-opus-4-6-1m" };
 
     // User flips the selector to a 200k model.
@@ -2876,9 +2877,10 @@ describe("usage_update computation", () => {
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
 
     const usageUpdates = updates.filter((u: any) => u.update?.sessionUpdate === "usage_update");
-    expect(usageUpdates).toHaveLength(2);
+    expect(session.contextWindowSizeSource).toBe("modelUsage");
+    expect(usageUpdates).toHaveLength(1);
     expect(usageUpdates[0].update.size).toBe(200000);
-    expect(usageUpdates[1].update.size).toBe(200000);
+    expect(usageUpdates[0].update.cost).toBeDefined();
   });
 
   it("non-usage stream events do not re-emit usage_update", async () => {
@@ -2943,6 +2945,10 @@ describe("usage_update computation", () => {
       }),
       { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
+    // This test is about suppressing non-usage stream events, so start from a
+    // learned window where real usage stream events are expected to publish.
+    agent.sessions["test-session"].contextWindowSize = 1000000;
+    agent.sessions["test-session"].contextWindowSizeSource = "modelUsage";
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
 
@@ -3379,6 +3385,7 @@ describe("emitRawSDKMessages", () => {
       abortController: new AbortController(),
       emitRawSDKMessages,
       contextWindowSize: 200000,
+      contextWindowSizeSource: "default",
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
@@ -3609,6 +3616,7 @@ describe("result origin handling", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowSizeSource: "default",
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
@@ -3786,6 +3794,7 @@ describe("memory_recall handling", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowSizeSource: "default",
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
@@ -4018,6 +4027,7 @@ describe("post-error recovery", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowSizeSource: "default",
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
@@ -4165,6 +4175,7 @@ describe("session/cancel wedge recovery (issue #680)", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowSizeSource: "default",
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -57,8 +57,31 @@ Comando's ACP client lives in TypeScript/Electron under `src/main/ai/` and curre
 ## Current Claude Delta
 
 The Claude vendor is based on upstream `@agentclientprotocol/claude-agent-acp`
-`0.42.0`. Comando currently carries no source-level Claude ACP delta; the
-vendored source is the upstream snapshot and `dist/` is rebuilt from it.
+`0.42.0`.
+
+Comando currently carries one source-level Claude ACP delta in:
+
+- `vendor/Claude-agent-acp-upstream/src/acp-agent.ts`
+- `vendor/Claude-agent-acp-upstream/src/tests/acp-agent.test.ts`
+
+The delta suppresses provisional live `usage_update` notifications while
+Claude ACP still only knows the generic `200000` token context-window fallback.
+Claude can emit those updates during `stream_event` before the later
+`result.modelUsage` message reports the real model context window, such as a
+1M-token Opus window. Publishing the provisional value makes Comando's context
+usage bar appear artificially inflated during the turn, then snap back when the
+final result arrives.
+
+The local patch tracks whether `contextWindowSize` came from the default
+placeholder, a model-name heuristic, or authoritative `modelUsage`. Streaming
+usage updates are only published once the size is no longer the default
+placeholder; final result usage updates still publish normally with cost and
+the modelUsage window.
+
+When updating Claude again, check upstream for an equivalent fix before
+carrying this delta forward. As of upstream `v0.48.0`, upstream still emits the
+streaming `usage_update` with `session.contextWindowSize` and has no equivalent
+`contextWindowSizeSource` guard.
 
 ## Updating Vendored Runtimes
 


### PR DESCRIPTION
## Summary

Fixes misleading Claude context usage updates by suppressing provisional live `usage_update` notifications while Claude ACP only knows the generic `200000` token fallback window.

## Root cause

Claude ACP can emit live `usage_update` events during `stream_event` before the later `result.modelUsage` event reports the authoritative model context window. For 1M-context Claude sessions, this made Comando's context usage bar appear artificially inflated during a turn, then snap back when the final result arrived.

## Changes

- Adds characterization tests for the provisional `200000` window behavior.
- Tracks whether Claude ACP's `contextWindowSize` came from the default placeholder, a model-name heuristic, or authoritative `modelUsage`.
- Suppresses only streaming usage updates while the context window is still default-sourced.
- Keeps final result usage updates unchanged, including cost and `modelUsage` window.
- Documents the local Claude vendor delta in `vendor/README.md`.

## Validation

- `npm run test:run -- src/tests/acp-agent.test.ts` from `vendor/Claude-agent-acp-upstream`
- `npm run build` from `vendor/Claude-agent-acp-upstream`
- `node scripts/ai/stage-claude-runtime.mjs`
- `pnpm run verify:ai-runtimes`
