### PR TITLE
Add manual Git branch creation

### DIFF
--- a/src/main/git/service.ts
+++ b/src/main/git/service.ts
@@ -89,6 +89,13 @@ export interface GitGateway {
             readonly startPoint?: string | null;
         },
     ): Promise<GitRepositorySnapshot>;
+    createBranch(
+        inputPath: string,
+        options: {
+            readonly branchName: string;
+            readonly startPoint?: string | null;
+        },
+    ): Promise<GitRepositorySnapshot>;
     createWorktree(
         inputPath: string,
         options: {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -44,6 +44,7 @@ import {
     type GitCommitDetailInput,
     type GitCommitInput,
     type GitCommitResult,
+    type GitCreateBranchInput,
     type GitCreateWorktreeInput,
     type GitDeleteLocalBranchInput,
     type GitDeleteRemoteBranchInput,
@@ -264,6 +265,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.discardGitPaths);
     ipcMain.removeHandler(IPC_CHANNELS.commitGitChanges);
     ipcMain.removeHandler(IPC_CHANNELS.checkoutGitBranch);
+    ipcMain.removeHandler(IPC_CHANNELS.createGitBranch);
     ipcMain.removeHandler(IPC_CHANNELS.createGitWorktree);
     ipcMain.removeHandler(IPC_CHANNELS.removeGitWorktree);
     ipcMain.removeHandler(IPC_CHANNELS.deleteLocalGitBranch);
@@ -863,6 +865,24 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
                         branchName: input.branchName,
                         force: input.force,
                         newBranchName: input.newBranchName,
+                        startPoint: input.startPoint,
+                    }),
+            ),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.createGitBranch,
+        async (
+            _event,
+            input: GitCreateBranchInput,
+        ): Promise<SharedGitRepositorySnapshot> =>
+            handleGitSnapshotMutation(
+                options.projectService,
+                options.gitService,
+                input,
+                "branch",
+                async (rootPath) =>
+                    options.gitService.createBranch(rootPath, {
+                        branchName: input.branchName,
                         startPoint: input.startPoint,
                     }),
             ),

--- a/src/main/native-backend/git.test.ts
+++ b/src/main/native-backend/git.test.ts
@@ -262,6 +262,10 @@ describe("NativeGitGateway", () => {
             branchName: "main",
             newBranchName: "feature/current",
         });
+        await gateway.createBranch("/tmp/comando-project", {
+            branchName: "feature/sidebar",
+            startPoint: "main",
+        });
         await gateway.createWorktree("/tmp/comando-project", {
             branchName: "feature/worktree",
             path: "/tmp/feature-worktree",
@@ -284,6 +288,16 @@ describe("NativeGitGateway", () => {
             expect.objectContaining({
                 branchName: "main",
                 newBranchName: "feature/current",
+                startPoint: "main",
+            }),
+        );
+        expect(requestMock).toHaveBeenCalledWith(
+            "git_create_branch",
+            expect.objectContaining({
+                branchName: "feature/sidebar",
+                scope: expect.objectContaining({
+                    rootPath: "/tmp/comando-project",
+                }),
                 startPoint: "main",
             }),
         );

--- a/src/main/native-backend/git.test.ts
+++ b/src/main/native-backend/git.test.ts
@@ -295,9 +295,11 @@ describe("NativeGitGateway", () => {
             "git_create_branch",
             expect.objectContaining({
                 branchName: "feature/sidebar",
-                scope: expect.objectContaining({
+                scope: {
+                    projectId: "native_git",
                     rootPath: "/tmp/comando-project",
-                }),
+                    worktreeId: null,
+                },
                 startPoint: "main",
             }),
         );

--- a/src/main/native-backend/git.ts
+++ b/src/main/native-backend/git.ts
@@ -304,6 +304,26 @@ export class NativeGitGateway implements ClosableGitGateway {
         );
     }
 
+    async createBranch(
+        inputPath: string,
+        options: {
+            readonly branchName: string;
+            readonly startPoint?: string | null;
+        },
+    ): Promise<GitRepositorySnapshot> {
+        return nativeOperationSnapshot(
+            parseNativeOperationResult(
+                await this.#client.request("git_create_branch", {
+                    branchName: options.branchName,
+                    force: null,
+                    newBranchName: null,
+                    scope: nativeGitScope(inputPath),
+                    startPoint: options.startPoint ?? null,
+                }),
+            ),
+        );
+    }
+
     async createWorktree(
         inputPath: string,
         options: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -77,6 +77,7 @@ import {
     type GitCommitDetailInput,
     type GitCommitInput,
     type GitCommitResult,
+    type GitCreateBranchInput,
     type GitCreateWorktreeInput,
     type GitDeleteLocalBranchInput,
     type GitDeleteRemoteBranchInput,
@@ -977,6 +978,11 @@ const comandoApi: ComandoApi = {
     checkoutGitBranch: (input: GitCheckoutBranchInput) =>
         ipcRenderer.invoke(
             IPC_CHANNELS.checkoutGitBranch,
+            input,
+        ) as Promise<GitRepositorySnapshot>,
+    createGitBranch: (input: GitCreateBranchInput) =>
+        ipcRenderer.invoke(
+            IPC_CHANNELS.createGitBranch,
             input,
         ) as Promise<GitRepositorySnapshot>,
     createGitWorktree: (input: GitCreateWorktreeInput) =>

--- a/src/renderer/src/app/store/git-store.ts
+++ b/src/renderer/src/app/store/git-store.ts
@@ -4,6 +4,7 @@ import type {
     GitBranchSummary,
     GitCommitDetail,
     GitCommitInput,
+    GitCreateBranchInput,
     GitCreateWorktreeInput,
     GitFileDiff,
     GitHistoryCommitSummary,
@@ -119,6 +120,9 @@ interface GitStoreState {
         readonly commitSha: string;
         readonly branchName: string | null;
     }>;
+    createBranch: (
+        input: GitCreateBranchInput,
+    ) => Promise<GitRepositorySnapshot>;
     createWorktree: (
         input: GitCreateWorktreeInput,
     ) => Promise<GitWorktreeSummary>;
@@ -353,6 +357,16 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
             branchName: result.branchName,
             commitSha: result.commitSha,
         };
+    },
+
+    createBranch: async (input) => {
+        const snapshot = await getComandoApi().createGitBranch(input);
+        applySnapshotState(set, input.projectId, snapshot);
+        void get().refreshHistory(
+            input.projectId,
+            snapshot.currentWorktreeId ?? input.worktreeId ?? null,
+        );
+        return snapshot;
     },
 
     createWorktree: async (input) => {

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
@@ -10,6 +10,13 @@ import {
     resolveRemoteBranchResolution,
     stripRemotePrefix,
 } from "./SidebarGitScopePicker";
+import {
+    buildBranchCreationBaseOptions,
+    createBranchCreationDraft,
+    getDefaultBranchCreationBase,
+    normalizeBranchNameInput,
+    validateNewBranchName,
+} from "./sidebarGitBranchCreation";
 
 function createBranch(
     overrides: Partial<GitBranchSummary> = {},
@@ -175,5 +182,79 @@ describe("SidebarGitScopePicker helpers", () => {
                 primaryWorktree,
             ),
         ).toBe(false);
+    });
+
+    it("uses the current branch as the default branch creation base when it exists", () => {
+        const branches = [
+            createBranch({ isCurrent: false, name: "main" }),
+            createBranch({ isCurrent: true, name: "feature/current" }),
+        ];
+
+        expect(
+            getDefaultBranchCreationBase({
+                branches,
+                currentBranchName: "feature/current",
+            }),
+        ).toBe("feature/current");
+    });
+
+    it("includes local and remote branches as creation base options", () => {
+        const localBranch = createBranch({ name: "feature/local" });
+        const remoteBranch = createBranch({
+            isRemote: true,
+            kind: "remote",
+            name: "origin/feature/remote",
+        });
+
+        expect(
+            buildBranchCreationBaseOptions([localBranch, remoteBranch]).map(
+                (option) => ({
+                    isRemote: option.isRemote,
+                    name: option.name,
+                }),
+            ),
+        ).toEqual([
+            { isRemote: false, name: "feature/local" },
+            { isRemote: true, name: "origin/feature/remote" },
+        ]);
+        expect(
+            createBranchCreationDraft({
+                baseBranchName: remoteBranch.name,
+                source: "context-menu",
+            }),
+        ).toMatchObject({
+            baseBranchName: remoteBranch.name,
+            checkoutAfterCreate: true,
+            source: "context-menu",
+        });
+    });
+
+    it("normalizes and validates new branch names for manual creation", () => {
+        const branches = [createBranch({ name: "feature/existing" })];
+
+        expect(normalizeBranchNameInput("  feature/new-picker  ")).toBe(
+            "feature/new-picker",
+        );
+        expect(
+            validateNewBranchName("feature/new-picker", branches),
+        ).toEqual({
+            error: null,
+            isValid: true,
+            value: "feature/new-picker",
+        });
+        expect(
+            validateNewBranchName("feature/existing", branches),
+        ).toMatchObject({
+            error: "A local branch with this name already exists.",
+            isValid: false,
+        });
+        expect(validateNewBranchName("", branches).isValid).toBe(false);
+        expect(validateNewBranchName("HEAD", branches).isValid).toBe(false);
+        expect(validateNewBranchName("/foo", branches).isValid).toBe(false);
+        expect(validateNewBranchName("foo/", branches).isValid).toBe(false);
+        expect(validateNewBranchName("foo..bar", branches).isValid).toBe(false);
+        expect(validateNewBranchName("feature/new picker", branches).isValid).toBe(
+            false,
+        );
     });
 });

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
@@ -295,7 +295,11 @@ describe("SidebarGitScopePicker helpers", () => {
             });
         }
 
-        for (const branchName of ["feature.", "feature.lock"]) {
+        for (const branchName of [
+            "feature.",
+            "feature.lock",
+            "feature.lock/nested",
+        ]) {
             expect(validateNewBranchName(branchName, branches)).toMatchObject({
                 error: 'Branch name cannot end with "." or ".lock".',
                 isValid: false,

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
@@ -231,7 +231,14 @@ describe("SidebarGitScopePicker helpers", () => {
     });
 
     it("normalizes and validates new branch names for manual creation", () => {
-        const branches = [createBranch({ name: "feature/existing" })];
+        const branches = [
+            createBranch({ name: "feature/existing" }),
+            createBranch({
+                isRemote: true,
+                kind: "remote",
+                name: "origin/main",
+            }),
+        ];
 
         expect(normalizeBranchNameInput("  feature/new-picker  ")).toBe(
             "feature/new-picker",
@@ -249,6 +256,12 @@ describe("SidebarGitScopePicker helpers", () => {
             error: "A local branch with this name already exists.",
             isValid: false,
         });
+        expect(
+            validateNewBranchName("origin/main", branches),
+        ).toMatchObject({
+            error: "A remote branch with this name already exists.",
+            isValid: false,
+        });
         expect(validateNewBranchName("", branches).isValid).toBe(false);
         expect(validateNewBranchName("HEAD", branches).isValid).toBe(false);
         expect(validateNewBranchName("/foo", branches).isValid).toBe(false);
@@ -260,7 +273,14 @@ describe("SidebarGitScopePicker helpers", () => {
     });
 
     it("offers branch creation from a valid search query that does not match a local branch", () => {
-        const branches = [createBranch({ name: "feature/existing" })];
+        const branches = [
+            createBranch({ name: "feature/existing" }),
+            createBranch({
+                isRemote: true,
+                kind: "remote",
+                name: "origin/main",
+            }),
+        ];
 
         expect(
             getBranchCreationQueryOffer(" feature/new-picker ", branches),
@@ -269,6 +289,9 @@ describe("SidebarGitScopePicker helpers", () => {
         });
         expect(
             getBranchCreationQueryOffer("feature/existing", branches),
+        ).toBeNull();
+        expect(
+            getBranchCreationQueryOffer("origin/main", branches),
         ).toBeNull();
         expect(getBranchCreationQueryOffer("foo..bar", branches)).toBeNull();
     });

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
@@ -272,6 +272,37 @@ describe("SidebarGitScopePicker helpers", () => {
         );
     });
 
+    it("rejects common Git ref name hazards before submitting branch creation", () => {
+        const branches: readonly GitBranchSummary[] = [];
+        const invalidCharacters = [
+            "@",
+            "feature/@{bad",
+            "feature//bad",
+            "feature\\bad",
+            "feature~bad",
+            "feature^bad",
+            "feature:bad",
+            "feature?bad",
+            "feature*bad",
+            "feature[bad",
+            "feature/.hidden",
+        ];
+
+        for (const branchName of invalidCharacters) {
+            expect(validateNewBranchName(branchName, branches)).toMatchObject({
+                error: "Branch name contains characters Git does not allow.",
+                isValid: false,
+            });
+        }
+
+        for (const branchName of ["feature.", "feature.lock"]) {
+            expect(validateNewBranchName(branchName, branches)).toMatchObject({
+                error: 'Branch name cannot end with "." or ".lock".',
+                isValid: false,
+            });
+        }
+    });
+
     it("offers branch creation from a valid search query that does not match a local branch", () => {
         const branches = [
             createBranch({ name: "feature/existing" }),

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
@@ -13,6 +13,7 @@ import {
 import {
     buildBranchCreationBaseOptions,
     createBranchCreationDraft,
+    getBranchCreationQueryOffer,
     getDefaultBranchCreationBase,
     normalizeBranchNameInput,
     validateNewBranchName,
@@ -256,5 +257,19 @@ describe("SidebarGitScopePicker helpers", () => {
         expect(validateNewBranchName("feature/new picker", branches).isValid).toBe(
             false,
         );
+    });
+
+    it("offers branch creation from a valid search query that does not match a local branch", () => {
+        const branches = [createBranch({ name: "feature/existing" })];
+
+        expect(
+            getBranchCreationQueryOffer(" feature/new-picker ", branches),
+        ).toEqual({
+            branchName: "feature/new-picker",
+        });
+        expect(
+            getBranchCreationQueryOffer("feature/existing", branches),
+        ).toBeNull();
+        expect(getBranchCreationQueryOffer("foo..bar", branches)).toBeNull();
     });
 });

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -6,6 +6,7 @@ import {
     useMemo,
     useRef,
     useState,
+    type FormEvent,
     type MouseEvent as ReactMouseEvent,
     type PointerEvent as ReactPointerEvent,
 } from "react";
@@ -36,6 +37,14 @@ import {
 } from "@renderer/components/virtual/MeasuredVirtualList";
 
 import { SidebarNodeRow, type SidebarBadge } from "./SidebarNodeRow";
+import {
+    buildBranchCreationBaseOptions,
+    createBranchCreationDraft,
+    getDefaultBranchCreationBase,
+    validateNewBranchName,
+    type BranchCreationBaseOption,
+    type BranchCreationDraft,
+} from "./sidebarGitBranchCreation";
 
 type GitScopeTabId = "branches" | "worktrees";
 
@@ -240,6 +249,12 @@ export function SidebarGitScopePicker({
     const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
     const [query, setQuery] = useState("");
     const [focusIndex, setFocusIndex] = useState(-1);
+    const [branchCreationDraft, setBranchCreationDraft] =
+        useState<BranchCreationDraft | null>(null);
+    const [branchCreationName, setBranchCreationName] = useState("");
+    const [branchCreationBaseName, setBranchCreationBaseName] = useState("");
+    const [branchCreationCheckout, setBranchCreationCheckout] = useState(true);
+    const [branchCreationSubmitted, setBranchCreationSubmitted] = useState(false);
     const [itemContextMenu, setItemContextMenu] = useState<
         ContextMenuState<GitScopeContextMenuPayload> | null
     >(null);
@@ -286,6 +301,7 @@ export function SidebarGitScopePicker({
             : EMPTY_BRANCHES,
     );
     const checkoutBranch = useGitStore((state) => state.checkoutBranch);
+    const createBranch = useGitStore((state) => state.createBranch);
     const createWorktree = useGitStore((state) => state.createWorktree);
     const deleteLocalBranch = useGitStore((state) => state.deleteLocalBranch);
     const deleteRemoteBranch = useGitStore((state) => state.deleteRemoteBranch);
@@ -316,6 +332,34 @@ export function SidebarGitScopePicker({
     const worktrees = snapshot?.worktrees ?? EMPTY_WORKTREES;
     const availableWorktrees = worktrees.length;
     const deferredQuery = useDeferredValue(query);
+    const branchCreationBaseOptions = useMemo(
+        () => buildBranchCreationBaseOptions(branches),
+        [branches],
+    );
+    const defaultBranchCreationBase = useMemo(
+        () =>
+            getDefaultBranchCreationBase({
+                branches,
+                currentBranchName:
+                    activeWorktree?.branchName ??
+                    (snapshot?.branch?.isDetached
+                        ? null
+                        : (snapshot?.branch?.name ?? null)),
+            }),
+        [
+            activeWorktree?.branchName,
+            branches,
+            snapshot?.branch?.isDetached,
+            snapshot?.branch?.name,
+        ],
+    );
+    const branchCreationValidation = useMemo(
+        () =>
+            branchCreationDraft
+                ? validateNewBranchName(branchCreationName, branches)
+                : null,
+        [branchCreationDraft, branchCreationName, branches],
+    );
 
     const branchRows = useMemo(() => {
         const localBranchByUpstream = new Map<string, GitBranchSummary>();
@@ -632,14 +676,26 @@ export function SidebarGitScopePicker({
         setActiveTab("branches");
         setIsBusy(false);
         setFocusIndex(-1);
+        setBranchCreationDraft(null);
+        setBranchCreationName("");
+        setBranchCreationBaseName("");
+        setBranchCreationCheckout(true);
+        setBranchCreationSubmitted(false);
         setCollapsedSections({});
     }, [projectId]);
 
     useEffect(() => {
         if (!isOpen) {
             setItemContextMenu(null);
+            setBranchCreationDraft(null);
         }
     }, [isOpen]);
+
+    useEffect(() => {
+        if (activeTab !== "branches") {
+            setBranchCreationDraft(null);
+        }
+    }, [activeTab]);
 
     useEffect(() => {
         if (!isOpen) {
@@ -936,6 +992,124 @@ export function SidebarGitScopePicker({
             projectId,
             snapshot?.currentWorktreeId,
             snapshot?.worktrees,
+            worktreeId,
+        ],
+    );
+
+    const openBranchCreationForm = useCallback(
+        (
+            baseBranchName: string | null,
+            source: BranchCreationDraft["source"],
+            initialName = "",
+        ) => {
+            const draft = createBranchCreationDraft({
+                baseBranchName,
+                initialName,
+                source,
+            });
+            if (!draft) {
+                setActionError("Choose a base branch before creating a branch.");
+                return;
+            }
+
+            setActiveTab("branches");
+            setActionError(null);
+            setItemContextMenu(null);
+            setBranchCreationDraft(draft);
+            setBranchCreationName(draft.initialName);
+            setBranchCreationBaseName(draft.baseBranchName);
+            setBranchCreationCheckout(draft.checkoutAfterCreate);
+            setBranchCreationSubmitted(false);
+        },
+        [],
+    );
+
+    const closeBranchCreationForm = useCallback(() => {
+        setBranchCreationDraft(null);
+        setBranchCreationName("");
+        setBranchCreationBaseName("");
+        setBranchCreationCheckout(true);
+        setBranchCreationSubmitted(false);
+        setActionError(null);
+    }, []);
+
+    const handleCreateBranchSubmit = useCallback(
+        async (event: FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+
+            if (!projectId || isBusy || !branchCreationDraft) {
+                return;
+            }
+
+            setBranchCreationSubmitted(true);
+            const validation = validateNewBranchName(branchCreationName, branches);
+            if (!validation.isValid) {
+                return;
+            }
+
+            const baseBranchName = branchCreationBaseName.trim();
+            if (!baseBranchName) {
+                setActionError("Choose a base branch before creating a branch.");
+                return;
+            }
+
+            const activeWorktreeId =
+                worktreeId ?? snapshot?.currentWorktreeId ?? null;
+
+            setActionError(null);
+            setIsBusy(true);
+
+            try {
+                const result = branchCreationCheckout
+                    ? await checkoutBranch(
+                          projectId,
+                          baseBranchName,
+                          activeWorktreeId,
+                          {
+                              newBranchName: validation.value,
+                              startPoint: baseBranchName,
+                          },
+                      )
+                    : await createBranch({
+                          branchName: validation.value,
+                          projectId,
+                          startPoint: baseBranchName,
+                          worktreeId: activeWorktreeId,
+                      });
+
+                await refreshProjectTree(
+                    projectId,
+                    result.currentWorktreeId ?? activeWorktreeId,
+                );
+                setIsOpen(false);
+                setQuery("");
+                setBranchCreationDraft(null);
+                setBranchCreationName("");
+                setBranchCreationBaseName("");
+                setBranchCreationCheckout(true);
+                setBranchCreationSubmitted(false);
+            } catch (error) {
+                setActionError(
+                    error instanceof Error
+                        ? error.message
+                        : "Could not create this branch.",
+                );
+            } finally {
+                setIsBusy(false);
+            }
+        },
+        [
+            branchCreationBaseName,
+            branchCreationCheckout,
+            branchCreationDraft,
+            branchCreationName,
+            branches,
+            checkoutBranch,
+            createBranch,
+            isBusy,
+            projectId,
+            refreshProjectTree,
+            snapshot?.currentWorktreeId,
             worktreeId,
         ],
     );
@@ -1572,6 +1746,10 @@ export function SidebarGitScopePicker({
         activeTab === "branches"
             ? "No branches match your search."
             : "No worktrees match your search.";
+    const canOpenBranchCreation =
+        activeTab === "branches" &&
+        !canInitializeGit &&
+        branchCreationBaseOptions.length > 0;
     const renderListItem = useCallback(
         (item: RenderListItem) => {
             if (item.kind === "section") {
@@ -1749,6 +1927,26 @@ export function SidebarGitScopePicker({
                                       onClick={() => setActiveTab("worktrees")}
                                   />
                               </div>
+                              {activeTab === "branches" && !canInitializeGit ? (
+                                  <div className="sidebar-git-scope-menu__actions">
+                                      <button
+                                          className="sidebar-git-scope-menu__new-branch-button"
+                                          disabled={
+                                              isBusy || !canOpenBranchCreation
+                                          }
+                                          onClick={() =>
+                                              openBranchCreationForm(
+                                                  defaultBranchCreationBase,
+                                                  "current",
+                                              )
+                                          }
+                                          type="button"
+                                      >
+                                          <PlusIcon />
+                                          <span>New Branch</span>
+                                      </button>
+                                  </div>
+                              ) : null}
                               <div className="sidebar-git-scope-menu__search">
                                   <SearchIcon />
                                   <input
@@ -1775,6 +1973,34 @@ export function SidebarGitScopePicker({
                                   />
                               </div>
                           </div>
+
+                          {branchCreationDraft ? (
+                              <BranchCreationForm
+                                  baseName={branchCreationBaseName}
+                                  baseOptions={branchCreationBaseOptions}
+                                  checkoutAfterCreate={branchCreationCheckout}
+                                  disabled={isBusy}
+                                  name={branchCreationName}
+                                  onBaseNameChange={setBranchCreationBaseName}
+                                  onCancel={closeBranchCreationForm}
+                                  onCheckoutAfterCreateChange={
+                                      setBranchCreationCheckout
+                                  }
+                                  onNameChange={(nextName) => {
+                                      setBranchCreationName(nextName);
+                                      setBranchCreationSubmitted(false);
+                                  }}
+                                  onSubmit={(event) => {
+                                      void handleCreateBranchSubmit(event);
+                                  }}
+                                  validationError={
+                                      branchCreationSubmitted
+                                          ? (branchCreationValidation?.error ??
+                                            null)
+                                          : null
+                                  }
+                              />
+                          ) : null}
 
                           <div
                               className="shell-scrollbar sidebar-git-scope-menu__list"
@@ -1951,6 +2177,125 @@ function GitInitState({
     );
 }
 
+function BranchCreationForm({
+    baseName,
+    baseOptions,
+    checkoutAfterCreate,
+    disabled,
+    name,
+    onBaseNameChange,
+    onCancel,
+    onCheckoutAfterCreateChange,
+    onNameChange,
+    onSubmit,
+    validationError,
+}: {
+    readonly baseName: string;
+    readonly baseOptions: readonly BranchCreationBaseOption[];
+    readonly checkoutAfterCreate: boolean;
+    readonly disabled: boolean;
+    readonly name: string;
+    readonly onBaseNameChange: (value: string) => void;
+    readonly onCancel: () => void;
+    readonly onCheckoutAfterCreateChange: (value: boolean) => void;
+    readonly onNameChange: (value: string) => void;
+    readonly onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+    readonly validationError: string | null;
+}) {
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    useEffect(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+    }, []);
+
+    return (
+        <form
+            className="sidebar-git-scope-menu__branch-form"
+            onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                    event.preventDefault();
+                    onCancel();
+                }
+                event.stopPropagation();
+            }}
+            onSubmit={onSubmit}
+        >
+            <div className="sidebar-git-scope-menu__branch-form-header">
+                <span>New Branch</span>
+            </div>
+
+            <label className="sidebar-git-scope-menu__branch-form-field">
+                <span>Name</span>
+                <input
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    className="ide-input app-no-drag w-full text-xs"
+                    disabled={disabled}
+                    onChange={(event) => onNameChange(event.target.value)}
+                    placeholder="feature/my-branch"
+                    ref={inputRef}
+                    spellCheck={false}
+                    value={name}
+                />
+            </label>
+            {validationError ? (
+                <div className="sidebar-git-scope-menu__branch-form-error">
+                    {validationError}
+                </div>
+            ) : null}
+
+            <label className="sidebar-git-scope-menu__branch-form-field">
+                <span>Base</span>
+                <select
+                    className="ide-input app-no-drag w-full text-xs"
+                    disabled={disabled || baseOptions.length === 0}
+                    onChange={(event) => onBaseNameChange(event.target.value)}
+                    value={baseName}
+                >
+                    {baseOptions.map((option) => (
+                        <option key={option.name} value={option.name}>
+                            {option.name}
+                            {option.isCurrent ? " · current" : ""}
+                            {option.isRemote ? " · remote" : ""}
+                        </option>
+                    ))}
+                </select>
+            </label>
+
+            <label className="sidebar-git-scope-menu__branch-form-checkbox">
+                <input
+                    checked={checkoutAfterCreate}
+                    disabled={disabled}
+                    onChange={(event) =>
+                        onCheckoutAfterCreateChange(event.target.checked)
+                    }
+                    type="checkbox"
+                />
+                <span>Checkout branch</span>
+            </label>
+
+            <div className="sidebar-git-scope-menu__branch-form-actions">
+                <button
+                    className="sidebar-git-scope-menu__branch-form-secondary"
+                    disabled={disabled}
+                    onClick={onCancel}
+                    type="button"
+                >
+                    Cancel
+                </button>
+                <button
+                    className="sidebar-git-scope-menu__branch-form-primary"
+                    disabled={disabled || baseOptions.length === 0}
+                    type="submit"
+                >
+                    Create Branch
+                </button>
+            </div>
+        </form>
+    );
+}
+
 function RowMenuTrigger({
     disabled = false,
     label,
@@ -1993,6 +2338,20 @@ function SearchIcon() {
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 strokeWidth="1.3"
+            />
+        </svg>
+    );
+}
+
+function PlusIcon() {
+    return (
+        <svg aria-hidden="true" fill="none" viewBox="0 0 16 16">
+            <path
+                d="M8 3.5v9M3.5 8h9"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.4"
             />
         </svg>
     );

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -2029,6 +2029,11 @@ export function SidebarGitScopePicker({
                                                   "current",
                                               )
                                           }
+                                          title={
+                                              canOpenBranchCreation
+                                                  ? "Create a branch from the current branch"
+                                                  : "No branch is available as a base"
+                                          }
                                           type="button"
                                       >
                                           <PlusIcon />

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -72,6 +72,9 @@ const GIT_SCOPE_VIRTUALIZATION_THRESHOLD = 120;
 const GIT_SCOPE_VIRTUALIZATION_OVERSCAN = 6;
 const GIT_SCOPE_ROW_ESTIMATE = 52;
 const GIT_SCOPE_SECTION_ESTIMATE = 30;
+const GIT_SCOPE_MENU_CHROME_ESTIMATE = 144;
+const GIT_SCOPE_BRANCH_CREATION_FORM_ESTIMATE = 188;
+const GIT_SCOPE_CREATE_QUERY_ESTIMATE = 44;
 const GIT_SCOPE_MENU_SIZE_STORAGE_KEY = "comando.git.scope.menu.size";
 const GIT_SCOPE_MENU_SIZE_VERSION = 1;
 const GIT_SCOPE_MENU_MIN_WIDTH = 280;
@@ -644,6 +647,8 @@ export function SidebarGitScopePicker({
         [listItems],
     );
     const shouldVirtualizeList = listItems.length >= GIT_SCOPE_VIRTUALIZATION_THRESHOLD;
+    const hasBranchCreationForm = branchCreationDraft !== null;
+    const hasBranchCreationQueryOffer = branchCreationQueryOffer !== null;
 
     const updateMenuPosition = useCallback(() => {
         const button = buttonRef.current;
@@ -660,13 +665,28 @@ export function SidebarGitScopePicker({
         const estimatedRows = Math.max(listItems.length, 1);
         const defaultHeight = Math.min(
             GIT_SCOPE_MENU_DEFAULT_MAX_HEIGHT,
-            estimatedRows * GIT_SCOPE_ROW_ESTIMATE + 144 + (actionError ? 40 : 0),
+            estimatedRows * GIT_SCOPE_ROW_ESTIMATE +
+                GIT_SCOPE_MENU_CHROME_ESTIMATE +
+                (hasBranchCreationForm
+                    ? GIT_SCOPE_BRANCH_CREATION_FORM_ESTIMATE
+                    : 0) +
+                (hasBranchCreationQueryOffer ? GIT_SCOPE_CREATE_QUERY_ESTIMATE : 0) +
+                (actionError ? 40 : 0),
         );
+        const measuredHeight = Math.ceil(measuredMenuRect?.height ?? 0);
+        const baseSize = userMenuSize
+            ? {
+                  height: hasBranchCreationForm
+                      ? Math.max(userMenuSize.height, defaultHeight)
+                      : userMenuSize.height,
+                  width: userMenuSize.width,
+              }
+            : {
+                  height: Math.max(measuredHeight, defaultHeight),
+                  width: defaultWidth,
+              };
         const size = clampGitScopeMenuSize(
-            userMenuSize ?? {
-                height: Math.ceil(measuredMenuRect?.height ?? defaultHeight),
-                width: defaultWidth,
-            },
+            baseSize,
             {
                 x: buttonRect.left,
                 y: buttonRect.bottom + 6,
@@ -693,6 +713,8 @@ export function SidebarGitScopePicker({
         });
     }, [
         actionError,
+        hasBranchCreationForm,
+        hasBranchCreationQueryOffer,
         listItems.length,
         userMenuSize,
     ]);

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -727,6 +727,45 @@ export function SidebarGitScopePicker({
     }, [activeTab]);
 
     useEffect(() => {
+        if (!branchCreationDraft) {
+            return;
+        }
+
+        const currentBaseExists = branchCreationBaseOptions.some(
+            (option) => option.name === branchCreationBaseName,
+        );
+        if (currentBaseExists) {
+            return;
+        }
+
+        const fallbackBase =
+            defaultBranchCreationBase &&
+            branchCreationBaseOptions.some(
+                (option) => option.name === defaultBranchCreationBase,
+            )
+                ? defaultBranchCreationBase
+                : (branchCreationBaseOptions[0]?.name ?? null);
+
+        if (fallbackBase) {
+            setBranchCreationBaseName(fallbackBase);
+            setActionError(null);
+            return;
+        }
+
+        setBranchCreationDraft(null);
+        setBranchCreationName("");
+        setBranchCreationBaseName("");
+        setBranchCreationCheckout(true);
+        setBranchCreationSubmitted(false);
+        setActionError("The selected base branch is no longer available.");
+    }, [
+        branchCreationBaseName,
+        branchCreationBaseOptions,
+        branchCreationDraft,
+        defaultBranchCreationBase,
+    ]);
+
+    useEffect(() => {
         if (!isOpen) {
             return;
         }

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -1802,6 +1802,14 @@ export function SidebarGitScopePicker({
     useEffect(() => {
         if (focusIndex < 0 || !listRef.current) return;
 
+        const mountedRow = listRef.current.querySelector<HTMLElement>(
+            `[data-row-index="${focusIndex}"]`,
+        );
+        if (mountedRow) {
+            mountedRow.scrollIntoView({ block: "nearest" });
+            return;
+        }
+
         const renderIndex = selectableRenderIndexByFocusIndex.get(focusIndex);
         if (renderIndex == null) {
             return;
@@ -1813,11 +1821,6 @@ export function SidebarGitScopePicker({
             });
             return;
         }
-
-        const row = listRef.current.querySelector<HTMLElement>(
-            `[data-row-index="${focusIndex}"]`,
-        );
-        row?.scrollIntoView({ block: "nearest" });
     }, [focusIndex, selectableRenderIndexByFocusIndex, shouldVirtualizeList]);
 
     const toggleSection = useCallback((section: string) => {

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -40,6 +40,7 @@ import { SidebarNodeRow, type SidebarBadge } from "./SidebarNodeRow";
 import {
     buildBranchCreationBaseOptions,
     createBranchCreationDraft,
+    getBranchCreationQueryOffer,
     getDefaultBranchCreationBase,
     validateNewBranchName,
     type BranchCreationBaseOption,
@@ -229,6 +230,10 @@ type RenderListItem =
       };
 
 type SelectableListItem =
+    | {
+          readonly branchName: string;
+          readonly kind: "create-branch";
+      }
     | {
           readonly branch: GitBranchSummary;
           readonly kind: "branch";
@@ -486,6 +491,23 @@ export function SidebarGitScopePicker({
     );
 
     const normalizedQuery = deferredQuery.trim().toLowerCase();
+    const branchCreationQueryOffer = useMemo(
+        () =>
+            activeTab === "branches" &&
+            !canInitializeGit &&
+            !branchCreationDraft &&
+            defaultBranchCreationBase
+                ? getBranchCreationQueryOffer(deferredQuery, branches)
+                : null,
+        [
+            activeTab,
+            branchCreationDraft,
+            branches,
+            canInitializeGit,
+            defaultBranchCreationBase,
+            deferredQuery,
+        ],
+    );
     const filteredBranchRows = useMemo(() => {
         if (!normalizedQuery) {
             return branchRows;
@@ -512,7 +534,7 @@ export function SidebarGitScopePicker({
     }, [normalizedQuery, worktreeRows]);
 
     const listItems = useMemo(() => {
-        let selectableIndex = 0;
+        let selectableIndex = branchCreationQueryOffer ? 1 : 0;
         const items: RenderListItem[] = [];
 
         if (activeTab === "worktrees") {
@@ -578,6 +600,7 @@ export function SidebarGitScopePicker({
         return items;
     }, [
         activeTab,
+        branchCreationQueryOffer,
         collapsedSections.local,
         collapsedSections.remote,
         filteredWorktreeRows,
@@ -587,6 +610,12 @@ export function SidebarGitScopePicker({
 
     const flatItems = useMemo<readonly SelectableListItem[]>(() => {
         const items: SelectableListItem[] = [];
+        if (branchCreationQueryOffer) {
+            items.push({
+                branchName: branchCreationQueryOffer.branchName,
+                kind: "create-branch",
+            });
+        }
 
         for (const item of listItems) {
             if (item.kind === "section") {
@@ -602,7 +631,7 @@ export function SidebarGitScopePicker({
         }
 
         return items;
-    }, [listItems]);
+    }, [branchCreationQueryOffer, listItems]);
     const selectableRenderIndexByFocusIndex = useMemo(
         () =>
             new Map(
@@ -1469,6 +1498,12 @@ export function SidebarGitScopePicker({
                 disabled: isBusy || row.isActive,
                 label: checkoutLabel,
             });
+            entries.push({
+                action: () =>
+                    openBranchCreationForm(row.branch.name, "context-menu"),
+                disabled: isBusy || !projectId,
+                label: "New Branch from...",
+            });
 
             if (linkedWorktree) {
                 entries.push({
@@ -1559,6 +1594,7 @@ export function SidebarGitScopePicker({
         handleSelectWorktree,
         isBusy,
         itemContextMenu,
+        openBranchCreationForm,
         projectId,
         snapshot?.currentWorktreeId,
         worktreeId,
@@ -1569,12 +1605,25 @@ export function SidebarGitScopePicker({
         const item = flatItems[focusIndex];
         if (!item) return;
 
-        if (item.kind === "branch") {
+        if (item.kind === "create-branch") {
+            openBranchCreationForm(
+                defaultBranchCreationBase,
+                "search",
+                item.branchName,
+            );
+        } else if (item.kind === "branch") {
             void handleSelectBranch(item.branch);
         } else {
             void handleSelectWorktree(item.worktree.id);
         }
-    }, [flatItems, focusIndex, handleSelectBranch, handleSelectWorktree]);
+    }, [
+        defaultBranchCreationBase,
+        flatItems,
+        focusIndex,
+        handleSelectBranch,
+        handleSelectWorktree,
+        openBranchCreationForm,
+    ]);
 
     const handleListKeyDown = useCallback(
         (event: React.KeyboardEvent) => {
@@ -2006,12 +2055,29 @@ export function SidebarGitScopePicker({
                               className="shell-scrollbar sidebar-git-scope-menu__list"
                               ref={listRef}
                           >
+                              {branchCreationQueryOffer ? (
+                                  <BranchCreationQueryOfferRow
+                                      branchName={
+                                          branchCreationQueryOffer.branchName
+                                      }
+                                      disabled={isBusy}
+                                      isSelected={focusIndex === 0}
+                                      onClick={() =>
+                                          openBranchCreationForm(
+                                              defaultBranchCreationBase,
+                                              "search",
+                                              branchCreationQueryOffer.branchName,
+                                          )
+                                      }
+                                  />
+                              ) : null}
                               {canInitializeGit ? (
                                   <GitInitState
                                       disabled={isBusy}
                                       onInit={handleInitRepository}
                                   />
-                              ) : listItems.length === 0 ? (
+                              ) : listItems.length === 0 &&
+                                !branchCreationQueryOffer ? (
                                   <EmptyState label={emptyLabel} />
                               ) : shouldVirtualizeList ? (
                                   <MeasuredVirtualList
@@ -2150,6 +2216,39 @@ function SectionHeader({
 
 function EmptyState({ label }: { readonly label: string }) {
     return <div className="sidebar-git-scope-menu__empty">{label}</div>;
+}
+
+function BranchCreationQueryOfferRow({
+    branchName,
+    disabled,
+    isSelected,
+    onClick,
+}: {
+    readonly branchName: string;
+    readonly disabled: boolean;
+    readonly isSelected: boolean;
+    readonly onClick: () => void;
+}) {
+    return (
+        <button
+            className={[
+                "sidebar-git-scope-menu__create-query",
+                isSelected ? "sidebar-git-scope-menu__create-query--selected" : "",
+            ]
+                .filter(Boolean)
+                .join(" ")}
+            disabled={disabled}
+            onClick={onClick}
+            type="button"
+        >
+            <span className="sidebar-git-scope-menu__create-query-icon">
+                <PlusIcon />
+            </span>
+            <span className="sidebar-git-scope-menu__create-query-copy">
+                Create <span>{branchName}</span>
+            </span>
+        </button>
+    );
 }
 
 function GitInitState({

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -1775,8 +1775,9 @@ export function SidebarGitScopePicker({
             return;
         }
 
-        const rows = listRef.current.querySelectorAll("[data-row-index]");
-        const row = rows[focusIndex] as HTMLElement | undefined;
+        const row = listRef.current.querySelector<HTMLElement>(
+            `[data-row-index="${focusIndex}"]`,
+        );
         row?.scrollIntoView({ block: "nearest" });
     }, [focusIndex, selectableRenderIndexByFocusIndex, shouldVirtualizeList]);
 
@@ -2056,20 +2057,22 @@ export function SidebarGitScopePicker({
                               ref={listRef}
                           >
                               {branchCreationQueryOffer ? (
-                                  <BranchCreationQueryOfferRow
-                                      branchName={
-                                          branchCreationQueryOffer.branchName
-                                      }
-                                      disabled={isBusy}
-                                      isSelected={focusIndex === 0}
-                                      onClick={() =>
-                                          openBranchCreationForm(
-                                              defaultBranchCreationBase,
-                                              "search",
-                                              branchCreationQueryOffer.branchName,
-                                          )
-                                      }
-                                  />
+                                  <div data-row-index={0}>
+                                      <BranchCreationQueryOfferRow
+                                          branchName={
+                                              branchCreationQueryOffer.branchName
+                                          }
+                                          disabled={isBusy}
+                                          isSelected={focusIndex === 0}
+                                          onClick={() =>
+                                              openBranchCreationForm(
+                                                  defaultBranchCreationBase,
+                                                  "search",
+                                                  branchCreationQueryOffer.branchName,
+                                              )
+                                          }
+                                      />
+                                  </div>
                               ) : null}
                               {canInitializeGit ? (
                                   <GitInitState

--- a/src/renderer/src/components/sidebar/sidebarGitBranchCreation.ts
+++ b/src/renderer/src/components/sidebar/sidebarGitBranchCreation.ts
@@ -139,6 +139,24 @@ export function validateNewBranchName(
         return invalid(value, "Branch names cannot contain '..'.");
     }
 
+    if (
+        value === "@" ||
+        value.includes("@{") ||
+        value.includes("//") ||
+        value.includes("\\") ||
+        /[~^:?*[]/.test(value) ||
+        value.split("/").some((segment) => segment.startsWith("."))
+    ) {
+        return invalid(
+            value,
+            "Branch name contains characters Git does not allow.",
+        );
+    }
+
+    if (value.endsWith(".") || value.endsWith(".lock")) {
+        return invalid(value, 'Branch name cannot end with "." or ".lock".');
+    }
+
     if (branches.some((branch) => !branch.isRemote && branch.name === value)) {
         return invalid(value, "A local branch with this name already exists.");
     }

--- a/src/renderer/src/components/sidebar/sidebarGitBranchCreation.ts
+++ b/src/renderer/src/components/sidebar/sidebarGitBranchCreation.ts
@@ -139,10 +139,15 @@ export function validateNewBranchName(
         return invalid(value, "Branch names cannot contain '..'.");
     }
 
-    if (
-        branches.some((branch) => !branch.isRemote && branch.name === value)
-    ) {
+    if (branches.some((branch) => !branch.isRemote && branch.name === value)) {
         return invalid(value, "A local branch with this name already exists.");
+    }
+
+    if (branches.some((branch) => branch.isRemote && branch.name === value)) {
+        return invalid(
+            value,
+            "A remote branch with this name already exists.",
+        );
     }
 
     return {

--- a/src/renderer/src/components/sidebar/sidebarGitBranchCreation.ts
+++ b/src/renderer/src/components/sidebar/sidebarGitBranchCreation.ts
@@ -28,6 +28,10 @@ export type BranchNameValidationResult =
           readonly value: string;
       };
 
+export type BranchCreationQueryOffer = {
+    readonly branchName: string;
+};
+
 export function normalizeBranchNameInput(input: string): string {
     return input.trim();
 }
@@ -145,6 +149,20 @@ export function validateNewBranchName(
         error: null,
         isValid: true,
         value,
+    };
+}
+
+export function getBranchCreationQueryOffer(
+    query: string,
+    branches: readonly GitBranchSummary[],
+): BranchCreationQueryOffer | null {
+    const validation = validateNewBranchName(query, branches);
+    if (!validation.isValid) {
+        return null;
+    }
+
+    return {
+        branchName: validation.value,
     };
 }
 

--- a/src/renderer/src/components/sidebar/sidebarGitBranchCreation.ts
+++ b/src/renderer/src/components/sidebar/sidebarGitBranchCreation.ts
@@ -153,7 +153,10 @@ export function validateNewBranchName(
         );
     }
 
-    if (value.endsWith(".") || value.endsWith(".lock")) {
+    if (
+        value.endsWith(".") ||
+        value.split("/").some((segment) => segment.endsWith(".lock"))
+    ) {
         return invalid(value, 'Branch name cannot end with "." or ".lock".');
     }
 

--- a/src/renderer/src/components/sidebar/sidebarGitBranchCreation.ts
+++ b/src/renderer/src/components/sidebar/sidebarGitBranchCreation.ts
@@ -1,0 +1,173 @@
+import type { GitBranchSummary } from "@shared/ipc";
+
+export type BranchCreationSource = "current" | "context-menu" | "search";
+
+export type BranchCreationDraft = {
+    readonly baseBranchName: string;
+    readonly checkoutAfterCreate: boolean;
+    readonly initialName: string;
+    readonly source: BranchCreationSource;
+};
+
+export type BranchCreationBaseOption = {
+    readonly description: string;
+    readonly isCurrent: boolean;
+    readonly isRemote: boolean;
+    readonly name: string;
+};
+
+export type BranchNameValidationResult =
+    | {
+          readonly error: null;
+          readonly isValid: true;
+          readonly value: string;
+      }
+    | {
+          readonly error: string;
+          readonly isValid: false;
+          readonly value: string;
+      };
+
+export function normalizeBranchNameInput(input: string): string {
+    return input.trim();
+}
+
+export function getDefaultBranchCreationBase(input: {
+    readonly branches: readonly GitBranchSummary[];
+    readonly currentBranchName?: string | null;
+}): string | null {
+    const currentBranchName = input.currentBranchName?.trim() ?? "";
+    if (
+        currentBranchName &&
+        input.branches.some(
+            (branch) => !branch.isRemote && branch.name === currentBranchName,
+        )
+    ) {
+        return currentBranchName;
+    }
+
+    const currentBranch = input.branches.find(
+        (branch) => branch.isCurrent && !branch.isDetached && !branch.isRemote,
+    );
+    if (currentBranch) {
+        return currentBranch.name;
+    }
+
+    const firstLocalBranch = input.branches.find(
+        (branch) => !branch.isDetached && !branch.isRemote,
+    );
+    if (firstLocalBranch) {
+        return firstLocalBranch.name;
+    }
+
+    const firstRemoteBranch = input.branches.find((branch) => branch.isRemote);
+    if (firstRemoteBranch) {
+        return firstRemoteBranch.name;
+    }
+
+    return currentBranchName || null;
+}
+
+export function buildBranchCreationBaseOptions(
+    branches: readonly GitBranchSummary[],
+): readonly BranchCreationBaseOption[] {
+    const seenNames = new Set<string>();
+    const options: BranchCreationBaseOption[] = [];
+
+    for (const branch of branches) {
+        if (!branch.name || branch.isDetached || seenNames.has(branch.name)) {
+            continue;
+        }
+
+        seenNames.add(branch.name);
+        options.push({
+            description: getBranchBaseDescription(branch),
+            isCurrent: branch.isCurrent,
+            isRemote: branch.isRemote,
+            name: branch.name,
+        });
+    }
+
+    return options;
+}
+
+export function createBranchCreationDraft(input: {
+    readonly baseBranchName: string | null;
+    readonly checkoutAfterCreate?: boolean;
+    readonly initialName?: string;
+    readonly source: BranchCreationSource;
+}): BranchCreationDraft | null {
+    const baseBranchName = input.baseBranchName?.trim() ?? "";
+    if (!baseBranchName) {
+        return null;
+    }
+
+    return {
+        baseBranchName,
+        checkoutAfterCreate: input.checkoutAfterCreate ?? true,
+        initialName: normalizeBranchNameInput(input.initialName ?? ""),
+        source: input.source,
+    };
+}
+
+export function validateNewBranchName(
+    input: string,
+    branches: readonly GitBranchSummary[],
+): BranchNameValidationResult {
+    const value = normalizeBranchNameInput(input);
+    if (!value) {
+        return invalid(value, "Enter a branch name.");
+    }
+
+    if (value.toUpperCase() === "HEAD") {
+        return invalid(value, "HEAD is reserved.");
+    }
+
+    if (/\s/.test(value)) {
+        return invalid(value, "Branch names cannot contain whitespace.");
+    }
+
+    if (value.startsWith("/") || value.endsWith("/")) {
+        return invalid(value, "Branch names cannot start or end with a slash.");
+    }
+
+    if (value.includes("..")) {
+        return invalid(value, "Branch names cannot contain '..'.");
+    }
+
+    if (
+        branches.some((branch) => !branch.isRemote && branch.name === value)
+    ) {
+        return invalid(value, "A local branch with this name already exists.");
+    }
+
+    return {
+        error: null,
+        isValid: true,
+        value,
+    };
+}
+
+function invalid(value: string, error: string): BranchNameValidationResult {
+    return {
+        error,
+        isValid: false,
+        value,
+    };
+}
+
+function getBranchBaseDescription(branch: GitBranchSummary): string {
+    if (branch.isRemote) {
+        return "Remote branch";
+    }
+
+    if (branch.isCurrent) {
+        return "Current branch";
+    }
+
+    if (branch.upstreamName) {
+        return `Tracks ${branch.upstreamName}`;
+    }
+
+    return "Local branch";
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1272,6 +1272,7 @@ button {
 .sidebar-git-scope-menu__branch-form {
     display: flex;
     flex-direction: column;
+    flex-shrink: 0;
     gap: 8px;
     border-bottom: 1px solid var(--color-border);
     background: color-mix(in srgb, var(--color-bg-elevated) 58%, transparent);

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1480,6 +1480,82 @@ button {
     font-size: 11px;
 }
 
+.sidebar-git-scope-menu__create-query {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    width: 100%;
+    min-height: 36px;
+    min-width: 0;
+    border: 1px solid
+        color-mix(in srgb, var(--color-accent) 24%, var(--color-border));
+    border-radius: 7px;
+    background: color-mix(
+        in srgb,
+        var(--color-accent) 8%,
+        var(--color-bg-elevated)
+    );
+    margin-bottom: 6px;
+    padding: 7px 9px;
+    color: var(--color-text-primary);
+    text-align: left;
+    transition:
+        background-color 120ms ease,
+        border-color 120ms ease,
+        color 120ms ease;
+}
+
+.sidebar-git-scope-menu__create-query:hover:not(:disabled),
+.sidebar-git-scope-menu__create-query--selected {
+    border-color: color-mix(
+        in srgb,
+        var(--color-accent) 45%,
+        var(--color-border)
+    );
+    background: color-mix(
+        in srgb,
+        var(--color-accent) 14%,
+        var(--color-bg-elevated)
+    );
+}
+
+.sidebar-git-scope-menu__create-query:disabled {
+    cursor: default;
+    opacity: 0.55;
+}
+
+.sidebar-git-scope-menu__create-query-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+    color: var(--color-text-primary);
+}
+
+.sidebar-git-scope-menu__create-query-icon svg {
+    width: 13px;
+    height: 13px;
+}
+
+.sidebar-git-scope-menu__create-query-copy {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--color-text-secondary);
+    font-size: 11px;
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sidebar-git-scope-menu__create-query-copy span {
+    color: var(--color-text-primary);
+    font-family: var(--font-mono);
+}
+
 .sidebar-git-scope-menu__init {
     display: flex;
     flex-direction: column;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1214,6 +1214,191 @@ button {
     padding-left: 28px;
 }
 
+.sidebar-git-scope-menu__actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0 12px 8px;
+}
+
+.sidebar-git-scope-menu__new-branch-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 26px;
+    max-width: 100%;
+    border: 1px solid
+        color-mix(in srgb, var(--color-accent) 34%, var(--color-border));
+    border-radius: 7px;
+    background: color-mix(
+        in srgb,
+        var(--color-accent) 11%,
+        var(--color-bg-elevated)
+    );
+    padding: 0 9px;
+    color: var(--color-text-primary);
+    font-size: 11px;
+    font-weight: 600;
+    transition:
+        background-color 120ms ease,
+        border-color 120ms ease,
+        color 120ms ease;
+}
+
+.sidebar-git-scope-menu__new-branch-button:hover:not(:disabled) {
+    border-color: color-mix(
+        in srgb,
+        var(--color-accent) 55%,
+        var(--color-border)
+    );
+    background: color-mix(
+        in srgb,
+        var(--color-accent) 17%,
+        var(--color-bg-elevated)
+    );
+}
+
+.sidebar-git-scope-menu__new-branch-button:disabled {
+    cursor: default;
+    opacity: 0.55;
+}
+
+.sidebar-git-scope-menu__new-branch-button svg {
+    width: 13px;
+    height: 13px;
+    flex-shrink: 0;
+}
+
+.sidebar-git-scope-menu__branch-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-bg-elevated) 58%, transparent);
+    padding: 10px 12px 12px;
+}
+
+.sidebar-git-scope-menu__branch-form-header {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+}
+
+.sidebar-git-scope-menu__branch-form-header span {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--color-text-primary);
+    font-size: 12px;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sidebar-git-scope-menu__branch-form-field {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.sidebar-git-scope-menu__branch-form-field > span {
+    color: var(--color-text-secondary);
+    font-size: 10px;
+    font-weight: 600;
+}
+
+.sidebar-git-scope-menu__branch-form-field select.ide-input {
+    min-width: 0;
+}
+
+.sidebar-git-scope-menu__branch-form-error {
+    overflow-wrap: anywhere;
+    color: var(--diff-remove);
+    font-size: 10px;
+    line-height: 1.35;
+}
+
+.sidebar-git-scope-menu__branch-form-checkbox {
+    display: inline-flex;
+    min-width: 0;
+    align-items: center;
+    gap: 7px;
+    color: var(--color-text-secondary);
+    font-size: 11px;
+}
+
+.sidebar-git-scope-menu__branch-form-checkbox input {
+    width: 13px;
+    height: 13px;
+    flex-shrink: 0;
+    accent-color: var(--color-accent);
+}
+
+.sidebar-git-scope-menu__branch-form-actions {
+    display: flex;
+    min-width: 0;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.sidebar-git-scope-menu__branch-form-primary,
+.sidebar-git-scope-menu__branch-form-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 28px;
+    min-width: 0;
+    border-radius: 7px;
+    padding: 0 10px;
+    font-size: 11px;
+    font-weight: 600;
+    transition:
+        background-color 120ms ease,
+        border-color 120ms ease,
+        color 120ms ease;
+}
+
+.sidebar-git-scope-menu__branch-form-primary {
+    border: 1px solid
+        color-mix(in srgb, var(--color-accent) 48%, var(--color-border));
+    background: color-mix(
+        in srgb,
+        var(--color-accent) 18%,
+        var(--color-bg-elevated)
+    );
+    color: var(--color-text-primary);
+}
+
+.sidebar-git-scope-menu__branch-form-primary:hover:not(:disabled) {
+    border-color: color-mix(
+        in srgb,
+        var(--color-accent) 68%,
+        var(--color-border)
+    );
+    background: color-mix(
+        in srgb,
+        var(--color-accent) 25%,
+        var(--color-bg-elevated)
+    );
+}
+
+.sidebar-git-scope-menu__branch-form-secondary {
+    border: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-bg-tertiary) 55%, transparent);
+    color: var(--color-text-secondary);
+}
+
+.sidebar-git-scope-menu__branch-form-secondary:hover:not(:disabled) {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+}
+
+.sidebar-git-scope-menu__branch-form-primary:disabled,
+.sidebar-git-scope-menu__branch-form-secondary:disabled {
+    cursor: default;
+    opacity: 0.55;
+}
+
 .sidebar-git-scope-menu__section-header {
     display: flex;
     align-items: center;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -58,6 +58,7 @@ export const IPC_CHANNELS = {
     discardGitPaths: "git:discard-paths",
     commitGitChanges: "git:commit",
     checkoutGitBranch: "git:checkout-branch",
+    createGitBranch: "git:create-branch",
     createGitWorktree: "git:create-worktree",
     removeGitWorktree: "git:remove-worktree",
     deleteLocalGitBranch: "git:delete-local-branch",
@@ -984,6 +985,11 @@ export interface GitCheckoutBranchInput extends GitRepositoryScopeInput {
     readonly branchName: string;
     readonly force?: boolean;
     readonly newBranchName?: string | null;
+    readonly startPoint?: string | null;
+}
+
+export interface GitCreateBranchInput extends GitRepositoryScopeInput {
+    readonly branchName: string;
     readonly startPoint?: string | null;
 }
 
@@ -2854,6 +2860,9 @@ export interface ComandoApi {
     commitGitChanges: (input: GitCommitInput) => Promise<GitCommitResult>;
     checkoutGitBranch: (
         input: GitCheckoutBranchInput,
+    ) => Promise<GitRepositorySnapshot>;
+    createGitBranch: (
+        input: GitCreateBranchInput,
     ) => Promise<GitRepositorySnapshot>;
     createGitWorktree: (
         input: GitCreateWorktreeInput,


### PR DESCRIPTION
## Summary

- Adds renderer-to-native plumbing for creating Git branches without checking them out.
- Adds a manual branch creation flow in the branch picker, including base selection, optional checkout, contextual branch actions, and search-driven creation.
- Hardens branch name validation, branch creation focus/scroll behavior, stale base handling, and the disabled New Branch button affordance.

## Validation

- `pnpm exec vitest run src/main/native-backend/git.test.ts`
- `pnpm exec vitest run src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`