### PR TITLE
Harden AI session stream recovery

### DIFF
--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -1019,6 +1019,197 @@ describe("AiService prepareSession", () => {
         ).toEqual([]);
         expect(keepTrackedFile).not.toHaveBeenCalled();
     });
+
+    it("returns active live session snapshots owned by a window for stream resync", async () => {
+        const nativeAi = createNativeAi({
+            prepareSession: vi.fn<NativeAiGateway["prepareSession"]>(({ input }) =>
+                Promise.resolve(
+                    createSnapshot({
+                        projectId: input.projectId,
+                        runtimeId: input.runtimeId,
+                        runtimeSessionId: `runtime-${input.sessionId}`,
+                        sessionId: input.sessionId,
+                        status:
+                            input.sessionId === "session-2"
+                                ? "waiting_permission"
+                                : "streaming",
+                        title: input.title,
+                        worktreeId: input.worktreeId ?? null,
+                    }),
+                ),
+            ),
+        });
+        const service = createPrepareService({ nativeAi });
+
+        await service.prepareSession(
+            {
+                projectId: "project-1",
+                runtimeId: "codex",
+                sessionId: "session-1",
+                title: "Session 1",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+        await service.prepareSession(
+            {
+                projectId: "project-1",
+                runtimeId: "codex",
+                sessionId: "session-2",
+                title: "Session 2",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+        await service.prepareSession(
+            {
+                projectId: "project-2",
+                runtimeId: "codex",
+                sessionId: "session-3",
+                title: "Session 3",
+                worktreeId: null,
+            },
+            "window-2",
+        );
+
+        expect(
+            service
+                .getLiveSessionSnapshotsForWindow("window-1")
+                .map((snapshot) => [snapshot.sessionId, snapshot.status]),
+        ).toEqual([
+            ["session-1", "streaming"],
+            ["session-2", "waiting_permission"],
+        ]);
+        expect(
+            service
+                .getLiveSessionSnapshotsForWindow("window-2")
+                .map((snapshot) => snapshot.sessionId),
+        ).toEqual(["session-3"]);
+    });
+
+    it("omits inactive sessions and snapshots without live context from stream resync", async () => {
+        const nativeAi = createNativeAi({
+            prepareSession: vi.fn<NativeAiGateway["prepareSession"]>(({ input }) =>
+                Promise.resolve(
+                    createSnapshot({
+                        runtimeSessionId: `runtime-${input.sessionId}`,
+                        sessionId: input.sessionId,
+                        status:
+                            input.sessionId === "session-1"
+                                ? "idle"
+                                : "starting",
+                        title: input.title,
+                    }),
+                ),
+            ),
+        });
+        const service = createPrepareService({ nativeAi });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-1",
+                title: "Idle",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-2",
+                title: "Starting",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+        service.handleNativeSessionSnapshot("window-1", {
+            kind: "snapshot",
+            snapshot: createSnapshot({
+                runtimeSessionId: "runtime-orphan",
+                sessionId: "orphan-session",
+                status: "streaming",
+                title: "Orphan",
+            }),
+        });
+
+        expect(
+            service
+                .getLiveSessionSnapshotsForWindow("window-1")
+                .map((snapshot) => snapshot.sessionId),
+        ).toEqual(["session-2"]);
+    });
+
+    it("does not mutate live snapshots while reading stream resync state", async () => {
+        const onSessionSnapshot = vi.fn();
+        const nativeAi = createNativeAi({
+            prepareSession: vi.fn<NativeAiGateway["prepareSession"]>(({ input }) =>
+                Promise.resolve(
+                    createSnapshot({
+                        runtimeSessionId: `runtime-${input.sessionId}`,
+                        sessionId: input.sessionId,
+                        status: "streaming",
+                        title: input.title,
+                    }),
+                ),
+            ),
+        });
+        const service = createPrepareService({
+            nativeAi,
+            onSessionSnapshot,
+        });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-1",
+                title: "Streaming",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+        const callsBeforeRead = onSessionSnapshot.mock.calls.length;
+        const before = service.getLiveSessionSnapshotsForWindow("window-1");
+        const after = service.getLiveSessionSnapshotsForWindow("window-1");
+
+        expect(after).toHaveLength(1);
+        expect(after[0]).toBe(before[0]);
+        expect(onSessionSnapshot).toHaveBeenCalledTimes(callsBeforeRead);
+    });
+
+    it("does not return live snapshots after the owning window is closed", async () => {
+        const nativeAi = createNativeAi({
+            prepareSession: vi.fn<NativeAiGateway["prepareSession"]>(({ input }) =>
+                Promise.resolve(
+                    createSnapshot({
+                        runtimeSessionId: `runtime-${input.sessionId}`,
+                        sessionId: input.sessionId,
+                        status: "streaming",
+                        title: input.title,
+                    }),
+                ),
+            ),
+        });
+        const service = createPrepareService({ nativeAi });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-1",
+                title: "Streaming",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+
+        service.closeOwnedByWindow("window-1");
+
+        expect(service.getLiveSessionSnapshotsForWindow("window-1")).toEqual([]);
+    });
 });
 
 function createNativeAi(

--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -1087,6 +1087,43 @@ describe("AiService prepareSession", () => {
         ).toEqual(["session-3"]);
     });
 
+    it("returns a single live session snapshot only to its owning window", async () => {
+        const nativeAi = createNativeAi({
+            prepareSession: vi.fn<NativeAiGateway["prepareSession"]>(({ input }) =>
+                Promise.resolve(
+                    createSnapshot({
+                        runtimeSessionId: `runtime-${input.sessionId}`,
+                        sessionId: input.sessionId,
+                        status: "streaming",
+                        title: input.title,
+                    }),
+                ),
+            ),
+        });
+        const service = createPrepareService({ nativeAi });
+
+        const snapshot = await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-1",
+                title: "Streaming",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+
+        expect(
+            service.getLiveSessionSnapshotForWindow("window-1", "session-1"),
+        ).toBe(snapshot);
+        expect(
+            service.getLiveSessionSnapshotForWindow("window-2", "session-1"),
+        ).toBeNull();
+        expect(
+            service.getLiveSessionSnapshotForWindow("window-1", "missing"),
+        ).toBeNull();
+    });
+
     it("omits inactive sessions and snapshots without live context from stream resync", async () => {
         const nativeAi = createNativeAi({
             prepareSession: vi.fn<NativeAiGateway["prepareSession"]>(({ input }) =>

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -209,6 +209,17 @@ const DEFAULT_AI_SESSION_RETENTION_CONFIG: AiSessionRetentionConfig = {
 };
 const RECENT_NATIVE_REVIEW_CONTEXT_TTL_MS = 60_000;
 
+function isResyncEligibleAiSessionStatus(
+    status: AiSessionSnapshot["status"],
+): boolean {
+    return (
+        status === "starting" ||
+        status === "streaming" ||
+        status === "waiting_permission" ||
+        status === "waiting_user_input"
+    );
+}
+
 type AiSchedulerPriority = 0 | 1 | 2 | 3;
 
 interface AiSchedulerDiagnostics {
@@ -531,6 +542,27 @@ export class AiService {
                 this.#retentionConfig.maxHotSessionsPerWindow,
             skipped: [...this.#lastRetentionSkippedRecords],
         };
+    }
+
+    getLiveSessionSnapshotsForWindow(
+        ownerWindowId: string,
+    ): readonly AiSessionSnapshot[] {
+        const snapshots: AiSessionSnapshot[] = [];
+        for (const context of this.#liveSessionContexts.values()) {
+            if (
+                context.ownerWindowId !== ownerWindowId ||
+                this.#deletedSessionIds.has(context.sessionId)
+            ) {
+                continue;
+            }
+
+            const snapshot = this.#liveSnapshots.get(context.sessionId) ?? null;
+            if (snapshot && isResyncEligibleAiSessionStatus(snapshot.status)) {
+                snapshots.push(snapshot);
+            }
+        }
+
+        return snapshots;
     }
 
     handleNativeRuntimeStatus(status: AiRuntimeStatus): void {

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -565,6 +565,22 @@ export class AiService {
         return snapshots;
     }
 
+    getLiveSessionSnapshotForWindow(
+        ownerWindowId: string,
+        sessionId: string,
+    ): AiSessionSnapshot | null {
+        const context = this.#liveSessionContexts.get(sessionId);
+        if (
+            !context ||
+            context.ownerWindowId !== ownerWindowId ||
+            this.#deletedSessionIds.has(sessionId)
+        ) {
+            return null;
+        }
+
+        return this.#liveSnapshots.get(sessionId) ?? null;
+    }
+
     handleNativeRuntimeStatus(status: AiRuntimeStatus): void {
         this.#onRuntimeStatus(status);
     }

--- a/src/main/ai/session-stream.test.ts
+++ b/src/main/ai/session-stream.test.ts
@@ -9,6 +9,7 @@ import type {
 
 import {
     buildAiSessionStreamRecoveryDiagnostic,
+    buildAiSessionStreamRecoveryFallbackPayloads,
     getAiSessionStreamPayloadKind,
     isAiSessionStreamAckStale,
     isAiSessionUpdate,
@@ -206,6 +207,7 @@ describe("AI session stream helpers", () => {
                 nowMs: 4_500,
                 pendingCriticalPayloadCount: 2,
                 reason: "ack-timeout",
+                resyncSnapshotCount: 1,
                 state: {
                     lastAckSeq: 7,
                     lastSentAt: 2_000,
@@ -218,6 +220,52 @@ describe("AI session stream helpers", () => {
             lastSentSeq: 9,
             pendingCriticalPayloadCount: 2,
             reason: "ack-timeout",
+            resyncSnapshotCount: 1,
         });
+    });
+
+    it("builds recovery fallback payloads with critical entries before resync snapshots", () => {
+        const laterCritical = createStatusEvent("idle");
+        const earlierCritical = createCompletedEvent("message-completed");
+        const snapshot = createSnapshot("streaming");
+
+        expect(
+            buildAiSessionStreamRecoveryFallbackPayloads({
+                pendingCriticalPayloads: [
+                    {
+                        payload: laterCritical,
+                        seq: 20,
+                    },
+                    {
+                        payload: earlierCritical,
+                        seq: 10,
+                    },
+                ],
+                resyncSnapshots: [snapshot],
+            }),
+        ).toEqual([
+            earlierCritical,
+            laterCritical,
+            {
+                kind: "snapshot",
+                snapshot,
+            },
+        ]);
+    });
+
+    it("does not add resync snapshots when none are available", () => {
+        const critical = createCompletedEvent("thinking-completed");
+
+        expect(
+            buildAiSessionStreamRecoveryFallbackPayloads({
+                pendingCriticalPayloads: [
+                    {
+                        payload: critical,
+                        seq: 1,
+                    },
+                ],
+                resyncSnapshots: [],
+            }),
+        ).toEqual([critical]);
     });
 });

--- a/src/main/ai/session-stream.test.ts
+++ b/src/main/ai/session-stream.test.ts
@@ -2,18 +2,25 @@ import { describe, expect, it } from "vitest";
 
 import type {
     AiSessionDomainEvent,
+    AiMessage,
+    AiSessionPatchChanges,
     AiSessionSnapshot,
     AiSessionStreamPayload,
     AiSessionUpdate,
+    AiToolActivity,
 } from "@shared/ipc";
 
 import {
     buildAiSessionStreamRecoveryDiagnostic,
     buildAiSessionStreamRecoveryFallbackPayloads,
     getAiSessionStreamPayloadKind,
+    getAiSessionStreamPreservationKey,
     isAiSessionStreamAckStale,
     isAiSessionUpdate,
     isCriticalAiSessionStreamPayload,
+    isPreservableAiSessionStreamPayload,
+    rememberAiSessionStreamPayloadForRecovery,
+    type AiSessionStreamPreservationQueue,
 } from "./session-stream";
 
 const BASE_EVENT = {
@@ -46,6 +53,82 @@ function createCompletedEvent(
         messageId: "message-1",
         ...(kind === "message-completed" ? { messageKind: "assistant" } : {}),
     } as AiSessionStreamPayload;
+}
+
+function createMessage(id: string, content = ""): AiMessage {
+    return {
+        attachments: [],
+        content,
+        createdAt: "2026-04-14T00:00:00.000Z",
+        id,
+        kind: "assistant",
+        status: "streaming",
+    };
+}
+
+function createVisibleTranscriptEvent(
+    kind:
+        | "message-delta"
+        | "message-started"
+        | "thinking-delta"
+        | "thinking-started",
+    messageId = "message-1",
+    content = "Hello",
+): AiSessionStreamPayload {
+    if (kind === "message-started") {
+        return {
+            ...BASE_EVENT,
+            kind,
+            message: createMessage(messageId),
+            messageKind: "assistant",
+        };
+    }
+    if (kind === "thinking-started") {
+        return {
+            ...BASE_EVENT,
+            kind,
+            message: {
+                ...createMessage(messageId),
+                kind: "thinking",
+            },
+        };
+    }
+    if (kind === "message-delta") {
+        return {
+            ...BASE_EVENT,
+            content,
+            delta: content,
+            kind,
+            messageId,
+            messageKind: "assistant",
+        };
+    }
+    return {
+        ...BASE_EVENT,
+        content,
+        delta: content,
+        kind,
+        messageId,
+    };
+}
+
+function createToolActivity(): AiToolActivity {
+    return {
+        createdAt: "2026-04-14T00:00:00.000Z",
+        diffs: [],
+        exitCode: null,
+        id: "tool-1",
+        kind: "shell",
+        locations: [],
+        rawInputJson: null,
+        rawOutputJson: null,
+        sessionId: "session-1",
+        status: "in_progress",
+        summary: null,
+        terminalOutput: null,
+        title: "Run command",
+        updatedAt: "2026-04-14T00:00:00.000Z",
+    };
 }
 
 function createSnapshot(status: AiSessionSnapshot["status"]): AiSessionSnapshot {
@@ -94,6 +177,19 @@ function createPatchUpdate(
             changes: {
                 status,
             },
+            runtimeId: "codex",
+            sessionId: "session-1",
+        },
+    };
+}
+
+function createPatchUpdateWithChanges(
+    changes: AiSessionPatchChanges,
+): AiSessionUpdate {
+    return {
+        kind: "patch",
+        patch: {
+            changes,
             runtimeId: "codex",
             sessionId: "session-1",
         },
@@ -163,6 +259,146 @@ describe("AI session stream helpers", () => {
         ).toBe(false);
     });
 
+    it("marks visible transcript payloads as preservable", () => {
+        expect(
+            isPreservableAiSessionStreamPayload(
+                createVisibleTranscriptEvent("message-started"),
+            ),
+        ).toBe(true);
+        expect(
+            isPreservableAiSessionStreamPayload(
+                createVisibleTranscriptEvent("thinking-started"),
+            ),
+        ).toBe(true);
+        expect(
+            isPreservableAiSessionStreamPayload(
+                createVisibleTranscriptEvent("message-delta"),
+            ),
+        ).toBe(true);
+        expect(
+            isPreservableAiSessionStreamPayload(
+                createVisibleTranscriptEvent("thinking-delta"),
+            ),
+        ).toBe(true);
+    });
+
+    it("marks patches with visible messages or tool activity as preservable", () => {
+        expect(
+            isPreservableAiSessionStreamPayload(
+                createPatchUpdateWithChanges({
+                    messages: [createMessage("message-1", "Hello")],
+                }),
+            ),
+        ).toBe(true);
+        expect(
+            isPreservableAiSessionStreamPayload(
+                createPatchUpdateWithChanges({
+                    toolActivity: [createToolActivity()],
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it("does not preserve patches without visible transcript changes", () => {
+        const queue: AiSessionStreamPreservationQueue = new Map();
+        const patch = createPatchUpdateWithChanges({
+            title: "Renamed chat",
+        });
+
+        expect(isPreservableAiSessionStreamPayload(patch)).toBe(false);
+        expect(
+            rememberAiSessionStreamPayloadForRecovery({
+                maxPayloads: 10,
+                payload: patch,
+                queue,
+                seq: 1,
+            }),
+        ).toEqual({
+            droppedOldest: false,
+            pendingCount: 0,
+            preserved: false,
+        });
+        expect(queue.size).toBe(0);
+    });
+
+    it("coalesces multiple deltas for the same message and keeps accumulated content", () => {
+        const queue: AiSessionStreamPreservationQueue = new Map();
+        const firstDelta = createVisibleTranscriptEvent(
+            "message-delta",
+            "message-1",
+            "Hel",
+        );
+        const latestDelta = createVisibleTranscriptEvent(
+            "message-delta",
+            "message-1",
+            "Hello",
+        );
+
+        rememberAiSessionStreamPayloadForRecovery({
+            maxPayloads: 10,
+            payload: firstDelta,
+            queue,
+            seq: 1,
+        });
+        rememberAiSessionStreamPayloadForRecovery({
+            maxPayloads: 10,
+            payload: latestDelta,
+            queue,
+            seq: 2,
+        });
+
+        const key = getAiSessionStreamPreservationKey(latestDelta);
+        expect(queue.size).toBe(1);
+        expect(key).not.toBeNull();
+        expect(queue.get(key ?? "")).toEqual({
+            payload: latestDelta,
+            seq: 2,
+        });
+    });
+
+    it("drops the oldest preserved payload when the queue exceeds its limit", () => {
+        const queue: AiSessionStreamPreservationQueue = new Map();
+        const firstDelta = createVisibleTranscriptEvent(
+            "message-delta",
+            "message-1",
+            "First",
+        );
+        const secondDelta = createVisibleTranscriptEvent(
+            "message-delta",
+            "message-2",
+            "Second",
+        );
+
+        rememberAiSessionStreamPayloadForRecovery({
+            maxPayloads: 1,
+            payload: firstDelta,
+            queue,
+            seq: 1,
+        });
+        expect(
+            rememberAiSessionStreamPayloadForRecovery({
+                maxPayloads: 1,
+                payload: secondDelta,
+                queue,
+                seq: 2,
+            }),
+        ).toEqual({
+            droppedOldest: true,
+            pendingCount: 1,
+            preserved: true,
+        });
+
+        expect(queue.has(getAiSessionStreamPreservationKey(firstDelta) ?? "")).toBe(
+            false,
+        );
+        expect(
+            queue.get(getAiSessionStreamPreservationKey(secondDelta) ?? ""),
+        ).toEqual({
+            payload: secondDelta,
+            seq: 2,
+        });
+    });
+
     it("only marks ack state stale when an unacked message exceeds the timeout", () => {
         const timeoutMs = 2_000;
 
@@ -205,7 +441,7 @@ describe("AI session stream helpers", () => {
         expect(
             buildAiSessionStreamRecoveryDiagnostic({
                 nowMs: 4_500,
-                pendingCriticalPayloadCount: 2,
+                pendingPreservedPayloadCount: 2,
                 reason: "ack-timeout",
                 resyncSnapshotCount: 1,
                 state: {
@@ -218,7 +454,7 @@ describe("AI session stream helpers", () => {
             ackLagMs: 2_500,
             lastAckSeq: 7,
             lastSentSeq: 9,
-            pendingCriticalPayloadCount: 2,
+            pendingPreservedPayloadCount: 2,
             reason: "ack-timeout",
             resyncSnapshotCount: 1,
         });
@@ -231,7 +467,7 @@ describe("AI session stream helpers", () => {
 
         expect(
             buildAiSessionStreamRecoveryFallbackPayloads({
-                pendingCriticalPayloads: [
+                pendingPreservedPayloads: [
                     {
                         payload: laterCritical,
                         seq: 20,
@@ -258,7 +494,7 @@ describe("AI session stream helpers", () => {
 
         expect(
             buildAiSessionStreamRecoveryFallbackPayloads({
-                pendingCriticalPayloads: [
+                pendingPreservedPayloads: [
                     {
                         payload: critical,
                         seq: 1,

--- a/src/main/ai/session-stream.test.ts
+++ b/src/main/ai/session-stream.test.ts
@@ -321,6 +321,54 @@ describe("AI session stream helpers", () => {
         expect(queue.size).toBe(0);
     });
 
+    it("merges preserved patch changes for the same session", () => {
+        const queue: AiSessionStreamPreservationQueue = new Map();
+        const toolActivity = createToolActivity();
+        const message = createMessage("message-1", "Hello");
+        const toolPatch = createPatchUpdateWithChanges({
+            toolActivity: [toolActivity],
+            updatedAt: "2026-04-14T00:00:01.000Z",
+        });
+        const terminalPatch = createPatchUpdateWithChanges({
+            messages: [message],
+            status: "idle",
+            updatedAt: "2026-04-14T00:00:02.000Z",
+        });
+
+        rememberAiSessionStreamPayloadForRecovery({
+            maxPayloads: 10,
+            payload: toolPatch,
+            queue,
+            seq: 1,
+        });
+        rememberAiSessionStreamPayloadForRecovery({
+            maxPayloads: 10,
+            payload: terminalPatch,
+            queue,
+            seq: 2,
+        });
+
+        expect(queue.size).toBe(1);
+        expect(
+            queue.get(getAiSessionStreamPreservationKey(terminalPatch) ?? ""),
+        ).toEqual({
+            payload: {
+                kind: "patch",
+                patch: {
+                    changes: {
+                        messages: [message],
+                        status: "idle",
+                        toolActivity: [toolActivity],
+                        updatedAt: "2026-04-14T00:00:02.000Z",
+                    },
+                    runtimeId: "codex",
+                    sessionId: "session-1",
+                },
+            },
+            seq: 2,
+        });
+    });
+
     it("coalesces multiple deltas for the same message and keeps accumulated content", () => {
         const queue: AiSessionStreamPreservationQueue = new Map();
         const firstDelta = createVisibleTranscriptEvent(

--- a/src/main/ai/session-stream.test.ts
+++ b/src/main/ai/session-stream.test.ts
@@ -408,6 +408,7 @@ describe("AI session stream helpers", () => {
                     lastAckSeq: 4,
                     lastSentAt: 1_000,
                     lastSentSeq: 4,
+                    pendingAckSentAtBySeq: new Map(),
                 },
                 5_000,
                 timeoutMs,
@@ -419,6 +420,7 @@ describe("AI session stream helpers", () => {
                     lastAckSeq: 3,
                     lastSentAt: 1_000,
                     lastSentSeq: 4,
+                    pendingAckSentAtBySeq: new Map([[4, 1_000]]),
                 },
                 2_999,
                 timeoutMs,
@@ -430,9 +432,29 @@ describe("AI session stream helpers", () => {
                     lastAckSeq: 3,
                     lastSentAt: 1_000,
                     lastSentSeq: 4,
+                    pendingAckSentAtBySeq: new Map([[4, 1_000]]),
                 },
                 3_000,
                 timeoutMs,
+            ),
+        ).toBe(true);
+    });
+
+    it("keeps an older unacked message stale after newer heartbeats", () => {
+        expect(
+            isAiSessionStreamAckStale(
+                {
+                    lastAckSeq: 3,
+                    lastSentAt: 2_900,
+                    lastSentSeq: 6,
+                    pendingAckSentAtBySeq: new Map([
+                        [4, 1_000],
+                        [5, 2_000],
+                        [6, 2_900],
+                    ]),
+                },
+                3_000,
+                2_000,
             ),
         ).toBe(true);
     });
@@ -446,8 +468,12 @@ describe("AI session stream helpers", () => {
                 resyncSnapshotCount: 1,
                 state: {
                     lastAckSeq: 7,
-                    lastSentAt: 2_000,
+                    lastSentAt: 4_000,
                     lastSentSeq: 9,
+                    pendingAckSentAtBySeq: new Map([
+                        [8, 2_000],
+                        [9, 4_000],
+                    ]),
                 },
             }),
         ).toEqual({

--- a/src/main/ai/session-stream.test.ts
+++ b/src/main/ai/session-stream.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+    AiSessionDomainEvent,
+    AiSessionSnapshot,
+    AiSessionStreamPayload,
+    AiSessionUpdate,
+} from "@shared/ipc";
+
+import {
+    buildAiSessionStreamRecoveryDiagnostic,
+    getAiSessionStreamPayloadKind,
+    isAiSessionStreamAckStale,
+    isAiSessionUpdate,
+    isCriticalAiSessionStreamPayload,
+} from "./session-stream";
+
+const BASE_EVENT = {
+    origin: "live",
+    parentSessionId: null,
+    runtimeId: "codex",
+    runtimeSessionId: "runtime-session-1",
+    sessionId: "session-1",
+    updatedAt: "2026-04-14T00:00:00.000Z",
+} satisfies Omit<AiSessionDomainEvent, "kind">;
+
+function createStatusEvent(
+    status: "error" | "idle" | "starting" | "streaming",
+): AiSessionStreamPayload {
+    return {
+        ...BASE_EVENT,
+        activeTurnStartedAt: null,
+        kind: "status",
+        lastError: status === "error" ? "Boom" : null,
+        status,
+    };
+}
+
+function createCompletedEvent(
+    kind: "message-completed" | "thinking-completed",
+): AiSessionStreamPayload {
+    return {
+        ...BASE_EVENT,
+        kind,
+        messageId: "message-1",
+        ...(kind === "message-completed" ? { messageKind: "assistant" } : {}),
+    } as AiSessionStreamPayload;
+}
+
+function createSnapshot(status: AiSessionSnapshot["status"]): AiSessionSnapshot {
+    return {
+        activeTurnStartedAt: null,
+        availableCommands: [],
+        configOptions: [],
+        lastError: status === "error" ? "Boom" : null,
+        messages: [],
+        modeId: null,
+        modes: [],
+        modelId: null,
+        models: [],
+        pendingPermission: null,
+        pendingUserInput: null,
+        plan: null,
+        projectId: "project-1",
+        runtimeId: "codex",
+        runtimeSessionId: "runtime-session-1",
+        sessionId: "session-1",
+        status,
+        title: "Chat",
+        tokenUsage: null,
+        toolActivity: [],
+        trackedFiles: [],
+        updatedAt: "2026-04-14T00:00:00.000Z",
+        worktreeId: null,
+    };
+}
+
+function createSnapshotUpdate(
+    status: AiSessionSnapshot["status"],
+): AiSessionUpdate {
+    return {
+        kind: "snapshot",
+        snapshot: createSnapshot(status),
+    };
+}
+
+function createPatchUpdate(
+    status: AiSessionSnapshot["status"],
+): AiSessionUpdate {
+    return {
+        kind: "patch",
+        patch: {
+            changes: {
+                status,
+            },
+            runtimeId: "codex",
+            sessionId: "session-1",
+        },
+    };
+}
+
+describe("AI session stream helpers", () => {
+    it("classifies session update payloads", () => {
+        const update = createSnapshotUpdate("streaming");
+        const event = createStatusEvent("streaming");
+
+        expect(isAiSessionUpdate(update)).toBe(true);
+        expect(isAiSessionUpdate(event)).toBe(false);
+        expect(getAiSessionStreamPayloadKind(update)).toBe("snapshot");
+        expect(getAiSessionStreamPayloadKind(event)).toBe("status");
+    });
+
+    it("marks completed message events as critical", () => {
+        expect(
+            isCriticalAiSessionStreamPayload(
+                createCompletedEvent("message-completed"),
+            ),
+        ).toBe(true);
+        expect(
+            isCriticalAiSessionStreamPayload(
+                createCompletedEvent("thinking-completed"),
+            ),
+        ).toBe(true);
+    });
+
+    it("marks terminal status events as critical", () => {
+        expect(isCriticalAiSessionStreamPayload(createStatusEvent("idle"))).toBe(
+            true,
+        );
+        expect(
+            isCriticalAiSessionStreamPayload(createStatusEvent("error")),
+        ).toBe(true);
+    });
+
+    it("does not mark streaming status events as terminal-critical", () => {
+        expect(
+            isCriticalAiSessionStreamPayload(createStatusEvent("streaming")),
+        ).toBe(false);
+    });
+
+    it("marks idle or error snapshots and patches as critical", () => {
+        expect(
+            isCriticalAiSessionStreamPayload(createSnapshotUpdate("idle")),
+        ).toBe(true);
+        expect(
+            isCriticalAiSessionStreamPayload(createSnapshotUpdate("error")),
+        ).toBe(true);
+        expect(isCriticalAiSessionStreamPayload(createPatchUpdate("idle"))).toBe(
+            true,
+        );
+        expect(
+            isCriticalAiSessionStreamPayload(createPatchUpdate("error")),
+        ).toBe(true);
+    });
+
+    it("does not mark active snapshots and patches as critical", () => {
+        expect(
+            isCriticalAiSessionStreamPayload(createSnapshotUpdate("streaming")),
+        ).toBe(false);
+        expect(
+            isCriticalAiSessionStreamPayload(createPatchUpdate("starting")),
+        ).toBe(false);
+    });
+
+    it("only marks ack state stale when an unacked message exceeds the timeout", () => {
+        const timeoutMs = 2_000;
+
+        expect(
+            isAiSessionStreamAckStale(
+                {
+                    lastAckSeq: 4,
+                    lastSentAt: 1_000,
+                    lastSentSeq: 4,
+                },
+                5_000,
+                timeoutMs,
+            ),
+        ).toBe(false);
+        expect(
+            isAiSessionStreamAckStale(
+                {
+                    lastAckSeq: 3,
+                    lastSentAt: 1_000,
+                    lastSentSeq: 4,
+                },
+                2_999,
+                timeoutMs,
+            ),
+        ).toBe(false);
+        expect(
+            isAiSessionStreamAckStale(
+                {
+                    lastAckSeq: 3,
+                    lastSentAt: 1_000,
+                    lastSentSeq: 4,
+                },
+                3_000,
+                timeoutMs,
+            ),
+        ).toBe(true);
+    });
+
+    it("builds recovery diagnostics from ack state", () => {
+        expect(
+            buildAiSessionStreamRecoveryDiagnostic({
+                nowMs: 4_500,
+                pendingCriticalPayloadCount: 2,
+                reason: "ack-timeout",
+                state: {
+                    lastAckSeq: 7,
+                    lastSentAt: 2_000,
+                    lastSentSeq: 9,
+                },
+            }),
+        ).toEqual({
+            ackLagMs: 2_500,
+            lastAckSeq: 7,
+            lastSentSeq: 9,
+            pendingCriticalPayloadCount: 2,
+            reason: "ack-timeout",
+        });
+    });
+});

--- a/src/main/ai/session-stream.test.ts
+++ b/src/main/ai/session-stream.test.ts
@@ -489,6 +489,51 @@ describe("AI session stream helpers", () => {
         ]);
     });
 
+    it("builds recovery fallback payloads with visible transcript payloads before authoritative snapshots", () => {
+        const started = createVisibleTranscriptEvent("message-started");
+        const delta = createVisibleTranscriptEvent(
+            "message-delta",
+            "message-1",
+            "Partial",
+        );
+        const snapshot = {
+            ...createSnapshot("idle"),
+            messages: [
+                {
+                    attachments: [],
+                    content: "Partial response complete",
+                    createdAt: "2026-04-14T00:00:00.000Z",
+                    id: "message-1",
+                    kind: "assistant",
+                    status: "completed",
+                },
+            ],
+        } satisfies AiSessionSnapshot;
+
+        expect(
+            buildAiSessionStreamRecoveryFallbackPayloads({
+                pendingPreservedPayloads: [
+                    {
+                        payload: delta,
+                        seq: 12,
+                    },
+                    {
+                        payload: started,
+                        seq: 10,
+                    },
+                ],
+                resyncSnapshots: [snapshot],
+            }),
+        ).toEqual([
+            started,
+            delta,
+            {
+                kind: "snapshot",
+                snapshot,
+            },
+        ]);
+    });
+
     it("does not add resync snapshots when none are available", () => {
         const critical = createCompletedEvent("thinking-completed");
 

--- a/src/main/ai/session-stream.ts
+++ b/src/main/ai/session-stream.ts
@@ -13,6 +13,7 @@ export type AiSessionStreamRecoveryReason =
 
 export interface AiSessionStreamAckState {
     readonly lastAckSeq: number;
+    readonly pendingAckSentAtBySeq: ReadonlyMap<number, number>;
     readonly lastSentAt: number;
     readonly lastSentSeq: number;
 }
@@ -185,9 +186,9 @@ export function isAiSessionStreamAckStale(
     nowMs: number,
     staleMs: number,
 ): boolean {
+    const oldestPendingSentAt = getOldestPendingAiSessionStreamAckSentAt(state);
     return (
-        state.lastSentSeq > state.lastAckSeq &&
-        nowMs - state.lastSentAt >= staleMs
+        oldestPendingSentAt !== null && nowMs - oldestPendingSentAt >= staleMs
     );
 }
 
@@ -198,8 +199,14 @@ export function buildAiSessionStreamRecoveryDiagnostic(input: {
     readonly resyncSnapshotCount: number;
     readonly state: AiSessionStreamAckState;
 }): AiSessionStreamRecoveryDiagnostic {
+    const oldestPendingSentAt = getOldestPendingAiSessionStreamAckSentAt(
+        input.state,
+    );
     return {
-        ackLagMs: Math.max(0, input.nowMs - input.state.lastSentAt),
+        ackLagMs:
+            oldestPendingSentAt === null
+                ? 0
+                : Math.max(0, input.nowMs - oldestPendingSentAt),
         lastAckSeq: input.state.lastAckSeq,
         lastSentSeq: input.state.lastSentSeq,
         pendingPreservedPayloadCount: input.pendingPreservedPayloadCount,
@@ -223,4 +230,20 @@ export function buildAiSessionStreamRecoveryFallbackPayloads(input: {
     );
 
     return [...pendingPayloads, ...snapshotPayloads];
+}
+
+function getOldestPendingAiSessionStreamAckSentAt(
+    state: AiSessionStreamAckState,
+): number | null {
+    let oldestPendingSentAt: number | null = null;
+    for (const [seq, sentAt] of state.pendingAckSentAtBySeq) {
+        if (seq <= state.lastAckSeq) {
+            continue;
+        }
+        if (oldestPendingSentAt === null || sentAt < oldestPendingSentAt) {
+            oldestPendingSentAt = sentAt;
+        }
+    }
+
+    return oldestPendingSentAt;
 }

--- a/src/main/ai/session-stream.ts
+++ b/src/main/ai/session-stream.ts
@@ -1,4 +1,5 @@
 import type {
+    AiSessionSnapshot,
     AiSessionStreamPayload,
     AiSessionUpdate,
 } from "@shared/ipc";
@@ -22,6 +23,12 @@ export interface AiSessionStreamRecoveryDiagnostic {
     readonly lastSentSeq: number;
     readonly pendingCriticalPayloadCount: number;
     readonly reason: AiSessionStreamRecoveryReason;
+    readonly resyncSnapshotCount: number;
+}
+
+export interface PendingCriticalAiSessionStreamPayload {
+    readonly payload: AiSessionStreamPayload;
+    readonly seq: number;
 }
 
 export type AiSessionStreamPayloadKind = AiSessionStreamPayload["kind"];
@@ -77,6 +84,7 @@ export function buildAiSessionStreamRecoveryDiagnostic(input: {
     readonly nowMs: number;
     readonly pendingCriticalPayloadCount: number;
     readonly reason: AiSessionStreamRecoveryReason;
+    readonly resyncSnapshotCount: number;
     readonly state: AiSessionStreamAckState;
 }): AiSessionStreamRecoveryDiagnostic {
     return {
@@ -85,5 +93,23 @@ export function buildAiSessionStreamRecoveryDiagnostic(input: {
         lastSentSeq: input.state.lastSentSeq,
         pendingCriticalPayloadCount: input.pendingCriticalPayloadCount,
         reason: input.reason,
+        resyncSnapshotCount: input.resyncSnapshotCount,
     };
+}
+
+export function buildAiSessionStreamRecoveryFallbackPayloads(input: {
+    readonly pendingCriticalPayloads: readonly PendingCriticalAiSessionStreamPayload[];
+    readonly resyncSnapshots: readonly AiSessionSnapshot[];
+}): readonly AiSessionStreamPayload[] {
+    const pendingPayloads = [...input.pendingCriticalPayloads]
+        .sort((left, right) => left.seq - right.seq)
+        .map((entry) => entry.payload);
+    const snapshotPayloads = input.resyncSnapshots.map(
+        (snapshot): AiSessionUpdate => ({
+            kind: "snapshot",
+            snapshot,
+        }),
+    );
+
+    return [...pendingPayloads, ...snapshotPayloads];
 }

--- a/src/main/ai/session-stream.ts
+++ b/src/main/ai/session-stream.ts
@@ -21,15 +21,26 @@ export interface AiSessionStreamRecoveryDiagnostic {
     readonly ackLagMs: number;
     readonly lastAckSeq: number;
     readonly lastSentSeq: number;
-    readonly pendingCriticalPayloadCount: number;
+    readonly pendingPreservedPayloadCount: number;
     readonly reason: AiSessionStreamRecoveryReason;
     readonly resyncSnapshotCount: number;
 }
 
-export interface PendingCriticalAiSessionStreamPayload {
+export interface PendingPreservedAiSessionStreamPayload {
     readonly payload: AiSessionStreamPayload;
     readonly seq: number;
 }
+
+export interface AiSessionStreamPreservationResult {
+    readonly droppedOldest: boolean;
+    readonly pendingCount: number;
+    readonly preserved: boolean;
+}
+
+export type AiSessionStreamPreservationQueue = Map<
+    string,
+    PendingPreservedAiSessionStreamPayload
+>;
 
 export type AiSessionStreamPayloadKind = AiSessionStreamPayload["kind"];
 
@@ -69,6 +80,106 @@ export function isCriticalAiSessionStreamPayload(
     );
 }
 
+export function isPreservableAiSessionStreamPayload(
+    payload: AiSessionStreamPayload,
+): boolean {
+    if (isCriticalAiSessionStreamPayload(payload)) {
+        return true;
+    }
+
+    if (payload.kind === "patch") {
+        return (
+            payload.patch.changes.messages !== undefined ||
+            payload.patch.changes.toolActivity !== undefined
+        );
+    }
+
+    return (
+        payload.kind === "message-started" ||
+        payload.kind === "message-delta" ||
+        payload.kind === "thinking-started" ||
+        payload.kind === "thinking-delta"
+    );
+}
+
+export function getAiSessionStreamPreservationKey(
+    payload: AiSessionStreamPayload,
+): string | null {
+    if (!isPreservableAiSessionStreamPayload(payload)) {
+        return null;
+    }
+
+    if (payload.kind === "patch") {
+        return `${payload.patch.sessionId}:patch`;
+    }
+
+    if (payload.kind === "snapshot") {
+        return `${payload.snapshot.sessionId}:snapshot`;
+    }
+
+    if (
+        payload.kind === "message-started" ||
+        payload.kind === "thinking-started"
+    ) {
+        return `${payload.sessionId}:${payload.message.id}:${payload.kind}`;
+    }
+
+    if (
+        payload.kind === "message-delta" ||
+        payload.kind === "thinking-delta" ||
+        payload.kind === "message-completed" ||
+        payload.kind === "thinking-completed"
+    ) {
+        return `${payload.sessionId}:${payload.messageId}:${payload.kind}`;
+    }
+
+    return `${payload.sessionId}:${payload.kind}`;
+}
+
+export function rememberAiSessionStreamPayloadForRecovery(input: {
+    readonly maxPayloads: number;
+    readonly payload: AiSessionStreamPayload;
+    readonly queue: AiSessionStreamPreservationQueue;
+    readonly seq: number;
+}): AiSessionStreamPreservationResult {
+    const key = getAiSessionStreamPreservationKey(input.payload);
+    if (key === null) {
+        return {
+            droppedOldest: false,
+            pendingCount: input.queue.size,
+            preserved: false,
+        };
+    }
+
+    input.queue.set(key, {
+        payload: input.payload,
+        seq: input.seq,
+    });
+
+    let droppedOldest = false;
+    while (input.queue.size > input.maxPayloads) {
+        let oldestKey: string | null = null;
+        let oldestSeq = Number.POSITIVE_INFINITY;
+        for (const [candidateKey, pendingPayload] of input.queue) {
+            if (pendingPayload.seq < oldestSeq) {
+                oldestKey = candidateKey;
+                oldestSeq = pendingPayload.seq;
+            }
+        }
+        if (oldestKey === null) {
+            break;
+        }
+        input.queue.delete(oldestKey);
+        droppedOldest = true;
+    }
+
+    return {
+        droppedOldest,
+        pendingCount: input.queue.size,
+        preserved: input.queue.has(key),
+    };
+}
+
 export function isAiSessionStreamAckStale(
     state: AiSessionStreamAckState,
     nowMs: number,
@@ -82,7 +193,7 @@ export function isAiSessionStreamAckStale(
 
 export function buildAiSessionStreamRecoveryDiagnostic(input: {
     readonly nowMs: number;
-    readonly pendingCriticalPayloadCount: number;
+    readonly pendingPreservedPayloadCount: number;
     readonly reason: AiSessionStreamRecoveryReason;
     readonly resyncSnapshotCount: number;
     readonly state: AiSessionStreamAckState;
@@ -91,17 +202,17 @@ export function buildAiSessionStreamRecoveryDiagnostic(input: {
         ackLagMs: Math.max(0, input.nowMs - input.state.lastSentAt),
         lastAckSeq: input.state.lastAckSeq,
         lastSentSeq: input.state.lastSentSeq,
-        pendingCriticalPayloadCount: input.pendingCriticalPayloadCount,
+        pendingPreservedPayloadCount: input.pendingPreservedPayloadCount,
         reason: input.reason,
         resyncSnapshotCount: input.resyncSnapshotCount,
     };
 }
 
 export function buildAiSessionStreamRecoveryFallbackPayloads(input: {
-    readonly pendingCriticalPayloads: readonly PendingCriticalAiSessionStreamPayload[];
+    readonly pendingPreservedPayloads: readonly PendingPreservedAiSessionStreamPayload[];
     readonly resyncSnapshots: readonly AiSessionSnapshot[];
 }): readonly AiSessionStreamPayload[] {
-    const pendingPayloads = [...input.pendingCriticalPayloads]
+    const pendingPayloads = [...input.pendingPreservedPayloads]
         .sort((left, right) => left.seq - right.seq)
         .map((entry) => entry.payload);
     const snapshotPayloads = input.resyncSnapshots.map(

--- a/src/main/ai/session-stream.ts
+++ b/src/main/ai/session-stream.ts
@@ -1,0 +1,89 @@
+import type {
+    AiSessionStreamPayload,
+    AiSessionUpdate,
+} from "@shared/ipc";
+
+export type AiSessionStreamRecoveryReason =
+    | "ack-timeout"
+    | "heartbeat-error"
+    | "heartbeat-stale"
+    | "post-error"
+    | "pre-send-stale";
+
+export interface AiSessionStreamAckState {
+    readonly lastAckSeq: number;
+    readonly lastSentAt: number;
+    readonly lastSentSeq: number;
+}
+
+export interface AiSessionStreamRecoveryDiagnostic {
+    readonly ackLagMs: number;
+    readonly lastAckSeq: number;
+    readonly lastSentSeq: number;
+    readonly pendingCriticalPayloadCount: number;
+    readonly reason: AiSessionStreamRecoveryReason;
+}
+
+export type AiSessionStreamPayloadKind = AiSessionStreamPayload["kind"];
+
+export function getAiSessionStreamPayloadKind(
+    payload: AiSessionStreamPayload,
+): AiSessionStreamPayloadKind {
+    return payload.kind;
+}
+
+export function isAiSessionUpdate(
+    payload: AiSessionStreamPayload,
+): payload is AiSessionUpdate {
+    return payload.kind === "patch" || payload.kind === "snapshot";
+}
+
+export function isCriticalAiSessionStreamPayload(
+    payload: AiSessionStreamPayload,
+): boolean {
+    if (isAiSessionUpdate(payload)) {
+        const status =
+            payload.kind === "snapshot"
+                ? payload.snapshot.status
+                : payload.patch.changes.status;
+        return status === "idle" || status === "error";
+    }
+
+    if (
+        payload.kind === "message-completed" ||
+        payload.kind === "thinking-completed"
+    ) {
+        return true;
+    }
+
+    return (
+        payload.kind === "status" &&
+        (payload.status === "idle" || payload.status === "error")
+    );
+}
+
+export function isAiSessionStreamAckStale(
+    state: AiSessionStreamAckState,
+    nowMs: number,
+    staleMs: number,
+): boolean {
+    return (
+        state.lastSentSeq > state.lastAckSeq &&
+        nowMs - state.lastSentAt >= staleMs
+    );
+}
+
+export function buildAiSessionStreamRecoveryDiagnostic(input: {
+    readonly nowMs: number;
+    readonly pendingCriticalPayloadCount: number;
+    readonly reason: AiSessionStreamRecoveryReason;
+    readonly state: AiSessionStreamAckState;
+}): AiSessionStreamRecoveryDiagnostic {
+    return {
+        ackLagMs: Math.max(0, input.nowMs - input.state.lastSentAt),
+        lastAckSeq: input.state.lastAckSeq,
+        lastSentSeq: input.state.lastSentSeq,
+        pendingCriticalPayloadCount: input.pendingCriticalPayloadCount,
+        reason: input.reason,
+    };
+}

--- a/src/main/ai/session-stream.ts
+++ b/src/main/ai/session-stream.ts
@@ -152,10 +152,30 @@ export function rememberAiSessionStreamPayloadForRecovery(input: {
         };
     }
 
-    input.queue.set(key, {
-        payload: input.payload,
-        seq: input.seq,
-    });
+    const existing = input.queue.get(key);
+    if (
+        existing?.payload.kind === "patch" &&
+        input.payload.kind === "patch"
+    ) {
+        input.queue.set(key, {
+            payload: {
+                kind: "patch",
+                patch: {
+                    ...input.payload.patch,
+                    changes: {
+                        ...existing.payload.patch.changes,
+                        ...input.payload.patch.changes,
+                    },
+                },
+            },
+            seq: input.seq,
+        });
+    } else {
+        input.queue.set(key, {
+            payload: input.payload,
+            seq: input.seq,
+        });
+    }
 
     let droppedOldest = false;
     while (input.queue.size > input.maxPayloads) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -124,6 +124,7 @@ type AiSessionStreamPortState = {
     lastSentAt: number;
     lastSentSeq: number;
     nextSeq: number;
+    readonly pendingAckSentAtBySeq: Map<number, number>;
     readonly pendingPreservedPayloads: AiSessionStreamPreservationQueue;
     staleTimer: ReturnType<typeof setTimeout> | null;
 };
@@ -1121,6 +1122,7 @@ function attachAiSessionStream(window: BrowserWindow, windowId: string): void {
             lastSentAt: now,
             lastSentSeq: 0,
             nextSeq: 1,
+            pendingAckSentAtBySeq: new Map(),
             pendingPreservedPayloads: new Map(),
             port: channel.port1,
             staleTimer: null,
@@ -1182,6 +1184,11 @@ function handleAiSessionStreamPortMessage(
 
     state.lastAckAt = Date.now();
     state.lastAckSeq = Math.max(state.lastAckSeq, candidate.seq);
+    for (const seq of [...state.pendingAckSentAtBySeq.keys()]) {
+        if (seq <= state.lastAckSeq) {
+            state.pendingAckSentAtBySeq.delete(seq);
+        }
+    }
     for (const [key, pendingPayload] of state.pendingPreservedPayloads) {
         if (pendingPayload.seq <= state.lastAckSeq) {
             state.pendingPreservedPayloads.delete(key);
@@ -1197,6 +1204,7 @@ function nextAiSessionStreamMessage(
     state.nextSeq += 1;
     state.lastSentAt = Date.now();
     state.lastSentSeq = seq;
+    state.pendingAckSentAtBySeq.set(seq, state.lastSentAt);
     return {
         payload,
         seq,
@@ -1211,6 +1219,7 @@ function nextAiSessionStreamPing(
     state.nextSeq += 1;
     state.lastSentAt = Date.now();
     state.lastSentSeq = seq;
+    state.pendingAckSentAtBySeq.set(seq, state.lastSentAt);
     return {
         sentAt: state.lastSentAt,
         seq,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,7 +38,8 @@ import {
     buildAiSessionStreamRecoveryDiagnostic,
     isAiSessionStreamAckStale,
     isAiSessionUpdate,
-    isCriticalAiSessionStreamPayload,
+    rememberAiSessionStreamPayloadForRecovery,
+    type AiSessionStreamPreservationQueue,
     type AiSessionStreamRecoveryReason,
 } from "./ai/session-stream";
 import { GitHubService } from "./github/service";
@@ -111,14 +112,9 @@ let isFinalizingQuit = false;
 let hasRequestedNativeBackendTestEvent = false;
 let pendingShutdown: Promise<void> | null = null;
 
-const AI_SESSION_STREAM_ACK_STALE_MS = 2_000;
+const AI_SESSION_STREAM_ACK_STALE_MS = 10_000;
 const AI_SESSION_STREAM_HEARTBEAT_MS = 1_000;
-
-type PendingCriticalAiSessionStreamPayload = {
-    readonly payload: AiSessionStreamPayload;
-    readonly sentAt: number;
-    readonly seq: number;
-};
+const AI_SESSION_STREAM_MAX_PRESERVED_PAYLOADS = 100;
 
 type AiSessionStreamPortState = {
     readonly port: MessagePortMain;
@@ -128,10 +124,7 @@ type AiSessionStreamPortState = {
     lastSentAt: number;
     lastSentSeq: number;
     nextSeq: number;
-    readonly pendingCriticalPayloads: Map<
-        number,
-        PendingCriticalAiSessionStreamPayload
-    >;
+    readonly pendingPreservedPayloads: AiSessionStreamPreservationQueue;
     staleTimer: ReturnType<typeof setTimeout> | null;
 };
 
@@ -1128,7 +1121,7 @@ function attachAiSessionStream(window: BrowserWindow, windowId: string): void {
             lastSentAt: now,
             lastSentSeq: 0,
             nextSeq: 1,
-            pendingCriticalPayloads: new Map(),
+            pendingPreservedPayloads: new Map(),
             port: channel.port1,
             staleTimer: null,
         };
@@ -1189,9 +1182,9 @@ function handleAiSessionStreamPortMessage(
 
     state.lastAckAt = Date.now();
     state.lastAckSeq = Math.max(state.lastAckSeq, candidate.seq);
-    for (const seq of [...state.pendingCriticalPayloads.keys()]) {
-        if (seq <= state.lastAckSeq) {
-            state.pendingCriticalPayloads.delete(seq);
+    for (const [key, pendingPayload] of state.pendingPreservedPayloads) {
+        if (pendingPayload.seq <= state.lastAckSeq) {
+            state.pendingPreservedPayloads.delete(key);
         }
     }
 }
@@ -1223,6 +1216,34 @@ function nextAiSessionStreamPing(
         seq,
         type: "ping",
     };
+}
+
+function preserveAiSessionStreamPayload(
+    windowId: string,
+    state: AiSessionStreamPortState,
+    payload: AiSessionStreamPayload,
+    seq: number,
+): void {
+    const result = rememberAiSessionStreamPayloadForRecovery({
+        maxPayloads: AI_SESSION_STREAM_MAX_PRESERVED_PAYLOADS,
+        payload,
+        queue: state.pendingPreservedPayloads,
+        seq,
+    });
+    if (!result.droppedOldest) {
+        return;
+    }
+
+    debugBenignError(
+        "aiSessionStreamPort.preservedPayloads",
+        new Error(
+            JSON.stringify({
+                limit: AI_SESSION_STREAM_MAX_PRESERVED_PAYLOADS,
+                pendingPreservedPayloadCount: result.pendingCount,
+                windowId,
+            }),
+        ),
+    );
 }
 
 function sendAiSessionStreamHeartbeat(windowId: string): void {
@@ -1283,7 +1304,8 @@ function recoverAiSessionStreamPort(
 ): void {
     const state = aiSessionStreamPorts.get(windowId);
     const targetWindow = windowRegistry.getWindowByStableId(windowId);
-    const pendingCriticalPayloadCount = state?.pendingCriticalPayloads.size ?? 0;
+    const pendingPreservedPayloadCount =
+        state?.pendingPreservedPayloads.size ?? 0;
     const canSendFallback = Boolean(targetWindow && !targetWindow.isDestroyed());
     const resyncSnapshots = canSendFallback
         ? (aiService?.getLiveSessionSnapshotsForWindow(windowId) ?? [])
@@ -1291,12 +1313,12 @@ function recoverAiSessionStreamPort(
 
     if (targetWindow && canSendFallback) {
         const fallbackPayloads = buildAiSessionStreamRecoveryFallbackPayloads({
-            pendingCriticalPayloads: state
-                ? [...state.pendingCriticalPayloads.values()]
+            pendingPreservedPayloads: state
+                ? [...state.pendingPreservedPayloads.values()]
                 : [],
             resyncSnapshots,
         });
-        state?.pendingCriticalPayloads.clear();
+        state?.pendingPreservedPayloads.clear();
         for (const payload of fallbackPayloads) {
             sendAiSessionStreamPayloadOverIpc(targetWindow, payload);
         }
@@ -1306,7 +1328,7 @@ function recoverAiSessionStreamPort(
         ? JSON.stringify(
               buildAiSessionStreamRecoveryDiagnostic({
                   nowMs: Date.now(),
-                  pendingCriticalPayloadCount,
+                  pendingPreservedPayloadCount,
                   reason,
                   resyncSnapshotCount: resyncSnapshots.length,
                   state,
@@ -1352,13 +1374,7 @@ function postAiSessionStreamPayload(
     }
 
     const message = nextAiSessionStreamMessage(state, payload);
-    if (isCriticalAiSessionStreamPayload(payload)) {
-        state.pendingCriticalPayloads.set(message.seq, {
-            payload,
-            sentAt: state.lastSentAt,
-            seq: message.seq,
-        });
-    }
+    preserveAiSessionStreamPayload(windowId, state, payload, message.seq);
 
     try {
         state.port.postMessage(message);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,7 @@ import type { SecretStoreGateway } from "./ai/secret-store";
 import { AiService } from "./ai/service";
 import type { NormalizedSessionCatalogPayload } from "./ai/session-core";
 import {
+    buildAiSessionStreamRecoveryFallbackPayloads,
     buildAiSessionStreamRecoveryDiagnostic,
     isAiSessionStreamAckStale,
     isAiSessionUpdate,
@@ -1283,15 +1284,31 @@ function recoverAiSessionStreamPort(
     const state = aiSessionStreamPorts.get(windowId);
     const targetWindow = windowRegistry.getWindowByStableId(windowId);
     const pendingCriticalPayloadCount = state?.pendingCriticalPayloads.size ?? 0;
-    if (state && targetWindow && !targetWindow.isDestroyed()) {
-        flushPendingCriticalAiSessionPayloads(targetWindow, state);
+    const canSendFallback = Boolean(targetWindow && !targetWindow.isDestroyed());
+    const resyncSnapshots = canSendFallback
+        ? (aiService?.getLiveSessionSnapshotsForWindow(windowId) ?? [])
+        : [];
+
+    if (targetWindow && canSendFallback) {
+        const fallbackPayloads = buildAiSessionStreamRecoveryFallbackPayloads({
+            pendingCriticalPayloads: state
+                ? [...state.pendingCriticalPayloads.values()]
+                : [],
+            resyncSnapshots,
+        });
+        state?.pendingCriticalPayloads.clear();
+        for (const payload of fallbackPayloads) {
+            sendAiSessionStreamPayloadOverIpc(targetWindow, payload);
+        }
     }
+
     const message = state
         ? JSON.stringify(
               buildAiSessionStreamRecoveryDiagnostic({
                   nowMs: Date.now(),
                   pendingCriticalPayloadCount,
                   reason,
+                  resyncSnapshotCount: resyncSnapshots.length,
                   state,
               }),
           )
@@ -1300,20 +1317,6 @@ function recoverAiSessionStreamPort(
     detachAiSessionStream(windowId);
     if (targetWindow && !targetWindow.isDestroyed()) {
         attachAiSessionStream(targetWindow, windowId);
-    }
-}
-
-function flushPendingCriticalAiSessionPayloads(
-    window: BrowserWindow,
-    state: AiSessionStreamPortState,
-): void {
-    const pending = [...state.pendingCriticalPayloads.values()].sort(
-        (left, right) => left.seq - right.seq,
-    );
-    state.pendingCriticalPayloads.clear();
-
-    for (const entry of pending) {
-        sendAiSessionStreamPayloadOverIpc(window, entry.payload);
     }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,6 +33,13 @@ import { appChannel, appIdentity, configureMainProcessApp } from "./app-runtime"
 import type { SecretStoreGateway } from "./ai/secret-store";
 import { AiService } from "./ai/service";
 import type { NormalizedSessionCatalogPayload } from "./ai/session-core";
+import {
+    buildAiSessionStreamRecoveryDiagnostic,
+    isAiSessionStreamAckStale,
+    isAiSessionUpdate,
+    isCriticalAiSessionStreamPayload,
+    type AiSessionStreamRecoveryReason,
+} from "./ai/session-stream";
 import { GitHubService } from "./github/service";
 import {
     installFilePreviewProtocol,
@@ -1223,7 +1230,13 @@ function sendAiSessionStreamHeartbeat(windowId: string): void {
         return;
     }
 
-    if (isAiSessionStreamAckStale(state)) {
+    if (
+        isAiSessionStreamAckStale(
+            state,
+            Date.now(),
+            AI_SESSION_STREAM_ACK_STALE_MS,
+        )
+    ) {
         recoverAiSessionStreamPort(windowId, "heartbeat-stale");
         return;
     }
@@ -1237,13 +1250,6 @@ function sendAiSessionStreamHeartbeat(windowId: string): void {
     }
 }
 
-function isAiSessionStreamAckStale(state: AiSessionStreamPortState): boolean {
-    return (
-        state.lastSentSeq > state.lastAckSeq &&
-        Date.now() - state.lastSentAt >= AI_SESSION_STREAM_ACK_STALE_MS
-    );
-}
-
 function scheduleAiSessionStreamStaleCheck(windowId: string): void {
     const state = aiSessionStreamPorts.get(windowId);
     if (!state) {
@@ -1255,7 +1261,14 @@ function scheduleAiSessionStreamStaleCheck(windowId: string): void {
     }
     state.staleTimer = setTimeout(() => {
         const latestState = aiSessionStreamPorts.get(windowId);
-        if (!latestState || !isAiSessionStreamAckStale(latestState)) {
+        if (
+            !latestState ||
+            !isAiSessionStreamAckStale(
+                latestState,
+                Date.now(),
+                AI_SESSION_STREAM_ACK_STALE_MS,
+            )
+        ) {
             return;
         }
         recoverAiSessionStreamPort(windowId, "ack-timeout");
@@ -1263,13 +1276,27 @@ function scheduleAiSessionStreamStaleCheck(windowId: string): void {
     state.staleTimer.unref?.();
 }
 
-function recoverAiSessionStreamPort(windowId: string, reason: string): void {
+function recoverAiSessionStreamPort(
+    windowId: string,
+    reason: AiSessionStreamRecoveryReason,
+): void {
     const state = aiSessionStreamPorts.get(windowId);
     const targetWindow = windowRegistry.getWindowByStableId(windowId);
+    const pendingCriticalPayloadCount = state?.pendingCriticalPayloads.size ?? 0;
     if (state && targetWindow && !targetWindow.isDestroyed()) {
         flushPendingCriticalAiSessionPayloads(targetWindow, state);
     }
-    debugBenignError("aiSessionStreamPort.recover", new Error(reason));
+    const message = state
+        ? JSON.stringify(
+              buildAiSessionStreamRecoveryDiagnostic({
+                  nowMs: Date.now(),
+                  pendingCriticalPayloadCount,
+                  reason,
+                  state,
+              }),
+          )
+        : reason;
+    debugBenignError("aiSessionStreamPort.recover", new Error(message));
     detachAiSessionStream(windowId);
     if (targetWindow && !targetWindow.isDestroyed()) {
         attachAiSessionStream(targetWindow, windowId);
@@ -1301,33 +1328,6 @@ function sendAiSessionStreamPayloadOverIpc(
     }
 }
 
-function isAiSessionUpdate(
-    payload: AiSessionStreamPayload,
-): payload is AiSessionUpdate {
-    return payload.kind === "patch" || payload.kind === "snapshot";
-}
-
-function isCriticalAiSessionStreamPayload(
-    payload: AiSessionStreamPayload,
-): boolean {
-    if (isAiSessionUpdate(payload)) {
-        const status =
-            payload.kind === "snapshot"
-                ? payload.snapshot.status
-                : payload.patch.changes.status;
-        return status === "idle" || status === "error";
-    }
-
-    if (payload.kind === "message-completed" || payload.kind === "thinking-completed") {
-        return true;
-    }
-
-    return (
-        payload.kind === "status" &&
-        (payload.status === "idle" || payload.status === "error")
-    );
-}
-
 function postAiSessionStreamPayload(
     windowId: string,
     payload: AiSessionStreamPayload,
@@ -1337,7 +1337,13 @@ function postAiSessionStreamPayload(
         return false;
     }
 
-    if (isAiSessionStreamAckStale(state)) {
+    if (
+        isAiSessionStreamAckStale(
+            state,
+            Date.now(),
+            AI_SESSION_STREAM_ACK_STALE_MS,
+        )
+    ) {
         recoverAiSessionStreamPort(windowId, "pre-send-stale");
         return false;
     }

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -337,6 +337,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.getAiEnvironmentDiagnostics);
     ipcMain.removeHandler(IPC_CHANNELS.getAiRuntimeStatus);
     ipcMain.removeHandler(IPC_CHANNELS.getAiSessionSnapshot);
+    ipcMain.removeHandler(IPC_CHANNELS.resyncAiSession);
     ipcMain.removeHandler(IPC_CHANNELS.listAiSessionHistory);
     ipcMain.removeHandler(IPC_CHANNELS.getAiSessionTranscriptPage);
     ipcMain.removeHandler(IPC_CHANNELS.sendAiPrompt);
@@ -1731,6 +1732,13 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         (_event, sessionId: string) =>
             options.aiService.getSessionSnapshot(sessionId),
     );
+    ipcMain.handle(IPC_CHANNELS.resyncAiSession, (event, sessionId: string) => {
+        const context = requireWindowContext(event.sender, "main");
+        return options.aiService.getLiveSessionSnapshotForWindow(
+            context.windowId,
+            sessionId,
+        );
+    });
     ipcMain.handle(
         IPC_CHANNELS.getAiSessionTranscriptPage,
         (_event, input: GetAiSessionTranscriptPageInput) =>

--- a/src/preload/ai-session-stream.test.ts
+++ b/src/preload/ai-session-stream.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+    AiSessionDomainEvent,
+    AiSessionStreamMessage,
+    AiSessionStreamPayload,
+} from "@shared/ipc";
+
+import { deliverAiSessionStreamMessage } from "./ai-session-stream";
+
+function createPayload(): AiSessionStreamPayload {
+    return {
+        kind: "status",
+        activeTurnStartedAt: null,
+        lastError: null,
+        origin: "live",
+        parentSessionId: null,
+        runtimeId: "codex",
+        runtimeSessionId: "runtime-session-1",
+        sessionId: "session-1",
+        status: "streaming",
+        updatedAt: "2026-04-14T00:00:00.000Z",
+    } satisfies AiSessionDomainEvent;
+}
+
+function createMessage(
+    payload: AiSessionStreamPayload = createPayload(),
+): AiSessionStreamMessage {
+    return {
+        payload,
+        seq: 7,
+        type: "payload",
+    };
+}
+
+function createHandlers() {
+    return {
+        acknowledge: vi.fn(),
+        notifyPayload: vi.fn(),
+        reportDispatchError: vi.fn(),
+        reportWarning: vi.fn(),
+    };
+}
+
+describe("AI session stream preload delivery", () => {
+    it("acknowledges valid payloads before notifying listeners", () => {
+        const handlers = createHandlers();
+
+        deliverAiSessionStreamMessage(createMessage(), handlers);
+
+        expect(handlers.acknowledge).toHaveBeenCalledWith(7);
+        expect(handlers.notifyPayload).toHaveBeenCalledTimes(1);
+        expect(handlers.acknowledge.mock.invocationCallOrder[0]).toBeLessThan(
+            handlers.notifyPayload.mock.invocationCallOrder[0],
+        );
+    });
+
+    it("acknowledges a valid payload even when listener dispatch fails", () => {
+        const error = new Error("listener failed");
+        const handlers = createHandlers();
+        handlers.notifyPayload.mockImplementation(() => {
+            throw error;
+        });
+
+        deliverAiSessionStreamMessage(createMessage(), handlers);
+
+        expect(handlers.acknowledge).toHaveBeenCalledWith(7);
+        expect(handlers.reportDispatchError).toHaveBeenCalledWith(
+            "[comando] AI session stream listener dispatch failed.",
+            error,
+        );
+    });
+
+    it("does not acknowledge or notify invalid envelopes", () => {
+        const handlers = createHandlers();
+
+        deliverAiSessionStreamMessage({ seq: 7, type: "payload" }, handlers);
+
+        expect(handlers.acknowledge).not.toHaveBeenCalled();
+        expect(handlers.notifyPayload).not.toHaveBeenCalled();
+        expect(handlers.reportWarning).toHaveBeenCalledWith(
+            "[comando] Dropped AI session stream envelope.",
+        );
+    });
+
+    it("logs ACK failures and still notifies valid payload listeners", () => {
+        const error = new Error("port closed");
+        const handlers = createHandlers();
+        handlers.acknowledge.mockImplementation(() => {
+            throw error;
+        });
+
+        deliverAiSessionStreamMessage(createMessage(), handlers);
+
+        expect(handlers.reportWarning).toHaveBeenCalledWith(
+            "[comando] Failed to acknowledge AI session stream.",
+            error,
+        );
+        expect(handlers.notifyPayload).toHaveBeenCalledWith(createPayload());
+    });
+});

--- a/src/preload/ai-session-stream.test.ts
+++ b/src/preload/ai-session-stream.test.ts
@@ -55,6 +55,22 @@ describe("AI session stream preload delivery", () => {
         );
     });
 
+    it("acknowledges ping envelopes without notifying payload listeners", () => {
+        const handlers = createHandlers();
+
+        deliverAiSessionStreamMessage(
+            {
+                sentAt: 1_000,
+                seq: 8,
+                type: "ping",
+            },
+            handlers,
+        );
+
+        expect(handlers.acknowledge).toHaveBeenCalledWith(8);
+        expect(handlers.notifyPayload).not.toHaveBeenCalled();
+    });
+
     it("acknowledges a valid payload even when listener dispatch fails", () => {
         const error = new Error("listener failed");
         const handlers = createHandlers();

--- a/src/preload/ai-session-stream.ts
+++ b/src/preload/ai-session-stream.ts
@@ -1,0 +1,63 @@
+import type { AiSessionStreamMessage } from "@shared/ipc";
+
+export interface AiSessionStreamDeliveryHandlers {
+    readonly acknowledge: (seq: number) => void;
+    readonly notifyPayload: (payload: unknown) => void;
+    readonly reportDispatchError: (message: string, error: unknown) => void;
+    readonly reportWarning: (message: string, error?: unknown) => void;
+}
+
+export function isAiSessionStreamMessage(
+    message: unknown,
+): message is AiSessionStreamMessage {
+    if (typeof message !== "object" || message === null) {
+        return false;
+    }
+
+    const candidate = message as {
+        readonly payload?: unknown;
+        readonly sentAt?: unknown;
+        readonly seq?: unknown;
+        readonly type?: unknown;
+    };
+    if (typeof candidate.seq !== "number") {
+        return false;
+    }
+    if (candidate.type === "payload") {
+        return candidate.payload !== undefined;
+    }
+    return candidate.type === "ping" && typeof candidate.sentAt === "number";
+}
+
+export function deliverAiSessionStreamMessage(
+    message: unknown,
+    handlers: AiSessionStreamDeliveryHandlers,
+): void {
+    if (!isAiSessionStreamMessage(message)) {
+        handlers.reportWarning("[comando] Dropped AI session stream envelope.");
+        return;
+    }
+
+    // ACK confirms delivery to preload, not completed renderer rendering.
+    try {
+        handlers.acknowledge(message.seq);
+    } catch (error) {
+        handlers.reportWarning(
+            "[comando] Failed to acknowledge AI session stream.",
+            error,
+        );
+    }
+
+    if (message.type !== "payload") {
+        return;
+    }
+
+    try {
+        handlers.notifyPayload(message.payload);
+    } catch (error) {
+        handlers.reportDispatchError(
+            "[comando] AI session stream listener dispatch failed.",
+            error,
+        );
+    }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1277,6 +1277,11 @@ const comandoApi: ComandoApi = {
                 sessionId,
             ),
         ),
+    resyncAiSession: async (sessionId: string) =>
+        assertIpcObjectOrNull<AiSessionSnapshot>(
+            IPC_CHANNELS.resyncAiSession,
+            await ipcRenderer.invoke(IPC_CHANNELS.resyncAiSession, sessionId),
+        ),
     getAiSessionTranscriptPage: (input: GetAiSessionTranscriptPageInput) =>
         ipcRenderer.invoke(
             IPC_CHANNELS.getAiSessionTranscriptPage,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,7 @@
 
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 
+import { deliverAiSessionStreamMessage } from "./ai-session-stream";
 import {
     IPC_CHANNELS,
     IPC_EVENTS,
@@ -13,7 +14,6 @@ import {
     type AiHistorySessionSummary,
     type AiSessionDomainEvent,
     type AiSessionStreamAckMessage,
-    type AiSessionStreamMessage,
     type AiSessionUpdate,
     type AiPermissionResponseInput,
     type AiRuntimeAuthDisconnectInput,
@@ -378,28 +378,6 @@ function notifyAiSessionStreamPayload(payload: unknown): void {
     console.warn("[comando] Dropped AI session stream payload.");
 }
 
-function isAiSessionStreamMessage(
-    message: unknown,
-): message is AiSessionStreamMessage {
-    if (typeof message !== "object" || message === null) {
-        return false;
-    }
-
-    const candidate = message as {
-        readonly payload?: unknown;
-        readonly sentAt?: unknown;
-        readonly seq?: unknown;
-        readonly type?: unknown;
-    };
-    if (typeof candidate.seq !== "number") {
-        return false;
-    }
-    if (candidate.type === "payload") {
-        return candidate.payload !== undefined;
-    }
-    return candidate.type === "ping" && typeof candidate.sentAt === "number";
-}
-
 function acknowledgeAiSessionStreamPort(seq: number): void {
     const port = aiSessionSnapshotPort;
     if (!port) {
@@ -410,26 +388,24 @@ function acknowledgeAiSessionStreamPort(seq: number): void {
         seq,
         type: "ack",
     };
-    try {
-        port.postMessage(message);
-    } catch (error) {
-        console.warn("[comando] Failed to acknowledge AI session stream.", error);
-    }
+    port.postMessage(message);
 }
 
 function notifyAiSessionStreamListeners(message: unknown): void {
-    if (!isAiSessionStreamMessage(message)) {
-        console.warn("[comando] Dropped AI session stream envelope.");
-        return;
-    }
-
-    try {
-        if (message.type === "payload") {
-            notifyAiSessionStreamPayload(message.payload);
-        }
-    } finally {
-        acknowledgeAiSessionStreamPort(message.seq);
-    }
+    deliverAiSessionStreamMessage(message, {
+        acknowledge: acknowledgeAiSessionStreamPort,
+        notifyPayload: notifyAiSessionStreamPayload,
+        reportDispatchError: (logMessage, error) => {
+            console.error(logMessage, error);
+        },
+        reportWarning: (logMessage, error) => {
+            if (error === undefined) {
+                console.warn(logMessage);
+                return;
+            }
+            console.warn(logMessage, error);
+        },
+    });
 }
 
 function bindAiSessionSnapshotPort(port: MessagePort): void {

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
     AiFileContextAttachment,
     AiImageAttachment,
+    AiMessage,
     AiRuntimeStatus,
     AiSessionDomainEvent,
     AiSessionSnapshot,
@@ -159,6 +160,18 @@ function createImageAttachment(
     };
 }
 
+function createMessage(overrides: Partial<AiMessage> = {}): AiMessage {
+    return {
+        attachments: [],
+        content: "Hello",
+        createdAt: "2026-04-14T00:00:00.000Z",
+        id: "message-1",
+        kind: "assistant",
+        status: "streaming",
+        ...overrides,
+    };
+}
+
 function createFileContext(
     overrides: Partial<AiFileContextAttachment> = {},
 ): AiFileContextAttachment {
@@ -243,6 +256,7 @@ describe("ai-store queue", () => {
             status: "idle",
         });
         vi.restoreAllMocks();
+        vi.useRealTimers();
     });
 
     it("keeps a command-only runtime catalog from status updates", () => {
@@ -341,6 +355,129 @@ describe("ai-store queue", () => {
         expect(
             useAiStore.getState().sessions[TAB.sessionId]?.snapshot?.title,
         ).toBe("Revisa login");
+    });
+
+    it("does not request resync for idle sessions", async () => {
+        vi.useFakeTimers();
+        const resyncAiSession = vi.fn().mockResolvedValue(null);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    resyncAiSession,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({ status: "idle" }),
+        );
+        await vi.advanceTimersByTimeAsync(20_000);
+
+        expect(resyncAiSession).not.toHaveBeenCalled();
+    });
+
+    it("does not request resync while active sessions keep making visible progress", async () => {
+        vi.useFakeTimers();
+        const resyncAiSession = vi.fn().mockResolvedValue(null);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    resyncAiSession,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                messages: [createMessage({ content: "Hel" })],
+                status: "streaming",
+                updatedAt: "2026-04-14T00:00:00.000Z",
+            }),
+        );
+        await vi.advanceTimersByTimeAsync(10_000);
+
+        useAiStore.getState().applySessionUpdate({
+            kind: "patch",
+            patch: {
+                changes: {
+                    messages: [createMessage({ content: "Hello" })],
+                    updatedAt: "2026-04-14T00:00:10.000Z",
+                },
+                runtimeId: TAB.runtimeId,
+                sessionId: TAB.sessionId,
+            },
+        });
+        await vi.advanceTimersByTimeAsync(19_999);
+        expect(resyncAiSession).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(resyncAiSession).toHaveBeenCalledTimes(1);
+    });
+
+    it("requests resync once for an unchanged active session", async () => {
+        vi.useFakeTimers();
+        const resyncAiSession = vi.fn().mockResolvedValue(null);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    resyncAiSession,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                messages: [createMessage()],
+                status: "streaming",
+            }),
+        );
+        await vi.advanceTimersByTimeAsync(20_000);
+        await vi.advanceTimersByTimeAsync(40_000);
+
+        expect(resyncAiSession).toHaveBeenCalledTimes(1);
+        expect(resyncAiSession).toHaveBeenCalledWith(TAB.sessionId);
+    });
+
+    it("applies a resynced snapshot without duplicating messages", async () => {
+        vi.useFakeTimers();
+        const message = createMessage({
+            content: "Complete",
+            status: "completed",
+        });
+        const resyncSnapshot = createSnapshot({
+            messages: [message],
+            status: "idle",
+            updatedAt: "2026-04-14T00:00:20.000Z",
+        });
+        const resyncAiSession = vi.fn().mockResolvedValue(resyncSnapshot);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    resyncAiSession,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                messages: [createMessage({ content: "Complete" })],
+                status: "streaming",
+            }),
+        );
+        await vi.advanceTimersByTimeAsync(20_000);
+
+        const snapshot =
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot ?? null;
+        expect(snapshot?.status).toBe("idle");
+        expect(snapshot?.messages).toEqual([message]);
     });
 
     it("applies a prepared runtime session snapshot from the backend", async () => {

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -480,6 +480,98 @@ describe("ai-store queue", () => {
         expect(snapshot?.messages).toEqual([message]);
     });
 
+    it("applies authoritative snapshots after visible transcript deltas were missed", () => {
+        useAiStore.getState().applySessionEvent(
+            createSessionEvent({
+                kind: "message-started",
+                message: createMessage({
+                    content: "",
+                    id: "assistant-1",
+                }),
+                messageKind: "assistant",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+        useAiStore.getState().applySessionEvent(
+            createSessionEvent({
+                content: "Hel",
+                delta: "Hel",
+                kind: "message-delta",
+                messageId: "assistant-1",
+                messageKind: "assistant",
+                updatedAt: "2026-04-14T00:00:02.000Z",
+            }),
+        );
+
+        const authoritativeMessage = createMessage({
+            content: "Hello from the completed snapshot",
+            id: "assistant-1",
+            status: "completed",
+        });
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                messages: [authoritativeMessage],
+                status: "idle",
+                updatedAt: "2026-04-14T00:00:20.000Z",
+            }),
+        );
+
+        const snapshot =
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot ?? null;
+        expect(snapshot?.status).toBe("idle");
+        expect(snapshot?.messages).toEqual([authoritativeMessage]);
+        expect(snapshot?.messages).toHaveLength(1);
+    });
+
+    it("applies resynced tool activity progress after an active stream goes quiet", async () => {
+        vi.useFakeTimers();
+        const initialTool = createToolActivity({
+            id: "tool-1",
+            status: "in_progress",
+            summary: "Running tests",
+            updatedAt: "2026-04-14T00:00:01.000Z",
+        });
+        const updatedTool = createToolActivity({
+            id: "tool-1",
+            status: "completed",
+            summary: "Tests passed",
+            updatedAt: "2026-04-14T00:00:20.000Z",
+        });
+        const resyncAiSession = vi.fn().mockResolvedValue(
+            createSnapshot({
+                messages: [createMessage({ status: "completed" })],
+                status: "idle",
+                toolActivity: [updatedTool],
+                updatedAt: "2026-04-14T00:00:20.000Z",
+            }),
+        );
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    resyncAiSession,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                messages: [createMessage()],
+                status: "streaming",
+                toolActivity: [initialTool],
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+        await vi.advanceTimersByTimeAsync(20_000);
+
+        const snapshot =
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot ?? null;
+        expect(resyncAiSession).toHaveBeenCalledWith(TAB.sessionId);
+        expect(snapshot?.status).toBe("idle");
+        expect(snapshot?.toolActivity).toEqual([updatedTool]);
+    });
+
     it("applies a prepared runtime session snapshot from the backend", async () => {
         const prepareAiSession = vi.fn().mockResolvedValue(createSnapshot());
         const sendAiPrompt = vi.fn().mockResolvedValue(undefined);

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -378,6 +378,27 @@ describe("ai-store queue", () => {
         expect(resyncAiSession).not.toHaveBeenCalled();
     });
 
+    it("requests resync for waiting permission sessions", async () => {
+        vi.useFakeTimers();
+        const resyncAiSession = vi.fn().mockResolvedValue(null);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    resyncAiSession,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({ status: "waiting_permission" }),
+        );
+        await vi.advanceTimersByTimeAsync(20_000);
+
+        expect(resyncAiSession).toHaveBeenCalledWith(TAB.sessionId);
+    });
+
     it("does not request resync while active sessions keep making visible progress", async () => {
         vi.useFakeTimers();
         const resyncAiSession = vi.fn().mockResolvedValue(null);
@@ -418,7 +439,7 @@ describe("ai-store queue", () => {
         expect(resyncAiSession).toHaveBeenCalledTimes(1);
     });
 
-    it("requests resync once for an unchanged active session", async () => {
+    it("retries resync for an unchanged active session when no snapshot is returned", async () => {
         vi.useFakeTimers();
         const resyncAiSession = vi.fn().mockResolvedValue(null);
         Object.defineProperty(globalThis, "window", {
@@ -440,8 +461,58 @@ describe("ai-store queue", () => {
         await vi.advanceTimersByTimeAsync(20_000);
         await vi.advanceTimersByTimeAsync(40_000);
 
-        expect(resyncAiSession).toHaveBeenCalledTimes(1);
+        expect(resyncAiSession).toHaveBeenCalledTimes(2);
         expect(resyncAiSession).toHaveBeenCalledWith(TAB.sessionId);
+    });
+
+    it("retries resync after a transient failure", async () => {
+        vi.useFakeTimers();
+        const error = new Error("ipc unavailable");
+        const message = createMessage({
+            content: "Complete",
+            status: "completed",
+        });
+        const resyncAiSession = vi
+            .fn()
+            .mockRejectedValueOnce(error)
+            .mockResolvedValue(
+                createSnapshot({
+                    messages: [message],
+                    status: "idle",
+                    updatedAt: "2026-04-14T00:00:50.000Z",
+                }),
+            );
+        const warn = vi
+            .spyOn(console, "warn")
+            .mockImplementation(() => undefined);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    resyncAiSession,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                messages: [createMessage()],
+                status: "streaming",
+            }),
+        );
+        await vi.advanceTimersByTimeAsync(20_000);
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        const snapshot =
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot ?? null;
+        expect(resyncAiSession).toHaveBeenCalledTimes(2);
+        expect(warn).toHaveBeenCalledWith(
+            "[comando] Failed to resync quiet AI session.",
+            error,
+        );
+        expect(snapshot?.status).toBe("idle");
+        expect(snapshot?.messages).toEqual([message]);
     });
 
     it("applies a resynced snapshot without duplicating messages", async () => {

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -304,11 +304,13 @@ const bufferedSessionDeltaEvents = new Map<string, BufferedSessionDeltaEvent>();
 let bufferedSessionDeltaFlushTimer: ReturnType<typeof setTimeout> | null = null;
 let isFlushingBufferedSessionDeltas = false;
 const AI_SESSION_RESYNC_SILENCE_MS = 20_000;
+const AI_SESSION_RESYNC_RETRY_DELAYS_MS = [20_000, 30_000, 45_000, 60_000];
 
 interface AiSessionResyncWatchdog {
     inFlight: boolean;
     progressKey: string;
     requestedProgressKey: string | null;
+    retryAttempt: number;
     timer: ReturnType<typeof setTimeout> | null;
 }
 
@@ -391,7 +393,12 @@ function resetBufferedSessionDeltas(): void {
 }
 
 function isAiSessionResyncWatchdogActive(snapshot: AiSessionSnapshot): boolean {
-    return snapshot.status === "starting" || snapshot.status === "streaming";
+    return (
+        snapshot.status === "starting" ||
+        snapshot.status === "streaming" ||
+        snapshot.status === "waiting_permission" ||
+        snapshot.status === "waiting_user_input"
+    );
 }
 
 function getAiSessionVisibleProgressKey(snapshot: AiSessionSnapshot): string {
@@ -430,6 +437,27 @@ function resetAiSessionResyncWatchdogs(): void {
     }
 }
 
+function getAiSessionResyncRetryDelayMs(retryAttempt: number): number {
+    return AI_SESSION_RESYNC_RETRY_DELAYS_MS[
+        Math.min(retryAttempt, AI_SESSION_RESYNC_RETRY_DELAYS_MS.length - 1)
+    ];
+}
+
+function scheduleAiSessionResyncWatchdogTimer(
+    sessionId: string,
+    watchdog: AiSessionResyncWatchdog,
+    get: GetAiState,
+    delayMs: number,
+): void {
+    watchdog.timer = setTimeout(() => {
+        void requestAiSessionResyncAfterSilence(
+            sessionId,
+            watchdog.progressKey,
+            get,
+        );
+    }, delayMs);
+}
+
 function scheduleAiSessionResyncWatchdog(
     sessionId: string,
     get: GetAiState,
@@ -462,10 +490,16 @@ function scheduleAiSessionResyncWatchdog(
             existing?.progressKey === progressKey
                 ? existing.requestedProgressKey
                 : null,
-        timer: setTimeout(() => {
-            void requestAiSessionResyncAfterSilence(sessionId, progressKey, get);
-        }, AI_SESSION_RESYNC_SILENCE_MS),
+        retryAttempt:
+            existing?.progressKey === progressKey ? existing.retryAttempt : 0,
+        timer: null,
     };
+    scheduleAiSessionResyncWatchdogTimer(
+        sessionId,
+        watchdog,
+        get,
+        AI_SESSION_RESYNC_SILENCE_MS,
+    );
     aiSessionResyncWatchdogs.set(sessionId, watchdog);
 }
 
@@ -493,9 +527,11 @@ async function requestAiSessionResyncAfterSilence(
 
     watchdog.inFlight = true;
     watchdog.requestedProgressKey = progressKey;
+    let appliedSnapshot = false;
     try {
         const resyncSnapshot = await getComandoApi().resyncAiSession(sessionId);
         if (resyncSnapshot) {
+            appliedSnapshot = true;
             get().applySessionSnapshot(resyncSnapshot);
         }
     } catch (error) {
@@ -504,6 +540,26 @@ async function requestAiSessionResyncAfterSilence(
         const latest = aiSessionResyncWatchdogs.get(sessionId);
         if (latest?.progressKey === progressKey) {
             latest.inFlight = false;
+            if (!appliedSnapshot) {
+                latest.requestedProgressKey = null;
+                latest.retryAttempt += 1;
+                const latestSnapshot =
+                    get().sessions[sessionId]?.snapshot ?? null;
+                if (
+                    latestSnapshot &&
+                    isAiSessionResyncWatchdogActive(latestSnapshot) &&
+                    getAiSessionVisibleProgressKey(latestSnapshot) ===
+                        progressKey &&
+                    latest.timer === null
+                ) {
+                    scheduleAiSessionResyncWatchdogTimer(
+                        sessionId,
+                        latest,
+                        get,
+                        getAiSessionResyncRetryDelayMs(latest.retryAttempt),
+                    );
+                }
+            }
         }
     }
 }

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -303,6 +303,16 @@ type BufferedSessionDeltaEvent = Extract<
 const bufferedSessionDeltaEvents = new Map<string, BufferedSessionDeltaEvent>();
 let bufferedSessionDeltaFlushTimer: ReturnType<typeof setTimeout> | null = null;
 let isFlushingBufferedSessionDeltas = false;
+const AI_SESSION_RESYNC_SILENCE_MS = 20_000;
+
+interface AiSessionResyncWatchdog {
+    inFlight: boolean;
+    progressKey: string;
+    requestedProgressKey: string | null;
+    timer: ReturnType<typeof setTimeout> | null;
+}
+
+const aiSessionResyncWatchdogs = new Map<string, AiSessionResyncWatchdog>();
 
 function isSessionDeltaEvent(
     event: AiSessionDomainEvent,
@@ -380,11 +390,130 @@ function resetBufferedSessionDeltas(): void {
     isFlushingBufferedSessionDeltas = false;
 }
 
+function isAiSessionResyncWatchdogActive(snapshot: AiSessionSnapshot): boolean {
+    return snapshot.status === "starting" || snapshot.status === "streaming";
+}
+
+function getAiSessionVisibleProgressKey(snapshot: AiSessionSnapshot): string {
+    const lastMessage = snapshot.messages[snapshot.messages.length - 1] ?? null;
+    const lastToolActivity =
+        snapshot.toolActivity[snapshot.toolActivity.length - 1] ?? null;
+
+    return JSON.stringify({
+        messageContentLength: lastMessage?.content.length ?? 0,
+        messageCount: snapshot.messages.length,
+        messageId: lastMessage?.id ?? null,
+        messageStatus: lastMessage?.status ?? null,
+        status: snapshot.status,
+        toolActivityCount: snapshot.toolActivity.length,
+        toolActivityId: lastToolActivity?.id ?? null,
+        toolActivityStatus: lastToolActivity?.status ?? null,
+        toolActivityUpdatedAt: lastToolActivity?.updatedAt ?? null,
+        updatedAt: snapshot.updatedAt,
+    });
+}
+
+function clearAiSessionResyncWatchdog(sessionId: string): void {
+    const existing = aiSessionResyncWatchdogs.get(sessionId);
+    if (!existing) {
+        return;
+    }
+    if (existing.timer) {
+        clearTimeout(existing.timer);
+    }
+    aiSessionResyncWatchdogs.delete(sessionId);
+}
+
+function resetAiSessionResyncWatchdogs(): void {
+    for (const sessionId of aiSessionResyncWatchdogs.keys()) {
+        clearAiSessionResyncWatchdog(sessionId);
+    }
+}
+
+function scheduleAiSessionResyncWatchdog(
+    sessionId: string,
+    get: GetAiState,
+): void {
+    const snapshot = get().sessions[sessionId]?.snapshot ?? null;
+    if (!snapshot || !isAiSessionResyncWatchdogActive(snapshot)) {
+        clearAiSessionResyncWatchdog(sessionId);
+        return;
+    }
+
+    const progressKey = getAiSessionVisibleProgressKey(snapshot);
+    const existing = aiSessionResyncWatchdogs.get(sessionId);
+    if (
+        existing?.progressKey === progressKey &&
+        (existing.timer ||
+            existing.inFlight ||
+            existing.requestedProgressKey === progressKey)
+    ) {
+        return;
+    }
+
+    if (existing?.timer) {
+        clearTimeout(existing.timer);
+    }
+
+    const watchdog: AiSessionResyncWatchdog = {
+        inFlight: false,
+        progressKey,
+        requestedProgressKey:
+            existing?.progressKey === progressKey
+                ? existing.requestedProgressKey
+                : null,
+        timer: setTimeout(() => {
+            void requestAiSessionResyncAfterSilence(sessionId, progressKey, get);
+        }, AI_SESSION_RESYNC_SILENCE_MS),
+    };
+    aiSessionResyncWatchdogs.set(sessionId, watchdog);
+}
+
+async function requestAiSessionResyncAfterSilence(
+    sessionId: string,
+    progressKey: string,
+    get: GetAiState,
+): Promise<void> {
+    const watchdog = aiSessionResyncWatchdogs.get(sessionId);
+    if (!watchdog || watchdog.progressKey !== progressKey) {
+        return;
+    }
+    watchdog.timer = null;
+
+    const snapshot = get().sessions[sessionId]?.snapshot ?? null;
+    if (
+        !snapshot ||
+        !isAiSessionResyncWatchdogActive(snapshot) ||
+        getAiSessionVisibleProgressKey(snapshot) !== progressKey ||
+        watchdog.inFlight ||
+        watchdog.requestedProgressKey === progressKey
+    ) {
+        return;
+    }
+
+    watchdog.inFlight = true;
+    watchdog.requestedProgressKey = progressKey;
+    try {
+        const resyncSnapshot = await getComandoApi().resyncAiSession(sessionId);
+        if (resyncSnapshot) {
+            get().applySessionSnapshot(resyncSnapshot);
+        }
+    } catch (error) {
+        console.warn("[comando] Failed to resync quiet AI session.", error);
+    } finally {
+        const latest = aiSessionResyncWatchdogs.get(sessionId);
+        if (latest?.progressKey === progressKey) {
+            latest.inFlight = false;
+        }
+    }
+}
+
 const activeQueueDrainSessionIds = new Set<string>();
 const pendingQueueDrainSessionIds = new Set<string>();
 
 export function resetAiStoreRuntimeBuffersForTests(): void {
     resetBufferedSessionDeltas();
+    resetAiSessionResyncWatchdogs();
 }
 
 export const useAiStore = create<AiStore>((set, get) => ({
@@ -643,6 +772,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
         }
 
         void drainQueueIfNeeded(event.sessionId, get, set);
+        scheduleAiSessionResyncWatchdog(event.sessionId, get);
     },
 
     applySessionUpdate: (update) => {
@@ -822,6 +952,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
         }
 
         void drainQueueIfNeeded(update.patch.sessionId, get, set);
+        scheduleAiSessionResyncWatchdog(update.patch.sessionId, get);
     },
 
     applySessionSnapshot: (snapshot) => {
@@ -894,6 +1025,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
         }
 
         void drainQueueIfNeeded(snapshot.sessionId, get, set);
+        scheduleAiSessionResyncWatchdog(snapshot.sessionId, get);
     },
 
     cancelSession: async (sessionId) => {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -135,6 +135,7 @@ export const IPC_CHANNELS = {
     refreshAiProjectScopes: "ai:refresh-project-scopes",
     listAiSessionHistory: "ai:list-session-history",
     getAiSessionSnapshot: "ai:get-session-snapshot",
+    resyncAiSession: "ai:resync-session",
     getAiSessionTranscriptPage: "ai:get-session-transcript-page",
     sendAiPrompt: "ai:send-prompt",
     setAiSessionMode: "ai:set-session-mode",
@@ -3040,6 +3041,7 @@ export interface ComandoApi {
     getAiSessionSnapshot: (
         sessionId: string,
     ) => Promise<AiSessionSnapshot | null>;
+    resyncAiSession: (sessionId: string) => Promise<AiSessionSnapshot | null>;
     getAiSessionTranscriptPage: (
         input: GetAiSessionTranscriptPageInput,
     ) => Promise<AiSessionTranscriptPage>;


### PR DESCRIPTION
## Summary

- Adds live AI session stream resync snapshots and fallback delivery for preserved stream payloads.
- Fixes ACK stale detection so unacknowledged messages age from their original send time instead of being refreshed by heartbeats.
- Merges preserved snapshot patches so terminal status updates do not discard pending transcript or tool activity changes.
- Retries quiet-session renderer resyncs with backoff after transient failures or null responses.

## Why

AI session streams could appear stuck when the renderer stopped acknowledging stream messages, when preserved patches replaced each other, or when the quiet-session resync hit a one-off failure. These changes make recovery deterministic and keep visible transcript/tool activity state intact.

## Validation

- `pnpm exec vitest run src/main/ai/session-stream.test.ts src/preload/ai-session-stream.test.ts src/renderer/src/app/store/ai-store.test.ts src/main/ai/service.prepare.test.ts`
- `pnpm run typecheck`