### PR TITLE
Add native terminal PTY backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,22 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -46,6 +58,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "comando-fs"
 version = "0.1.0"
 dependencies = [
@@ -56,7 +74,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "walkdir",
 ]
@@ -70,7 +88,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -82,7 +100,7 @@ dependencies = [
  "comando-types",
  "serde",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "uuid",
  "walkdir",
@@ -113,7 +131,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -126,7 +144,20 @@ dependencies = [
  "rusqlite",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "comando-terminal"
+version = "0.1.0"
+dependencies = [
+ "comando-types",
+ "portable-pty",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -136,7 +167,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -175,6 +206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +238,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -301,7 +349,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -348,9 +396,15 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -400,12 +454,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -423,7 +489,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -449,6 +515,27 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
 
 [[package]]
 name = "powerfmt"
@@ -487,7 +574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -496,7 +583,7 @@ version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -511,7 +598,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -577,6 +664,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +684,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -643,11 +757,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -788,6 +922,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +945,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -884,6 +1040,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "comando-index",
  "comando-persistence",
  "comando-projects",
+ "comando-terminal",
  "comando-types",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/comando-fs",
     "crates/comando-persistence",
     "crates/comando-projects",
+    "crates/comando-terminal",
     "crates/comando-types",
 ]
 resolver = "3"
@@ -18,6 +19,7 @@ edition = "2024"
 comando-types = { path = "crates/comando-types" }
 base64 = "0.22.1"
 notify = "8.2.0"
+portable-pty = "0.9.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10.9"

--- a/apps/native-backend/Cargo.toml
+++ b/apps/native-backend/Cargo.toml
@@ -9,6 +9,7 @@ comando-git = { path = "../../crates/comando-git" }
 comando-index = { path = "../../crates/comando-index" }
 comando-persistence = { path = "../../crates/comando-persistence" }
 comando-projects = { path = "../../crates/comando-projects" }
+comando-terminal = { path = "../../crates/comando-terminal" }
 comando-types.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -87,10 +87,12 @@ pub fn handle_request(request: RpcRequest) -> CommandResult {
 }
 
 impl NativeBackend {
+    const TERMINAL_EVENT_CHANNEL_CAPACITY: usize = 256;
+
     pub fn handle_request_background(
         &mut self,
         request: RpcRequest,
-        background_sender: mpsc::Sender<Vec<RpcOutput>>,
+        background_sender: mpsc::SyncSender<Vec<RpcOutput>>,
     ) -> CommandResult {
         match request.command.as_str() {
             "project_search_entries" | "search_project_entries" => {
@@ -889,7 +891,7 @@ impl NativeBackend {
     fn spawn_search_project_entries(
         &mut self,
         request: RpcRequest,
-        background_sender: mpsc::Sender<Vec<RpcOutput>>,
+        background_sender: mpsc::SyncSender<Vec<RpcOutput>>,
     ) -> CommandResult {
         if let Err(error) = self.sync_fs_registry_from_store().map(|_| ()) {
             return error_only(request.id, error);
@@ -986,7 +988,7 @@ impl NativeBackend {
     fn handle_terminal_request(
         &mut self,
         request: RpcRequest,
-        background_sender: mpsc::Sender<Vec<RpcOutput>>,
+        background_sender: mpsc::SyncSender<Vec<RpcOutput>>,
     ) -> CommandResult {
         let command = request.command.clone();
         match command.as_str() {
@@ -1111,10 +1113,11 @@ impl NativeBackend {
 
     fn ensure_terminal_service(
         &mut self,
-        background_sender: mpsc::Sender<Vec<RpcOutput>>,
+        background_sender: mpsc::SyncSender<Vec<RpcOutput>>,
     ) -> &TerminalService {
         self.terminal_service.get_or_insert_with(|| {
-            let (event_sender, event_receiver) = mpsc::channel::<TerminalRuntimeEvent>();
+            let (event_sender, event_receiver) =
+                mpsc::sync_channel::<TerminalRuntimeEvent>(Self::TERMINAL_EVENT_CHANNEL_CAPACITY);
             thread::spawn(move || {
                 for event in event_receiver {
                     let output = terminal_runtime_event_output(event);
@@ -2548,7 +2551,7 @@ mod tests {
         let (temp_dir, mut backend, project_id) = backend_with_registered_project();
         let project_path = temp_dir.path().join("project-native");
         fs::write(project_path.join("main.ts"), "console.log('hi');\n").expect("main");
-        let (sender, receiver) = mpsc::channel();
+        let (sender, receiver) = mpsc::sync_channel(16);
 
         let search_result = backend.handle_request_background(
             request(

--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -17,6 +17,7 @@ use comando_index::{
 };
 use comando_persistence::{NativeStorageConfig, SqlitePersistenceStore, closed_storage_health};
 use comando_projects::{ProjectRegistry, ProjectRegistryError};
+use comando_terminal::{TerminalRuntimeEvent, TerminalService};
 use comando_types::capabilities::{
     BACKEND_NAME, NativeBackendCapabilitiesOutput, NativeBackendHandshakeInput,
     NativeBackendHandshakeOutput, PROTOCOL_VERSION, RUST_VERSION, backend_capabilities,
@@ -36,6 +37,7 @@ use comando_types::persistence::{
 use comando_types::projects::{NativeProjectAddInput, NativeProjectState};
 use comando_types::{
     fs as native_fs, git as native_git, index as native_index, projects as native_projects,
+    terminal as native_terminal,
 };
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
@@ -54,6 +56,7 @@ pub struct NativeBackend {
     git_runner: GitRunner,
     index_service: IndexService,
     persistence_store: Option<SqlitePersistenceStore>,
+    terminal_service: Option<TerminalService>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -93,6 +96,13 @@ impl NativeBackend {
             "project_search_entries" | "search_project_entries" => {
                 self.spawn_search_project_entries(request, background_sender)
             }
+            "terminal_create"
+            | "terminal_write"
+            | "terminal_resize"
+            | "terminal_kill"
+            | "terminal_close"
+            | "terminal_close_window"
+            | "terminal_list" => self.handle_terminal_request(request, background_sender),
             _ => self.handle_request(request),
         }
     }
@@ -973,6 +983,151 @@ impl NativeBackend {
         }
     }
 
+    fn handle_terminal_request(
+        &mut self,
+        request: RpcRequest,
+        background_sender: mpsc::Sender<Vec<RpcOutput>>,
+    ) -> CommandResult {
+        let command = request.command.clone();
+        match command.as_str() {
+            "terminal_create" => {
+                let input = match parse_args::<native_terminal::NativeTerminalCreateInput>(&request)
+                {
+                    Ok(input) => input,
+                    Err(error) => return error_only(request.id, error),
+                };
+                match self
+                    .ensure_terminal_service(background_sender)
+                    .create_session(input)
+                {
+                    Ok(session) => response_only(
+                        request.id,
+                        serde_json::to_value(session).expect("terminal session serializes"),
+                    ),
+                    Err(error) => error_only(request.id, error.to_native_error()),
+                }
+            }
+            "terminal_write" => {
+                let input = match parse_args::<native_terminal::NativeTerminalWriteInput>(&request)
+                {
+                    Ok(input) => input,
+                    Err(error) => return error_only(request.id, error),
+                };
+                match self
+                    .ensure_terminal_service(background_sender)
+                    .write_input(input)
+                {
+                    Ok(()) => response_only(request.id, json!({"ok": true})),
+                    Err(error) => error_only(request.id, error.to_native_error()),
+                }
+            }
+            "terminal_resize" => {
+                let input = match parse_args::<native_terminal::NativeTerminalResizeInput>(&request)
+                {
+                    Ok(input) => input,
+                    Err(error) => return error_only(request.id, error),
+                };
+                match self
+                    .ensure_terminal_service(background_sender)
+                    .resize_session(input)
+                {
+                    Ok(Some(session)) => response_only(
+                        request.id,
+                        serde_json::to_value(session).expect("terminal session serializes"),
+                    ),
+                    Ok(None) => response_only(request.id, json!({"ok": true})),
+                    Err(error) => error_only(request.id, error.to_native_error()),
+                }
+            }
+            "terminal_kill" => {
+                let input = match parse_args::<native_terminal::NativeTerminalKillInput>(&request) {
+                    Ok(input) => input,
+                    Err(error) => return error_only(request.id, error),
+                };
+                match self
+                    .ensure_terminal_service(background_sender)
+                    .kill_session(input)
+                {
+                    Ok(()) => response_only(request.id, json!({"ok": true})),
+                    Err(error) => error_only(request.id, error.to_native_error()),
+                }
+            }
+            "terminal_close" => {
+                let input = match parse_args::<native_terminal::NativeTerminalCloseInput>(&request)
+                {
+                    Ok(input) => input,
+                    Err(error) => return error_only(request.id, error),
+                };
+                match self
+                    .ensure_terminal_service(background_sender)
+                    .close_session(input)
+                {
+                    Ok(()) => response_only(request.id, json!({"ok": true})),
+                    Err(error) => error_only(request.id, error.to_native_error()),
+                }
+            }
+            "terminal_close_window" => {
+                let input =
+                    match parse_args::<native_terminal::NativeTerminalCloseWindowInput>(&request) {
+                        Ok(input) => input,
+                        Err(error) => return error_only(request.id, error),
+                    };
+                match self
+                    .ensure_terminal_service(background_sender)
+                    .close_window(input)
+                {
+                    Ok(()) => response_only(request.id, json!({"ok": true})),
+                    Err(error) => error_only(request.id, error.to_native_error()),
+                }
+            }
+            "terminal_list" => {
+                let input = match parse_args::<native_terminal::NativeTerminalListInput>(&request) {
+                    Ok(input) => input,
+                    Err(error) => return error_only(request.id, error),
+                };
+                match self
+                    .ensure_terminal_service(background_sender)
+                    .list_sessions(input)
+                {
+                    Ok(result) => response_only(
+                        request.id,
+                        serde_json::to_value(result).expect("terminal list serializes"),
+                    ),
+                    Err(error) => error_only(request.id, error.to_native_error()),
+                }
+            }
+            _ => CommandResult {
+                outputs: vec![error_response(
+                    Some(request.id),
+                    NativeError::new(
+                        NativeErrorCode::UnknownCommand,
+                        format!("Unknown command: {command}"),
+                    ),
+                )],
+                should_shutdown: false,
+            },
+        }
+    }
+
+    fn ensure_terminal_service(
+        &mut self,
+        background_sender: mpsc::Sender<Vec<RpcOutput>>,
+    ) -> &TerminalService {
+        self.terminal_service.get_or_insert_with(|| {
+            let (event_sender, event_receiver) = mpsc::channel::<TerminalRuntimeEvent>();
+            thread::spawn(move || {
+                for event in event_receiver {
+                    let output = terminal_runtime_event_output(event);
+                    if background_sender.send(vec![output]).is_err() {
+                        break;
+                    }
+                }
+            });
+
+            TerminalService::new(event_sender)
+        })
+    }
+
     fn search_project_content(&mut self, request: RpcRequest) -> CommandResult {
         match parse_args::<native_index::NativeContentSearchInput>(&request) {
             Ok(_) => error_only(
@@ -1611,6 +1766,31 @@ fn git_response<T: Serialize>(
     match result {
         Ok(output) => response_only(id, serde_json::to_value(output).expect(serialize_message)),
         Err(error) => error_only(id, git_error(error)),
+    }
+}
+
+fn terminal_runtime_event_output(event_payload: TerminalRuntimeEvent) -> RpcOutput {
+    match event_payload {
+        TerminalRuntimeEvent::Created(payload) => event(
+            "terminal://created",
+            serde_json::to_value(payload).expect("terminal created event serializes"),
+        ),
+        TerminalRuntimeEvent::Data(payload) => event(
+            "terminal://data",
+            serde_json::to_value(payload).expect("terminal data event serializes"),
+        ),
+        TerminalRuntimeEvent::Exit(payload) => event(
+            "terminal://exit",
+            serde_json::to_value(payload).expect("terminal exit event serializes"),
+        ),
+        TerminalRuntimeEvent::Closed(payload) => event(
+            "terminal://closed",
+            serde_json::to_value(payload).expect("terminal closed event serializes"),
+        ),
+        TerminalRuntimeEvent::Error(payload) => event(
+            "terminal://error",
+            serde_json::to_value(payload).expect("terminal error event serializes"),
+        ),
     }
 }
 

--- a/apps/native-backend/src/lib.rs
+++ b/apps/native-backend/src/lib.rs
@@ -10,6 +10,9 @@ pub mod protocol;
 use commands::NativeBackend;
 use protocol::{JsonlWriter, RpcOutput, error_response, parse_request_line};
 
+const BACKGROUND_CHANNEL_CAPACITY: usize = 256;
+const BACKGROUND_DRAIN_OUTPUT_LIMIT: usize = 64;
+
 enum InputMessage {
     Line(io::Result<String>),
     Eof,
@@ -23,7 +26,8 @@ where
     let mut writer = JsonlWriter::new(writer);
     let mut backend = NativeBackend::default();
     let (sender, receiver) = mpsc::channel::<InputMessage>();
-    let (background_sender, background_receiver) = mpsc::channel::<Vec<RpcOutput>>();
+    let (background_sender, background_receiver) =
+        mpsc::sync_channel::<Vec<RpcOutput>>(BACKGROUND_CHANNEL_CAPACITY);
 
     thread::spawn(move || {
         for line_result in reader.lines() {
@@ -38,7 +42,11 @@ where
         let message = match receiver.recv_timeout(Duration::from_millis(50)) {
             Ok(message) => message,
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                write_background_outputs(&mut writer, &background_receiver)?;
+                write_background_outputs(
+                    &mut writer,
+                    &background_receiver,
+                    BACKGROUND_DRAIN_OUTPUT_LIMIT,
+                )?;
                 write_outputs(&mut writer, backend.drain_fs_events(false))?;
                 continue;
             }
@@ -48,7 +56,7 @@ where
         let line = match message {
             InputMessage::Line(line_result) => line_result?,
             InputMessage::Eof => {
-                write_background_outputs(&mut writer, &background_receiver)?;
+                write_background_outputs(&mut writer, &background_receiver, usize::MAX)?;
                 write_outputs(&mut writer, backend.drain_fs_events(true))?;
                 break;
             }
@@ -73,7 +81,11 @@ where
         };
 
         write_outputs(&mut writer, command_result.outputs)?;
-        write_background_outputs(&mut writer, &background_receiver)?;
+        write_background_outputs(
+            &mut writer,
+            &background_receiver,
+            BACKGROUND_DRAIN_OUTPUT_LIMIT,
+        )?;
 
         if command_result.should_shutdown {
             break;
@@ -86,11 +98,17 @@ where
 fn write_background_outputs<W>(
     writer: &mut JsonlWriter<W>,
     receiver: &mpsc::Receiver<Vec<RpcOutput>>,
+    max_outputs: usize,
 ) -> io::Result<()>
 where
     W: Write,
 {
+    let mut written = 0usize;
     for outputs in receiver.try_iter() {
+        if written >= max_outputs {
+            break;
+        }
+        written = written.saturating_add(outputs.len());
         write_outputs(writer, outputs)?;
     }
     Ok(())

--- a/apps/native-backend/tests/jsonl_contract.rs
+++ b/apps/native-backend/tests/jsonl_contract.rs
@@ -179,7 +179,8 @@ fn reports_capabilities() {
             "native-git-history",
             "native-git-worktrees",
             "native-git-mutations",
-            "native-git-network"
+            "native-git-network",
+            "native-terminal"
         ])
     );
     assert_eq!(
@@ -221,6 +222,78 @@ fn handshakes_protocol_v1() {
 }
 
 #[test]
+fn terminal_create_streams_data_exit_and_closed_events() {
+    let mut backend = BackendProcess::spawn();
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+
+    backend.send(json!({
+        "id": "term-create",
+        "command": "terminal_create",
+        "args": {
+            "windowId": "window_main",
+            "terminalId": "terminal_tab_1",
+            "preferredSessionId": null,
+            "projectId": null,
+            "worktreeId": null,
+            "cwd": temp_dir.path().to_string_lossy(),
+            "cols": 120,
+            "rows": 32,
+            "extraEnv": {},
+            "shellPreference": {"windowsShell": "default"},
+            "purpose": "workspace",
+            "launchedBy": "user",
+            "launch": terminal_print_command(),
+        },
+    }));
+
+    let response = backend.read_json();
+    assert_eq!(response["type"], "response");
+    assert_eq!(response["id"], "term-create");
+    assert_eq!(response["ok"], true);
+    let session_id = response["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let mut saw_created = false;
+    let mut saw_data = false;
+    let mut saw_exit = false;
+    let mut saw_closed = false;
+    for _ in 0..8 {
+        let output = backend.read_json();
+        match output["eventName"].as_str() {
+            Some("terminal://created") => {
+                saw_created = output["payload"]["session"]["sessionId"] == session_id;
+            }
+            Some("terminal://data") => {
+                saw_data = output["payload"]["sessionId"] == session_id
+                    && output["payload"]["windowId"] == "window_main"
+                    && output["payload"]["data"]
+                        .as_str()
+                        .is_some_and(|data| data.contains("ready"));
+            }
+            Some("terminal://exit") => {
+                saw_exit = output["payload"]["sessionId"] == session_id
+                    && output["payload"]["exitCode"] == 0;
+            }
+            Some("terminal://closed") => {
+                saw_closed = output["payload"]["sessionId"] == session_id
+                    && output["payload"]["reason"] == "process_exit";
+            }
+            _ => {}
+        }
+
+        if saw_created && saw_data && saw_exit && saw_closed {
+            return;
+        }
+    }
+
+    panic!(
+        "missing terminal events created={saw_created} data={saw_data} exit={saw_exit} closed={saw_closed}"
+    );
+}
+
+#[test]
 fn rejects_incompatible_handshake_version() {
     let mut backend = BackendProcess::spawn();
 
@@ -241,6 +314,26 @@ fn rejects_incompatible_handshake_version() {
     assert_eq!(response["ok"], false);
     assert_eq!(response["error"]["code"], "unsupported_protocol_version");
     assert_eq!(response["error"]["retryable"], false);
+}
+
+#[cfg(unix)]
+fn terminal_print_command() -> Value {
+    json!({
+        "kind": "command",
+        "program": "/bin/sh",
+        "args": ["-lc", "printf ready"],
+        "displayName": "print",
+    })
+}
+
+#[cfg(windows)]
+fn terminal_print_command() -> Value {
+    json!({
+        "kind": "command",
+        "program": "cmd.exe",
+        "args": ["/C", "echo ready"],
+        "displayName": "print",
+    })
 }
 
 #[test]

--- a/crates/comando-terminal/Cargo.toml
+++ b/crates/comando-terminal/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "comando-terminal"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+comando-types.workspace = true
+portable-pty.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/crates/comando-terminal/src/error.rs
+++ b/crates/comando-terminal/src/error.rs
@@ -1,0 +1,76 @@
+use std::io;
+
+use comando_types::error::{NativeError, NativeErrorCode};
+use serde_json::json;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TerminalError {
+    #[error("Terminal session was not found.")]
+    NotFound,
+    #[error("Terminal session belongs to another window.")]
+    ForeignWindow,
+    #[error("Terminal working directory does not exist.")]
+    CwdNotFound,
+    #[error("Terminal working directory is not a directory.")]
+    CwdNotDirectory,
+    #[error("Terminal working directory is not accessible: {0}")]
+    CwdIo(#[source] io::Error),
+    #[error("Terminal PTY is not available.")]
+    PtyUnavailable,
+    #[error("Failed to create terminal PTY: {0}")]
+    OpenPty(String),
+    #[error("Failed to start terminal process: {0}")]
+    Spawn(String),
+    #[error("Failed to open terminal writer: {0}")]
+    Writer(String),
+    #[error("Failed to open terminal reader: {0}")]
+    Reader(String),
+    #[error("Failed to write to terminal session: {0}")]
+    Write(String),
+    #[error("Failed to resize terminal PTY: {0}")]
+    Resize(String),
+    #[error("Internal terminal state error: {0}")]
+    State(String),
+}
+
+impl TerminalError {
+    pub fn terminal_code(&self) -> &'static str {
+        match self {
+            Self::NotFound => "not_found",
+            Self::ForeignWindow => "foreign_window",
+            Self::CwdNotFound => "cwd_not_found",
+            Self::CwdNotDirectory => "cwd_not_directory",
+            Self::CwdIo(_) => "cwd_io",
+            Self::PtyUnavailable => "pty_unavailable",
+            Self::OpenPty(_) => "open_pty",
+            Self::Spawn(_) => "spawn",
+            Self::Writer(_) => "writer",
+            Self::Reader(_) => "reader",
+            Self::Write(_) => "write",
+            Self::Resize(_) => "resize",
+            Self::State(_) => "state",
+        }
+    }
+
+    pub fn to_native_error(&self) -> NativeError {
+        let code = match self {
+            Self::NotFound => NativeErrorCode::NotFound,
+            Self::ForeignWindow => NativeErrorCode::PermissionDenied,
+            Self::CwdNotFound | Self::CwdNotDirectory => NativeErrorCode::InvalidArgs,
+            Self::CwdIo(_)
+            | Self::PtyUnavailable
+            | Self::OpenPty(_)
+            | Self::Spawn(_)
+            | Self::Writer(_)
+            | Self::Reader(_)
+            | Self::Write(_)
+            | Self::Resize(_)
+            | Self::State(_) => NativeErrorCode::InternalError,
+        };
+
+        NativeError::new(code, self.to_string()).with_details(json!({
+            "terminalCode": self.terminal_code(),
+        }))
+    }
+}

--- a/crates/comando-terminal/src/lib.rs
+++ b/crates/comando-terminal/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod error;
+pub mod output;
+pub mod service;
+pub mod session;
+pub mod shell;
+pub mod utf8;
+
+pub use error::TerminalError;
+pub use output::{TerminalOutputMessage, TerminalRuntimeEvent, start_output_coalescer};
+pub use service::TerminalService;
+pub use session::{normalize_terminal_cols, normalize_terminal_rows};

--- a/crates/comando-terminal/src/output.rs
+++ b/crates/comando-terminal/src/output.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -37,7 +37,7 @@ struct PendingOutput {
 
 pub fn start_output_coalescer(
     receiver: Receiver<TerminalOutputMessage>,
-    event_sender: Sender<TerminalRuntimeEvent>,
+    event_sender: SyncSender<TerminalRuntimeEvent>,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
         let mut pending = HashMap::<String, PendingOutput>::new();
@@ -65,7 +65,7 @@ pub fn start_output_coalescer(
 
 fn handle_message(
     message: TerminalOutputMessage,
-    event_sender: &Sender<TerminalRuntimeEvent>,
+    event_sender: &SyncSender<TerminalRuntimeEvent>,
     pending: &mut HashMap<String, PendingOutput>,
     pending_bytes: &mut usize,
 ) {
@@ -106,7 +106,7 @@ fn handle_message(
 }
 
 fn flush_all(
-    event_sender: &Sender<TerminalRuntimeEvent>,
+    event_sender: &SyncSender<TerminalRuntimeEvent>,
     pending: &mut HashMap<String, PendingOutput>,
     pending_bytes: &mut usize,
 ) {
@@ -117,7 +117,7 @@ fn flush_all(
 }
 
 fn flush_session(
-    event_sender: &Sender<TerminalRuntimeEvent>,
+    event_sender: &SyncSender<TerminalRuntimeEvent>,
     pending: &mut HashMap<String, PendingOutput>,
     pending_bytes: &mut usize,
     session_id: &str,
@@ -162,7 +162,7 @@ fn split_at_byte_limit(value: &str, limit: usize) -> usize {
     if split_at == 0 { value.len() } else { split_at }
 }
 
-fn send_event(sender: &Sender<TerminalRuntimeEvent>, event: TerminalRuntimeEvent) {
+fn send_event(sender: &SyncSender<TerminalRuntimeEvent>, event: TerminalRuntimeEvent) {
     let _ = sender.send(event);
 }
 
@@ -179,7 +179,7 @@ mod tests {
     #[test]
     fn coalesces_small_chunks() {
         let (input_tx, input_rx) = mpsc::channel();
-        let (event_tx, event_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::sync_channel(64);
         let _handle = start_output_coalescer(input_rx, event_tx);
 
         for chunk in ["a", "b", "c"] {
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn flushes_session_before_exit() {
         let (input_tx, input_rx) = mpsc::channel();
-        let (event_tx, event_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::sync_channel(64);
         let _handle = start_output_coalescer(input_rx, event_tx);
 
         input_tx
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn chunks_large_output_on_flush() {
         let (input_tx, input_rx) = mpsc::channel();
-        let (event_tx, event_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::sync_channel(64);
         let _handle = start_output_coalescer(input_rx, event_tx);
         let data = "x".repeat(OUTPUT_MAX_EVENT_BYTES + 5);
 

--- a/crates/comando-terminal/src/output.rs
+++ b/crates/comando-terminal/src/output.rs
@@ -1,0 +1,259 @@
+use std::collections::HashMap;
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use comando_types::terminal::{
+    NativeTerminalClosedEvent, NativeTerminalCreatedEvent, NativeTerminalDataEvent,
+    NativeTerminalErrorEvent, NativeTerminalExitEvent,
+};
+
+pub const OUTPUT_FLUSH_INTERVAL: Duration = Duration::from_millis(16);
+pub const OUTPUT_FLUSH_BYTES: usize = 256 * 1024;
+pub const OUTPUT_MAX_EVENT_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TerminalRuntimeEvent {
+    Created(NativeTerminalCreatedEvent),
+    Data(NativeTerminalDataEvent),
+    Exit(NativeTerminalExitEvent),
+    Closed(NativeTerminalClosedEvent),
+    Error(NativeTerminalErrorEvent),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TerminalOutputMessage {
+    Created(NativeTerminalCreatedEvent),
+    Data(NativeTerminalDataEvent),
+    Exit(NativeTerminalExitEvent),
+    Closed(NativeTerminalClosedEvent),
+    Error(NativeTerminalErrorEvent),
+}
+
+#[derive(Debug, Clone)]
+struct PendingOutput {
+    event: NativeTerminalDataEvent,
+}
+
+pub fn start_output_coalescer(
+    receiver: Receiver<TerminalOutputMessage>,
+    event_sender: Sender<TerminalRuntimeEvent>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        let mut pending = HashMap::<String, PendingOutput>::new();
+        let mut pending_bytes = 0usize;
+
+        loop {
+            match receiver.recv_timeout(OUTPUT_FLUSH_INTERVAL) {
+                Ok(message) => {
+                    handle_message(message, &event_sender, &mut pending, &mut pending_bytes);
+                    if pending_bytes >= OUTPUT_FLUSH_BYTES {
+                        flush_all(&event_sender, &mut pending, &mut pending_bytes);
+                    }
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    flush_all(&event_sender, &mut pending, &mut pending_bytes);
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    flush_all(&event_sender, &mut pending, &mut pending_bytes);
+                    break;
+                }
+            }
+        }
+    })
+}
+
+fn handle_message(
+    message: TerminalOutputMessage,
+    event_sender: &Sender<TerminalRuntimeEvent>,
+    pending: &mut HashMap<String, PendingOutput>,
+    pending_bytes: &mut usize,
+) {
+    match message {
+        TerminalOutputMessage::Created(event) => {
+            send_event(event_sender, TerminalRuntimeEvent::Created(event));
+        }
+        TerminalOutputMessage::Data(event) => {
+            if event.data.is_empty() {
+                return;
+            }
+
+            let key = event.session_id.0.clone();
+            let event_len = event.data.len();
+            pending
+                .entry(key)
+                .and_modify(|pending| {
+                    pending.event.data.push_str(&event.data);
+                })
+                .or_insert_with(|| PendingOutput { event });
+            *pending_bytes = pending_bytes.saturating_add(event_len);
+        }
+        TerminalOutputMessage::Exit(event) => {
+            flush_session(event_sender, pending, pending_bytes, &event.session_id.0);
+            send_event(event_sender, TerminalRuntimeEvent::Exit(event));
+        }
+        TerminalOutputMessage::Closed(event) => {
+            flush_session(event_sender, pending, pending_bytes, &event.session_id.0);
+            send_event(event_sender, TerminalRuntimeEvent::Closed(event));
+        }
+        TerminalOutputMessage::Error(event) => {
+            if let Some(session_id) = &event.session_id {
+                flush_session(event_sender, pending, pending_bytes, &session_id.0);
+            }
+            send_event(event_sender, TerminalRuntimeEvent::Error(event));
+        }
+    }
+}
+
+fn flush_all(
+    event_sender: &Sender<TerminalRuntimeEvent>,
+    pending: &mut HashMap<String, PendingOutput>,
+    pending_bytes: &mut usize,
+) {
+    let keys = pending.keys().cloned().collect::<Vec<_>>();
+    for key in keys {
+        flush_session(event_sender, pending, pending_bytes, &key);
+    }
+}
+
+fn flush_session(
+    event_sender: &Sender<TerminalRuntimeEvent>,
+    pending: &mut HashMap<String, PendingOutput>,
+    pending_bytes: &mut usize,
+    session_id: &str,
+) {
+    let Some(mut pending_output) = pending.remove(session_id) else {
+        return;
+    };
+    *pending_bytes = pending_bytes.saturating_sub(pending_output.event.data.len());
+
+    while !pending_output.event.data.is_empty() {
+        let split_at = split_at_byte_limit(&pending_output.event.data, OUTPUT_MAX_EVENT_BYTES);
+        let chunk = pending_output.event.data[..split_at].to_string();
+        pending_output.event.data.replace_range(..split_at, "");
+        if chunk.is_empty() {
+            continue;
+        }
+
+        send_event(
+            event_sender,
+            TerminalRuntimeEvent::Data(NativeTerminalDataEvent {
+                window_id: pending_output.event.window_id.clone(),
+                session_id: pending_output.event.session_id.clone(),
+                data: chunk,
+            }),
+        );
+    }
+}
+
+fn split_at_byte_limit(value: &str, limit: usize) -> usize {
+    if value.len() <= limit {
+        return value.len();
+    }
+
+    let mut split_at = 0;
+    for (index, _) in value.char_indices() {
+        if index > limit {
+            break;
+        }
+        split_at = index;
+    }
+
+    if split_at == 0 { value.len() } else { split_at }
+}
+
+fn send_event(sender: &Sender<TerminalRuntimeEvent>, event: TerminalRuntimeEvent) {
+    let _ = sender.send(event);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use comando_types::ids::{TerminalSessionId, WindowId};
+    use comando_types::terminal::NativeTerminalExitEvent;
+
+    use super::*;
+
+    #[test]
+    fn coalesces_small_chunks() {
+        let (input_tx, input_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::channel();
+        let _handle = start_output_coalescer(input_rx, event_tx);
+
+        for chunk in ["a", "b", "c"] {
+            input_tx
+                .send(TerminalOutputMessage::Data(data_event(chunk)))
+                .expect("send data");
+        }
+
+        let event = event_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("coalesced event");
+        assert_eq!(event, TerminalRuntimeEvent::Data(data_event("abc")));
+    }
+
+    #[test]
+    fn flushes_session_before_exit() {
+        let (input_tx, input_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::channel();
+        let _handle = start_output_coalescer(input_rx, event_tx);
+
+        input_tx
+            .send(TerminalOutputMessage::Data(data_event("ready\n")))
+            .expect("send data");
+        input_tx
+            .send(TerminalOutputMessage::Exit(NativeTerminalExitEvent {
+                window_id: WindowId("window_1".to_string()),
+                session_id: TerminalSessionId("terminal_1".to_string()),
+                exit_code: Some(0),
+                signal_code: None,
+            }))
+            .expect("send exit");
+
+        assert_eq!(
+            event_rx.recv_timeout(Duration::from_secs(1)).expect("data"),
+            TerminalRuntimeEvent::Data(data_event("ready\n")),
+        );
+        assert!(matches!(
+            event_rx.recv_timeout(Duration::from_secs(1)).expect("exit"),
+            TerminalRuntimeEvent::Exit(_)
+        ));
+    }
+
+    #[test]
+    fn chunks_large_output_on_flush() {
+        let (input_tx, input_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::channel();
+        let _handle = start_output_coalescer(input_rx, event_tx);
+        let data = "x".repeat(OUTPUT_MAX_EVENT_BYTES + 5);
+
+        input_tx
+            .send(TerminalOutputMessage::Data(data_event(&data)))
+            .expect("send data");
+
+        let first = event_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("first");
+        let second = event_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("second");
+        let TerminalRuntimeEvent::Data(first) = first else {
+            panic!("expected data");
+        };
+        let TerminalRuntimeEvent::Data(second) = second else {
+            panic!("expected data");
+        };
+        assert_eq!(first.data.len(), OUTPUT_MAX_EVENT_BYTES);
+        assert_eq!(second.data.len(), 5);
+    }
+
+    fn data_event(data: &str) -> NativeTerminalDataEvent {
+        NativeTerminalDataEvent {
+            window_id: WindowId("window_1".to_string()),
+            session_id: TerminalSessionId("terminal_1".to_string()),
+            data: data.to_string(),
+        }
+    }
+}

--- a/crates/comando-terminal/src/service.rs
+++ b/crates/comando-terminal/src/service.rs
@@ -1,0 +1,1045 @@
+use std::collections::HashMap;
+use std::env;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+    mpsc::{self, Sender, SyncSender},
+};
+use std::thread;
+use std::time::Duration;
+
+use comando_types::ids::{TerminalSessionId, WindowId};
+use comando_types::terminal::{
+    NativeTerminalCloseInput, NativeTerminalCloseReason, NativeTerminalCloseWindowInput,
+    NativeTerminalClosedEvent, NativeTerminalCreateInput, NativeTerminalCreatedEvent,
+    NativeTerminalDataEvent, NativeTerminalErrorEvent, NativeTerminalExitEvent,
+    NativeTerminalKillInput, NativeTerminalLaunch, NativeTerminalListInput,
+    NativeTerminalListResult, NativeTerminalResizeInput, NativeTerminalSession,
+    NativeTerminalStatus, NativeTerminalWindowsShell, NativeTerminalWriteInput,
+};
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+use uuid::Uuid;
+
+use crate::error::TerminalError;
+use crate::output::{TerminalOutputMessage, TerminalRuntimeEvent, start_output_coalescer};
+use crate::session::{
+    OwnerTerminalKey, RegistryState, SessionHandle, normalize_terminal_cols,
+    normalize_terminal_rows,
+};
+use crate::shell::resolve_current_terminal_shell;
+use crate::utf8::Utf8CarryDecoder;
+
+const OUTPUT_CHANNEL_CAPACITY: usize = 1024;
+const OUTPUT_READ_BUFFER_SIZE: usize = 4096;
+const MONITOR_INTERVAL: Duration = Duration::from_millis(120);
+
+#[derive(Debug, Clone)]
+struct TerminalLaunchConfig {
+    program: String,
+    args: Vec<String>,
+    display_name: String,
+    cwd: PathBuf,
+    env: HashMap<String, String>,
+}
+
+pub struct TerminalService {
+    state: Arc<Mutex<RegistryState>>,
+    output_tx: SyncSender<TerminalOutputMessage>,
+}
+
+impl TerminalService {
+    pub fn new(event_sender: Sender<TerminalRuntimeEvent>) -> Self {
+        let (output_tx, output_rx) = mpsc::sync_channel(OUTPUT_CHANNEL_CAPACITY);
+        let _coalescer = start_output_coalescer(output_rx, event_sender);
+        Self {
+            state: Arc::new(Mutex::new(RegistryState::default())),
+            output_tx,
+        }
+    }
+
+    pub fn create_session(
+        &self,
+        input: NativeTerminalCreateInput,
+    ) -> Result<NativeTerminalSession, TerminalError> {
+        if let Some(existing) = self.reusable_session(&input)? {
+            return Ok(existing);
+        }
+
+        let session_id = self.next_session_id(input.preferred_session_id.as_ref())?;
+        let cols = normalize_terminal_cols(input.cols);
+        let rows = normalize_terminal_rows(input.rows);
+        let launch_config = resolve_launch_config(&input, cols, rows)?;
+
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                cols,
+                rows,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|error| TerminalError::OpenPty(error.to_string()))?;
+
+        let master = Arc::new(Mutex::new(Some(pair.master)));
+        let mut command = CommandBuilder::new(&launch_config.program);
+        command.args(&launch_config.args);
+        command.cwd(&launch_config.cwd);
+        for (key, value) in &launch_config.env {
+            command.env(key, value);
+        }
+
+        let child = pair
+            .slave
+            .spawn_command(command)
+            .map_err(|error| TerminalError::Spawn(error.to_string()))?;
+        let killer = child.clone_killer();
+        let writer = master
+            .lock()
+            .map_err(|error| TerminalError::State(error.to_string()))?
+            .as_ref()
+            .ok_or(TerminalError::PtyUnavailable)?
+            .take_writer()
+            .map_err(|error| TerminalError::Writer(error.to_string()))?;
+        let reader = master
+            .lock()
+            .map_err(|error| TerminalError::State(error.to_string()))?
+            .as_ref()
+            .ok_or(TerminalError::PtyUnavailable)?
+            .try_clone_reader()
+            .map_err(|error| TerminalError::Reader(error.to_string()))?;
+
+        let owner_key = input
+            .terminal_id
+            .as_ref()
+            .map(|terminal_id| OwnerTerminalKey::new(input.window_id.clone(), terminal_id.clone()));
+        let snapshot = Arc::new(Mutex::new(NativeTerminalSession {
+            session_id: TerminalSessionId(session_id.clone()),
+            window_id: input.window_id.clone(),
+            terminal_id: input.terminal_id.clone(),
+            project_id: input.project_id.clone(),
+            worktree_id: input.worktree_id.clone(),
+            cwd: launch_config.cwd.to_string_lossy().into_owned(),
+            cols,
+            rows,
+            status: NativeTerminalStatus::Running,
+            exit_code: None,
+            signal_code: None,
+            program: launch_config.program.clone(),
+            display_name: launch_config.display_name.clone(),
+            purpose: input.purpose,
+            launched_by: input.launched_by,
+        }));
+
+        let handle = Arc::new(SessionHandle {
+            snapshot: Arc::clone(&snapshot),
+            master: Arc::clone(&master),
+            writer: Arc::new(Mutex::new(Some(writer))),
+            child: Arc::new(Mutex::new(Some(child))),
+            killer: Arc::new(Mutex::new(Some(killer))),
+            closed: Arc::new(AtomicBool::new(false)),
+            owner_key: owner_key.clone(),
+        });
+
+        spawn_output_reader(
+            reader,
+            Arc::clone(&handle.closed),
+            self.output_tx.clone(),
+            input.window_id.clone(),
+            TerminalSessionId(session_id.clone()),
+            input.terminal_id.clone(),
+        );
+        spawn_exit_monitor(
+            Arc::clone(&self.state),
+            Arc::clone(&handle.master),
+            Arc::clone(&handle.writer),
+            Arc::clone(&handle.child),
+            Arc::clone(&handle.killer),
+            Arc::clone(&handle.snapshot),
+            Arc::clone(&handle.closed),
+            self.output_tx.clone(),
+            owner_key.clone(),
+        );
+
+        let created_snapshot = handle.snapshot()?;
+        self.insert_session(session_id, owner_key, Arc::clone(&handle))?;
+        send_output(
+            &self.output_tx,
+            TerminalOutputMessage::Created(NativeTerminalCreatedEvent {
+                session: created_snapshot.clone(),
+            }),
+        );
+
+        Ok(created_snapshot)
+    }
+
+    pub fn write_input(&self, input: NativeTerminalWriteInput) -> Result<(), TerminalError> {
+        let Some(handle) = self.owned_session(&input.window_id, &input.session_id.0)? else {
+            return Ok(());
+        };
+
+        let mut writer_guard = handle
+            .writer
+            .lock()
+            .map_err(|error| TerminalError::State(error.to_string()))?;
+        let Some(writer) = writer_guard.as_mut() else {
+            return Ok(());
+        };
+
+        writer
+            .write_all(input.data.as_bytes())
+            .map_err(|error| TerminalError::Write(error.to_string()))?;
+        writer
+            .flush()
+            .map_err(|error| TerminalError::Write(error.to_string()))?;
+        Ok(())
+    }
+
+    pub fn resize_session(
+        &self,
+        input: NativeTerminalResizeInput,
+    ) -> Result<Option<NativeTerminalSession>, TerminalError> {
+        let Some(handle) = self.owned_session(&input.window_id, &input.session_id.0)? else {
+            return Ok(None);
+        };
+
+        let cols = normalize_terminal_cols(Some(input.cols));
+        let rows = normalize_terminal_rows(Some(input.rows));
+        {
+            let mut snapshot = handle
+                .snapshot
+                .lock()
+                .map_err(|error| TerminalError::State(error.to_string()))?;
+            if snapshot.cols == cols && snapshot.rows == rows {
+                return Ok(Some(snapshot.clone()));
+            }
+            snapshot.cols = cols;
+            snapshot.rows = rows;
+        }
+
+        if let Some(master) = handle
+            .master
+            .lock()
+            .map_err(|error| TerminalError::State(error.to_string()))?
+            .as_ref()
+        {
+            master
+                .resize(PtySize {
+                    cols,
+                    rows,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                })
+                .map_err(|error| TerminalError::Resize(error.to_string()))?;
+        }
+
+        Ok(Some(handle.snapshot()?))
+    }
+
+    pub fn kill_session(&self, input: NativeTerminalKillInput) -> Result<(), TerminalError> {
+        self.close_session_by_id(
+            &input.window_id,
+            &input.session_id.0,
+            NativeTerminalCloseReason::User,
+        )
+        .map(|_| ())
+    }
+
+    pub fn close_session(&self, input: NativeTerminalCloseInput) -> Result<(), TerminalError> {
+        self.close_session_or_owned_terminal(&input.window_id, &input.id, input.reason)
+            .map(|_| ())
+    }
+
+    pub fn close_window(&self, input: NativeTerminalCloseWindowInput) -> Result<(), TerminalError> {
+        self.close_owned_by_window(&input.window_id, NativeTerminalCloseReason::WindowClosed)
+    }
+
+    pub fn list_sessions(
+        &self,
+        input: NativeTerminalListInput,
+    ) -> Result<NativeTerminalListResult, TerminalError> {
+        let handles = {
+            let state = self
+                .state
+                .lock()
+                .map_err(|error| TerminalError::State(error.to_string()))?;
+            state.sessions.values().cloned().collect::<Vec<_>>()
+        };
+
+        let mut sessions = Vec::new();
+        for handle in handles {
+            let snapshot = handle.snapshot()?;
+            if input
+                .window_id
+                .as_ref()
+                .is_none_or(|window_id| *window_id == snapshot.window_id)
+            {
+                sessions.push(snapshot);
+            }
+        }
+
+        Ok(NativeTerminalListResult { sessions })
+    }
+
+    pub fn close(&self) {
+        let _ = self.close_all(NativeTerminalCloseReason::User);
+    }
+
+    fn reusable_session(
+        &self,
+        input: &NativeTerminalCreateInput,
+    ) -> Result<Option<NativeTerminalSession>, TerminalError> {
+        let owner_key = input
+            .terminal_id
+            .as_ref()
+            .map(|terminal_id| OwnerTerminalKey::new(input.window_id.clone(), terminal_id.clone()));
+
+        if let Some(owner_key) = &owner_key {
+            let existing = {
+                let mut state = self
+                    .state
+                    .lock()
+                    .map_err(|error| TerminalError::State(error.to_string()))?;
+                match state
+                    .session_ids_by_owner_terminal_id
+                    .get(owner_key)
+                    .cloned()
+                {
+                    Some(session_id) => {
+                        if let Some(handle) = state.sessions.get(&session_id) {
+                            Some(handle.clone())
+                        } else {
+                            state.session_ids_by_owner_terminal_id.remove(owner_key);
+                            None
+                        }
+                    }
+                    None => None,
+                }
+            };
+
+            if let Some(handle) = existing {
+                return Ok(Some(handle.snapshot()?));
+            }
+        }
+
+        if let Some(preferred_session_id) = &input.preferred_session_id {
+            let preferred = {
+                let state = self
+                    .state
+                    .lock()
+                    .map_err(|error| TerminalError::State(error.to_string()))?;
+                state.sessions.get(&preferred_session_id.0).cloned()
+            };
+
+            if let Some(handle) = preferred {
+                let snapshot = handle.snapshot()?;
+                if snapshot.window_id == input.window_id {
+                    return Ok(Some(snapshot));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn next_session_id(
+        &self,
+        preferred_session_id: Option<&TerminalSessionId>,
+    ) -> Result<String, TerminalError> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|error| TerminalError::State(error.to_string()))?;
+        let mut session_id = preferred_session_id
+            .map(|id| id.0.clone())
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+        while state.sessions.contains_key(&session_id) {
+            session_id = Uuid::new_v4().to_string();
+        }
+
+        Ok(session_id)
+    }
+
+    fn insert_session(
+        &self,
+        session_id: String,
+        owner_key: Option<OwnerTerminalKey>,
+        handle: Arc<SessionHandle>,
+    ) -> Result<(), TerminalError> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|error| TerminalError::State(error.to_string()))?;
+        state.sessions.insert(session_id.clone(), handle);
+        if let Some(owner_key) = owner_key {
+            state
+                .session_ids_by_owner_terminal_id
+                .insert(owner_key, session_id);
+        }
+        Ok(())
+    }
+
+    fn owned_session(
+        &self,
+        window_id: &WindowId,
+        session_id: &str,
+    ) -> Result<Option<Arc<SessionHandle>>, TerminalError> {
+        let handle = {
+            let state = self
+                .state
+                .lock()
+                .map_err(|error| TerminalError::State(error.to_string()))?;
+            state.sessions.get(session_id).cloned()
+        };
+
+        let Some(handle) = handle else {
+            return Ok(None);
+        };
+        if handle.snapshot()?.window_id != *window_id {
+            return Ok(None);
+        }
+
+        Ok(Some(handle))
+    }
+
+    fn close_session_or_owned_terminal(
+        &self,
+        window_id: &WindowId,
+        id: &str,
+        reason: NativeTerminalCloseReason,
+    ) -> Result<bool, TerminalError> {
+        let direct_session = {
+            let state = self
+                .state
+                .lock()
+                .map_err(|error| TerminalError::State(error.to_string()))?;
+            state.sessions.get(id).cloned()
+        };
+
+        if let Some(handle) = direct_session {
+            if handle.snapshot()?.window_id == *window_id {
+                return self.close_handle(handle, reason).map(|_| true);
+            }
+            return Ok(false);
+        }
+
+        let owner_key = OwnerTerminalKey::new(window_id.clone(), id.to_string());
+        let session_id = {
+            let state = self
+                .state
+                .lock()
+                .map_err(|error| TerminalError::State(error.to_string()))?;
+            state
+                .session_ids_by_owner_terminal_id
+                .get(&owner_key)
+                .cloned()
+        };
+
+        if let Some(session_id) = session_id {
+            return self.close_session_by_id(window_id, &session_id, reason);
+        }
+
+        Ok(false)
+    }
+
+    fn close_session_by_id(
+        &self,
+        window_id: &WindowId,
+        session_id: &str,
+        reason: NativeTerminalCloseReason,
+    ) -> Result<bool, TerminalError> {
+        let Some(handle) = self.owned_session(window_id, session_id)? else {
+            return Ok(false);
+        };
+        self.close_handle(handle, reason).map(|_| true)
+    }
+
+    fn close_owned_by_window(
+        &self,
+        window_id: &WindowId,
+        reason: NativeTerminalCloseReason,
+    ) -> Result<(), TerminalError> {
+        let handles = {
+            let state = self
+                .state
+                .lock()
+                .map_err(|error| TerminalError::State(error.to_string()))?;
+            state.sessions.values().cloned().collect::<Vec<_>>()
+        };
+
+        for handle in handles {
+            if handle.snapshot()?.window_id == *window_id {
+                self.close_handle(handle, reason)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn close_all(&self, reason: NativeTerminalCloseReason) -> Result<(), TerminalError> {
+        let handles = {
+            let state = self
+                .state
+                .lock()
+                .map_err(|error| TerminalError::State(error.to_string()))?;
+            state.sessions.values().cloned().collect::<Vec<_>>()
+        };
+
+        for handle in handles {
+            self.close_handle(handle, reason)?;
+        }
+
+        Ok(())
+    }
+
+    fn close_handle(
+        &self,
+        handle: Arc<SessionHandle>,
+        reason: NativeTerminalCloseReason,
+    ) -> Result<(), TerminalError> {
+        let snapshot = handle.snapshot()?;
+        remove_session_from_state(&self.state, &snapshot.session_id.0, &handle.owner_key)?;
+        handle.closed.store(true, Ordering::Relaxed);
+        handle.release_runtime_resources(true);
+        send_output(
+            &self.output_tx,
+            TerminalOutputMessage::Closed(NativeTerminalClosedEvent {
+                window_id: snapshot.window_id,
+                session_id: snapshot.session_id,
+                terminal_id: snapshot.terminal_id,
+                reason,
+            }),
+        );
+        Ok(())
+    }
+}
+
+impl Drop for TerminalService {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+fn resolve_launch_config(
+    input: &NativeTerminalCreateInput,
+    cols: u16,
+    rows: u16,
+) -> Result<TerminalLaunchConfig, TerminalError> {
+    let cwd = resolve_terminal_cwd(input.cwd.as_deref())?;
+    let (program, args, display_name) = match &input.launch {
+        NativeTerminalLaunch::Shell => {
+            let windows_shell = input
+                .shell_preference
+                .as_ref()
+                .map(|preference| preference.windows_shell)
+                .unwrap_or(NativeTerminalWindowsShell::Default);
+            let resolved = resolve_current_terminal_shell(windows_shell);
+            let display_name = shell_display_name(&resolved.command);
+            (resolved.command, resolved.args, display_name)
+        }
+        NativeTerminalLaunch::Command {
+            program,
+            args,
+            display_name,
+        } => (
+            program.clone(),
+            args.clone(),
+            display_name
+                .clone()
+                .unwrap_or_else(|| shell_display_name(program)),
+        ),
+    };
+
+    let mut environment = env::vars().collect::<HashMap<_, _>>();
+    environment.insert("TERM".to_string(), "xterm-256color".to_string());
+    environment.insert("COLORTERM".to_string(), "truecolor".to_string());
+    environment.insert("COLUMNS".to_string(), cols.to_string());
+    environment.insert("LINES".to_string(), rows.to_string());
+    for (key, value) in &input.extra_env {
+        environment.insert(key.clone(), value.clone());
+    }
+
+    Ok(TerminalLaunchConfig {
+        program,
+        args,
+        display_name,
+        cwd,
+        env: environment,
+    })
+}
+
+fn resolve_terminal_cwd(requested_cwd: Option<&str>) -> Result<PathBuf, TerminalError> {
+    let cwd = match requested_cwd {
+        Some(cwd) if !cwd.trim().is_empty() => PathBuf::from(cwd),
+        _ => env::current_dir().map_err(TerminalError::CwdIo)?,
+    };
+
+    let metadata = cwd.metadata().map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            TerminalError::CwdNotFound
+        } else {
+            TerminalError::CwdIo(error)
+        }
+    })?;
+    if !metadata.is_dir() {
+        return Err(TerminalError::CwdNotDirectory);
+    }
+
+    cwd.canonicalize().map_err(TerminalError::CwdIo)
+}
+
+fn shell_display_name(program: &str) -> String {
+    program
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|name| !name.is_empty())
+        .unwrap_or(program)
+        .to_string()
+}
+
+fn spawn_output_reader(
+    mut reader: Box<dyn Read + Send>,
+    closed: Arc<AtomicBool>,
+    output_tx: SyncSender<TerminalOutputMessage>,
+    window_id: WindowId,
+    session_id: TerminalSessionId,
+    terminal_id: Option<String>,
+) {
+    thread::spawn(move || {
+        let mut buffer = [0_u8; OUTPUT_READ_BUFFER_SIZE];
+        let mut decoder = Utf8CarryDecoder::default();
+
+        loop {
+            if closed.load(Ordering::Relaxed) {
+                break;
+            }
+
+            match reader.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(read) => {
+                    if closed.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let data = decoder.decode(&buffer[..read]);
+                    if data.is_empty() {
+                        continue;
+                    }
+                    if output_tx
+                        .send(TerminalOutputMessage::Data(NativeTerminalDataEvent {
+                            window_id: window_id.clone(),
+                            session_id: session_id.clone(),
+                            data,
+                        }))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    if !closed.load(Ordering::Relaxed) {
+                        send_output(
+                            &output_tx,
+                            TerminalOutputMessage::Error(NativeTerminalErrorEvent {
+                                window_id: window_id.clone(),
+                                session_id: Some(session_id.clone()),
+                                terminal_id: terminal_id.clone(),
+                                message: format!("Failed to read terminal output: {error}"),
+                                retryable: false,
+                            }),
+                        );
+                    }
+                    break;
+                }
+            }
+        }
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_exit_monitor(
+    state: Arc<Mutex<RegistryState>>,
+    master: Arc<Mutex<Option<Box<dyn portable_pty::MasterPty + Send>>>>,
+    writer: Arc<Mutex<Option<Box<dyn Write + Send>>>>,
+    child: Arc<Mutex<Option<Box<dyn portable_pty::Child + Send + Sync>>>>,
+    killer: Arc<Mutex<Option<Box<dyn portable_pty::ChildKiller + Send + Sync>>>>,
+    snapshot: Arc<Mutex<NativeTerminalSession>>,
+    closed: Arc<AtomicBool>,
+    output_tx: SyncSender<TerminalOutputMessage>,
+    owner_key: Option<OwnerTerminalKey>,
+) {
+    thread::spawn(move || {
+        loop {
+            if closed.load(Ordering::Relaxed) {
+                break;
+            }
+
+            let exit_status = {
+                let mut child_guard = match child.lock() {
+                    Ok(child_guard) => child_guard,
+                    Err(error) => {
+                        emit_monitor_error(
+                            &snapshot,
+                            &output_tx,
+                            format!("Internal terminal state error: {error}"),
+                        );
+                        break;
+                    }
+                };
+                let Some(process) = child_guard.as_mut() else {
+                    break;
+                };
+
+                match process.try_wait() {
+                    Ok(status) => status,
+                    Err(error) => {
+                        emit_monitor_error(
+                            &snapshot,
+                            &output_tx,
+                            format!("Failed to monitor terminal process: {error}"),
+                        );
+                        release_runtime_resources(&master, &writer, &child, &killer, false);
+                        break;
+                    }
+                }
+            };
+
+            if let Some(exit_status) = exit_status {
+                let snapshot_after_exit = {
+                    let mut snapshot_guard = match snapshot.lock() {
+                        Ok(snapshot_guard) => snapshot_guard,
+                        Err(error) => {
+                            emit_monitor_error(
+                                &snapshot,
+                                &output_tx,
+                                format!("Internal terminal state error: {error}"),
+                            );
+                            break;
+                        }
+                    };
+                    snapshot_guard.status = NativeTerminalStatus::Exited;
+                    snapshot_guard.exit_code = i32::try_from(exit_status.exit_code()).ok();
+                    snapshot_guard.signal_code = None;
+                    snapshot_guard.clone()
+                };
+
+                release_runtime_resources(&master, &writer, &child, &killer, false);
+                remove_session_from_state(&state, &snapshot_after_exit.session_id.0, &owner_key)
+                    .ok();
+                closed.store(true, Ordering::Relaxed);
+                send_output(
+                    &output_tx,
+                    TerminalOutputMessage::Exit(NativeTerminalExitEvent {
+                        window_id: snapshot_after_exit.window_id.clone(),
+                        session_id: snapshot_after_exit.session_id.clone(),
+                        exit_code: snapshot_after_exit.exit_code,
+                        signal_code: snapshot_after_exit.signal_code.clone(),
+                    }),
+                );
+                send_output(
+                    &output_tx,
+                    TerminalOutputMessage::Closed(NativeTerminalClosedEvent {
+                        window_id: snapshot_after_exit.window_id,
+                        session_id: snapshot_after_exit.session_id,
+                        terminal_id: snapshot_after_exit.terminal_id,
+                        reason: NativeTerminalCloseReason::ProcessExit,
+                    }),
+                );
+                break;
+            }
+
+            thread::sleep(MONITOR_INTERVAL);
+        }
+    });
+}
+
+fn emit_monitor_error(
+    snapshot: &Arc<Mutex<NativeTerminalSession>>,
+    output_tx: &SyncSender<TerminalOutputMessage>,
+    message: String,
+) {
+    let event = match snapshot.lock() {
+        Ok(mut snapshot_guard) => {
+            snapshot_guard.status = NativeTerminalStatus::Error;
+            NativeTerminalErrorEvent {
+                window_id: snapshot_guard.window_id.clone(),
+                session_id: Some(snapshot_guard.session_id.clone()),
+                terminal_id: snapshot_guard.terminal_id.clone(),
+                message,
+                retryable: false,
+            }
+        }
+        Err(_) => NativeTerminalErrorEvent {
+            window_id: WindowId("unknown".to_string()),
+            session_id: None,
+            terminal_id: None,
+            message,
+            retryable: false,
+        },
+    };
+
+    send_output(output_tx, TerminalOutputMessage::Error(event));
+}
+
+fn release_runtime_resources(
+    master: &Arc<Mutex<Option<Box<dyn portable_pty::MasterPty + Send>>>>,
+    writer: &Arc<Mutex<Option<Box<dyn Write + Send>>>>,
+    child: &Arc<Mutex<Option<Box<dyn portable_pty::Child + Send + Sync>>>>,
+    killer: &Arc<Mutex<Option<Box<dyn portable_pty::ChildKiller + Send + Sync>>>>,
+    terminate_process: bool,
+) {
+    if terminate_process {
+        if let Ok(mut killer_guard) = killer.lock() {
+            if let Some(killer) = killer_guard.as_mut() {
+                let _ = killer.kill();
+            }
+        }
+    }
+
+    if let Ok(mut writer_guard) = writer.lock() {
+        writer_guard.take();
+    }
+    if let Ok(mut child_guard) = child.lock() {
+        child_guard.take();
+    }
+    if let Ok(mut killer_guard) = killer.lock() {
+        killer_guard.take();
+    }
+    if let Ok(mut master_guard) = master.lock() {
+        master_guard.take();
+    }
+}
+
+fn remove_session_from_state(
+    state: &Arc<Mutex<RegistryState>>,
+    session_id: &str,
+    owner_key: &Option<OwnerTerminalKey>,
+) -> Result<(), TerminalError> {
+    let mut state = state
+        .lock()
+        .map_err(|error| TerminalError::State(error.to_string()))?;
+    state.sessions.remove(session_id);
+    if let Some(owner_key) = owner_key {
+        if state
+            .session_ids_by_owner_terminal_id
+            .get(owner_key)
+            .is_some_and(|tracked_session_id| tracked_session_id == session_id)
+        {
+            state.session_ids_by_owner_terminal_id.remove(owner_key);
+        }
+    }
+    Ok(())
+}
+
+fn send_output(sender: &SyncSender<TerminalOutputMessage>, message: TerminalOutputMessage) {
+    let _ = sender.send(message);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::mpsc;
+
+    use comando_types::terminal::{
+        NativeTerminalLaunchedBy, NativeTerminalPurpose, NativeTerminalShellPreference,
+    };
+
+    use super::*;
+
+    #[test]
+    fn resolves_cwd_and_rejects_missing_paths() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let resolved =
+            resolve_terminal_cwd(Some(temp_dir.path().to_string_lossy().as_ref())).expect("cwd");
+        assert!(resolved.is_dir());
+
+        let missing = temp_dir.path().join("missing");
+        assert!(matches!(
+            resolve_terminal_cwd(Some(missing.to_string_lossy().as_ref())),
+            Err(TerminalError::CwdNotFound)
+        ));
+    }
+
+    #[test]
+    fn reuses_terminal_id_only_inside_owner_window() {
+        let (event_tx, _event_rx) = mpsc::channel();
+        let service = TerminalService::new(event_tx);
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+
+        let first = service
+            .create_session(create_input(
+                "window_1",
+                "terminal_1",
+                temp_dir.path(),
+                long_running_command(),
+            ))
+            .expect("first session");
+        let reused = service
+            .create_session(create_input(
+                "window_1",
+                "terminal_1",
+                temp_dir.path(),
+                long_running_command(),
+            ))
+            .expect("reused session");
+        let other_window = service
+            .create_session(create_input(
+                "window_2",
+                "terminal_1",
+                temp_dir.path(),
+                long_running_command(),
+            ))
+            .expect("other window session");
+
+        assert_eq!(first.session_id, reused.session_id);
+        assert_ne!(first.session_id, other_window.session_id);
+        service.close();
+    }
+
+    #[test]
+    fn close_does_not_reinterpret_foreign_session_id_as_terminal_id() {
+        let (event_tx, _event_rx) = mpsc::channel();
+        let service = TerminalService::new(event_tx);
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let foreign = service
+            .create_session(create_input(
+                "window_1",
+                "terminal_1",
+                temp_dir.path(),
+                long_running_command(),
+            ))
+            .expect("foreign session");
+        let owned = service
+            .create_session(create_input(
+                "window_2",
+                &foreign.session_id.0,
+                temp_dir.path(),
+                long_running_command(),
+            ))
+            .expect("owned terminal id");
+
+        service
+            .close_session_or_owned_terminal(
+                &WindowId("window_2".to_string()),
+                &foreign.session_id.0,
+                NativeTerminalCloseReason::User,
+            )
+            .expect("close foreign no-op");
+
+        let sessions = service
+            .list_sessions(NativeTerminalListInput { window_id: None })
+            .expect("list")
+            .sessions;
+        assert!(
+            sessions
+                .iter()
+                .any(|session| session.session_id == foreign.session_id)
+        );
+        assert!(
+            sessions
+                .iter()
+                .any(|session| session.session_id == owned.session_id)
+        );
+        service.close();
+    }
+
+    #[test]
+    fn command_session_emits_output_before_exit() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let service = TerminalService::new(event_tx);
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let session = service
+            .create_session(create_input(
+                "window_1",
+                "terminal_1",
+                temp_dir.path(),
+                print_and_exit_command(),
+            ))
+            .expect("session");
+
+        let mut saw_data = false;
+        let mut saw_exit = false;
+        for _ in 0..10 {
+            let event = event_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("terminal event");
+            match event {
+                TerminalRuntimeEvent::Data(event) if event.session_id == session.session_id => {
+                    if event.data.contains("ready") {
+                        saw_data = true;
+                    }
+                }
+                TerminalRuntimeEvent::Exit(event) if event.session_id == session.session_id => {
+                    saw_exit = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        assert!(saw_data);
+        assert!(saw_exit);
+    }
+
+    fn create_input(
+        window_id: &str,
+        terminal_id: &str,
+        cwd: &Path,
+        launch: NativeTerminalLaunch,
+    ) -> NativeTerminalCreateInput {
+        NativeTerminalCreateInput {
+            window_id: WindowId(window_id.to_string()),
+            terminal_id: Some(terminal_id.to_string()),
+            preferred_session_id: None,
+            project_id: None,
+            worktree_id: None,
+            cwd: Some(cwd.to_string_lossy().into_owned()),
+            cols: Some(120),
+            rows: Some(32),
+            extra_env: HashMap::new(),
+            shell_preference: Some(NativeTerminalShellPreference {
+                windows_shell: NativeTerminalWindowsShell::Default,
+            }),
+            purpose: NativeTerminalPurpose::Workspace,
+            launched_by: NativeTerminalLaunchedBy::User,
+            launch,
+        }
+    }
+
+    #[cfg(unix)]
+    fn long_running_command() -> NativeTerminalLaunch {
+        NativeTerminalLaunch::Command {
+            program: "/bin/sh".to_string(),
+            args: vec!["-lc".to_string(), "sleep 5".to_string()],
+            display_name: Some("sleep".to_string()),
+        }
+    }
+
+    #[cfg(unix)]
+    fn print_and_exit_command() -> NativeTerminalLaunch {
+        NativeTerminalLaunch::Command {
+            program: "/bin/sh".to_string(),
+            args: vec!["-lc".to_string(), "printf ready".to_string()],
+            display_name: Some("print".to_string()),
+        }
+    }
+
+    #[cfg(windows)]
+    fn long_running_command() -> NativeTerminalLaunch {
+        NativeTerminalLaunch::Command {
+            program: "cmd.exe".to_string(),
+            args: vec!["/C".to_string(), "ping -n 6 127.0.0.1 >NUL".to_string()],
+            display_name: Some("ping".to_string()),
+        }
+    }
+
+    #[cfg(windows)]
+    fn print_and_exit_command() -> NativeTerminalLaunch {
+        NativeTerminalLaunch::Command {
+            program: "cmd.exe".to_string(),
+            args: vec!["/C".to_string(), "echo ready".to_string()],
+            display_name: Some("print".to_string()),
+        }
+    }
+}

--- a/crates/comando-terminal/src/service.rs
+++ b/crates/comando-terminal/src/service.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicBool, Ordering},
-    mpsc::{self, Sender, SyncSender},
+    mpsc::{self, SyncSender},
 };
 use std::thread;
 use std::time::Duration;
@@ -50,7 +50,7 @@ pub struct TerminalService {
 }
 
 impl TerminalService {
-    pub fn new(event_sender: Sender<TerminalRuntimeEvent>) -> Self {
+    pub fn new(event_sender: SyncSender<TerminalRuntimeEvent>) -> Self {
         let (output_tx, output_rx) = mpsc::sync_channel(OUTPUT_CHANNEL_CAPACITY);
         let _coalescer = start_output_coalescer(output_rx, event_sender);
         Self {
@@ -142,6 +142,9 @@ impl TerminalService {
             owner_key: owner_key.clone(),
         });
 
+        let created_snapshot = handle.snapshot()?;
+        self.insert_session(session_id.clone(), owner_key.clone(), Arc::clone(&handle))?;
+
         spawn_output_reader(
             reader,
             Arc::clone(&handle.closed),
@@ -162,9 +165,7 @@ impl TerminalService {
             owner_key.clone(),
         );
 
-        let created_snapshot = handle.snapshot()?;
-        self.insert_session(session_id, owner_key, Arc::clone(&handle))?;
-        send_output(
+        send_output_deferred(
             &self.output_tx,
             TerminalOutputMessage::Created(NativeTerminalCreatedEvent {
                 session: created_snapshot.clone(),
@@ -503,7 +504,7 @@ impl TerminalService {
         remove_session_from_state(&self.state, &snapshot.session_id.0, &handle.owner_key)?;
         handle.closed.store(true, Ordering::Relaxed);
         handle.release_runtime_resources(true);
-        send_output(
+        send_output_deferred(
             &self.output_tx,
             TerminalOutputMessage::Closed(NativeTerminalClosedEvent {
                 window_id: snapshot.window_id,
@@ -587,7 +588,7 @@ fn resolve_terminal_cwd(requested_cwd: Option<&str>) -> Result<PathBuf, Terminal
         return Err(TerminalError::CwdNotDirectory);
     }
 
-    cwd.canonicalize().map_err(TerminalError::CwdIo)
+    Ok(cwd)
 }
 
 fn shell_display_name(program: &str) -> String {
@@ -597,6 +598,15 @@ fn shell_display_name(program: &str) -> String {
         .filter(|name| !name.is_empty())
         .unwrap_or(program)
         .to_string()
+}
+
+fn normalize_signal_code(signal: &str) -> String {
+    let trimmed = signal.trim();
+    let trailing_number = trimmed
+        .rsplit(|character: char| !character.is_ascii_digit())
+        .find(|part| !part.is_empty());
+
+    trailing_number.unwrap_or(trimmed).to_string()
 }
 
 fn spawn_output_reader(
@@ -720,7 +730,7 @@ fn spawn_exit_monitor(
                     };
                     snapshot_guard.status = NativeTerminalStatus::Exited;
                     snapshot_guard.exit_code = i32::try_from(exit_status.exit_code()).ok();
-                    snapshot_guard.signal_code = None;
+                    snapshot_guard.signal_code = exit_status.signal().map(normalize_signal_code);
                     snapshot_guard.clone()
                 };
 
@@ -836,6 +846,22 @@ fn send_output(sender: &SyncSender<TerminalOutputMessage>, message: TerminalOutp
     let _ = sender.send(message);
 }
 
+fn send_output_deferred(
+    sender: &SyncSender<TerminalOutputMessage>,
+    message: TerminalOutputMessage,
+) {
+    match sender.try_send(message) {
+        Ok(()) => {}
+        Err(mpsc::TrySendError::Full(message)) => {
+            let sender = sender.clone();
+            thread::spawn(move || {
+                let _ = sender.send(message);
+            });
+        }
+        Err(mpsc::TrySendError::Disconnected(_)) => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;
@@ -861,9 +887,24 @@ mod tests {
         ));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn preserves_requested_cwd_path_after_validation() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let real_dir = temp_dir.path().join("real");
+        std::fs::create_dir_all(&real_dir).expect("real dir");
+        let symlink_dir = temp_dir.path().join("linked");
+        std::os::unix::fs::symlink(&real_dir, &symlink_dir).expect("symlink");
+
+        let resolved =
+            resolve_terminal_cwd(Some(symlink_dir.to_string_lossy().as_ref())).expect("cwd");
+
+        assert_eq!(resolved, symlink_dir);
+    }
+
     #[test]
     fn reuses_terminal_id_only_inside_owner_window() {
-        let (event_tx, _event_rx) = mpsc::channel();
+        let (event_tx, _event_rx) = mpsc::sync_channel(64);
         let service = TerminalService::new(event_tx);
         let temp_dir = tempfile::tempdir().expect("temp dir");
 
@@ -899,7 +940,7 @@ mod tests {
 
     #[test]
     fn close_does_not_reinterpret_foreign_session_id_as_terminal_id() {
-        let (event_tx, _event_rx) = mpsc::channel();
+        let (event_tx, _event_rx) = mpsc::sync_channel(64);
         let service = TerminalService::new(event_tx);
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let foreign = service
@@ -946,7 +987,7 @@ mod tests {
 
     #[test]
     fn command_session_emits_output_before_exit() {
-        let (event_tx, event_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::sync_channel(64);
         let service = TerminalService::new(event_tx);
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let session = service
@@ -980,6 +1021,36 @@ mod tests {
 
         assert!(saw_data);
         assert!(saw_exit);
+    }
+
+    #[test]
+    fn foreground_lifecycle_send_does_not_block_when_pipeline_is_full() {
+        let (sender, receiver) = mpsc::sync_channel(0);
+
+        send_output_deferred(
+            &sender,
+            TerminalOutputMessage::Error(NativeTerminalErrorEvent {
+                window_id: WindowId("window_1".to_string()),
+                session_id: None,
+                terminal_id: None,
+                message: "Terminal lifecycle event queued.".to_string(),
+                retryable: false,
+            }),
+        );
+
+        assert!(matches!(
+            receiver
+                .recv_timeout(Duration::from_secs(1))
+                .expect("deferred lifecycle event"),
+            TerminalOutputMessage::Error(_)
+        ));
+    }
+
+    #[test]
+    fn normalizes_portable_pty_signal_text_to_numeric_string() {
+        assert_eq!(normalize_signal_code("Terminated: 15"), "15");
+        assert_eq!(normalize_signal_code("Signal 9"), "9");
+        assert_eq!(normalize_signal_code("SIGTERM"), "SIGTERM");
     }
 
     fn create_input(

--- a/crates/comando-terminal/src/session.rs
+++ b/crates/comando-terminal/src/session.rs
@@ -1,0 +1,134 @@
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use comando_types::ids::WindowId;
+use comando_types::terminal::NativeTerminalSession;
+use portable_pty::{Child as PtyChild, ChildKiller, MasterPty};
+
+use crate::error::TerminalError;
+
+pub const DEFAULT_COLS: u16 = 120;
+pub const DEFAULT_ROWS: u16 = 34;
+pub const MIN_COLS: u16 = 10;
+pub const MIN_ROWS: u16 = 4;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct OwnerTerminalKey {
+    window_id: WindowId,
+    terminal_id: String,
+}
+
+impl OwnerTerminalKey {
+    pub(crate) fn new(window_id: WindowId, terminal_id: String) -> Self {
+        Self {
+            window_id,
+            terminal_id,
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct RegistryState {
+    pub(crate) sessions: HashMap<String, Arc<SessionHandle>>,
+    pub(crate) session_ids_by_owner_terminal_id: HashMap<OwnerTerminalKey, String>,
+}
+
+pub(crate) struct SessionHandle {
+    pub(crate) snapshot: Arc<Mutex<NativeTerminalSession>>,
+    pub(crate) master: Arc<Mutex<Option<Box<dyn MasterPty + Send>>>>,
+    pub(crate) writer: Arc<Mutex<Option<Box<dyn Write + Send>>>>,
+    pub(crate) child: Arc<Mutex<Option<Box<dyn PtyChild + Send + Sync>>>>,
+    pub(crate) killer: Arc<Mutex<Option<Box<dyn ChildKiller + Send + Sync>>>>,
+    pub(crate) closed: Arc<AtomicBool>,
+    pub(crate) owner_key: Option<OwnerTerminalKey>,
+}
+
+impl SessionHandle {
+    pub(crate) fn snapshot(&self) -> Result<NativeTerminalSession, TerminalError> {
+        self.snapshot
+            .lock()
+            .map_err(|error| TerminalError::State(error.to_string()))
+            .map(|snapshot| snapshot.clone())
+    }
+
+    pub(crate) fn release_runtime_resources(&self, terminate_process: bool) {
+        release_session_runtime_resources(
+            &self.master,
+            &self.writer,
+            &self.child,
+            &self.killer,
+            terminate_process,
+        );
+    }
+}
+
+impl Drop for SessionHandle {
+    fn drop(&mut self) {
+        self.closed.store(true, Ordering::Relaxed);
+        self.release_runtime_resources(true);
+    }
+}
+
+pub fn normalize_terminal_cols(cols: Option<u16>) -> u16 {
+    cols.unwrap_or(DEFAULT_COLS).max(MIN_COLS)
+}
+
+pub fn normalize_terminal_rows(rows: Option<u16>) -> u16 {
+    rows.unwrap_or(DEFAULT_ROWS).max(MIN_ROWS)
+}
+
+fn release_session_runtime_resources(
+    master: &Arc<Mutex<Option<Box<dyn MasterPty + Send>>>>,
+    writer: &Arc<Mutex<Option<Box<dyn Write + Send>>>>,
+    child: &Arc<Mutex<Option<Box<dyn PtyChild + Send + Sync>>>>,
+    killer: &Arc<Mutex<Option<Box<dyn ChildKiller + Send + Sync>>>>,
+    terminate_process: bool,
+) {
+    if terminate_process {
+        if let Ok(mut killer_guard) = killer.lock() {
+            if let Some(killer) = killer_guard.as_mut() {
+                let _ = killer.kill();
+            }
+        }
+    }
+
+    if let Ok(mut writer_guard) = writer.lock() {
+        writer_guard.take();
+    }
+    if let Ok(mut child_guard) = child.lock() {
+        child_guard.take();
+    }
+    if let Ok(mut killer_guard) = killer.lock() {
+        killer_guard.take();
+    }
+    if let Ok(mut master_guard) = master.lock() {
+        master_guard.take();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_terminal_dimensions_like_legacy_service() {
+        assert_eq!(normalize_terminal_cols(None), 120);
+        assert_eq!(normalize_terminal_rows(None), 34);
+        assert_eq!(normalize_terminal_cols(Some(1)), 10);
+        assert_eq!(normalize_terminal_rows(Some(1)), 4);
+        assert_eq!(normalize_terminal_cols(Some(82)), 82);
+        assert_eq!(normalize_terminal_rows(Some(18)), 18);
+    }
+
+    #[test]
+    fn owner_terminal_key_is_scoped_by_window() {
+        assert_ne!(
+            OwnerTerminalKey::new(WindowId("window_1".to_string()), "terminal".to_string()),
+            OwnerTerminalKey::new(WindowId("window_2".to_string()), "terminal".to_string()),
+        );
+    }
+}

--- a/crates/comando-terminal/src/shell.rs
+++ b/crates/comando-terminal/src/shell.rs
@@ -1,0 +1,332 @@
+use std::collections::HashMap;
+use std::env;
+use std::path::Path;
+
+use comando_types::terminal::NativeTerminalWindowsShell;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalPlatform {
+    Windows,
+    MacOs,
+    Linux,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedTerminalShell {
+    pub command: String,
+    pub args: Vec<String>,
+    pub fallback_reason: Option<String>,
+}
+
+pub fn resolve_current_terminal_shell(
+    windows_shell: NativeTerminalWindowsShell,
+) -> ResolvedTerminalShell {
+    let env = env::vars().collect::<HashMap<_, _>>();
+    resolve_terminal_shell_with_env(windows_shell, current_platform(), &env, &|command| {
+        command_is_available(command, &env)
+    })
+}
+
+pub fn resolve_terminal_shell_with_env(
+    windows_shell: NativeTerminalWindowsShell,
+    platform: TerminalPlatform,
+    env: &HashMap<String, String>,
+    is_command_available: &dyn Fn(&str) -> bool,
+) -> ResolvedTerminalShell {
+    let (command, fallback_reason) = if platform == TerminalPlatform::Windows {
+        resolve_windows_shell(windows_shell, env, is_command_available)
+    } else {
+        (resolve_posix_shell(platform, env), None::<String>)
+    };
+
+    let args = resolve_terminal_shell_args(&command, platform);
+    ResolvedTerminalShell {
+        command,
+        args,
+        fallback_reason,
+    }
+}
+
+pub fn resolve_terminal_shell_args(shell: &str, platform: TerminalPlatform) -> Vec<String> {
+    if platform == TerminalPlatform::Windows {
+        let normalized_shell = shell.to_ascii_lowercase();
+        let shell_base_name = windows_base_name(&normalized_shell);
+        return if normalized_shell.contains("powershell") || shell_base_name == "pwsh.exe" {
+            vec!["-NoLogo".to_string()]
+        } else {
+            Vec::new()
+        };
+    }
+
+    let shell_base_name = posix_base_name(shell).to_ascii_lowercase();
+    if shell_base_name == "fish" {
+        return Vec::new();
+    }
+
+    vec!["-l".to_string()]
+}
+
+fn resolve_windows_shell(
+    windows_shell: NativeTerminalWindowsShell,
+    env: &HashMap<String, String>,
+    is_command_available: &dyn Fn(&str) -> bool,
+) -> (String, Option<String>) {
+    match windows_shell {
+        NativeTerminalWindowsShell::Cmd => ("cmd.exe".to_string(), None),
+        NativeTerminalWindowsShell::Powershell => ("powershell.exe".to_string(), None),
+        NativeTerminalWindowsShell::Pwsh => {
+            if !is_command_available("pwsh") {
+                return (
+                    "powershell.exe".to_string(),
+                    Some(
+                        "PowerShell 7 (pwsh) was not found. Falling back to Windows PowerShell."
+                            .to_string(),
+                    ),
+                );
+            }
+
+            ("pwsh.exe".to_string(), None)
+        }
+        NativeTerminalWindowsShell::Default => (
+            env.get("COMSPEC")
+                .or_else(|| env.get("ComSpec"))
+                .cloned()
+                .unwrap_or_else(|| "powershell.exe".to_string()),
+            None,
+        ),
+    }
+}
+
+fn resolve_posix_shell(platform: TerminalPlatform, env: &HashMap<String, String>) -> String {
+    env.get("SHELL").cloned().unwrap_or_else(|| {
+        if platform == TerminalPlatform::MacOs {
+            "zsh".to_string()
+        } else {
+            "bash".to_string()
+        }
+    })
+}
+
+fn current_platform() -> TerminalPlatform {
+    if cfg!(target_os = "windows") {
+        TerminalPlatform::Windows
+    } else if cfg!(target_os = "macos") {
+        TerminalPlatform::MacOs
+    } else if cfg!(target_os = "linux") {
+        TerminalPlatform::Linux
+    } else {
+        TerminalPlatform::Other
+    }
+}
+
+fn command_is_available(command: &str, env: &HashMap<String, String>) -> bool {
+    if command.contains('/') || command.contains('\\') {
+        return Path::new(command).is_file();
+    }
+
+    let Some(path) = env.get("PATH") else {
+        return false;
+    };
+
+    let extensions = if current_platform() == TerminalPlatform::Windows {
+        env.get("PATHEXT")
+            .map(|value| {
+                value
+                    .split(';')
+                    .filter(|part| !part.is_empty())
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_else(|| vec![".EXE".to_string(), ".CMD".to_string(), ".BAT".to_string()])
+    } else {
+        vec![String::new()]
+    };
+
+    env::split_paths(path).any(|entry| {
+        extensions.iter().any(|extension| {
+            let candidate = entry.join(format!("{command}{extension}"));
+            candidate.is_file()
+        })
+    })
+}
+
+fn windows_base_name(path: &str) -> &str {
+    path.rsplit(['\\', '/']).next().unwrap_or(path)
+}
+
+fn posix_base_name(path: &str) -> &str {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn uses_comspec_for_the_default_windows_shell() {
+        assert_eq!(
+            resolve_terminal_shell_with_env(
+                NativeTerminalWindowsShell::Default,
+                TerminalPlatform::Windows,
+                &env(&[("COMSPEC", "C:\\Windows\\System32\\cmd.exe")]),
+                &|_| true,
+            ),
+            ResolvedTerminalShell {
+                args: Vec::new(),
+                command: "C:\\Windows\\System32\\cmd.exe".to_string(),
+                fallback_reason: None,
+            }
+        );
+    }
+
+    #[test]
+    fn falls_back_to_windows_powershell_when_comspec_is_absent() {
+        assert_eq!(
+            resolve_terminal_shell_with_env(
+                NativeTerminalWindowsShell::Default,
+                TerminalPlatform::Windows,
+                &HashMap::new(),
+                &|_| true,
+            ),
+            ResolvedTerminalShell {
+                args: vec!["-NoLogo".to_string()],
+                command: "powershell.exe".to_string(),
+                fallback_reason: None,
+            }
+        );
+    }
+
+    #[test]
+    fn resolves_configured_windows_shells() {
+        for (preference, command, args) in [
+            (
+                NativeTerminalWindowsShell::Cmd,
+                "cmd.exe",
+                Vec::<String>::new(),
+            ),
+            (
+                NativeTerminalWindowsShell::Powershell,
+                "powershell.exe",
+                vec!["-NoLogo".to_string()],
+            ),
+            (
+                NativeTerminalWindowsShell::Pwsh,
+                "pwsh.exe",
+                vec!["-NoLogo".to_string()],
+            ),
+        ] {
+            assert_eq!(
+                resolve_terminal_shell_with_env(
+                    preference,
+                    TerminalPlatform::Windows,
+                    &HashMap::new(),
+                    &|_| true,
+                ),
+                ResolvedTerminalShell {
+                    args,
+                    command: command.to_string(),
+                    fallback_reason: None,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn falls_back_when_pwsh_is_unavailable() {
+        assert_eq!(
+            resolve_terminal_shell_with_env(
+                NativeTerminalWindowsShell::Pwsh,
+                TerminalPlatform::Windows,
+                &HashMap::new(),
+                &|command| command != "pwsh",
+            ),
+            ResolvedTerminalShell {
+                args: vec!["-NoLogo".to_string()],
+                command: "powershell.exe".to_string(),
+                fallback_reason: Some(
+                    "PowerShell 7 (pwsh) was not found. Falling back to Windows PowerShell."
+                        .to_string(),
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn resolves_windows_args_from_absolute_paths_on_any_host() {
+        assert_eq!(
+            resolve_terminal_shell_args(
+                "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+                TerminalPlatform::Windows,
+            ),
+            vec!["-NoLogo".to_string()],
+        );
+        assert_eq!(
+            resolve_terminal_shell_args(
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                TerminalPlatform::Windows,
+            ),
+            vec!["-NoLogo".to_string()],
+        );
+        assert_eq!(
+            resolve_terminal_shell_args(
+                "C:\\Windows\\System32\\cmd.exe",
+                TerminalPlatform::Windows
+            ),
+            Vec::<String>::new(),
+        );
+    }
+
+    #[test]
+    fn resolves_posix_shells_from_env_and_defaults() {
+        assert_eq!(
+            resolve_terminal_shell_with_env(
+                NativeTerminalWindowsShell::Pwsh,
+                TerminalPlatform::MacOs,
+                &env(&[("SHELL", "/opt/homebrew/bin/fish")]),
+                &|_| false,
+            ),
+            ResolvedTerminalShell {
+                args: Vec::new(),
+                command: "/opt/homebrew/bin/fish".to_string(),
+                fallback_reason: None,
+            }
+        );
+        assert_eq!(
+            resolve_terminal_shell_with_env(
+                NativeTerminalWindowsShell::Pwsh,
+                TerminalPlatform::MacOs,
+                &HashMap::new(),
+                &|_| false,
+            ),
+            ResolvedTerminalShell {
+                args: vec!["-l".to_string()],
+                command: "zsh".to_string(),
+                fallback_reason: None,
+            }
+        );
+        assert_eq!(
+            resolve_terminal_shell_with_env(
+                NativeTerminalWindowsShell::Pwsh,
+                TerminalPlatform::Linux,
+                &HashMap::new(),
+                &|_| false,
+            ),
+            ResolvedTerminalShell {
+                args: vec!["-l".to_string()],
+                command: "bash".to_string(),
+                fallback_reason: None,
+            }
+        );
+    }
+}

--- a/crates/comando-terminal/src/utf8.rs
+++ b/crates/comando-terminal/src/utf8.rs
@@ -1,0 +1,85 @@
+/// Incrementally decodes PTY bytes as UTF-8 while carrying incomplete trailing
+/// multi-byte sequences across reads. Invalid bytes are replaced with U+FFFD.
+#[derive(Debug, Default)]
+pub struct Utf8CarryDecoder {
+    carry: Vec<u8>,
+}
+
+impl Utf8CarryDecoder {
+    pub fn decode(&mut self, bytes: &[u8]) -> String {
+        decode_utf8_with_carry(&mut self.carry, bytes)
+    }
+}
+
+pub fn decode_utf8_with_carry(carry: &mut Vec<u8>, bytes: &[u8]) -> String {
+    carry.extend_from_slice(bytes);
+    let mut output = String::new();
+    let mut start = 0;
+
+    loop {
+        match std::str::from_utf8(&carry[start..]) {
+            Ok(valid) => {
+                output.push_str(valid);
+                carry.clear();
+                return output;
+            }
+            Err(error) => {
+                let valid_up_to = error.valid_up_to();
+                // SAFETY: valid_up_to is guaranteed to be a valid UTF-8 boundary.
+                output.push_str(unsafe {
+                    std::str::from_utf8_unchecked(&carry[start..start + valid_up_to])
+                });
+
+                match error.error_len() {
+                    Some(invalid_len) => {
+                        output.push('\u{FFFD}');
+                        start += valid_up_to + invalid_len;
+                    }
+                    None => {
+                        *carry = carry[start + valid_up_to..].to_vec();
+                        return output;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_split_two_byte_sequence() {
+        let mut carry = Vec::new();
+        assert_eq!(decode_utf8_with_carry(&mut carry, &[b'a', 0xC3]), "a");
+        assert_eq!(decode_utf8_with_carry(&mut carry, &[0xA9, b'b']), "éb");
+        assert!(carry.is_empty());
+    }
+
+    #[test]
+    fn decodes_split_three_byte_sequence() {
+        let mut decoder = Utf8CarryDecoder::default();
+        assert_eq!(decoder.decode(&[0xE2]), "");
+        assert_eq!(decoder.decode(&[0x86]), "");
+        assert_eq!(decoder.decode(&[0x92]), "\u{2192}");
+    }
+
+    #[test]
+    fn decodes_split_four_byte_sequence() {
+        let mut decoder = Utf8CarryDecoder::default();
+        assert_eq!(decoder.decode(&[0xF0, 0x9F]), "");
+        assert_eq!(decoder.decode(&[0x98]), "");
+        assert_eq!(decoder.decode(&[0x80, b'!']), "\u{1F600}!");
+    }
+
+    #[test]
+    fn replaces_real_invalid_bytes() {
+        let mut carry = Vec::new();
+        assert_eq!(
+            decode_utf8_with_carry(&mut carry, &[b'a', 0xFF, b'b']),
+            "a\u{FFFD}b",
+        );
+        assert!(carry.is_empty());
+    }
+}

--- a/crates/comando-types/src/capabilities.rs
+++ b/crates/comando-types/src/capabilities.rs
@@ -97,6 +97,7 @@ pub fn backend_capabilities() -> NativeCapabilitySet {
             "native-git-worktrees".to_string(),
             "native-git-mutations".to_string(),
             "native-git-network".to_string(),
+            "native-terminal".to_string(),
         ],
     }
 }

--- a/crates/comando-types/src/commands.rs
+++ b/crates/comando-types/src/commands.rs
@@ -99,6 +99,7 @@ pub const TERMINAL_COMMANDS: &[&str] = &[
     "terminal_resize",
     "terminal_kill",
     "terminal_close",
+    "terminal_close_window",
     "terminal_list",
 ];
 

--- a/crates/comando-types/src/terminal.rs
+++ b/crates/comando-types/src/terminal.rs
@@ -57,6 +57,7 @@ pub struct NativeTerminalShellPreference {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum NativeTerminalLaunch {
     Shell,
+    #[serde(rename_all = "camelCase")]
     Command {
         program: String,
         args: Vec<String>,

--- a/crates/comando-types/src/terminal.rs
+++ b/crates/comando-types/src/terminal.rs
@@ -1,8 +1,18 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::ids::{ProjectId, TerminalSessionId, WindowId, WorktreeId};
 
 pub type NativeTerminalSessionId = TerminalSessionId;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeTerminalStatus {
+    Running,
+    Exited,
+    Error,
+}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -13,35 +23,97 @@ pub enum NativeTerminalCloseReason {
     Error,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeTerminalPurpose {
+    Workspace,
+    Auth,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeTerminalLaunchedBy {
+    User,
+    Agent,
+    System,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeTerminalWindowsShell {
+    Default,
+    Cmd,
+    Powershell,
+    Pwsh,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTerminalShellPreference {
+    pub windows_shell: NativeTerminalWindowsShell,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum NativeTerminalLaunch {
+    Shell,
+    Command {
+        program: String,
+        args: Vec<String>,
+        #[serde(default)]
+        display_name: Option<String>,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct NativeTerminalSession {
     pub session_id: NativeTerminalSessionId,
     pub window_id: WindowId,
+    #[serde(default)]
+    pub terminal_id: Option<String>,
     pub project_id: Option<ProjectId>,
     pub worktree_id: Option<WorktreeId>,
     pub cwd: String,
     pub cols: u16,
     pub rows: u16,
-    pub status: String,
+    pub status: NativeTerminalStatus,
     pub exit_code: Option<i32>,
     pub signal_code: Option<String>,
+    pub program: String,
+    pub display_name: String,
+    pub purpose: NativeTerminalPurpose,
+    pub launched_by: NativeTerminalLaunchedBy,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct NativeTerminalCreateInput {
     pub window_id: WindowId,
+    #[serde(default)]
+    pub terminal_id: Option<String>,
+    #[serde(default)]
+    pub preferred_session_id: Option<NativeTerminalSessionId>,
     pub project_id: Option<ProjectId>,
     pub worktree_id: Option<WorktreeId>,
     pub cwd: Option<String>,
-    pub cols: u16,
-    pub rows: u16,
+    #[serde(default)]
+    pub cols: Option<u16>,
+    #[serde(default)]
+    pub rows: Option<u16>,
+    #[serde(default)]
+    pub extra_env: HashMap<String, String>,
+    #[serde(default)]
+    pub shell_preference: Option<NativeTerminalShellPreference>,
+    pub purpose: NativeTerminalPurpose,
+    pub launched_by: NativeTerminalLaunchedBy,
+    pub launch: NativeTerminalLaunch,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct NativeTerminalWriteInput {
+    pub window_id: WindowId,
     pub session_id: NativeTerminalSessionId,
     pub data: String,
 }
@@ -49,6 +121,7 @@ pub struct NativeTerminalWriteInput {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct NativeTerminalResizeInput {
+    pub window_id: WindowId,
     pub session_id: NativeTerminalSessionId,
     pub cols: u16,
     pub rows: u16,
@@ -56,7 +129,48 @@ pub struct NativeTerminalResizeInput {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct NativeTerminalKillInput {
+    pub window_id: WindowId,
+    pub session_id: NativeTerminalSessionId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTerminalCloseInput {
+    pub window_id: WindowId,
+    pub id: String,
+    pub reason: NativeTerminalCloseReason,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTerminalCloseWindowInput {
+    pub window_id: WindowId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTerminalListInput {
+    #[serde(default)]
+    pub window_id: Option<WindowId>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTerminalListResult {
+    pub sessions: Vec<NativeTerminalSession>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTerminalCreatedEvent {
+    pub session: NativeTerminalSession,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct NativeTerminalDataEvent {
+    pub window_id: WindowId,
     pub session_id: NativeTerminalSessionId,
     pub data: String,
 }
@@ -64,7 +178,27 @@ pub struct NativeTerminalDataEvent {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct NativeTerminalExitEvent {
+    pub window_id: WindowId,
     pub session_id: NativeTerminalSessionId,
     pub exit_code: Option<i32>,
     pub signal_code: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTerminalClosedEvent {
+    pub window_id: WindowId,
+    pub session_id: NativeTerminalSessionId,
+    pub terminal_id: Option<String>,
+    pub reason: NativeTerminalCloseReason,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTerminalErrorEvent {
+    pub window_id: WindowId,
+    pub session_id: Option<NativeTerminalSessionId>,
+    pub terminal_id: Option<String>,
+    pub message: String,
+    pub retryable: bool,
 }

--- a/docs/native-backend.md
+++ b/docs/native-backend.md
@@ -9,9 +9,11 @@ tree domain behind flags.
 Rust can open the current Comando SQLite store and own `project_list` /
 `project_add` only when the explicit native project registry write flag is set.
 Rust can also own project tree, file read/write, filesystem mutations, copies,
-and watcher invalidations when native filesystem flags are enabled. Search,
-real git status/diff, terminal, AI, review, and renderer UI behavior remain
-owned by the existing TypeScript path.
+and watcher invalidations when native filesystem flags are enabled. Search and
+real git status/diff also have native rollout flags. Integrated terminals can
+be owned by Rust under `COMANDO_NATIVE_TERMINAL=1`; with the flag off, the
+existing TypeScript `node-pty` path remains the owner. AI, review, and renderer
+UI behavior remain owned by the existing TypeScript path.
 
 ## Flags
 
@@ -58,10 +60,21 @@ owned by the existing TypeScript path.
   legacy TypeScript search/index path after a native search failure.
 - `COMANDO_NATIVE_CONTENT_SEARCH=0` is the default. Visible content search is
   not part of this rollout.
+- `COMANDO_NATIVE_TERMINAL=1` routes integrated terminal session lifecycle,
+  PTY IO, resize, close, exit, and cleanup through the Rust sidecar.
+- `COMANDO_NATIVE_TERMINAL_MODE=native` is the explicit native terminal mode.
+  If the mode is omitted, `COMANDO_NATIVE_TERMINAL=1` still means native.
+- `COMANDO_NATIVE_TERMINAL_DEBUG=1` is reserved for lifecycle diagnostics.
+  Terminal input, output, and env values must not be logged.
 
 With flags unset, Comando uses the existing TypeScript path. Write mode requires
 `COMANDO_NATIVE_BACKEND=1`, `COMANDO_NATIVE_PERSISTENCE=1`, and
 `COMANDO_NATIVE_PROJECT_REGISTRY=1`.
+
+Native terminal has no shadow mode. Running the same PTY twice would duplicate
+command side effects, credentials prompts, filesystem writes, and destructive
+commands. Rollback is simply leaving `COMANDO_NATIVE_TERMINAL` unset or setting
+it to `0`; `node-pty` remains installed as the legacy fallback.
 
 ## Protocol V1
 

--- a/fixtures/native-backend/protocol/capabilities.v1.json
+++ b/fixtures/native-backend/protocol/capabilities.v1.json
@@ -94,6 +94,7 @@
       "terminal_resize",
       "terminal_kill",
       "terminal_close",
+      "terminal_close_window",
       "terminal_list",
       "settings_get_snapshot",
       "settings_save_snapshot",
@@ -215,7 +216,8 @@
       "native-git-history",
       "native-git-worktrees",
       "native-git-mutations",
-      "native-git-network"
+      "native-git-network",
+      "native-terminal"
     ]
   }
 }

--- a/fixtures/native-backend/protocol/registry.commands.json
+++ b/fixtures/native-backend/protocol/registry.commands.json
@@ -70,6 +70,7 @@
   "terminal_resize",
   "terminal_kill",
   "terminal_close",
+  "terminal_close_window",
   "terminal_list",
   "settings_get_snapshot",
   "settings_save_snapshot",

--- a/fixtures/native-backend/terminal/terminal.close_input.json
+++ b/fixtures/native-backend/terminal/terminal.close_input.json
@@ -1,0 +1,5 @@
+{
+  "windowId": "window_main",
+  "id": "terminal_1",
+  "reason": "user"
+}

--- a/fixtures/native-backend/terminal/terminal.close_window_input.json
+++ b/fixtures/native-backend/terminal/terminal.close_window_input.json
@@ -1,0 +1,3 @@
+{
+  "windowId": "window_main"
+}

--- a/fixtures/native-backend/terminal/terminal.closed_event.json
+++ b/fixtures/native-backend/terminal/terminal.closed_event.json
@@ -1,5 +1,6 @@
 {
   "windowId": "window_main",
   "sessionId": "terminal_1",
-  "data": "ready\n"
+  "terminalId": "workspace-terminal-1",
+  "reason": "user"
 }

--- a/fixtures/native-backend/terminal/terminal.create_input.json
+++ b/fixtures/native-backend/terminal/terminal.create_input.json
@@ -1,17 +1,21 @@
 {
-  "sessionId": "terminal_1",
   "windowId": "window_main",
   "terminalId": "workspace-terminal-1",
+  "preferredSessionId": null,
   "projectId": "project_1",
   "worktreeId": "worktree_1",
   "cwd": "/tmp/comando-project",
   "cols": 120,
   "rows": 32,
-  "status": "running",
-  "exitCode": null,
-  "signalCode": null,
-  "program": "/bin/zsh",
-  "displayName": "zsh",
+  "extraEnv": {
+    "CLAUDE_CODE_NO_FLICKER": "1"
+  },
+  "shellPreference": {
+    "windowsShell": "default"
+  },
   "purpose": "workspace",
-  "launchedBy": "user"
+  "launchedBy": "user",
+  "launch": {
+    "kind": "shell"
+  }
 }

--- a/fixtures/native-backend/terminal/terminal.created_event.json
+++ b/fixtures/native-backend/terminal/terminal.created_event.json
@@ -1,0 +1,19 @@
+{
+  "session": {
+    "sessionId": "terminal_1",
+    "windowId": "window_main",
+    "terminalId": "workspace-terminal-1",
+    "projectId": "project_1",
+    "worktreeId": "worktree_1",
+    "cwd": "/tmp/comando-project",
+    "cols": 120,
+    "rows": 32,
+    "status": "running",
+    "exitCode": null,
+    "signalCode": null,
+    "program": "/bin/zsh",
+    "displayName": "zsh",
+    "purpose": "workspace",
+    "launchedBy": "user"
+  }
+}

--- a/fixtures/native-backend/terminal/terminal.error_event.json
+++ b/fixtures/native-backend/terminal/terminal.error_event.json
@@ -1,0 +1,7 @@
+{
+  "windowId": "window_main",
+  "sessionId": "terminal_1",
+  "terminalId": "workspace-terminal-1",
+  "message": "Terminal session failed.",
+  "retryable": false
+}

--- a/fixtures/native-backend/terminal/terminal.exit_event.json
+++ b/fixtures/native-backend/terminal/terminal.exit_event.json
@@ -1,4 +1,5 @@
 {
+  "windowId": "window_main",
   "sessionId": "terminal_1",
   "exitCode": 0,
   "signalCode": null

--- a/fixtures/native-backend/terminal/terminal.kill_input.json
+++ b/fixtures/native-backend/terminal/terminal.kill_input.json
@@ -1,0 +1,4 @@
+{
+  "windowId": "window_main",
+  "sessionId": "terminal_1"
+}

--- a/fixtures/native-backend/terminal/terminal.list_input.json
+++ b/fixtures/native-backend/terminal/terminal.list_input.json
@@ -1,0 +1,3 @@
+{
+  "windowId": "window_main"
+}

--- a/fixtures/native-backend/terminal/terminal.list_result.json
+++ b/fixtures/native-backend/terminal/terminal.list_result.json
@@ -1,0 +1,21 @@
+{
+  "sessions": [
+    {
+      "sessionId": "terminal_1",
+      "windowId": "window_main",
+      "terminalId": "workspace-terminal-1",
+      "projectId": "project_1",
+      "worktreeId": "worktree_1",
+      "cwd": "/tmp/comando-project",
+      "cols": 120,
+      "rows": 32,
+      "status": "running",
+      "exitCode": null,
+      "signalCode": null,
+      "program": "/bin/zsh",
+      "displayName": "zsh",
+      "purpose": "workspace",
+      "launchedBy": "user"
+    }
+  ]
+}

--- a/fixtures/native-backend/terminal/terminal.resize_input.json
+++ b/fixtures/native-backend/terminal/terminal.resize_input.json
@@ -1,0 +1,6 @@
+{
+  "windowId": "window_main",
+  "sessionId": "terminal_1",
+  "cols": 100,
+  "rows": 28
+}

--- a/fixtures/native-backend/terminal/terminal.write_input.json
+++ b/fixtures/native-backend/terminal/terminal.write_input.json
@@ -1,0 +1,5 @@
+{
+  "windowId": "window_main",
+  "sessionId": "terminal_1",
+  "data": "pwd\r"
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -409,13 +409,13 @@ async function shutdownApplication(): Promise<void> {
     mainProcessPerformance.stop();
 
     aiService?.close();
-    terminalService?.close();
 
     const aiWorkerClientToClose = aiWorkerClient;
     const dbWorkerClientToClose = dbWorkerClient;
     const gitServiceToClose = gitService;
     const nativeBackendClientToClose = nativeBackendClient;
     const projectServiceToClose = projectService;
+    const terminalServiceToClose = terminalService;
 
     aiService = null;
     aiWorkerClient = null;
@@ -433,7 +433,10 @@ async function shutdownApplication(): Promise<void> {
     const shutdownResults = await Promise.allSettled([
         aiWorkerClientToClose?.close(),
         gitServiceToClose?.close(),
-        nativeBackendClientToClose?.dispose(),
+        (async () => {
+            await terminalServiceToClose?.close();
+            await nativeBackendClientToClose?.dispose();
+        })(),
         projectServiceToClose?.close(),
         dbWorkerClientToClose?.close(),
     ]);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -60,6 +60,10 @@ import { NativeFsGateway } from "./native-backend/fs";
 import { NativeGitGateway, NativeGitRoutingGateway } from "./native-backend/git";
 import { NativeSearchGateway } from "./native-backend/index-search";
 import {
+    NativeTerminalGateway,
+    shouldUseNativeTerminal,
+} from "./native-backend/terminal";
+import {
     createNativeProjectRegistryStore,
     resolveNativeProjectRegistryMode,
 } from "./native-backend/projects";
@@ -76,7 +80,7 @@ import {
     broadcastSettingsUpdated,
 } from "./settings/window-zoom";
 import { openSettingsWindow } from "./settings/window";
-import { TerminalService } from "./terminals/service";
+import { TerminalService, type TerminalGateway } from "./terminals/service";
 import { initializeAutoUpdates } from "./updater";
 import {
     createMainWindow,
@@ -96,7 +100,7 @@ let gitService: GitWorkerClient | null = null;
 let githubService: GitHubService | null = null;
 let secretStore: SecretStoreGateway | null = null;
 let settingsService: SettingsGateway | null = null;
-let terminalService: TerminalService | null = null;
+let terminalService: TerminalGateway | null = null;
 let nativeBackendClient: NativeBackendClient | null = null;
 let workspaceService: WorkspaceGateway | null = null;
 let isQuitting = false;
@@ -248,7 +252,8 @@ if (!hasSingleInstanceLock) {
                     error,
                 );
             }
-            terminalService = new TerminalService({
+            terminalService = createTerminalGateway({
+                nativeClient: nativeBackendClient,
                 onData: broadcastTerminalData,
                 onExit: broadcastTerminalExit,
                 projectService,
@@ -447,6 +452,41 @@ function parseAiWorkerShardCount(value: string | undefined): number {
     }
 
     return Math.max(1, Math.min(8, parsed));
+}
+
+function createTerminalGateway(input: {
+    readonly nativeClient: NativeBackendClient | null;
+    readonly onData: (ownerWindowId: string, event: TerminalDataEvent) => void;
+    readonly onExit: (ownerWindowId: string, event: TerminalExitEvent) => void;
+    readonly projectService: ProjectService;
+    readonly settingsService: SettingsGateway;
+}): TerminalGateway {
+    if (shouldUseNativeTerminal()) {
+        if (input.nativeClient) {
+            console.info("[native-backend] Native terminal backend enabled.");
+            return new NativeTerminalGateway({
+                client: input.nativeClient,
+                onData: input.onData,
+                onDiagnostic: (message) => {
+                    console.warn(`[native-terminal] ${message}`);
+                },
+                onExit: input.onExit,
+                projectService: input.projectService,
+                settingsService: input.settingsService,
+            });
+        }
+
+        console.warn(
+            "[native-backend] Native terminal backend is enabled but the native backend sidecar is not running; using the legacy terminal backend.",
+        );
+    }
+
+    return new TerminalService({
+        onData: input.onData,
+        onExit: input.onExit,
+        projectService: input.projectService,
+        settingsService: input.settingsService,
+    });
 }
 
 async function startNativeBackendIfEnabled(): Promise<void> {

--- a/src/main/ipc/coverage.test.ts
+++ b/src/main/ipc/coverage.test.ts
@@ -27,4 +27,20 @@ describe("IPC channel coverage", () => {
             ).toBe(true);
         });
     }
+
+    it("returns terminal mutation promises to Electron", () => {
+        for (const method of [
+            "writeInput",
+            "resizeSession",
+            "closeSessionOrOwnedTerminal",
+        ]) {
+            const pattern = new RegExp(
+                `return\\s+options\\.terminalService\\.${method}\\(`,
+            );
+            expect(
+                pattern.test(source),
+                `Expected terminal IPC handler to return ${method}(...)`,
+            ).toBe(true);
+        }
+    });
 });

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1672,7 +1672,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         IPC_CHANNELS.writeTerminalInput,
         (event, input: WriteTerminalInput) => {
             const context = requireWindowContext(event.sender, "main");
-            options.terminalService.writeInput(
+            return options.terminalService.writeInput(
                 context.windowId,
                 input.sessionId,
                 input.data,
@@ -1683,7 +1683,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         IPC_CHANNELS.resizeTerminalSession,
         (event, input: ResizeTerminalSessionInput) => {
             const context = requireWindowContext(event.sender, "main");
-            options.terminalService.resizeSession(
+            return options.terminalService.resizeSession(
                 context.windowId,
                 input.sessionId,
                 input.cols,
@@ -1695,7 +1695,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         IPC_CHANNELS.closeTerminalSession,
         (event, sessionId: string) => {
             const context = requireWindowContext(event.sender, "main");
-            options.terminalService.closeSessionOrOwnedTerminal(
+            return options.terminalService.closeSessionOrOwnedTerminal(
                 context.windowId,
                 sessionId,
             );

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -189,7 +189,7 @@ import {
     broadcastSettingsUpdated,
 } from "@main/settings/window-zoom";
 import { openSettingsWindow } from "@main/settings/window";
-import type { TerminalService } from "@main/terminals/service";
+import type { TerminalGateway } from "@main/terminals/service";
 import {
     checkForAppUpdates,
     getAppUpdateState,
@@ -218,7 +218,7 @@ interface RegisterIpcHandlersOptions {
     readonly persistenceService: PersistenceGateway;
     readonly projectService: ProjectService;
     readonly settingsService: SettingsGateway;
-    readonly terminalService: TerminalService;
+    readonly terminalService: TerminalGateway;
     readonly workspaceService: WorkspaceGateway;
 }
 

--- a/src/main/native-backend/path.test.ts
+++ b/src/main/native-backend/path.test.ts
@@ -20,6 +20,9 @@ describe("native backend flags", () => {
         expect(isNativeBackendEnabled({ [NATIVE_BACKEND_ENABLED_ENV]: "1" })).toBe(
             true,
         );
+        expect(isNativeBackendEnabled({ COMANDO_NATIVE_TERMINAL: "1" })).toBe(
+            true,
+        );
     });
 
     it("supports strict mode as a separate opt-in", () => {

--- a/src/main/native-backend/path.ts
+++ b/src/main/native-backend/path.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 export const NATIVE_BACKEND_ENABLED_ENV = "COMANDO_NATIVE_BACKEND";
 export const NATIVE_BACKEND_PATH_ENV = "COMANDO_NATIVE_BACKEND_PATH";
 export const NATIVE_BACKEND_STRICT_ENV = "COMANDO_NATIVE_BACKEND_STRICT";
+const NATIVE_TERMINAL_ENABLED_ENV = "COMANDO_NATIVE_TERMINAL";
 
 export type NativeBackendPathSource =
     | "override"
@@ -33,7 +34,10 @@ const BASE_EXECUTABLE_NAME = "comando-native-backend";
 export function isNativeBackendEnabled(
     env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-    return env[NATIVE_BACKEND_ENABLED_ENV] === "1";
+    return (
+        env[NATIVE_BACKEND_ENABLED_ENV] === "1" ||
+        env[NATIVE_TERMINAL_ENABLED_ENV] === "1"
+    );
 }
 
 export function isNativeBackendStrict(

--- a/src/main/native-backend/terminal.test.ts
+++ b/src/main/native-backend/terminal.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_APP_TERMINAL_SETTINGS } from "@shared/terminal-settings";
+import type { NativeBackendEvent } from "@shared/native-backend";
+
+import type { ProjectService } from "@main/projects/service";
+import type { SettingsGateway } from "@main/settings/service";
+
+import {
+    NATIVE_TERMINAL_ENABLED_ENV,
+    NATIVE_TERMINAL_MODE_ENV,
+    NativeTerminalGateway,
+    type NativeTerminalGatewayOptions,
+    shouldUseNativeTerminal,
+} from "./terminal";
+
+describe("native terminal flags", () => {
+    it("requires explicit terminal opt-in and defaults to native mode", () => {
+        expect(shouldUseNativeTerminal({})).toBe(false);
+        expect(shouldUseNativeTerminal({ [NATIVE_TERMINAL_ENABLED_ENV]: "1" })).toBe(
+            true,
+        );
+        expect(
+            shouldUseNativeTerminal({
+                [NATIVE_TERMINAL_ENABLED_ENV]: "1",
+                [NATIVE_TERMINAL_MODE_ENV]: "native",
+            }),
+        ).toBe(true);
+        expect(
+            shouldUseNativeTerminal({
+                [NATIVE_TERMINAL_ENABLED_ENV]: "1",
+                [NATIVE_TERMINAL_MODE_ENV]: "legacy",
+            }),
+        ).toBe(false);
+    });
+});
+
+describe("NativeTerminalGateway", () => {
+    it("creates native sessions with owner window, cwd, settings, and env", async () => {
+        const client = createClient();
+        const gateway = new NativeTerminalGateway({
+            client,
+            onData: vi.fn(),
+            onExit: vi.fn(),
+            projectService: createProjectService(),
+            settingsService: createSettingsService(),
+        });
+
+        await expect(
+            gateway.createSession(
+                {
+                    cols: 82,
+                    extraEnv: { CLAUDE_CODE_NO_FLICKER: "1" },
+                    preferredSessionId: "preferred-session",
+                    projectId: "project-1",
+                    rows: 18,
+                    terminalId: "terminal-tab",
+                    worktreeId: "worktree-1",
+                },
+                "window-1",
+            ),
+        ).resolves.toMatchObject({
+            cols: 82,
+            cwd: "/workspace/worktree",
+            projectId: "project-1",
+            rows: 18,
+            sessionId: "native-session",
+            status: "running",
+        });
+
+        expect(client.request).toHaveBeenCalledWith(
+            "terminal_create",
+            expect.objectContaining({
+                cols: 82,
+                cwd: "/workspace/worktree",
+                extraEnv: { CLAUDE_CODE_NO_FLICKER: "1" },
+                launchedBy: "user",
+                launch: { kind: "shell" },
+                preferredSessionId: "preferred-session",
+                shellPreference: { windowsShell: "pwsh" },
+                terminalId: "terminal-tab",
+                windowId: "window-1",
+            }),
+        );
+    });
+
+    it("adapts native data and exit events back to terminal IPC events", () => {
+        const client = createClient();
+        const onData = vi.fn();
+        const onExit = vi.fn();
+        new NativeTerminalGateway({
+            client,
+            onData,
+            onExit,
+            projectService: createProjectService(),
+            settingsService: createSettingsService(),
+        });
+
+        client.emit({
+            eventName: "terminal://data",
+            payload: {
+                data: "ready\n",
+                sessionId: "native-session",
+                windowId: "window-1",
+            },
+            type: "event",
+        });
+        client.emit({
+            eventName: "terminal://exit",
+            payload: {
+                exitCode: 0,
+                sessionId: "native-session",
+                signalCode: "15",
+                windowId: "window-1",
+            },
+            type: "event",
+        });
+
+        expect(onData).toHaveBeenCalledWith("window-1", {
+            data: "ready\n",
+            sessionId: "native-session",
+        });
+        expect(onExit).toHaveBeenCalledWith("window-1", {
+            exitCode: 0,
+            sessionId: "native-session",
+            signalCode: 15,
+        });
+    });
+
+    it("closes all sessions for a window without surfacing cleanup rejections", () => {
+        const client = createClient();
+        const diagnostic = vi.fn();
+        client.request.mockRejectedValueOnce(new Error("sidecar stopped"));
+        const gateway = new NativeTerminalGateway({
+            client,
+            onData: vi.fn(),
+            onDiagnostic: diagnostic,
+            onExit: vi.fn(),
+            projectService: createProjectService(),
+            settingsService: createSettingsService(),
+        });
+
+        gateway.closeOwnedByWindow("window-1");
+
+        expect(client.request).toHaveBeenCalledWith("terminal_close_window", {
+            windowId: "window-1",
+        });
+    });
+});
+
+function createClient() {
+    let listener: ((event: NativeBackendEvent) => void) | null = null;
+    const request = vi.fn(async <T = unknown>(command: string): Promise<T> => {
+        if (command === "terminal_create") {
+            return {
+                cols: 82,
+                cwd: "/workspace/worktree",
+                displayName: "zsh",
+                exitCode: null,
+                launchedBy: "user",
+                program: "/bin/zsh",
+                projectId: "project-1",
+                purpose: "workspace",
+                rows: 18,
+                sessionId: "native-session",
+                signalCode: null,
+                status: "running",
+                terminalId: "terminal-tab",
+                windowId: "window-1",
+                worktreeId: "worktree-1",
+            } as T;
+        }
+
+        if (command === "terminal_list") {
+            return { sessions: [] } as T;
+        }
+
+        return { ok: true } as T;
+    });
+
+    return {
+        emit(event: NativeBackendEvent) {
+            listener?.(event);
+        },
+        onEvent(callback: (event: NativeBackendEvent) => void) {
+            listener = callback;
+            return () => {
+                listener = null;
+            };
+        },
+        request,
+    } as NativeTerminalGatewayOptions["client"] & {
+        readonly emit: (event: NativeBackendEvent) => void;
+        readonly request: typeof request;
+    };
+}
+
+function createProjectService() {
+    return {
+        getProjectRootPath: vi.fn(() => "/workspace/worktree"),
+    } as unknown as ProjectService;
+}
+
+function createSettingsService() {
+    return {
+        loadAppTerminalSettings: vi.fn(() => ({
+            ...DEFAULT_APP_TERMINAL_SETTINGS,
+            windowsShell: "pwsh",
+        })),
+    } as unknown as SettingsGateway;
+}

--- a/src/main/native-backend/terminal.ts
+++ b/src/main/native-backend/terminal.ts
@@ -142,9 +142,9 @@ export class NativeTerminalGateway implements TerminalGateway {
             });
     }
 
-    close(): void {
+    async close(): Promise<void> {
         this.#disposeEventListener();
-        void this.#closeAll().catch((error) => {
+        await this.#closeAll().catch((error) => {
             this.#reportDiagnostic(
                 `Native terminal shutdown cleanup failed: ${formatError(error)}`,
             );

--- a/src/main/native-backend/terminal.ts
+++ b/src/main/native-backend/terminal.ts
@@ -1,0 +1,272 @@
+import type {
+    CreateTerminalSessionInput,
+    TerminalDataEvent,
+    TerminalExitEvent,
+    TerminalSession,
+} from "@shared/ipc";
+import {
+    nativeTerminalDataEventToIpc,
+    nativeTerminalExitEventToIpc,
+    type NativeBackendEvent,
+    type NativeTerminalCreateInput,
+    type NativeTerminalDataEvent,
+    type NativeTerminalExitEvent,
+    type NativeTerminalSession,
+    type NativeTerminalWindowsShell,
+} from "@shared/native-backend";
+
+import type { ProjectService } from "@main/projects/service";
+import type { SettingsGateway } from "@main/settings/service";
+import type { TerminalGateway } from "@main/terminals/service";
+
+import type { NativeBackendRequester } from "./persistence";
+
+export const NATIVE_TERMINAL_ENABLED_ENV = "COMANDO_NATIVE_TERMINAL";
+export const NATIVE_TERMINAL_MODE_ENV = "COMANDO_NATIVE_TERMINAL_MODE";
+
+type NativeTerminalClient = NativeBackendRequester & {
+    onEvent(listener: (event: NativeBackendEvent) => void): () => void;
+};
+
+export interface NativeTerminalGatewayOptions {
+    readonly client: NativeTerminalClient;
+    readonly onData: (ownerWindowId: string, event: TerminalDataEvent) => void;
+    readonly onDiagnostic?: (message: string) => void;
+    readonly onExit: (ownerWindowId: string, event: TerminalExitEvent) => void;
+    readonly projectService: ProjectService;
+    readonly settingsService: SettingsGateway;
+}
+
+export class NativeTerminalGateway implements TerminalGateway {
+    readonly #client: NativeTerminalClient;
+    readonly #disposeEventListener: () => void;
+    readonly #onData: (ownerWindowId: string, event: TerminalDataEvent) => void;
+    readonly #onDiagnostic?: (message: string) => void;
+    readonly #onExit: (ownerWindowId: string, event: TerminalExitEvent) => void;
+    readonly #projectService: ProjectService;
+    readonly #settingsService: SettingsGateway;
+
+    constructor(options: NativeTerminalGatewayOptions) {
+        this.#client = options.client;
+        this.#onData = options.onData;
+        this.#onDiagnostic = options.onDiagnostic;
+        this.#onExit = options.onExit;
+        this.#projectService = options.projectService;
+        this.#settingsService = options.settingsService;
+        this.#disposeEventListener = this.#client.onEvent((event) => {
+            this.#handleNativeEvent(event);
+        });
+    }
+
+    async createSession(
+        input: CreateTerminalSessionInput,
+        ownerWindowId: string,
+    ): Promise<TerminalSession> {
+        const cwd = input.projectId
+            ? this.#projectService.getProjectRootPath(
+                  input.projectId,
+                  input.worktreeId ?? null,
+              )
+            : process.cwd();
+        const request: NativeTerminalCreateInput = {
+            cols: input.cols ?? null,
+            cwd,
+            extraEnv: sanitizeExtraEnv(input.extraEnv),
+            launchedBy: "user",
+            launch: { kind: "shell" },
+            preferredSessionId: input.preferredSessionId ?? null,
+            projectId: input.projectId,
+            purpose: "workspace",
+            rows: input.rows ?? null,
+            shellPreference: {
+                windowsShell: normalizeNativeTerminalWindowsShell(
+                    this.#settingsService.loadAppTerminalSettings().windowsShell,
+                ),
+            },
+            terminalId: input.terminalId ?? null,
+            windowId: ownerWindowId,
+            worktreeId: input.worktreeId ?? null,
+        };
+        const session = await this.#client.request<NativeTerminalSession>(
+            "terminal_create",
+            request,
+        );
+
+        return nativeTerminalSessionToIpc(session);
+    }
+
+    async writeInput(
+        ownerWindowId: string,
+        sessionId: string,
+        data: string,
+    ): Promise<void> {
+        await this.#client.request("terminal_write", {
+            data,
+            sessionId,
+            windowId: ownerWindowId,
+        });
+    }
+
+    async resizeSession(
+        ownerWindowId: string,
+        sessionId: string,
+        cols: number,
+        rows: number,
+    ): Promise<void> {
+        await this.#client.request("terminal_resize", {
+            cols,
+            rows,
+            sessionId,
+            windowId: ownerWindowId,
+        });
+    }
+
+    async closeSessionOrOwnedTerminal(
+        ownerWindowId: string,
+        id: string,
+    ): Promise<void> {
+        await this.#client.request("terminal_close", {
+            id,
+            reason: "user",
+            windowId: ownerWindowId,
+        });
+    }
+
+    closeOwnedByWindow(ownerWindowId: string): void {
+        void this.#client
+            .request("terminal_close_window", { windowId: ownerWindowId })
+            .catch((error) => {
+                this.#reportDiagnostic(
+                    `Native terminal window cleanup failed: ${formatError(error)}`,
+                );
+            });
+    }
+
+    close(): void {
+        this.#disposeEventListener();
+        void this.#closeAll().catch((error) => {
+            this.#reportDiagnostic(
+                `Native terminal shutdown cleanup failed: ${formatError(error)}`,
+            );
+        });
+    }
+
+    async #closeAll(): Promise<void> {
+        const result = await this.#client.request<{
+            readonly sessions?: readonly NativeTerminalSession[];
+        }>("terminal_list", { windowId: null });
+        for (const session of result.sessions ?? []) {
+            await this.#client.request("terminal_close", {
+                id: session.sessionId,
+                reason: "user",
+                windowId: session.windowId,
+            });
+        }
+    }
+
+    #handleNativeEvent(event: NativeBackendEvent): void {
+        if (event.eventName === "terminal://data") {
+            const payload = requireRecord(
+                event.payload,
+                "Native terminal data event",
+            ) as unknown as NativeTerminalDataEvent;
+            this.#onData(payload.windowId, nativeTerminalDataEventToIpc(payload));
+            return;
+        }
+
+        if (event.eventName === "terminal://exit") {
+            const payload = requireRecord(
+                event.payload,
+                "Native terminal exit event",
+            ) as unknown as NativeTerminalExitEvent;
+            this.#onExit(payload.windowId, nativeTerminalExitEventToIpc(payload));
+            return;
+        }
+
+        if (event.eventName === "terminal://error") {
+            const payload = requireRecord(
+                event.payload,
+                "Native terminal error event",
+            );
+            const message =
+                typeof payload.message === "string"
+                    ? payload.message
+                    : "Native terminal error.";
+            this.#reportDiagnostic(message);
+        }
+    }
+
+    #reportDiagnostic(message: string): void {
+        this.#onDiagnostic?.(message);
+    }
+}
+
+export function shouldUseNativeTerminal(
+    env: NodeJS.ProcessEnv = process.env,
+): boolean {
+    if (env[NATIVE_TERMINAL_ENABLED_ENV] !== "1") {
+        return false;
+    }
+
+    const mode = env[NATIVE_TERMINAL_MODE_ENV];
+    return mode === undefined || mode === "" || mode === "native";
+}
+
+function nativeTerminalSessionToIpc(
+    session: NativeTerminalSession,
+): TerminalSession {
+    return {
+        cols: session.cols,
+        cwd: session.cwd,
+        exitCode: session.exitCode,
+        projectId: session.projectId,
+        rows: session.rows,
+        sessionId: session.sessionId,
+        status: session.status,
+        worktreeId: session.worktreeId,
+    };
+}
+
+function sanitizeExtraEnv(
+    extraEnv: Record<string, string> | undefined,
+): Record<string, string> {
+    if (!extraEnv) {
+        return {};
+    }
+
+    return Object.fromEntries(
+        Object.entries(extraEnv).filter(
+            (entry): entry is [string, string] =>
+                typeof entry[0] === "string" && typeof entry[1] === "string",
+        ),
+    );
+}
+
+function requireRecord(
+    value: unknown,
+    label: string,
+): Record<string, unknown> {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error(`${label} must be an object.`);
+    }
+
+    return value as Record<string, unknown>;
+}
+
+function formatError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+export function normalizeNativeTerminalWindowsShell(
+    value: string,
+): NativeTerminalWindowsShell {
+    switch (value) {
+        case "cmd":
+        case "powershell":
+        case "pwsh":
+            return value;
+        case "default":
+        default:
+            return "default";
+    }
+}

--- a/src/main/terminals/service.ts
+++ b/src/main/terminals/service.ts
@@ -22,6 +22,30 @@ interface ManagedTerminalSession {
     readonly terminalId: string | null;
 }
 
+export interface TerminalGateway {
+    createSession(
+        input: CreateTerminalSessionInput,
+        ownerWindowId: string,
+    ): Promise<TerminalSession> | TerminalSession;
+    writeInput(
+        ownerWindowId: string,
+        sessionId: string,
+        data: string,
+    ): Promise<void> | void;
+    resizeSession(
+        ownerWindowId: string,
+        sessionId: string,
+        cols: number,
+        rows: number,
+    ): Promise<void> | void;
+    closeSessionOrOwnedTerminal(
+        ownerWindowId: string,
+        id: string,
+    ): Promise<void> | void;
+    closeOwnedByWindow(ownerWindowId: string): void;
+    close(): void;
+}
+
 interface TerminalServiceOptions {
     readonly onData: (ownerWindowId: string, event: TerminalDataEvent) => void;
     readonly onExit: (ownerWindowId: string, event: TerminalExitEvent) => void;
@@ -29,7 +53,7 @@ interface TerminalServiceOptions {
     readonly settingsService: SettingsGateway;
 }
 
-export class TerminalService {
+export class TerminalService implements TerminalGateway {
     readonly #onData: (ownerWindowId: string, event: TerminalDataEvent) => void;
     readonly #onExit: (ownerWindowId: string, event: TerminalExitEvent) => void;
     readonly #projectService: ProjectService;

--- a/src/main/terminals/service.ts
+++ b/src/main/terminals/service.ts
@@ -43,7 +43,7 @@ export interface TerminalGateway {
         id: string,
     ): Promise<void> | void;
     closeOwnedByWindow(ownerWindowId: string): void;
-    close(): void;
+    close(): Promise<void> | void;
 }
 
 interface TerminalServiceOptions {

--- a/src/shared/native-backend/adapters.ts
+++ b/src/shared/native-backend/adapters.ts
@@ -271,7 +271,8 @@ function parseSignalCode(signalCode: string | null): number | null {
         return null;
     }
 
-    const numericSignal = Number.parseInt(signalCode, 10);
+    const signalMatch = signalCode.trim().match(/(\d+)\D*$/u);
+    const numericSignal = Number.parseInt(signalMatch?.[1] ?? signalCode, 10);
     return Number.isFinite(numericSignal) ? numericSignal : null;
 }
 

--- a/src/shared/native-backend/commands.ts
+++ b/src/shared/native-backend/commands.ts
@@ -88,6 +88,7 @@ export const NATIVE_TERMINAL_COMMANDS = [
     "terminal_resize",
     "terminal_kill",
     "terminal_close",
+    "terminal_close_window",
     "terminal_list",
 ] as const;
 

--- a/src/shared/native-backend/fixtures.test.ts
+++ b/src/shared/native-backend/fixtures.test.ts
@@ -48,12 +48,17 @@ import type {
 import type {
     NativeTerminalCloseInput,
     NativeTerminalClosedEvent,
+    NativeTerminalCloseWindowInput,
     NativeTerminalCreateInput,
     NativeTerminalCreatedEvent,
     NativeTerminalDataEvent,
     NativeTerminalErrorEvent,
     NativeTerminalExitEvent,
+    NativeTerminalKillInput,
+    NativeTerminalListInput,
     NativeTerminalListResult,
+    NativeTerminalResizeInput,
+    NativeTerminalWriteInput,
 } from "./terminal";
 
 const fixtureRoot = path.join(process.cwd(), "fixtures", "native-backend");
@@ -349,6 +354,34 @@ describe("native backend fixtures", () => {
             windowId: "window_main",
         };
         expect(closeInput.id).toBe("terminal_1");
+        expect(
+            fixture<NativeTerminalWriteInput>(
+                "terminal/terminal.write_input.json",
+            ),
+        ).toMatchObject({ data: "pwd\r", windowId: "window_main" });
+        expect(
+            fixture<NativeTerminalResizeInput>(
+                "terminal/terminal.resize_input.json",
+            ),
+        ).toMatchObject({ cols: 100, rows: 28 });
+        expect(
+            fixture<NativeTerminalKillInput>("terminal/terminal.kill_input.json"),
+        ).toMatchObject({ sessionId: "terminal_1" });
+        expect(
+            fixture<NativeTerminalCloseInput>(
+                "terminal/terminal.close_input.json",
+            ),
+        ).toMatchObject({ id: "terminal_1", reason: "user" });
+        expect(
+            fixture<NativeTerminalCloseWindowInput>(
+                "terminal/terminal.close_window_input.json",
+            ),
+        ).toMatchObject({ windowId: "window_main" });
+        expect(
+            fixture<NativeTerminalListInput>(
+                "terminal/terminal.list_input.json",
+            ),
+        ).toMatchObject({ windowId: "window_main" });
 
         const event = fixture<NativeTerminalDataEvent>(
             "terminal/terminal.data_event.json",
@@ -366,6 +399,17 @@ describe("native backend fixtures", () => {
             exitCode: 0,
             sessionId: "terminal_1",
             signalCode: null,
+        });
+        expect(
+            nativeTerminalExitEventToIpc({
+                ...exitEvent,
+                exitCode: null,
+                signalCode: "Terminated: 15",
+            }),
+        ).toEqual({
+            exitCode: null,
+            sessionId: "terminal_1",
+            signalCode: 15,
         });
     });
 });

--- a/src/shared/native-backend/fixtures.test.ts
+++ b/src/shared/native-backend/fixtures.test.ts
@@ -45,7 +45,16 @@ import type {
     NativeProjectSummary,
     NativeProjectTreeEntry,
 } from "./projects";
-import type { NativeTerminalDataEvent, NativeTerminalExitEvent } from "./terminal";
+import type {
+    NativeTerminalCloseInput,
+    NativeTerminalClosedEvent,
+    NativeTerminalCreateInput,
+    NativeTerminalCreatedEvent,
+    NativeTerminalDataEvent,
+    NativeTerminalErrorEvent,
+    NativeTerminalExitEvent,
+    NativeTerminalListResult,
+} from "./terminal";
 
 const fixtureRoot = path.join(process.cwd(), "fixtures", "native-backend");
 
@@ -294,6 +303,53 @@ describe("native backend fixtures", () => {
     });
 
     it("accepts terminal fixtures and adapters", () => {
+        expect(
+            fixture<NativeTerminalCreateInput>(
+                "terminal/terminal.create_input.json",
+            ),
+        ).toMatchObject({
+            launch: { kind: "shell" },
+            terminalId: "workspace-terminal-1",
+            windowId: "window_main",
+        });
+        expect(
+            fixture<NativeTerminalCreatedEvent>(
+                "terminal/terminal.created_event.json",
+            ).session,
+        ).toMatchObject({
+            launchedBy: "user",
+            program: "/bin/zsh",
+            purpose: "workspace",
+        });
+        expect(
+            fixture<NativeTerminalListResult>(
+                "terminal/terminal.list_result.json",
+            ).sessions,
+        ).toHaveLength(1);
+        expect(
+            fixture<NativeTerminalClosedEvent>(
+                "terminal/terminal.closed_event.json",
+            ),
+        ).toMatchObject({
+            reason: "user",
+            sessionId: "terminal_1",
+            windowId: "window_main",
+        });
+        expect(
+            fixture<NativeTerminalErrorEvent>(
+                "terminal/terminal.error_event.json",
+            ),
+        ).toMatchObject({
+            retryable: false,
+            terminalId: "workspace-terminal-1",
+        });
+        const closeInput: NativeTerminalCloseInput = {
+            id: "terminal_1",
+            reason: "user",
+            windowId: "window_main",
+        };
+        expect(closeInput.id).toBe("terminal_1");
+
         const event = fixture<NativeTerminalDataEvent>(
             "terminal/terminal.data_event.json",
         );

--- a/src/shared/native-backend/terminal.ts
+++ b/src/shared/native-backend/terminal.ts
@@ -11,46 +11,131 @@ export type NativeTerminalCloseReason =
     | "user"
     | "window_closed";
 
+export type NativeTerminalStatus = "error" | "exited" | "running";
+
+export type NativeTerminalPurpose = "auth" | "workspace";
+
+export type NativeTerminalLaunchedBy = "agent" | "system" | "user";
+
+export type NativeTerminalWindowsShell =
+    | "cmd"
+    | "default"
+    | "powershell"
+    | "pwsh";
+
+export type NativeTerminalShellPreference = {
+    readonly windowsShell: NativeTerminalWindowsShell;
+};
+
+export type NativeTerminalLaunch =
+    | {
+          readonly kind: "shell";
+      }
+    | {
+          readonly args: readonly string[];
+          readonly displayName: string | null;
+          readonly kind: "command";
+          readonly program: string;
+      };
+
 export type NativeTerminalSession = {
     readonly sessionId: NativeTerminalSessionId;
     readonly windowId: NativeWindowId;
+    readonly terminalId: string | null;
     readonly projectId: NativeProjectId | null;
     readonly worktreeId: NativeWorktreeId | null;
     readonly cwd: string;
     readonly cols: number;
     readonly rows: number;
-    readonly status: string;
+    readonly status: NativeTerminalStatus;
     readonly exitCode: number | null;
     readonly signalCode: string | null;
+    readonly program: string;
+    readonly displayName: string;
+    readonly purpose: NativeTerminalPurpose;
+    readonly launchedBy: NativeTerminalLaunchedBy;
 };
 
 export type NativeTerminalCreateInput = {
     readonly windowId: NativeWindowId;
+    readonly terminalId: string | null;
+    readonly preferredSessionId: NativeTerminalSessionId | null;
     readonly projectId: NativeProjectId | null;
     readonly worktreeId: NativeWorktreeId | null;
     readonly cwd: string | null;
-    readonly cols: number;
-    readonly rows: number;
+    readonly cols: number | null;
+    readonly rows: number | null;
+    readonly extraEnv: Readonly<Record<string, string>>;
+    readonly shellPreference: NativeTerminalShellPreference | null;
+    readonly purpose: NativeTerminalPurpose;
+    readonly launchedBy: NativeTerminalLaunchedBy;
+    readonly launch: NativeTerminalLaunch;
 };
 
 export type NativeTerminalWriteInput = {
+    readonly windowId: NativeWindowId;
     readonly sessionId: NativeTerminalSessionId;
     readonly data: string;
 };
 
 export type NativeTerminalResizeInput = {
+    readonly windowId: NativeWindowId;
     readonly sessionId: NativeTerminalSessionId;
     readonly cols: number;
     readonly rows: number;
 };
 
+export type NativeTerminalKillInput = {
+    readonly windowId: NativeWindowId;
+    readonly sessionId: NativeTerminalSessionId;
+};
+
+export type NativeTerminalCloseInput = {
+    readonly windowId: NativeWindowId;
+    readonly id: NativeTerminalSessionId | string;
+    readonly reason: NativeTerminalCloseReason;
+};
+
+export type NativeTerminalCloseWindowInput = {
+    readonly windowId: NativeWindowId;
+};
+
+export type NativeTerminalListInput = {
+    readonly windowId: NativeWindowId | null;
+};
+
+export type NativeTerminalListResult = {
+    readonly sessions: readonly NativeTerminalSession[];
+};
+
+export type NativeTerminalCreatedEvent = {
+    readonly session: NativeTerminalSession;
+};
+
 export type NativeTerminalDataEvent = {
+    readonly windowId: NativeWindowId;
     readonly sessionId: NativeTerminalSessionId;
     readonly data: string;
 };
 
 export type NativeTerminalExitEvent = {
+    readonly windowId: NativeWindowId;
     readonly sessionId: NativeTerminalSessionId;
     readonly exitCode: number | null;
     readonly signalCode: string | null;
+};
+
+export type NativeTerminalClosedEvent = {
+    readonly windowId: NativeWindowId;
+    readonly sessionId: NativeTerminalSessionId;
+    readonly terminalId: string | null;
+    readonly reason: NativeTerminalCloseReason;
+};
+
+export type NativeTerminalErrorEvent = {
+    readonly windowId: NativeWindowId;
+    readonly sessionId: NativeTerminalSessionId | null;
+    readonly terminalId: string | null;
+    readonly message: string;
+    readonly retryable: boolean;
 };


### PR DESCRIPTION
## Summary

- Adds a Rust `comando-terminal` crate backed by `portable-pty` for integrated terminal lifecycle, PTY IO, resize, close, exit, cleanup, UTF-8-safe output, and bounded output coalescing.
- Wires `terminal_create/write/resize/kill/close/close_window/list` into the native backend JSONL sidecar with `terminal://created`, `terminal://data`, `terminal://exit`, `terminal://closed`, and `terminal://error` events.
- Adds a TypeScript `NativeTerminalGateway` behind `COMANDO_NATIVE_TERMINAL=1`, preserving the existing renderer IPC shape and keeping `node-pty` as the legacy fallback.
- Hardens owner-window validation, terminalId dedupe, cleanup, backpressure, signal handling, and protocol fixtures.

## Notes

- This PR references and adapts the PTY lifecycle architecture from NeverWrite

## Testing

- `pnpm run native:build`
- `cargo test -p comando-types -p comando-terminal -p comando-native-backend`
- `pnpm run typecheck`
- `pnpm test src/shared/native-backend/fixtures.test.ts src/main/native-backend/terminal.test.ts src/main/native-backend/path.test.ts src/main/terminals/service.test.ts src/main/terminals/shell.test.ts src/main/ipc/coverage.test.ts src/renderer/src/features/terminal/terminalRuntimeStore.test.ts src/renderer/src/components/workspace/terminalSurface.test.ts`
