### PR TITLE
Clean up Rust Clippy warnings

### DIFF
--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -1895,23 +1895,27 @@ impl NativeBackend {
             input.include_ancestor_directories,
             input.context_key.as_deref(),
         ) {
-            Ok((entries, matches, operation_id, events)) => {
+            Ok(result) => {
                 let status = self
                     .index_service
                     .get_status(&input.project_id, input.worktree_id.as_ref());
                 let mut outputs = vec![response_ok(
                     request.id,
                     serde_json::to_value(native_index::NativeProjectEntrySearchResult {
-                        operation_id,
+                        operation_id: result.operation_id,
                         generation: status.generation,
                         status: native_index_status_kind(status.status),
-                        entries: entries.into_iter().map(indexed_project_entry).collect(),
-                        matches: path_search_matches(matches),
+                        entries: result
+                            .entries
+                            .into_iter()
+                            .map(indexed_project_entry)
+                            .collect(),
+                        matches: path_search_matches(result.matches),
                         stats: native_index_stats(status.stats),
                     })
                     .expect("project entry search result serializes"),
                 )];
-                outputs.extend(index_event_outputs(events));
+                outputs.extend(index_event_outputs(result.events));
                 CommandResult {
                     outputs,
                     should_shutdown: false,
@@ -1947,23 +1951,27 @@ impl NativeBackend {
                 input.include_ancestor_directories,
                 input.context_key.as_deref(),
             ) {
-                Ok((entries, matches, operation_id, events)) => {
+                Ok(result) => {
                     let status = self
                         .index_service
                         .get_status(&input.project_id, input.worktree_id.as_ref());
                     let mut outputs = vec![response_ok(
                         request.id,
                         serde_json::to_value(native_index::NativeProjectEntrySearchResult {
-                            operation_id,
+                            operation_id: result.operation_id,
                             generation: status.generation,
                             status: native_index_status_kind(status.status),
-                            entries: entries.into_iter().map(indexed_project_entry).collect(),
-                            matches: path_search_matches(matches),
+                            entries: result
+                                .entries
+                                .into_iter()
+                                .map(indexed_project_entry)
+                                .collect(),
+                            matches: path_search_matches(result.matches),
                             stats: native_index_stats(status.stats),
                         })
                         .expect("project entry search result serializes"),
                     )];
-                    outputs.extend(index_event_outputs(events));
+                    outputs.extend(index_event_outputs(result.events));
                     CommandResult {
                         outputs,
                         should_shutdown: false,

--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -4639,7 +4639,7 @@ mod tests {
         };
         assert_eq!(updated_event.event_name, "project://updated");
         assert_eq!(updated_event.payload["reason"], "project_add");
-        assert_eq!(updated_event.payload["projectId"].as_str().is_some(), true);
+        assert!(updated_event.payload["projectId"].as_str().is_some());
         assert_eq!(
             updated_event.payload["worktreeId"].as_str().unwrap(),
             format!(

--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -603,18 +603,16 @@ pub fn start_acp_session(
     let task_sessions = Arc::clone(&sessions);
 
     runtime.spawn(async move {
-        let result = run_acp_session(
-            spec,
-            task_session,
-            task_sessions,
+        let context = AcpSessionRuntimeContext {
+            sessions: task_sessions,
             event_sender,
             command_receiver,
-            Arc::clone(&task_started_sender),
+            started_sender: Arc::clone(&task_started_sender),
             permission_waiters,
             prompt_capabilities,
             user_input_waiters,
-        )
-        .await;
+        };
+        let result = run_acp_session(spec, task_session, context).await;
         if let Err(error) = result {
             send_start_result(&task_started_sender, Err(error.clone()));
         }
@@ -734,17 +732,31 @@ async fn run_acp_runtime_auth_async(
     result
 }
 
-async fn run_acp_session(
-    spec: AcpProcessSpec,
-    session: NativeAiSession,
+struct AcpSessionRuntimeContext {
     sessions: Arc<Mutex<SessionRegistry>>,
     event_sender: Option<std_mpsc::SyncSender<AiRuntimeEvent>>,
-    mut command_receiver: tokio_mpsc::UnboundedReceiver<AcpSessionCommand>,
+    command_receiver: tokio_mpsc::UnboundedReceiver<AcpSessionCommand>,
     started_sender: AcpStartSender,
     permission_waiters: PermissionWaiterMap,
     prompt_capabilities: PromptCapabilitiesState,
     user_input_waiters: UserInputWaiterMap,
+}
+
+async fn run_acp_session(
+    spec: AcpProcessSpec,
+    session: NativeAiSession,
+    context: AcpSessionRuntimeContext,
 ) -> Result<(), String> {
+    let AcpSessionRuntimeContext {
+        sessions,
+        event_sender,
+        mut command_receiver,
+        started_sender,
+        permission_waiters,
+        prompt_capabilities,
+        user_input_waiters,
+    } = context;
+
     let mut command = Command::new(&spec.executable);
     command
         .args(&spec.args)

--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -4323,10 +4323,10 @@ fn anchored_candidate_matches_diff(
     path: &str,
     cwd: &str,
 ) -> bool {
-    if let Some(candidate_path) = candidate.path.as_deref() {
-        if !paths_match(candidate_path, path, cwd) {
-            return false;
-        }
+    if let Some(candidate_path) = candidate.path.as_deref()
+        && !paths_match(candidate_path, path, cwd)
+    {
+        return false;
     }
 
     match candidate.match_mode {

--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -91,6 +91,8 @@ const TERMINAL_OUTPUT_MAX_LENGTH: usize = 10_000;
 type PermissionWaiterMap = Arc<Mutex<HashMap<String, PendingPermissionRequest>>>;
 type PromptCapabilitiesState = Arc<Mutex<AcpPromptCapabilities>>;
 type UserInputWaiterMap = Arc<Mutex<HashMap<String, PendingUserInputRequest>>>;
+type AcpStartResult = Result<RuntimeSessionId, String>;
+type AcpStartSender = Arc<Mutex<Option<oneshot::Sender<AcpStartResult>>>>;
 
 #[derive(Debug)]
 struct PendingPermissionRequest {
@@ -594,8 +596,8 @@ pub fn start_acp_session(
         sender: command_sender,
         user_input_waiters: Arc::clone(&user_input_waiters),
     };
-    let (started_sender, started_receiver) = oneshot::channel::<Result<RuntimeSessionId, String>>();
-    let started_sender = Arc::new(Mutex::new(Some(started_sender)));
+    let (started_sender, started_receiver) = oneshot::channel::<AcpStartResult>();
+    let started_sender: AcpStartSender = Arc::new(Mutex::new(Some(started_sender)));
     let task_started_sender = Arc::clone(&started_sender);
     let task_session = session.clone();
     let task_sessions = Arc::clone(&sessions);
@@ -738,7 +740,7 @@ async fn run_acp_session(
     sessions: Arc<Mutex<SessionRegistry>>,
     event_sender: Option<std_mpsc::SyncSender<AiRuntimeEvent>>,
     mut command_receiver: tokio_mpsc::UnboundedReceiver<AcpSessionCommand>,
-    started_sender: Arc<Mutex<Option<oneshot::Sender<Result<RuntimeSessionId, String>>>>>,
+    started_sender: AcpStartSender,
     permission_waiters: PermissionWaiterMap,
     prompt_capabilities: PromptCapabilitiesState,
     user_input_waiters: UserInputWaiterMap,
@@ -1356,10 +1358,7 @@ fn mark_session_status(
     Some(session.session.summary())
 }
 
-fn send_start_result(
-    sender: &Arc<Mutex<Option<oneshot::Sender<Result<RuntimeSessionId, String>>>>>,
-    result: Result<RuntimeSessionId, String>,
-) {
+fn send_start_result(sender: &AcpStartSender, result: AcpStartResult) {
     if let Ok(mut sender) = sender.lock() {
         if let Some(sender) = sender.take() {
             let _ = sender.send(result);

--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -944,20 +944,22 @@ async fn run_acp_session(
                             let root_session_id = session.session_id.clone();
                             let sessions = Arc::clone(&sessions);
                             tokio::spawn(async move {
-                                run_prompt(
-                                    &connection,
-                                    &root_session_id,
-                                    &target_session_id,
-                                    &runtime_id,
-                                    &runtime_session_id,
+                                let request = RunPromptRequest {
+                                    session_id: root_session_id,
+                                    target_session_id,
+                                    runtime_id,
+                                    runtime_session_id,
                                     message_id,
                                     prompt,
                                     attachments,
-                                    &sessions,
-                                    event_sender.as_ref(),
-                                    &notification_context,
-                                )
-                                .await;
+                                };
+                                let context = RunPromptContext {
+                                    connection: &connection,
+                                    sessions: &sessions,
+                                    event_sender: event_sender.as_ref(),
+                                    notification_context: &notification_context,
+                                };
+                                run_prompt(request, context).await;
                             });
                         }
                         AcpSessionCommand::Cancel { runtime_session_id } => {
@@ -1004,19 +1006,40 @@ async fn run_acp_session(
     connect_result.map_err(|error| error.to_string())
 }
 
-async fn run_prompt(
-    connection: &ConnectionTo<Agent>,
-    session_id: &SessionId,
-    target_session_id: &SessionId,
-    runtime_id: &RuntimeId,
-    runtime_session_id: &RuntimeSessionId,
+struct RunPromptRequest {
+    session_id: SessionId,
+    target_session_id: SessionId,
+    runtime_id: RuntimeId,
+    runtime_session_id: RuntimeSessionId,
     message_id: MessageId,
     prompt: String,
     attachments: Vec<NativeAiImageAttachment>,
-    sessions: &Arc<Mutex<SessionRegistry>>,
-    event_sender: Option<&std_mpsc::SyncSender<AiRuntimeEvent>>,
-    notification_context: &NotificationContext,
-) {
+}
+
+struct RunPromptContext<'a> {
+    connection: &'a ConnectionTo<Agent>,
+    sessions: &'a Arc<Mutex<SessionRegistry>>,
+    event_sender: Option<&'a std_mpsc::SyncSender<AiRuntimeEvent>>,
+    notification_context: &'a NotificationContext,
+}
+
+async fn run_prompt(request: RunPromptRequest, context: RunPromptContext<'_>) {
+    let RunPromptRequest {
+        session_id,
+        target_session_id,
+        runtime_id,
+        runtime_session_id,
+        message_id,
+        prompt,
+        attachments,
+    } = request;
+    let RunPromptContext {
+        connection,
+        sessions,
+        event_sender,
+        notification_context,
+    } = context;
+
     let runtime_session =
         agent_client_protocol::schema::SessionId::from(runtime_session_id.0.clone());
     let prompt_request =
@@ -1026,7 +1049,7 @@ async fn run_prompt(
     notification_context.complete_open_messages();
     match response {
         Ok(response) => {
-            let summary = mark_session_idle(sessions, session_id);
+            let summary = mark_session_idle(sessions, &session_id);
             if let Some(summary) = summary.as_ref() {
                 let mut target_summary = summary.clone();
                 if target_session_id != session_id {
@@ -1056,7 +1079,7 @@ async fn run_prompt(
             }
         }
         Err(error) => {
-            let summary = mark_session_error(sessions, session_id);
+            let summary = mark_session_error(sessions, &session_id);
             let updated_at = now_iso8601();
             emit_event(
                 event_sender,

--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -1394,10 +1394,10 @@ fn mark_session_status(
 }
 
 fn send_start_result(sender: &AcpStartSender, result: AcpStartResult) {
-    if let Ok(mut sender) = sender.lock() {
-        if let Some(sender) = sender.take() {
-            let _ = sender.send(result);
-        }
+    if let Ok(mut sender) = sender.lock()
+        && let Some(sender) = sender.take()
+    {
+        let _ = sender.send(result);
     }
 }
 

--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -619,7 +619,7 @@ pub fn start_acp_session(
     });
 
     let runtime_session_id = runtime
-        .block_on(async { started_receiver.await })
+        .block_on(started_receiver)
         .map_err(|_| AiError::RuntimeExited {
             message: "The ACP runtime exited before creating a session.".to_string(),
         })?

--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -2101,12 +2101,11 @@ impl NotificationContextInner {
                     update.current_mode_id.0.to_string(),
                 );
             }
-            SessionUpdate::UserMessageChunk(chunk) => {
+            SessionUpdate::UserMessageChunk(chunk)
                 if self.supports_subagents
-                    && self.runtime_session_id.as_ref() != Some(&runtime_session_id)
-                {
-                    self.handle_user_message_chunk(&runtime_session_id, chunk);
-                }
+                    && self.runtime_session_id.as_ref() != Some(&runtime_session_id) =>
+            {
+                self.handle_user_message_chunk(&runtime_session_id, chunk);
             }
             _ => {}
         }

--- a/crates/comando-ai/src/engine.rs
+++ b/crates/comando-ai/src/engine.rs
@@ -534,10 +534,10 @@ impl AiEngine {
             session.session.title = input.title.clone();
             session.session.updated_at = now_iso8601();
         }
-        if let Some(store) = self.history_store()? {
-            if store.has_session(&input.session_id) {
-                store.rename_session(&input.session_id, input.title)?;
-            }
+        if let Some(store) = self.history_store()?
+            && store.has_session(&input.session_id)
+        {
+            store.rename_session(&input.session_id, input.title)?;
         }
         Ok(())
     }
@@ -789,18 +789,18 @@ impl AiEngine {
     }
 
     fn update_history_status(&self, summary: &NativeAiSessionSummary) -> AiResult<()> {
-        if let Some(store) = self.history_store()? {
-            if store.has_session(&summary.session_id) {
-                let mut metadata = store.load_metadata(&summary.session_id)?;
-                metadata.runtime_session_id = summary.runtime_session_id.clone();
-                metadata.status = summary.status.clone();
-                metadata.title = summary.title.clone();
-                metadata.updated_at = summary.updated_at.clone();
-                if summary.status == NativeAiSessionStatus::Closed {
-                    metadata.closed_at = Some(summary.updated_at.clone());
-                }
-                store.save_metadata(&metadata)?;
+        if let Some(store) = self.history_store()?
+            && store.has_session(&summary.session_id)
+        {
+            let mut metadata = store.load_metadata(&summary.session_id)?;
+            metadata.runtime_session_id = summary.runtime_session_id.clone();
+            metadata.status = summary.status.clone();
+            metadata.title = summary.title.clone();
+            metadata.updated_at = summary.updated_at.clone();
+            if summary.status == NativeAiSessionStatus::Closed {
+                metadata.closed_at = Some(summary.updated_at.clone());
             }
+            store.save_metadata(&metadata)?;
         }
         Ok(())
     }
@@ -1375,28 +1375,28 @@ impl AiEngine {
         let Some(session_id) = payload_session_id(payload) else {
             return Ok(());
         };
-        if let Some(store) = self.history_store()? {
-            if store.has_session(&session_id) {
-                let mut metadata = store.load_metadata(&session_id)?;
-                metadata.status = NativeAiSessionStatus::Error;
-                metadata.updated_at = payload
-                    .get("updatedAt")
-                    .and_then(Value::as_str)
-                    .unwrap_or(&metadata.updated_at)
-                    .to_string();
-                store.save_metadata(&metadata)?;
-                let message = payload
-                    .get("message")
-                    .and_then(Value::as_str)
-                    .unwrap_or("Native AI session failed.")
-                    .to_string();
-                store.update_session_state(&session_id, |state| {
-                    state.active_turn_started_at = None;
-                    state.last_error = Some(message);
-                    state.pending_permission = None;
-                    state.pending_user_input = None;
-                })?;
-            }
+        if let Some(store) = self.history_store()?
+            && store.has_session(&session_id)
+        {
+            let mut metadata = store.load_metadata(&session_id)?;
+            metadata.status = NativeAiSessionStatus::Error;
+            metadata.updated_at = payload
+                .get("updatedAt")
+                .and_then(Value::as_str)
+                .unwrap_or(&metadata.updated_at)
+                .to_string();
+            store.save_metadata(&metadata)?;
+            let message = payload
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("Native AI session failed.")
+                .to_string();
+            store.update_session_state(&session_id, |state| {
+                state.active_turn_started_at = None;
+                state.last_error = Some(message);
+                state.pending_permission = None;
+                state.pending_user_input = None;
+            })?;
         }
         Ok(())
     }

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -1145,10 +1145,10 @@ impl<'a> LegacyAiHistoryReader<'a> {
         if !shadow.is_empty() {
             return Ok(shadow);
         }
-        if let Some(messages) = self.load_runtime_state_messages(session_id)? {
-            if !messages.is_empty() {
-                return Ok(messages);
-            }
+        if let Some(messages) = self.load_runtime_state_messages(session_id)?
+            && !messages.is_empty()
+        {
+            return Ok(messages);
         }
         Ok(self
             .load_transcript_json_messages(session_id)?
@@ -1178,10 +1178,10 @@ impl<'a> LegacyAiHistoryReader<'a> {
         for row in rows {
             let payload_json =
                 row.map_err(|error| history_sql("read legacy shadow message", error))?;
-            if let Ok(value) = serde_json::from_str::<Value>(&payload_json) {
-                if value.is_object() {
-                    messages.push(value);
-                }
+            if let Ok(value) = serde_json::from_str::<Value>(&payload_json)
+                && value.is_object()
+            {
+                messages.push(value);
             }
         }
         Ok(messages)

--- a/crates/comando-ai/src/permissions.rs
+++ b/crates/comando-ai/src/permissions.rs
@@ -43,6 +43,10 @@ impl PermissionWaiters {
     pub fn len(&self) -> usize {
         self.waiters.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.waiters.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/crates/comando-ai/src/permissions.rs
+++ b/crates/comando-ai/src/permissions.rs
@@ -30,7 +30,8 @@ impl PermissionWaiters {
         let keys = self
             .waiters
             .iter()
-            .filter_map(|(key, waiter)| (waiter.session_id == session_id).then(|| key.clone()))
+            .filter(|(_, waiter)| waiter.session_id == session_id)
+            .map(|(key, _)| key.clone())
             .collect::<Vec<_>>();
         let count = keys.len();
         for key in keys {

--- a/crates/comando-ai/src/runtime_setup.rs
+++ b/crates/comando-ai/src/runtime_setup.rs
@@ -574,15 +574,17 @@ fn codex_auth_state(store: &RuntimeSetupStore, setup: &RuntimeSetupState) -> Run
         setup.auth_method.as_deref(),
         &["chatgpt", "codex-api-key", "openai-api-key"],
     );
+    let selected_ready = match selected.as_deref() {
+        Some("chatgpt") => chatgpt_ready,
+        Some("codex-api-key") => codex_secret,
+        Some("openai-api-key") => openai_secret,
+        _ => false,
+    };
     let method = if codex_env {
         Some("codex-api-key".to_string())
     } else if openai_env {
         Some("openai-api-key".to_string())
-    } else if selected.as_deref() == Some("chatgpt") && chatgpt_ready {
-        selected
-    } else if selected.as_deref() == Some("codex-api-key") && codex_secret {
-        selected
-    } else if selected.as_deref() == Some("openai-api-key") && openai_secret {
+    } else if selected_ready {
         selected
     } else if selected.is_some() {
         None
@@ -644,38 +646,36 @@ fn claude_auth_state(store: &RuntimeSetupStore, setup: &RuntimeSetupState) -> Ru
     );
     let gateway_url = validate_gateway_url(setup.gateway_base_url.as_deref());
     let bedrock_url = validate_gateway_url(setup.bedrock_gateway_base_url.as_deref());
+    let gateway_has_url = gateway_url
+        .as_ref()
+        .ok()
+        .and_then(|value| value.as_ref())
+        .is_some();
+    let bedrock_has_url = bedrock_url
+        .as_ref()
+        .ok()
+        .and_then(|value| value.as_ref())
+        .is_some();
+    let selected_ready = match selected.as_deref() {
+        Some("anthropic-api-key") => api_key_secret,
+        Some("gateway") => {
+            gateway_url.is_ok()
+                && gateway_has_url
+                && (token_env || headers_env || token_secret || headers_secret)
+        }
+        Some("gateway-bedrock") => bedrock_url.is_ok() && bedrock_has_url,
+        Some("claude-login" | "claude-ai-login" | "console-login") => {
+            external_auth_available(claude_auth_file_path(), setup.auth_invalidated_at_ms)
+        }
+        _ => false,
+    };
     let method = if bedrock_url_env {
         Some("gateway-bedrock".to_string())
     } else if base_url_env {
         Some("gateway".to_string())
     } else if anthropic_env {
         Some("anthropic-api-key".to_string())
-    } else if selected.as_deref() == Some("anthropic-api-key") && api_key_secret {
-        selected
-    } else if selected.as_deref() == Some("gateway")
-        && gateway_url.is_ok()
-        && gateway_url
-            .as_ref()
-            .ok()
-            .and_then(|value| value.as_ref())
-            .is_some()
-        && (token_env || headers_env || token_secret || headers_secret)
-    {
-        selected
-    } else if selected.as_deref() == Some("gateway-bedrock")
-        && bedrock_url.is_ok()
-        && bedrock_url
-            .as_ref()
-            .ok()
-            .and_then(|value| value.as_ref())
-            .is_some()
-    {
-        selected
-    } else if matches!(
-        selected.as_deref(),
-        Some("claude-login" | "claude-ai-login" | "console-login")
-    ) && external_auth_available(claude_auth_file_path(), setup.auth_invalidated_at_ms)
-    {
+    } else if selected_ready {
         selected
     } else if selected.is_some() {
         None
@@ -792,11 +792,14 @@ fn kilo_auth_state(store: &RuntimeSetupStore, setup: &RuntimeSetupState) -> Runt
         &["kilo-login", "kilo-api-key"],
     );
     let login_ready = external_auth_available(kilo_auth_file_path(), setup.auth_invalidated_at_ms);
+    let selected_ready = match selected.as_deref() {
+        Some("kilo-api-key") => stored_ready,
+        Some("kilo-login") => login_ready,
+        _ => false,
+    };
     let method = if env_ready {
         Some("kilo-api-key".to_string())
-    } else if selected.as_deref() == Some("kilo-api-key") && stored_ready {
-        selected
-    } else if selected.as_deref() == Some("kilo-login") && login_ready {
+    } else if selected_ready {
         selected
     } else if selected.is_some() {
         None

--- a/crates/comando-ai/src/runtime_setup.rs
+++ b/crates/comando-ai/src/runtime_setup.rs
@@ -1156,10 +1156,7 @@ fn credential_source_label(runtime_id: &str, source: &NativeAiCredentialSource) 
 
 fn normalize_auth_method(method: Option<&str>, allowed: &[&str]) -> Option<String> {
     let method = method?.trim();
-    allowed
-        .iter()
-        .any(|allowed| *allowed == method)
-        .then(|| method.to_string())
+    allowed.contains(&method).then(|| method.to_string())
 }
 
 fn definition_args(definition: RuntimeDefinition) -> Vec<String> {

--- a/crates/comando-ai/src/runtime_setup.rs
+++ b/crates/comando-ai/src/runtime_setup.rs
@@ -362,15 +362,15 @@ fn resolve_runtime_command(
         "opencode" => "COMANDO_OPENCODE_ACP_BIN",
         _ => "",
     };
-    if let Ok(value) = env::var(env_var) {
-        if !value.trim().is_empty() {
-            return resolve_command_candidate(definition, value.trim(), "env");
-        }
+    if let Ok(value) = env::var(env_var)
+        && !value.trim().is_empty()
+    {
+        return resolve_command_candidate(definition, value.trim(), "env");
     }
-    if let Some(binary_path) = setup.binary_path.as_deref() {
-        if !binary_path.trim().is_empty() {
-            return resolve_command_candidate(definition, binary_path.trim(), "settings");
-        }
+    if let Some(binary_path) = setup.binary_path.as_deref()
+        && !binary_path.trim().is_empty()
+    {
+        return resolve_command_candidate(definition, binary_path.trim(), "settings");
     }
     if definition.id == "claude" {
         if let Some(command) = find_explicit_ai_resource_runtime(definition) {
@@ -394,18 +394,18 @@ fn resolve_runtime_command(
     if let Some(candidate) = resolve_from_runtime_path(definition.default_executable, None) {
         return command_from_existing_path(definition, candidate, "path");
     }
-    if definition.id == "codex" {
-        if let Some(candidate) = resolve_from_runtime_path("codex", None) {
-            return ResolvedCommand {
-                executable: candidate.display().to_string(),
-                args: Vec::new(),
-                command: Some(candidate.display().to_string()),
-                source: Some("path".to_string()),
-                state: "error".to_string(),
-                message: Some("`codex` was found, but this CLI exposes App Server/MCP instead of an ACP runtime. Current Comando integration still uses ACP.".to_string()),
-                has_custom_binary_path: false,
-            };
-        }
+    if definition.id == "codex"
+        && let Some(candidate) = resolve_from_runtime_path("codex", None)
+    {
+        return ResolvedCommand {
+            executable: candidate.display().to_string(),
+            args: Vec::new(),
+            command: Some(candidate.display().to_string()),
+            source: Some("path".to_string()),
+            state: "error".to_string(),
+            message: Some("`codex` was found, but this CLI exposes App Server/MCP instead of an ACP runtime. Current Comando integration still uses ACP.".to_string()),
+            has_custom_binary_path: false,
+        };
     }
     ResolvedCommand {
         executable: definition.default_executable.to_string(),
@@ -961,10 +961,10 @@ fn apply_claude_env(
         return;
     }
     if auth.method.as_deref() == Some("gateway-bedrock") {
-        if !env_secret_present_in(env_map, "ANTHROPIC_BEDROCK_BASE_URL") {
-            if let Some(url) = setup.bedrock_gateway_base_url.as_deref() {
-                env_map.insert("ANTHROPIC_BEDROCK_BASE_URL".to_string(), url.to_string());
-            }
+        if !env_secret_present_in(env_map, "ANTHROPIC_BEDROCK_BASE_URL")
+            && let Some(url) = setup.bedrock_gateway_base_url.as_deref()
+        {
+            env_map.insert("ANTHROPIC_BEDROCK_BASE_URL".to_string(), url.to_string());
         }
         env_map
             .entry("CLAUDE_CODE_USE_BEDROCK".to_string())
@@ -978,10 +978,10 @@ fn apply_claude_env(
         return;
     }
     if auth.method.as_deref() == Some("gateway") {
-        if !env_secret_present_in(env_map, "ANTHROPIC_BASE_URL") {
-            if let Some(url) = setup.gateway_base_url.as_deref() {
-                env_map.insert("ANTHROPIC_BASE_URL".to_string(), url.to_string());
-            }
+        if !env_secret_present_in(env_map, "ANTHROPIC_BASE_URL")
+            && let Some(url) = setup.gateway_base_url.as_deref()
+        {
+            env_map.insert("ANTHROPIC_BASE_URL".to_string(), url.to_string());
         }
         if !env_secret_present_in(env_map, "ANTHROPIC_AUTH_TOKEN") {
             insert_secret_env(store, env_map, "claude", "ANTHROPIC_AUTH_TOKEN");
@@ -998,10 +998,10 @@ fn insert_secret_env(
     runtime_id: &str,
     env_key: &str,
 ) {
-    if let Ok(Some(value)) = store.secrets().get_secret(runtime_id, env_key) {
-        if !value.trim().is_empty() {
-            env_map.insert(env_key.to_string(), value);
-        }
+    if let Ok(Some(value)) = store.secrets().get_secret(runtime_id, env_key)
+        && !value.trim().is_empty()
+    {
+        env_map.insert(env_key.to_string(), value);
     }
 }
 
@@ -1320,12 +1320,11 @@ fn packaged_darwin_arch() -> &'static str {
 
 fn find_explicit_ai_resource_runtime(definition: RuntimeDefinition) -> Option<ResolvedCommand> {
     let resource_dir = explicit_ai_resource_dir()?;
-    if definition.id == "claude" {
-        if let Some(command) =
+    if definition.id == "claude"
+        && let Some(command) =
             claude_embedded_node_command_from_ai_resource_dir(&resource_dir, "bundled")
-        {
-            return Some(command);
-        }
+    {
+        return Some(command);
     }
     find_ai_resource_binary(definition, &resource_dir)
         .map(|candidate| command_from_existing_path(definition, candidate, "bundled"))
@@ -1527,10 +1526,10 @@ fn find_app_root() -> Option<PathBuf> {
 
 fn runtime_search_roots() -> Vec<PathBuf> {
     let mut roots = Vec::new();
-    if let Ok(exe) = env::current_exe() {
-        if let Some(parent) = exe.parent() {
-            roots.push(parent.to_path_buf());
-        }
+    if let Ok(exe) = env::current_exe()
+        && let Some(parent) = exe.parent()
+    {
+        roots.push(parent.to_path_buf());
     }
     if let Ok(cwd) = env::current_dir() {
         roots.push(cwd);
@@ -1585,10 +1584,10 @@ fn runtime_path_entries(
 ) -> Vec<String> {
     let mut entries = Vec::new();
     let executable_path = Path::new(executable);
-    if executable_path.is_absolute() {
-        if let Some(parent) = executable_path.parent() {
-            entries.push(parent.display().to_string());
-        }
+    if executable_path.is_absolute()
+        && let Some(parent) = executable_path.parent()
+    {
+        entries.push(parent.display().to_string());
     }
     if let Some(home) = env_map
         .get("HOME")
@@ -1784,11 +1783,12 @@ fn external_auth_dir_available(path: Option<PathBuf>, invalidated_at_ms: Option<
     let mut newest = modified_at_ms(&path);
     let mut has_non_empty_file = false;
     for entry in entries.flatten() {
-        if let Ok(metadata) = entry.metadata() {
-            if metadata.is_file() && metadata.len() > 0 {
-                has_non_empty_file = true;
-                newest = newest.max(modified_at_ms(&entry.path()));
-            }
+        if let Ok(metadata) = entry.metadata()
+            && metadata.is_file()
+            && metadata.len() > 0
+        {
+            has_non_empty_file = true;
+            newest = newest.max(modified_at_ms(&entry.path()));
         }
     }
     has_non_empty_file
@@ -1811,17 +1811,16 @@ fn home_dir() -> Option<PathBuf> {
 }
 
 fn xdg_data_dir() -> Option<PathBuf> {
-    if let Ok(value) = env::var("XDG_DATA_HOME") {
-        if !value.trim().is_empty() {
-            return Some(PathBuf::from(value));
-        }
+    if let Ok(value) = env::var("XDG_DATA_HOME")
+        && !value.trim().is_empty()
+    {
+        return Some(PathBuf::from(value));
     }
-    if cfg!(windows) {
-        if let Ok(value) = env::var("LOCALAPPDATA") {
-            if !value.trim().is_empty() {
-                return Some(PathBuf::from(value));
-            }
-        }
+    if cfg!(windows)
+        && let Ok(value) = env::var("LOCALAPPDATA")
+        && !value.trim().is_empty()
+    {
+        return Some(PathBuf::from(value));
     }
     home_dir().map(|home| home.join(".local").join("share"))
 }
@@ -1864,10 +1863,10 @@ fn opencode_auth_file_path() -> Option<PathBuf> {
 }
 
 fn codex_auth_file_path() -> Option<PathBuf> {
-    if let Ok(value) = env::var("CODEX_HOME") {
-        if !value.trim().is_empty() {
-            return Some(PathBuf::from(value).join("auth.json"));
-        }
+    if let Ok(value) = env::var("CODEX_HOME")
+        && !value.trim().is_empty()
+    {
+        return Some(PathBuf::from(value).join("auth.json"));
     }
     home_dir().map(|home| home.join(".codex").join("auth.json"))
 }

--- a/crates/comando-ai/src/session.rs
+++ b/crates/comando-ai/src/session.rs
@@ -287,9 +287,8 @@ impl SessionRegistry {
         let session_ids = self
             .sessions
             .iter()
-            .filter_map(|(session_id, session)| {
-                (session.session.owner_window_id == owner_window_id).then(|| session_id.clone())
-            })
+            .filter(|(_, session)| session.session.owner_window_id == owner_window_id)
+            .map(|(session_id, _)| session_id.clone())
             .collect::<Vec<_>>();
 
         session_ids

--- a/crates/comando-ai/src/user_input.rs
+++ b/crates/comando-ai/src/user_input.rs
@@ -43,6 +43,10 @@ impl UserInputWaiters {
     pub fn len(&self) -> usize {
         self.waiters.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.waiters.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/crates/comando-ai/src/user_input.rs
+++ b/crates/comando-ai/src/user_input.rs
@@ -30,7 +30,8 @@ impl UserInputWaiters {
         let keys = self
             .waiters
             .iter()
-            .filter_map(|(key, waiter)| (waiter.session_id == session_id).then(|| key.clone()))
+            .filter(|(_, waiter)| waiter.session_id == session_id)
+            .map(|(key, _)| key.clone())
             .collect::<Vec<_>>();
         let count = keys.len();
         for key in keys {

--- a/crates/comando-fs/src/mutations.rs
+++ b/crates/comando-fs/src/mutations.rs
@@ -51,14 +51,12 @@ pub fn rename_entry(
         .map(str::to_string)
         .or_else(|| parent_relative_path(&current_relative_path));
 
-    if current_metadata.is_dir() {
-        if let Some(parent) = next_parent_relative_path.as_deref() {
-            if parent == current_relative_path
-                || parent.starts_with(&format!("{current_relative_path}/"))
-            {
-                return Err(FsError::DirectoryIntoItself);
-            }
-        }
+    if current_metadata.is_dir()
+        && let Some(parent) = next_parent_relative_path.as_deref()
+        && (parent == current_relative_path
+            || parent.starts_with(&format!("{current_relative_path}/")))
+    {
+        return Err(FsError::DirectoryIntoItself);
     }
 
     let parent = resolve_scoped_path(

--- a/crates/comando-fs/src/tree.rs
+++ b/crates/comando-fs/src/tree.rs
@@ -372,15 +372,12 @@ mod tests {
         let root = project_root(temp.path());
 
         let entries = list_tree_children(&root, None).expect("entries");
-        assert_eq!(find_entry(&entries, "local.env").is_git_ignored, true);
-        assert_eq!(find_entry(&entries, "logs").is_git_ignored, true);
-        assert_eq!(find_entry(&entries, "tracked.env").is_git_ignored, false);
+        assert!(find_entry(&entries, "local.env").is_git_ignored);
+        assert!(find_entry(&entries, "logs").is_git_ignored);
+        assert!(!find_entry(&entries, "tracked.env").is_git_ignored);
 
         let all_entries = list_entries(&root, None).expect("all entries").entries;
-        assert_eq!(
-            find_entry(&all_entries, "logs/app.log").is_git_ignored,
-            true
-        );
+        assert!(find_entry(&all_entries, "logs/app.log").is_git_ignored);
     }
 
     fn find_entry<'a>(

--- a/crates/comando-fs/src/watcher.rs
+++ b/crates/comando-fs/src/watcher.rs
@@ -198,13 +198,15 @@ impl WatcherRegistry {
                 };
 
                 handle_notify_event(
-                    &key_for_callback,
-                    &root_for_callback,
-                    &watch_root,
-                    &write_tracker,
-                    &pending,
-                    &pending_git_invalidations,
-                    &fs_events,
+                    NotifyEventContext {
+                        key: &key_for_callback,
+                        root: &root_for_callback,
+                        watch_root: &watch_root,
+                        write_tracker: &write_tracker,
+                        pending: &pending,
+                        pending_git_invalidations: &pending_git_invalidations,
+                        fs_events: &fs_events,
+                    },
                     event,
                 );
             })?;
@@ -244,16 +246,17 @@ impl Default for WatcherRegistry {
     }
 }
 
-fn handle_notify_event(
-    key: &str,
-    root: &ProjectRoot,
-    watch_root: &Path,
-    write_tracker: &WriteTracker,
-    pending: &Arc<Mutex<HashMap<String, PendingInvalidation>>>,
-    pending_git_invalidations: &Arc<Mutex<HashMap<String, PendingGitInvalidation>>>,
-    fs_events: &Arc<Mutex<Vec<(String, NativeFsWatchEvent)>>>,
-    event: Event,
-) {
+struct NotifyEventContext<'a> {
+    key: &'a str,
+    root: &'a ProjectRoot,
+    watch_root: &'a Path,
+    write_tracker: &'a WriteTracker,
+    pending: &'a Arc<Mutex<HashMap<String, PendingInvalidation>>>,
+    pending_git_invalidations: &'a Arc<Mutex<HashMap<String, PendingGitInvalidation>>>,
+    fs_events: &'a Arc<Mutex<Vec<(String, NativeFsWatchEvent)>>>,
+}
+
+fn handle_notify_event(context: NotifyEventContext<'_>, event: Event) {
     let event_name = event_name_for_kind(&event.kind);
     let event_kind = event_kind_for_kind(&event.kind);
 
@@ -261,14 +264,14 @@ fn handle_notify_event(
         let absolute_path = if path.is_absolute() {
             path.clone()
         } else {
-            watch_root.join(&path)
+            context.watch_root.join(&path)
         };
 
-        if absolute_path == watch_root {
+        if absolute_path == context.watch_root {
             continue;
         }
 
-        let Some(relative_path) = normalize_watched_path(watch_root, &absolute_path) else {
+        let Some(relative_path) = normalize_watched_path(context.watch_root, &absolute_path) else {
             continue;
         };
         if should_ignore_watch_path(&relative_path) {
@@ -276,23 +279,31 @@ fn handle_notify_event(
         }
 
         if let Some(reason) = git_watch_invalidation_reason(&relative_path) {
-            record_pending_git_invalidation(key, root, reason, pending_git_invalidations);
+            record_pending_git_invalidation(
+                context.key,
+                context.root,
+                reason,
+                context.pending_git_invalidations,
+            );
             continue;
         }
 
         let current_hash = std::fs::read(&absolute_path)
             .ok()
             .map(|bytes| hash_bytes(&bytes));
-        if write_tracker.has_recent_match(&absolute_path, current_hash) {
+        if context
+            .write_tracker
+            .has_recent_match(&absolute_path, current_hash)
+        {
             continue;
         }
 
-        record_pending_invalidation(key, root, &relative_path, pending);
-        fs_events.lock().expect("watch events lock").push((
+        record_pending_invalidation(context.key, context.root, &relative_path, context.pending);
+        context.fs_events.lock().expect("watch events lock").push((
             event_name.to_string(),
             NativeFsWatchEvent {
-                project_id: root.project_id.clone(),
-                worktree_id: root.worktree_id.clone(),
+                project_id: context.root.project_id.clone(),
+                worktree_id: context.root.worktree_id.clone(),
                 relative_path: Some(RelativePath(relative_path)),
                 kind: event_kind.to_string(),
                 origin: NativeFsMutationOrigin::External,

--- a/crates/comando-git/src/branches.rs
+++ b/crates/comando-git/src/branches.rs
@@ -30,10 +30,10 @@ pub fn list_branches(
     let output = runner.run(root_path, &args, GitRunOptions::read_only())?;
     let mut branches = parse_branch_rows(&output.stdout, sync);
 
-    if branches.iter().all(|branch| !branch.is_current) {
-        if let Some(detached) = detached_branch(sync) {
-            branches.push(detached);
-        }
+    if branches.iter().all(|branch| !branch.is_current)
+        && let Some(detached) = detached_branch(sync)
+    {
+        branches.push(detached);
     }
 
     branches.sort_by(|left, right| {

--- a/crates/comando-git/src/remotes.rs
+++ b/crates/comando-git/src/remotes.rs
@@ -44,13 +44,13 @@ pub fn list_remotes(
 }
 
 fn default_remote_name(names: &[&str], tracking_branch_name: Option<&str>) -> Option<String> {
-    if let Some(remote_name) = tracking_branch_name.and_then(|name| name.split('/').next()) {
-        if names.iter().any(|name| *name == remote_name) {
-            return Some(remote_name.to_string());
-        }
+    if let Some(remote_name) = tracking_branch_name.and_then(|name| name.split('/').next())
+        && names.contains(&remote_name)
+    {
+        return Some(remote_name.to_string());
     }
 
-    if names.iter().any(|name| *name == "origin") {
+    if names.contains(&"origin") {
         return Some("origin".to_string());
     }
 

--- a/crates/comando-git/src/snapshot.rs
+++ b/crates/comando-git/src/snapshot.rs
@@ -2,9 +2,7 @@ use std::path::PathBuf;
 
 use comando_types::git::{
     NativeGitBranchSummary, NativeGitRepositoryScope, NativeGitRepositorySnapshot,
-    NativeGitStatusSnapshot,
 };
-use comando_types::ids::RepositoryId;
 
 use crate::branches::{GitBranchListScope, list_branches};
 use crate::error::GitResult;
@@ -67,33 +65,7 @@ pub fn get_repository_snapshot(
     .unwrap_or_default();
     let branch = current_branch(&branches);
 
-    Ok(snapshot_from_parts(
-        repository_id,
-        scope,
-        root_path,
-        resolution,
-        status,
-        branches,
-        branch,
-        remotes,
-        worktrees,
-        updated_at,
-    ))
-}
-
-fn snapshot_from_parts(
-    repository_id: RepositoryId,
-    scope: &NativeGitRepositoryScope,
-    root_path: String,
-    resolution: comando_types::git::NativeGitRepositoryResolution,
-    status: NativeGitStatusSnapshot,
-    branches: Vec<NativeGitBranchSummary>,
-    branch: Option<NativeGitBranchSummary>,
-    remotes: Vec<comando_types::git::NativeGitRemoteSummary>,
-    worktrees: Vec<comando_types::git::NativeGitWorktreeSummary>,
-    updated_at: String,
-) -> NativeGitRepositorySnapshot {
-    NativeGitRepositorySnapshot {
+    Ok(NativeGitRepositorySnapshot {
         repository_id,
         project_id: scope.project_id.clone(),
         current_worktree_id: scope.worktree_id.clone(),
@@ -108,7 +80,7 @@ fn snapshot_from_parts(
         status,
         worktrees,
         updated_at,
-    }
+    })
 }
 
 fn current_branch(branches: &[NativeGitBranchSummary]) -> Option<NativeGitBranchSummary> {

--- a/crates/comando-index/src/builder.rs
+++ b/crates/comando-index/src/builder.rs
@@ -11,17 +11,9 @@ use crate::error::IndexResult;
 use crate::policy::{IndexPolicy, IndexPolicyState};
 use crate::stats::IndexBuildStats;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct IndexBuildOptions {
     pub policy: IndexPolicy,
-}
-
-impl Default for IndexBuildOptions {
-    fn default() -> Self {
-        Self {
-            policy: IndexPolicy::default(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/comando-index/src/cancellation.rs
+++ b/crates/comando-index/src/cancellation.rs
@@ -41,18 +41,17 @@ impl CancellationRegistry {
             .lock()
             .expect("cancel registry lock")
             .insert(operation_id.0.clone());
-        if let Some(context_key) = context_key {
-            if let Some(previous_operation_id) = self
+        if let Some(context_key) = context_key
+            && let Some(previous_operation_id) = self
                 .contexts
                 .lock()
                 .expect("cancel registry lock")
                 .insert(context_key.to_string(), operation_id.0.clone())
-            {
-                self.cancelled
-                    .lock()
-                    .expect("cancel registry lock")
-                    .insert(previous_operation_id);
-            }
+        {
+            self.cancelled
+                .lock()
+                .expect("cancel registry lock")
+                .insert(previous_operation_id);
         }
         CancellationToken {
             operation_id,

--- a/crates/comando-index/src/lib.rs
+++ b/crates/comando-index/src/lib.rs
@@ -23,7 +23,7 @@ pub use policy::{IndexPolicy, IndexPolicyState};
 pub use query::{ProjectSearchQuery, normalize_project_search_query};
 pub use ranking::{SearchMatch, search_entries};
 pub use service::{
-    IndexEvent, IndexService, ProjectSearchOperation, ProjectSearchSnapshot,
+    IndexEvent, IndexService, ProjectSearchOperation, ProjectSearchResult, ProjectSearchSnapshot,
     search_project_entries_snapshot,
 };
 pub use stats::{IndexBuildStats, IndexStatus, IndexStatusSnapshot};

--- a/crates/comando-index/src/service.rs
+++ b/crates/comando-index/src/service.rs
@@ -435,10 +435,11 @@ fn include_ancestor_directory_entries(
 
     for match_ in matches {
         for ancestor_path in ancestor_directory_paths(&match_.entry.relative_path) {
-            if let Some(ancestor) = entries_by_path.get(ancestor_path.as_str()) {
-                if ancestor.kind.is_directory() && seen.insert(ancestor.relative_path.clone()) {
-                    result.push((*ancestor).clone());
-                }
+            if let Some(ancestor) = entries_by_path.get(ancestor_path.as_str())
+                && ancestor.kind.is_directory()
+                && seen.insert(ancestor.relative_path.clone())
+            {
+                result.push((*ancestor).clone());
             }
         }
 

--- a/crates/comando-index/src/service.rs
+++ b/crates/comando-index/src/service.rs
@@ -49,6 +49,14 @@ pub struct ProjectSearchOperation {
 }
 
 #[derive(Debug, Clone)]
+pub struct ProjectSearchResult {
+    pub entries: Vec<IndexedProjectEntry>,
+    pub matches: Vec<SearchMatch>,
+    pub operation_id: OperationId,
+    pub events: Vec<IndexEvent>,
+}
+
+#[derive(Debug, Clone)]
 pub struct IndexService {
     indexes: HashMap<String, ProjectIndex>,
     options: IndexBuildOptions,
@@ -155,17 +163,17 @@ impl IndexService {
         limit: usize,
         include_ancestor_directories: bool,
         context_key: Option<&str>,
-    ) -> IndexResult<(
-        Vec<IndexedProjectEntry>,
-        Vec<SearchMatch>,
-        OperationId,
-        Vec<IndexEvent>,
-    )> {
+    ) -> IndexResult<ProjectSearchResult> {
         if query.is_empty() {
             let token = self.cancellations.start_operation(context_key);
             let operation_id = token.operation_id().clone();
             self.cancellations.clear(&operation_id);
-            return Ok((Vec::new(), Vec::new(), operation_id, Vec::new()));
+            return Ok(ProjectSearchResult {
+                entries: Vec::new(),
+                matches: Vec::new(),
+                operation_id,
+                events: Vec::new(),
+            });
         }
 
         let events = self.ensure_ready(root)?;
@@ -181,7 +189,12 @@ impl IndexService {
             operation,
         )?;
 
-        Ok((entries, matches, operation_id, events.1))
+        Ok(ProjectSearchResult {
+            entries,
+            matches,
+            operation_id,
+            events: events.1,
+        })
     }
 
     pub fn ensure_project_index(&mut self, root: ProjectRoot) -> IndexResult<Vec<IndexEvent>> {
@@ -581,7 +594,7 @@ mod tests {
         fs::write(temp.path().join("src/shared/search.ts"), "search").expect("file");
         let mut service = IndexService::default();
 
-        let (entries, _, _, _) = service
+        let result = service
             .search_project_entries(
                 project_root(temp.path()),
                 &ProjectSearchQuery::new("search"),
@@ -590,7 +603,8 @@ mod tests {
                 None,
             )
             .expect("search");
-        let paths = entries
+        let paths = result
+            .entries
             .iter()
             .map(|entry| entry.relative_path.as_str())
             .collect::<Vec<_>>();

--- a/crates/comando-projects/src/registry.rs
+++ b/crates/comando-projects/src/registry.rs
@@ -1253,7 +1253,7 @@ mod tests {
         let mut connection = create_current_schema();
 
         let result = ProjectRegistry::new(&mut connection)
-            .add_project_paths(&[project_root.clone()])
+            .add_project_paths(std::slice::from_ref(&project_root))
             .expect("add project");
 
         assert_eq!(result.project_ids_to_open.len(), 1);

--- a/crates/comando-settings/src/runtime_setup.rs
+++ b/crates/comando-settings/src/runtime_setup.rs
@@ -76,11 +76,8 @@ impl RuntimeSetupState {
         self.auth_method = normalize_optional_text(self.auth_method);
         self.gateway_base_url = normalize_optional_text(self.gateway_base_url);
         self.bedrock_gateway_base_url = normalize_optional_text(self.bedrock_gateway_base_url);
-        self.secret_env_keys = self
-            .secret_env_keys
-            .into_iter()
-            .filter(|key| is_secret_env_key_for_runtime(runtime_id, key))
-            .collect();
+        self.secret_env_keys
+            .retain(|key| is_secret_env_key_for_runtime(runtime_id, key));
         self.non_secret_env = self
             .non_secret_env
             .into_iter()

--- a/crates/comando-terminal/src/service.rs
+++ b/crates/comando-terminal/src/service.rs
@@ -829,14 +829,13 @@ fn remove_session_from_state(
         .lock()
         .map_err(|error| TerminalError::State(error.to_string()))?;
     state.sessions.remove(session_id);
-    if let Some(owner_key) = owner_key {
-        if state
+    if let Some(owner_key) = owner_key
+        && state
             .session_ids_by_owner_terminal_id
             .get(owner_key)
             .is_some_and(|tracked_session_id| tracked_session_id == session_id)
-        {
-            state.session_ids_by_owner_terminal_id.remove(owner_key);
-        }
+    {
+        state.session_ids_by_owner_terminal_id.remove(owner_key);
     }
     Ok(())
 }

--- a/crates/comando-terminal/src/service.rs
+++ b/crates/comando-terminal/src/service.rs
@@ -799,12 +799,11 @@ fn release_runtime_resources(
     killer: &Arc<Mutex<Option<Box<dyn portable_pty::ChildKiller + Send + Sync>>>>,
     terminate_process: bool,
 ) {
-    if terminate_process {
-        if let Ok(mut killer_guard) = killer.lock() {
-            if let Some(killer) = killer_guard.as_mut() {
-                let _ = killer.kill();
-            }
-        }
+    if terminate_process
+        && let Ok(mut killer_guard) = killer.lock()
+        && let Some(killer) = killer_guard.as_mut()
+    {
+        let _ = killer.kill();
     }
 
     if let Ok(mut writer_guard) = writer.lock() {

--- a/crates/comando-terminal/src/session.rs
+++ b/crates/comando-terminal/src/session.rs
@@ -88,12 +88,11 @@ fn release_session_runtime_resources(
     killer: &Arc<Mutex<Option<Box<dyn ChildKiller + Send + Sync>>>>,
     terminate_process: bool,
 ) {
-    if terminate_process {
-        if let Ok(mut killer_guard) = killer.lock() {
-            if let Some(killer) = killer_guard.as_mut() {
-                let _ = killer.kill();
-            }
-        }
+    if terminate_process
+        && let Ok(mut killer_guard) = killer.lock()
+        && let Some(killer) = killer_guard.as_mut()
+    {
+        let _ = killer.kill();
     }
 
     if let Ok(mut writer_guard) = writer.lock() {


### PR DESCRIPTION
## Summary

- Cleans up Rust Clippy warnings across the workspace with focused, incremental Rust refactors.
- Simplifies nested guards, auth readiness selection, iterator chains, boolean assertions, and small type/argument complexity issues.
- Leaves the workspace passing strict Clippy checks across all targets.

## Validation

- `cargo test -p comando-ai`
- `cargo clippy --workspace --all-targets -- -D warnings`