### PR TITLE
Harden release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,12 +205,11 @@ jobs:
                     gh release create "$tag" --title "$title" --notes-file "$notes_file" --verify-tag
                   fi
 
-    release-macos:
+    build-macos:
         name: macOS universal
-        needs: ensure-github-release
+        needs: release-gate
         runs-on: macos-latest
         env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
             APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY }}
             APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -304,22 +303,26 @@ jobs:
                     chmod +x "resources/ai/prebuilt/node/darwin-${arch}/bin/node"
                   done
 
-            - name: Publish macOS artifacts
-              run: pnpm run release:mac -- --config.forceCodeSigning=true
+            - name: Package macOS artifacts
+              run: pnpm run package:mac -- --config.forceCodeSigning=true
 
-            - name: Upload macOS workflow artifacts
+            - name: Stage macOS release assets
               uses: actions/upload-artifact@v4
-              if: always()
               with:
-                  name: macos-universal-dist
-                  path: build/macos-package/project/dist/*
+                  name: release-assets-macos-universal
+                  path: |
+                      build/macos-package/project/dist/*.dmg
+                      build/macos-package/project/dist/*.zip
+                      build/macos-package/project/dist/*.blockmap
+                      build/macos-package/project/dist/latest*.yml
+                  if-no-files-found: error
 
-    release-windows-x64:
+    build-windows-x64:
         name: Windows x64
-        needs: ensure-github-release
+        needs: release-gate
         runs-on: windows-latest
         env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            CSC_IDENTITY_AUTO_DISCOVERY: "false"
             NODE_OPTIONS: --max-old-space-size=8192
         steps:
             - uses: actions/checkout@v4
@@ -344,22 +347,25 @@ jobs:
             - name: Build Windows x64 ACP payload
               run: pnpm run build:windows-acp:x64
 
-            - name: Publish Windows x64 artifacts
-              run: pnpm run release:win:x64
+            - name: Package Windows x64 artifacts
+              run: pnpm run package:win:x64 -- --publish never
 
-            - name: Upload Windows x64 workflow artifacts
+            - name: Stage Windows x64 release assets
               uses: actions/upload-artifact@v4
-              if: always()
               with:
-                  name: windows-x64-dist
-                  path: dist/*
+                  name: release-assets-windows-x64
+                  path: |
+                      dist/*.exe
+                      dist/*.exe.blockmap
+                      dist/latest*.yml
+                  if-no-files-found: error
 
-    release-windows-arm64:
+    build-windows-arm64:
         name: Windows arm64
-        needs: ensure-github-release
+        needs: release-gate
         runs-on: windows-11-arm
         env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            CSC_IDENTITY_AUTO_DISCOVERY: "false"
             NODE_OPTIONS: --max-old-space-size=8192
         steps:
             - uses: actions/checkout@v4
@@ -384,21 +390,23 @@ jobs:
             - name: Build Windows arm64 ACP payload
               run: pnpm run build:windows-acp:arm64
 
-            - name: Publish Windows arm64 artifacts
-              run: pnpm run release:win:arm64
+            - name: Package Windows arm64 artifacts
+              run: pnpm run package:win:arm64 -- --publish never
 
-            - name: Upload Windows arm64 workflow artifacts
+            - name: Stage Windows arm64 release assets
               uses: actions/upload-artifact@v4
-              if: always()
               with:
-                  name: windows-arm64-dist
-                  path: dist/*
+                  name: release-assets-windows-arm64
+                  path: |
+                      dist/*.exe
+                      dist/*.exe.blockmap
+                      dist/latest*.yml
+                  if-no-files-found: error
 
-    release-linux:
+    build-linux:
         name: Linux ${{ matrix.arch }}
         needs:
-            - prepare
-            - ensure-github-release
+            - release-gate
             - apt-repository-preflight
         runs-on: ${{ matrix.runner }}
         strategy:
@@ -413,7 +421,6 @@ jobs:
             APT_REPO_GPG_PRIVATE_KEY: ${{ secrets.APT_REPO_GPG_PRIVATE_KEY }}
             APT_REPO_GPG_PASSPHRASE: ${{ secrets.APT_REPO_GPG_PASSPHRASE }}
             APT_REPO_GPG_KEY_ID: ${{ secrets.APT_REPO_GPG_KEY_ID }}
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             NODE_OPTIONS: --max-old-space-size=8192
         steps:
             - uses: actions/checkout@v4
@@ -472,44 +479,26 @@ jobs:
                     --version "${RELEASE_TAG#v}" \
                     --require-signature
 
-            - name: Upload Linux release assets
-              run: |
-                  shopt -s nullglob
-                  linux_assets=(
-                    dist/*.AppImage
-                    dist/*.AppImage.blockmap
-                    dist/*.deb
-                    dist/*.rpm
-                    dist/latest*-linux*.yml
-                  )
-
-                  if (( ${#linux_assets[@]} == 0 )); then
-                    echo "No Linux release assets found." >&2
-                    exit 1
-                  fi
-
-                  gh release upload "$RELEASE_TAG" "${linux_assets[@]}" --clobber
-
-            - name: Upload Linux workflow artifacts
+            - name: Stage Linux release assets
               uses: actions/upload-artifact@v4
-              if: always()
               with:
-                  name: linux-${{ matrix.arch }}-dist
+                  name: release-assets-linux-${{ matrix.arch }}
                   path: |
                       dist/*.AppImage
                       dist/*.AppImage.blockmap
                       dist/*.deb
                       dist/*.rpm
                       dist/latest*-linux*.yml
+                  if-no-files-found: error
 
     publish-release-notes:
         name: Publish release notes
         needs:
             - prepare
-            - release-macos
-            - release-windows-x64
-            - release-windows-arm64
-            - release-linux
+            - build-macos
+            - build-windows-x64
+            - build-windows-arm64
+            - build-linux
             - publish-apt-repository
             - publish-dnf-repository
         runs-on: ubuntu-latest
@@ -539,10 +528,10 @@ jobs:
         name: Publish APT repository
         needs:
             - prepare
-            - release-macos
-            - release-windows-x64
-            - release-windows-arm64
-            - release-linux
+            - build-macos
+            - build-windows-x64
+            - build-windows-arm64
+            - build-linux
             - apt-repository-preflight
         runs-on: ubuntu-latest
         env:
@@ -568,7 +557,7 @@ jobs:
             - name: Download Linux workflow artifacts
               uses: actions/download-artifact@v4
               with:
-                  pattern: linux-*-dist
+                  pattern: release-assets-linux-*
                   path: .artifacts/linux
                   merge-multiple: true
 
@@ -771,7 +760,7 @@ jobs:
         needs:
             - prepare
             - ensure-github-release
-            - release-linux
+            - build-linux
             - dnf-repository-preflight
             - publish-apt-repository
         runs-on: ubuntu-latest
@@ -798,7 +787,7 @@ jobs:
             - name: Download Linux workflow artifacts
               uses: actions/download-artifact@v4
               with:
-                  pattern: linux-*-dist
+                  pattern: release-assets-linux-*
                   path: .artifacts/linux
                   merge-multiple: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,14 +491,41 @@ jobs:
                       dist/latest*-linux*.yml
                   if-no-files-found: error
 
-    publish-release-notes:
-        name: Publish release notes
+    validate-release-assets:
+        name: Validate release assets
         needs:
-            - prepare
             - build-macos
             - build-windows-x64
             - build-windows-arm64
             - build-linux
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  ref: ${{ env.RELEASE_TAG }}
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+
+            - name: Download staged release assets
+              uses: actions/download-artifact@v4
+              with:
+                  pattern: release-assets-*
+                  path: .artifacts/release-assets
+
+            - name: Validate staged release asset coverage
+              run: |
+                  node scripts/validate-release-assets.mjs \
+                    --assets-dir .artifacts/release-assets \
+                    --version "$RELEASE_TAG"
+
+    publish-release-notes:
+        name: Publish release notes
+        needs:
+            - prepare
+            - validate-release-assets
             - publish-apt-repository
             - publish-dnf-repository
         runs-on: ubuntu-latest
@@ -528,10 +555,7 @@ jobs:
         name: Publish APT repository
         needs:
             - prepare
-            - build-macos
-            - build-windows-x64
-            - build-windows-arm64
-            - build-linux
+            - validate-release-assets
             - apt-repository-preflight
         runs-on: ubuntu-latest
         env:
@@ -760,7 +784,7 @@ jobs:
         needs:
             - prepare
             - ensure-github-release
-            - build-linux
+            - validate-release-assets
             - dnf-repository-preflight
             - publish-apt-repository
         runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -573,7 +573,7 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install -y ca-certificates dpkg gnupg gzip
 
-            - name: Download Linux workflow artifacts
+            - name: Download staged Linux release assets
               uses: actions/download-artifact@v4
               with:
                   pattern: release-assets-linux-*
@@ -788,7 +788,7 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install -y createrepo-c gnupg gzip rpm
 
-            - name: Download Linux workflow artifacts
+            - name: Download staged Linux release assets
               uses: actions/download-artifact@v4
               with:
                   pattern: release-assets-linux-*
@@ -905,3 +905,42 @@ jobs:
                     git -C "$PAGES_DIR" commit -m "Publish DNF repository for $RELEASE_TAG"
                     git -C "$PAGES_DIR" push origin HEAD:gh-pages
                   fi
+
+            - name: Validate published DNF repository endpoint
+              run: |
+                  repo_name="${GITHUB_REPOSITORY#*/}"
+                  baseurl="https://${GITHUB_REPOSITORY_OWNER}.github.io/${repo_name}/dnf"
+                  version="${RELEASE_TAG#v}"
+
+                  for attempt in {1..12}; do
+                    echo "Validating published DNF repository endpoint, attempt ${attempt}/12."
+                    if docker run --rm \
+                      -e BASEURL="$baseurl" \
+                      -e VERSION="$version" \
+                      fedora:latest \
+                      bash -lc '
+                        set -euo pipefail
+                        dnf install -y ca-certificates curl
+                        curl -fsSL "$BASEURL/comando-archive-keyring.asc" \
+                          -o /etc/pki/rpm-gpg/comando-archive-keyring.asc
+                        rpm --import /etc/pki/rpm-gpg/comando-archive-keyring.asc
+                        {
+                          printf "%s\n" "[comando]"
+                          printf "%s\n" "name=Comando"
+                          printf "%s\n" "baseurl=${BASEURL}"
+                          printf "%s\n" "enabled=1"
+                          printf "%s\n" "gpgcheck=1"
+                          printf "%s\n" "repo_gpgcheck=1"
+                          printf "%s\n" "gpgkey=${BASEURL}/comando-archive-keyring.asc"
+                        } >/etc/yum.repos.d/comando.repo
+                        dnf -y makecache
+                        dnf info comando | grep -F "$VERSION"
+                        dnf install -y --downloadonly comando
+                      '; then
+                      exit 0
+                    fi
+
+                    sleep 10
+                  done
+
+                  exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,11 @@ jobs:
                     exit 1
                   fi
 
-                  echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
-                  echo "version=$package_version" >> "$GITHUB_OUTPUT"
-                  echo "repo_slug=$GITHUB_REPOSITORY" >> "$GITHUB_OUTPUT"
+                  {
+                    echo "tag=$RELEASE_TAG"
+                    echo "version=$package_version"
+                    echo "repo_slug=$GITHUB_REPOSITORY"
+                  } >> "$GITHUB_OUTPUT"
 
             - name: Build release notes
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,16 +37,9 @@ jobs:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
 
-            - uses: pnpm/action-setup@v4
-              with:
-                  version: 10.33.0
-
             - uses: actions/setup-node@v4
               with:
                   node-version: 22
-                  cache: pnpm
-
-            - uses: dtolnay/rust-toolchain@stable
 
             - name: Validate release metadata
               id: release
@@ -81,6 +74,29 @@ jobs:
                   path: release-body.md
                   if-no-files-found: error
 
+    release-gate:
+        name: Release gate
+        needs: prepare
+        runs-on: ubuntu-latest
+        env:
+            NODE_OPTIONS: --max-old-space-size=8192
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  ref: ${{ env.RELEASE_TAG }}
+
+            - uses: pnpm/action-setup@v4
+              with:
+                  version: 10.33.0
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: pnpm
+
+            - uses: ./.github/actions/setup-rust
+
             - name: Install Linux check toolchain
               run: |
                   sudo apt-get update
@@ -94,8 +110,14 @@ jobs:
                   npm ci --prefix vendor/Claude-agent-acp-upstream
                   npm run build --prefix vendor/Claude-agent-acp-upstream
 
-            - name: Run release gate
-              run: pnpm run check
+            - name: Run desktop release checks
+              run: pnpm run check:ci
+
+            - name: Run native release checks
+              run: pnpm run native:check
+
+            - name: Run release script tests
+              run: pnpm exec vitest run scripts/*.test.mjs
 
     apt-repository-preflight:
         name: APT repository preflight
@@ -157,7 +179,9 @@ jobs:
 
     ensure-github-release:
         name: Ensure GitHub release
-        needs: prepare
+        needs:
+            - prepare
+            - release-gate
         runs-on: ubuntu-latest
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -208,6 +232,10 @@ jobs:
                   node-version: 22
                   cache: pnpm
 
+            - uses: ./.github/actions/setup-rust
+              with:
+                  targets: aarch64-apple-darwin,x86_64-apple-darwin
+
             - name: Validate macOS release secrets
               run: |
                   required=(
@@ -251,7 +279,6 @@ jobs:
                   npm ci --prefix vendor/Claude-agent-acp-upstream
                   npm run build --prefix vendor/Claude-agent-acp-upstream
 
-                  rustup target add aarch64-apple-darwin x86_64-apple-darwin
                   export CARGO_TARGET_DIR="$PWD/resources/ai/embedded/codex-acp/target"
                   cargo build --manifest-path vendor/codex-acp/Cargo.toml --release --locked --target aarch64-apple-darwin
                   cargo build --manifest-path vendor/codex-acp/Cargo.toml --release --locked --target x86_64-apple-darwin
@@ -309,7 +336,7 @@ jobs:
                   node-version: 22
                   cache: pnpm
 
-            - uses: dtolnay/rust-toolchain@stable
+            - uses: ./.github/actions/setup-rust
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
@@ -349,7 +376,7 @@ jobs:
                   node-version: 22
                   cache: pnpm
 
-            - uses: dtolnay/rust-toolchain@stable
+            - uses: ./.github/actions/setup-rust
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
@@ -403,7 +430,7 @@ jobs:
                   node-version: 22
                   cache: pnpm
 
-            - uses: dtolnay/rust-toolchain@stable
+            - uses: ./.github/actions/setup-rust
 
             - name: Install Linux package toolchain
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,34 +177,6 @@ jobs:
                   printf '%s' "$APT_REPO_GPG_PRIVATE_KEY" | gpg --batch --import
                   gpg --batch --list-secret-keys "$APT_REPO_GPG_KEY_ID" >/dev/null
 
-    ensure-github-release:
-        name: Ensure GitHub release
-        needs:
-            - prepare
-            - release-gate
-        runs-on: ubuntu-latest
-        env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        steps:
-            - name: Download release body
-              uses: actions/download-artifact@v4
-              with:
-                  name: release-body-${{ needs.prepare.outputs.tag }}
-                  path: .release
-
-            - name: Create or update release shell
-              run: |
-                  tag="$RELEASE_TAG"
-                  version="${tag#v}"
-                  title="Comando v${version}"
-                  notes_file=".release/release-body.md"
-
-                  if gh release view "$tag" >/dev/null 2>&1; then
-                    gh release edit "$tag" --title "$title" --notes-file "$notes_file"
-                  else
-                    gh release create "$tag" --title "$title" --notes-file "$notes_file" --verify-tag
-                  fi
-
     build-macos:
         name: macOS universal
         needs: release-gate
@@ -521,24 +493,38 @@ jobs:
                     --assets-dir .artifacts/release-assets \
                     --version "$RELEASE_TAG"
 
-    publish-release-notes:
-        name: Publish release notes
+    publish-github-release:
+        name: Publish GitHub release
         needs:
             - prepare
+            - release-gate
+            - build-macos
+            - build-windows-x64
+            - build-windows-arm64
+            - build-linux
             - validate-release-assets
-            - publish-apt-repository
-            - publish-dnf-repository
         runs-on: ubuntu-latest
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  ref: ${{ env.RELEASE_TAG }}
+
             - name: Download release body
               uses: actions/download-artifact@v4
               with:
                   name: release-body-${{ needs.prepare.outputs.tag }}
                   path: .release
 
-            - name: Create or update GitHub release notes
+            - name: Download staged release assets
+              uses: actions/download-artifact@v4
+              with:
+                  pattern: release-assets-*
+                  path: .artifacts/release-assets
+
+            - name: Publish GitHub release assets
               run: |
                   tag="$RELEASE_TAG"
                   version="${tag#v}"
@@ -551,11 +537,20 @@ jobs:
                     gh release create "$tag" --title "$title" --notes-file "$notes_file" --verify-tag
                   fi
 
+                  mapfile -t release_assets < <(find .artifacts/release-assets -type f | sort)
+
+                  if (( ${#release_assets[@]} == 0 )); then
+                    echo "No staged release assets found." >&2
+                    exit 1
+                  fi
+
+                  gh release upload "$tag" "${release_assets[@]}" --clobber
+
     publish-apt-repository:
         name: Publish APT repository
         needs:
             - prepare
-            - validate-release-assets
+            - publish-github-release
             - apt-repository-preflight
         runs-on: ubuntu-latest
         env:
@@ -687,21 +682,6 @@ jobs:
                   git -C "$PAGES_DIR" config user.name "github-actions[bot]"
                   git -C "$PAGES_DIR" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-            - name: Ensure GitHub release exists
-              run: |
-                  tag="$RELEASE_TAG"
-                  version="${tag#v}"
-                  title="Comando v${version}"
-
-                  if gh release view "$tag" >/dev/null 2>&1; then
-                    gh release edit "$tag" --title "$title"
-                  else
-                    gh release create "$tag" \
-                      --title "$title" \
-                      --notes "Release artifacts are still being finalized." \
-                      --verify-tag
-                  fi
-
             - name: Upload APT metadata to GitHub release
               env:
                   APT_RELEASE_DIR: ${{ runner.temp }}/apt-release
@@ -783,7 +763,7 @@ jobs:
         name: Publish DNF repository
         needs:
             - prepare
-            - ensure-github-release
+            - publish-github-release
             - validate-release-assets
             - dnf-repository-preflight
             - publish-apt-repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,24 +5,37 @@ on:
         tags:
             - "v*"
     workflow_dispatch:
+        inputs:
+            tag:
+                description: Existing release tag to publish, for example v0.1.0
+                required: true
+                type: string
 
 permissions:
     contents: write
 
+env:
+    RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+
 concurrency:
-    group: release-${{ github.ref }}
+    group: release-${{ github.event.inputs.tag || github.ref_name }}
     cancel-in-progress: false
 
 jobs:
-    release-preflight:
-        name: Release preflight
+    prepare:
+        name: Prepare release
         runs-on: ubuntu-latest
+        outputs:
+            tag: ${{ steps.release.outputs.tag }}
+            version: ${{ steps.release.outputs.version }}
+            repo_slug: ${{ steps.release.outputs.repo_slug }}
         env:
             NODE_OPTIONS: --max-old-space-size=8192
         steps:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  ref: ${{ env.RELEASE_TAG }}
 
             - uses: pnpm/action-setup@v4
               with:
@@ -35,30 +48,36 @@ jobs:
 
             - uses: dtolnay/rust-toolchain@stable
 
-            - name: Validate release tag
+            - name: Validate release metadata
+              id: release
               run: |
-                  if [[ "$GITHUB_REF_TYPE" != "tag" ]]; then
-                    echo "Release workflow must run from a tag, got $GITHUB_REF_TYPE: $GITHUB_REF_NAME" >&2
+                  if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "Release tag must use vX.Y.Z format, got $RELEASE_TAG." >&2
                     exit 1
                   fi
 
                   package_version="$(node -p "require('./package.json').version")"
                   expected_tag="v${package_version}"
 
-                  if [[ "$GITHUB_REF_NAME" != "$expected_tag" ]]; then
-                    echo "Release tag $GITHUB_REF_NAME does not match package.json version $package_version (expected $expected_tag)." >&2
+                  if [[ "$RELEASE_TAG" != "$expected_tag" ]]; then
+                    echo "Release tag $RELEASE_TAG does not match package.json version $package_version (expected $expected_tag)." >&2
                     exit 1
                   fi
 
+                  echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+                  echo "version=$package_version" >> "$GITHUB_OUTPUT"
+                  echo "repo_slug=$GITHUB_REPOSITORY" >> "$GITHUB_OUTPUT"
+
             - name: Build release notes
               run: |
-                  node scripts/extract-changelog-release-notes.mjs "$GITHUB_REF_NAME" > release-notes.md
-                  node scripts/build-release-body.mjs --version "$GITHUB_REF_NAME" --notes-file release-notes.md --output release-body.md
+                  node scripts/extract-changelog-release-notes.mjs "$RELEASE_TAG" > release-notes.md
+                  node scripts/build-release-body.mjs --version "$RELEASE_TAG" --notes-file release-notes.md --output release-body.md
+                  test -s release-body.md
 
             - name: Upload release body
               uses: actions/upload-artifact@v4
               with:
-                  name: release-body-${{ github.ref_name }}
+                  name: release-body-${{ env.RELEASE_TAG }}
                   path: release-body.md
                   if-no-files-found: error
 
@@ -80,7 +99,7 @@ jobs:
 
     apt-repository-preflight:
         name: APT repository preflight
-        needs: release-preflight
+        needs: prepare
         runs-on: ubuntu-latest
         env:
             APT_REPO_GPG_PRIVATE_KEY: ${{ secrets.APT_REPO_GPG_PRIVATE_KEY }}
@@ -109,7 +128,7 @@ jobs:
 
     dnf-repository-preflight:
         name: DNF repository preflight
-        needs: release-preflight
+        needs: prepare
         runs-on: ubuntu-latest
         env:
             APT_REPO_GPG_PRIVATE_KEY: ${{ secrets.APT_REPO_GPG_PRIVATE_KEY }}
@@ -138,7 +157,7 @@ jobs:
 
     ensure-github-release:
         name: Ensure GitHub release
-        needs: release-preflight
+        needs: prepare
         runs-on: ubuntu-latest
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -146,12 +165,12 @@ jobs:
             - name: Download release body
               uses: actions/download-artifact@v4
               with:
-                  name: release-body-${{ github.ref_name }}
+                  name: release-body-${{ needs.prepare.outputs.tag }}
                   path: .release
 
             - name: Create or update release shell
               run: |
-                  tag="$GITHUB_REF_NAME"
+                  tag="$RELEASE_TAG"
                   version="${tag#v}"
                   title="Comando v${version}"
                   notes_file=".release/release-body.md"
@@ -178,6 +197,7 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  ref: ${{ env.RELEASE_TAG }}
 
             - uses: pnpm/action-setup@v4
               with:
@@ -278,6 +298,7 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  ref: ${{ env.RELEASE_TAG }}
 
             - uses: pnpm/action-setup@v4
               with:
@@ -317,6 +338,7 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  ref: ${{ env.RELEASE_TAG }}
 
             - uses: pnpm/action-setup@v4
               with:
@@ -348,7 +370,7 @@ jobs:
     release-linux:
         name: Linux ${{ matrix.arch }}
         needs:
-            - release-preflight
+            - prepare
             - ensure-github-release
             - apt-repository-preflight
         runs-on: ${{ matrix.runner }}
@@ -370,6 +392,7 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  ref: ${{ env.RELEASE_TAG }}
 
             - uses: pnpm/action-setup@v4
               with:
@@ -419,7 +442,7 @@ jobs:
                   node scripts/validate-linux-rpm-package.mjs \
                     --staged-assets-dir dist \
                     --arch "${{ matrix.arch }}" \
-                    --version "${GITHUB_REF_NAME#v}" \
+                    --version "${RELEASE_TAG#v}" \
                     --require-signature
 
             - name: Upload Linux release assets
@@ -438,7 +461,7 @@ jobs:
                     exit 1
                   fi
 
-                  gh release upload "$GITHUB_REF_NAME" "${linux_assets[@]}" --clobber
+                  gh release upload "$RELEASE_TAG" "${linux_assets[@]}" --clobber
 
             - name: Upload Linux workflow artifacts
               uses: actions/upload-artifact@v4
@@ -455,7 +478,7 @@ jobs:
     publish-release-notes:
         name: Publish release notes
         needs:
-            - release-preflight
+            - prepare
             - release-macos
             - release-windows-x64
             - release-windows-arm64
@@ -469,12 +492,12 @@ jobs:
             - name: Download release body
               uses: actions/download-artifact@v4
               with:
-                  name: release-body-${{ github.ref_name }}
+                  name: release-body-${{ needs.prepare.outputs.tag }}
                   path: .release
 
             - name: Create or update GitHub release notes
               run: |
-                  tag="$GITHUB_REF_NAME"
+                  tag="$RELEASE_TAG"
                   version="${tag#v}"
                   title="Comando v${version}"
                   notes_file=".release/release-body.md"
@@ -488,7 +511,7 @@ jobs:
     publish-apt-repository:
         name: Publish APT repository
         needs:
-            - release-preflight
+            - prepare
             - release-macos
             - release-windows-x64
             - release-windows-arm64
@@ -504,6 +527,7 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  ref: ${{ env.RELEASE_TAG }}
 
             - uses: actions/setup-node@v4
               with:
@@ -527,7 +551,7 @@ jobs:
               run: |
                   node scripts/build-apt-repository.mjs \
                     --layout flat-release \
-                    --version "$GITHUB_REF_NAME" \
+                    --version "$RELEASE_TAG" \
                     --release-assets-dir .artifacts/linux \
                     --output-dir "$APT_RELEASE_DIR" \
                     --repo-slug "$GITHUB_REPOSITORY" \
@@ -563,7 +587,7 @@ jobs:
                     --layout flat-release \
                     --apt-dir "$APT_RELEASE_DIR" \
                     --package-assets-dir .artifacts/linux \
-                    --version "$GITHUB_REF_NAME" \
+                    --version "$RELEASE_TAG" \
                     --suite stable \
                     --component main
 
@@ -584,7 +608,7 @@ jobs:
                   find .artifacts/linux -type f -name '*.deb' -exec cp {} "$APT_SMOKE_DIR"/ \;
 
                   docker run --rm \
-                    -e VERSION="${GITHUB_REF_NAME#v}" \
+                    -e VERSION="${RELEASE_TAG#v}" \
                     -v "$APT_SMOKE_DIR:/repo:ro" \
                     ubuntu:24.04 \
                     bash -lc '
@@ -625,7 +649,7 @@ jobs:
 
             - name: Ensure GitHub release exists
               run: |
-                  tag="$GITHUB_REF_NAME"
+                  tag="$RELEASE_TAG"
                   version="${tag#v}"
                   title="Comando v${version}"
 
@@ -642,7 +666,7 @@ jobs:
               env:
                   APT_RELEASE_DIR: ${{ runner.temp }}/apt-release
               run: |
-                  gh release upload "$GITHUB_REF_NAME" \
+                  gh release upload "$RELEASE_TAG" \
                     "$APT_RELEASE_DIR/InRelease" \
                     "$APT_RELEASE_DIR/Release" \
                     "$APT_RELEASE_DIR/Release.gpg" \
@@ -658,8 +682,8 @@ jobs:
               run: |
                   docker run --rm \
                     -e REPO_SLUG="$GITHUB_REPOSITORY" \
-                    -e RELEASE_TAG="$GITHUB_REF_NAME" \
-                    -e VERSION="${GITHUB_REF_NAME#v}" \
+                    -e RELEASE_TAG="$RELEASE_TAG" \
+                    -e VERSION="${RELEASE_TAG#v}" \
                     -v "$APT_RELEASE_DIR:/repo:ro" \
                     ubuntu:24.04 \
                     bash -lc '
@@ -711,14 +735,14 @@ jobs:
                   if git -C "$PAGES_DIR" diff --cached --quiet; then
                     echo "No APT entrypoint changes to publish."
                   else
-                    git -C "$PAGES_DIR" commit -m "Publish APT entrypoints for $GITHUB_REF_NAME"
+                    git -C "$PAGES_DIR" commit -m "Publish APT entrypoints for $RELEASE_TAG"
                     git -C "$PAGES_DIR" push origin HEAD:gh-pages
                   fi
 
     publish-dnf-repository:
         name: Publish DNF repository
         needs:
-            - release-preflight
+            - prepare
             - ensure-github-release
             - release-linux
             - dnf-repository-preflight
@@ -733,6 +757,7 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  ref: ${{ env.RELEASE_TAG }}
 
             - uses: actions/setup-node@v4
               with:
@@ -774,8 +799,8 @@ jobs:
                   PAGES_DIR: ${{ runner.temp }}/gh-pages
               run: |
                   node scripts/build-dnf-repository.mjs \
-                    --version "$GITHUB_REF_NAME" \
-                    --tag "$GITHUB_REF_NAME" \
+                    --version "$RELEASE_TAG" \
+                    --tag "$RELEASE_TAG" \
                     --release-assets-dir .artifacts/linux \
                     --pages-dir "$PAGES_DIR" \
                     --repo-slug "$GITHUB_REPOSITORY"
@@ -805,14 +830,14 @@ jobs:
 
                   node scripts/validate-dnf-repository.mjs \
                     --dnf-dir "$PAGES_DIR/dnf" \
-                    --version "$GITHUB_REF_NAME"
+                    --version "$RELEASE_TAG"
 
             - name: Validate DNF repository with Fedora
               env:
                   PAGES_DIR: ${{ runner.temp }}/gh-pages
               run: |
                   docker run --rm \
-                    -e VERSION="${GITHUB_REF_NAME#v}" \
+                    -e VERSION="${RELEASE_TAG#v}" \
                     -v "$PAGES_DIR/dnf:/repo:ro" \
                     fedora:latest \
                     bash -lc '
@@ -857,6 +882,6 @@ jobs:
                   if git -C "$PAGES_DIR" diff --cached --quiet; then
                     echo "No DNF repository changes to publish."
                   else
-                    git -C "$PAGES_DIR" commit -m "Publish DNF repository for $GITHUB_REF_NAME"
+                    git -C "$PAGES_DIR" commit -m "Publish DNF repository for $RELEASE_TAG"
                     git -C "$PAGES_DIR" push origin HEAD:gh-pages
                   fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
                 type: string
 
 permissions:
-    contents: write
+    contents: read
 
 env:
     RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
@@ -504,6 +504,8 @@ jobs:
             - build-linux
             - validate-release-assets
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
@@ -553,6 +555,8 @@ jobs:
             - publish-github-release
             - apt-repository-preflight
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         env:
             APT_REPO_GPG_PRIVATE_KEY: ${{ secrets.APT_REPO_GPG_PRIVATE_KEY }}
             APT_REPO_GPG_PASSPHRASE: ${{ secrets.APT_REPO_GPG_PASSPHRASE }}
@@ -768,11 +772,12 @@ jobs:
             - dnf-repository-preflight
             - publish-apt-repository
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         env:
             APT_REPO_GPG_PRIVATE_KEY: ${{ secrets.APT_REPO_GPG_PRIVATE_KEY }}
             APT_REPO_GPG_PASSPHRASE: ${{ secrets.APT_REPO_GPG_PASSPHRASE }}
             APT_REPO_GPG_KEY_ID: ${{ secrets.APT_REPO_GPG_KEY_ID }}
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
             - uses: actions/checkout@v4
               with:

--- a/.github/workflows/validate-release-metadata.yml
+++ b/.github/workflows/validate-release-metadata.yml
@@ -54,9 +54,11 @@ jobs:
                   node --check scripts/build-dnf-repository.mjs
                   node --check scripts/build-release-body.mjs
                   node --check scripts/extract-changelog-release-notes.mjs
+                  node --check scripts/release-target-metadata.mjs
                   node --check scripts/sign-apt-repository.mjs
                   node --check scripts/sign-dnf-repository.mjs
                   node --check scripts/sign-rpm-packages.mjs
                   node --check scripts/validate-apt-repository.mjs
                   node --check scripts/validate-dnf-repository.mjs
                   node --check scripts/validate-linux-rpm-package.mjs
+                  node --check scripts/validate-release-assets.mjs

--- a/scripts/release-target-metadata.mjs
+++ b/scripts/release-target-metadata.mjs
@@ -1,0 +1,119 @@
+import path from "node:path";
+
+import { resolveLinuxReleaseArtifacts } from "./linux-release-metadata.mjs";
+import { resolveWindowsReleaseArtifacts } from "./windows-release-metadata.mjs";
+
+export const RELEASE_TARGETS = Object.freeze([
+    {
+        artifactName: "release-assets-macos-universal",
+        id: "darwin-universal",
+        platform: "darwin",
+    },
+    {
+        artifactName: "release-assets-windows-x64",
+        id: "win-x64",
+        platform: "win32",
+        targetArch: "x64",
+    },
+    {
+        artifactName: "release-assets-windows-arm64",
+        id: "win-arm64",
+        platform: "win32",
+        targetArch: "arm64",
+    },
+    {
+        artifactName: "release-assets-linux-x64",
+        id: "linux-x64",
+        platform: "linux",
+        targetArch: "x64",
+    },
+    {
+        artifactName: "release-assets-linux-arm64",
+        id: "linux-arm64",
+        platform: "linux",
+        targetArch: "arm64",
+    },
+]);
+
+export function normalizeReleaseVersion(versionOrTag) {
+    const version = String(versionOrTag ?? "").replace(/^v/u, "");
+    if (!/^[0-9]+\.[0-9]+\.[0-9]+$/u.test(version)) {
+        throw new Error(
+            `Expected release version X.Y.Z or vX.Y.Z, got ${versionOrTag}.`,
+        );
+    }
+    return version;
+}
+
+export function resolveReleaseTargetArtifacts({
+    distDir,
+    packageJson,
+    target,
+    version,
+}) {
+    const productName = packageJson.build?.productName ?? packageJson.name;
+    const normalizedVersion = normalizeReleaseVersion(version);
+
+    if (target.platform === "darwin") {
+        const dmgFileName = `${productName}-${normalizedVersion}-universal.dmg`;
+        const zipFileName = `${productName}-${normalizedVersion}-universal.zip`;
+
+        return {
+            artifactName: target.artifactName,
+            files: [
+                path.join(distDir, dmgFileName),
+                path.join(distDir, zipFileName),
+                path.join(distDir, "latest-mac.yml"),
+            ],
+            id: target.id,
+            metadataPath: path.join(distDir, "latest-mac.yml"),
+            primaryArtifactName: zipFileName,
+        };
+    }
+
+    if (target.platform === "win32") {
+        const artifacts = resolveWindowsReleaseArtifacts({
+            distDir,
+            productName,
+            targetArch: target.targetArch,
+            version: normalizedVersion,
+        });
+
+        return {
+            artifactName: target.artifactName,
+            files: [
+                artifacts.installerPath,
+                artifacts.blockmapPath,
+                artifacts.metadataPath,
+            ],
+            id: target.id,
+            metadataPath: artifacts.metadataPath,
+            primaryArtifactName: artifacts.installerFileName,
+        };
+    }
+
+    if (target.platform === "linux") {
+        const artifacts = resolveLinuxReleaseArtifacts({
+            distDir,
+            productName,
+            targetArch: target.targetArch,
+            version: normalizedVersion,
+        });
+
+        return {
+            artifactName: target.artifactName,
+            files: [
+                artifacts.appImagePath,
+                artifacts.appImageBlockmapPath,
+                artifacts.debPath,
+                artifacts.rpmPath,
+                artifacts.metadataPath,
+            ],
+            id: target.id,
+            metadataPath: artifacts.metadataPath,
+            primaryArtifactName: path.basename(artifacts.appImagePath),
+        };
+    }
+
+    throw new Error(`Unsupported release target platform: ${target.platform}.`);
+}

--- a/scripts/validate-release-assets.mjs
+++ b/scripts/validate-release-assets.mjs
@@ -1,0 +1,249 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+    RELEASE_TARGETS,
+    resolveReleaseTargetArtifacts,
+} from "./release-target-metadata.mjs";
+import { verifyLinuxReleaseArtifacts } from "./linux-release-metadata.mjs";
+import { verifyWindowsReleaseArtifacts } from "./windows-release-metadata.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const defaultPackageJsonPath = path.join(repoRoot, "package.json");
+const forbiddenSharedMetadataNames = new Set([
+    "latest.yml",
+    "latest-linux.yml",
+    "latest-linux-arm64.yml",
+]);
+
+export function validateReleaseAssets({
+    assetsDir,
+    packageJson,
+    version,
+}) {
+    const rootDir = path.resolve(assetsDir);
+    assertDirectory(rootDir, "release assets directory");
+
+    const productName = packageJson.build?.productName ?? packageJson.name;
+    if (!productName) {
+        throw new Error("package.json must define build.productName or name.");
+    }
+
+    const targetByArtifactName = new Map(
+        RELEASE_TARGETS.map((target) => [target.artifactName, target]),
+    );
+    const actualArtifactNames = new Set(
+        fs.readdirSync(rootDir, { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => entry.name),
+    );
+
+    for (const target of RELEASE_TARGETS) {
+        if (!actualArtifactNames.has(target.artifactName)) {
+            throw new Error(
+                `Missing staged release artifact directory: ${target.artifactName}.`,
+            );
+        }
+    }
+
+    for (const artifactName of actualArtifactNames) {
+        if (!targetByArtifactName.has(artifactName)) {
+            throw new Error(
+                `Unexpected staged release artifact directory: ${artifactName}.`,
+            );
+        }
+    }
+
+    assertNoDuplicateAssetNames(rootDir);
+    assertNoForbiddenSharedMetadata(rootDir);
+
+    const validatedTargets = [];
+    for (const target of RELEASE_TARGETS) {
+        const distDir = path.join(rootDir, target.artifactName);
+        assertDirectory(distDir, target.artifactName);
+
+        const targetArtifacts = resolveReleaseTargetArtifacts({
+            distDir,
+            packageJson,
+            target,
+            version,
+        });
+
+        for (const filePath of targetArtifacts.files) {
+            assertFile(filePath, rootDir, `Missing expected ${target.id} asset`);
+        }
+
+        if (target.platform === "darwin") {
+            verifyMacReleaseMetadata({
+                metadataPath: targetArtifacts.metadataPath,
+                primaryArtifactName: targetArtifacts.primaryArtifactName,
+                relativePath: (filePath) => path.relative(rootDir, filePath),
+            });
+        } else if (target.platform === "win32") {
+            verifyWindowsReleaseArtifacts({
+                distDir,
+                productName,
+                relativePath: (filePath) => path.relative(rootDir, filePath),
+                targetArch: target.targetArch,
+                version: stripTagPrefix(version),
+            });
+        } else if (target.platform === "linux") {
+            verifyLinuxReleaseArtifacts({
+                distDir,
+                productName,
+                relativePath: (filePath) => path.relative(rootDir, filePath),
+                targetArch: target.targetArch,
+                version: stripTagPrefix(version),
+            });
+        }
+
+        validatedTargets.push(target.id);
+    }
+
+    return {
+        targets: validatedTargets,
+    };
+}
+
+function verifyMacReleaseMetadata({
+    metadataPath,
+    primaryArtifactName,
+    relativePath,
+}) {
+    const metadata = fs.readFileSync(metadataPath, "utf8");
+    if (!metadata.includes(primaryArtifactName)) {
+        throw new Error(
+            `macOS updater metadata ${relativePath(metadataPath)} does not reference ${primaryArtifactName}.`,
+        );
+    }
+}
+
+function assertNoDuplicateAssetNames(rootDir) {
+    const seen = new Map();
+    for (const filePath of listFiles(rootDir)) {
+        const basename = path.basename(filePath);
+        const existingPath = seen.get(basename);
+        if (existingPath) {
+            throw new Error(
+                `Duplicate staged release asset name ${basename}: ${path.relative(rootDir, existingPath)} and ${path.relative(rootDir, filePath)}.`,
+            );
+        }
+        seen.set(basename, filePath);
+    }
+}
+
+function assertNoForbiddenSharedMetadata(rootDir) {
+    for (const filePath of listFiles(rootDir)) {
+        const basename = path.basename(filePath);
+        if (forbiddenSharedMetadataNames.has(basename)) {
+            throw new Error(
+                `Release assets must not include shared updater metadata: ${path.relative(rootDir, filePath)}.`,
+            );
+        }
+    }
+}
+
+function listFiles(rootDir) {
+    const files = [];
+    const entries = fs.readdirSync(rootDir, { withFileTypes: true });
+    for (const entry of entries) {
+        const entryPath = path.join(rootDir, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...listFiles(entryPath));
+        } else if (entry.isFile()) {
+            files.push(entryPath);
+        }
+    }
+    return files;
+}
+
+function assertDirectory(directoryPath, label) {
+    const stats = fs.existsSync(directoryPath) ? fs.statSync(directoryPath) : null;
+    if (!stats?.isDirectory()) {
+        throw new Error(`Missing ${label}: ${directoryPath}.`);
+    }
+}
+
+function assertFile(filePath, rootDir, message) {
+    const stats = fs.existsSync(filePath) ? fs.statSync(filePath) : null;
+    if (!stats?.isFile()) {
+        throw new Error(`${message}: ${path.relative(rootDir, filePath)}.`);
+    }
+}
+
+function stripTagPrefix(version) {
+    return String(version).replace(/^v/u, "");
+}
+
+function parseArgs(argv) {
+    const args = {
+        assetsDir: path.join(repoRoot, ".artifacts", "release-assets"),
+        packageJsonPath: defaultPackageJsonPath,
+        version: null,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        const next = argv[index + 1] ?? null;
+
+        if (arg === "--assets-dir") {
+            args.assetsDir = path.resolve(requireValue(arg, next));
+            index += 1;
+            continue;
+        }
+        if (arg === "--package-json") {
+            args.packageJsonPath = path.resolve(requireValue(arg, next));
+            index += 1;
+            continue;
+        }
+        if (arg === "--version") {
+            args.version = requireValue(arg, next);
+            index += 1;
+            continue;
+        }
+
+        throw new Error(
+            `Unknown argument "${arg}". Supported args: --assets-dir, --package-json, --version.`,
+        );
+    }
+
+    if (!args.version) {
+        throw new Error("Missing required argument --version <X.Y.Z-or-tag>.");
+    }
+
+    return args;
+}
+
+function requireValue(arg, value) {
+    if (!value) {
+        throw new Error(`Missing value for ${arg}.`);
+    }
+    return value;
+}
+
+function main() {
+    try {
+        const args = parseArgs(process.argv.slice(2));
+        const packageJson = JSON.parse(
+            fs.readFileSync(args.packageJsonPath, "utf8"),
+        );
+        const result = validateReleaseAssets({
+            assetsDir: args.assetsDir,
+            packageJson,
+            version: args.version,
+        });
+
+        console.log(
+            `Validated staged release assets for ${result.targets.join(", ")}.`,
+        );
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    main();
+}

--- a/scripts/validate-release-assets.test.mjs
+++ b/scripts/validate-release-assets.test.mjs
@@ -1,0 +1,232 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { RELEASE_TARGETS } from "./release-target-metadata.mjs";
+import { resolveLinuxReleaseArtifacts } from "./linux-release-metadata.mjs";
+import { validateReleaseAssets } from "./validate-release-assets.mjs";
+import { resolveWindowsReleaseArtifacts } from "./windows-release-metadata.mjs";
+
+const temporaryDirectories = new Set();
+const packageJson = {
+    build: {
+        productName: "Comando",
+    },
+    name: "comando",
+};
+
+afterEach(() => {
+    for (const directoryPath of temporaryDirectories) {
+        fs.rmSync(directoryPath, {
+            force: true,
+            recursive: true,
+        });
+    }
+    temporaryDirectories.clear();
+});
+
+describe("release asset coverage validation", () => {
+    it("accepts the full staged release asset matrix", () => {
+        const assetsDir = createCompleteAssetsDir();
+
+        expect(
+            validateReleaseAssets({
+                assetsDir,
+                packageJson,
+                version: "v1.2.3",
+            }),
+        ).toEqual({
+            targets: RELEASE_TARGETS.map((target) => target.id),
+        });
+    });
+
+    it("rejects a missing target artifact directory", () => {
+        const assetsDir = createCompleteAssetsDir();
+        fs.rmSync(path.join(assetsDir, "release-assets-windows-arm64"), {
+            force: true,
+            recursive: true,
+        });
+
+        expect(() =>
+            validateReleaseAssets({
+                assetsDir,
+                packageJson,
+                version: "v1.2.3",
+            }),
+        ).toThrow(/release-assets-windows-arm64/u);
+    });
+
+    it("rejects duplicate asset names across staged artifacts", () => {
+        const assetsDir = createCompleteAssetsDir();
+        fs.writeFileSync(
+            path.join(
+                assetsDir,
+                "release-assets-windows-arm64",
+                "Comando-1.2.3-win-x64.exe",
+            ),
+            "",
+            "utf8",
+        );
+
+        expect(() =>
+            validateReleaseAssets({
+                assetsDir,
+                packageJson,
+                version: "v1.2.3",
+            }),
+        ).toThrow(/Duplicate staged release asset name/u);
+    });
+
+    it("rejects shared updater metadata", () => {
+        const assetsDir = createCompleteAssetsDir();
+        fs.writeFileSync(
+            path.join(assetsDir, "release-assets-linux-x64", "latest-linux.yml"),
+            "",
+            "utf8",
+        );
+
+        expect(() =>
+            validateReleaseAssets({
+                assetsDir,
+                packageJson,
+                version: "v1.2.3",
+            }),
+        ).toThrow(/shared updater metadata/u);
+    });
+
+    it("requires explicit macOS updater metadata", () => {
+        const assetsDir = createCompleteAssetsDir();
+        fs.rmSync(
+            path.join(assetsDir, "release-assets-macos-universal", "latest-mac.yml"),
+        );
+
+        expect(() =>
+            validateReleaseAssets({
+                assetsDir,
+                packageJson,
+                version: "v1.2.3",
+            }),
+        ).toThrow(/latest-mac\.yml/u);
+    });
+
+    it("rejects macOS updater metadata that does not point at the zip", () => {
+        const assetsDir = createCompleteAssetsDir();
+        fs.writeFileSync(
+            path.join(assetsDir, "release-assets-macos-universal", "latest-mac.yml"),
+            "path: Comando-1.2.3-universal.dmg\n",
+            "utf8",
+        );
+
+        expect(() =>
+            validateReleaseAssets({
+                assetsDir,
+                packageJson,
+                version: "v1.2.3",
+            }),
+        ).toThrow(/does not reference Comando-1\.2\.3-universal\.zip/u);
+    });
+
+    it("rejects Linux metadata that points at another architecture", () => {
+        const assetsDir = createCompleteAssetsDir();
+        const linuxX64Dir = path.join(assetsDir, "release-assets-linux-x64");
+        const artifacts = resolveLinuxReleaseArtifacts({
+            distDir: linuxX64Dir,
+            productName: "Comando",
+            targetArch: "x64",
+            version: "1.2.3",
+        });
+        fs.writeFileSync(
+            artifacts.metadataPath,
+            "path: Comando-1.2.3-linux-arm64.AppImage\n",
+            "utf8",
+        );
+
+        expect(() =>
+            validateReleaseAssets({
+                assetsDir,
+                packageJson,
+                version: "v1.2.3",
+            }),
+        ).toThrow(/linux-x86_64\.AppImage/u);
+    });
+});
+
+function createCompleteAssetsDir() {
+    const assetsDir = createTempDir();
+    writeMacAssets(path.join(assetsDir, "release-assets-macos-universal"));
+    writeWindowsAssets(path.join(assetsDir, "release-assets-windows-x64"), "x64");
+    writeWindowsAssets(
+        path.join(assetsDir, "release-assets-windows-arm64"),
+        "arm64",
+    );
+    writeLinuxAssets(path.join(assetsDir, "release-assets-linux-x64"), "x64");
+    writeLinuxAssets(path.join(assetsDir, "release-assets-linux-arm64"), "arm64");
+    return assetsDir;
+}
+
+function writeMacAssets(distDir) {
+    fs.mkdirSync(distDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(distDir, "Comando-1.2.3-universal.dmg"),
+        "",
+        "utf8",
+    );
+    fs.writeFileSync(
+        path.join(distDir, "Comando-1.2.3-universal.zip"),
+        "",
+        "utf8",
+    );
+    fs.writeFileSync(
+        path.join(distDir, "latest-mac.yml"),
+        "path: Comando-1.2.3-universal.zip\n",
+        "utf8",
+    );
+}
+
+function writeWindowsAssets(distDir, targetArch) {
+    fs.mkdirSync(distDir, { recursive: true });
+    const artifacts = resolveWindowsReleaseArtifacts({
+        distDir,
+        productName: "Comando",
+        targetArch,
+        version: "1.2.3",
+    });
+
+    fs.writeFileSync(artifacts.installerPath, "", "utf8");
+    fs.writeFileSync(artifacts.blockmapPath, "", "utf8");
+    fs.writeFileSync(
+        artifacts.metadataPath,
+        `path: ${artifacts.installerFileName}\n`,
+        "utf8",
+    );
+}
+
+function writeLinuxAssets(distDir, targetArch) {
+    fs.mkdirSync(distDir, { recursive: true });
+    const artifacts = resolveLinuxReleaseArtifacts({
+        distDir,
+        productName: "Comando",
+        targetArch,
+        version: "1.2.3",
+    });
+
+    fs.writeFileSync(artifacts.appImagePath, "", "utf8");
+    fs.writeFileSync(artifacts.appImageBlockmapPath, "", "utf8");
+    fs.writeFileSync(artifacts.debPath, "", "utf8");
+    fs.writeFileSync(artifacts.rpmPath, "", "utf8");
+    fs.writeFileSync(
+        artifacts.metadataPath,
+        `path: ${path.basename(artifacts.appImagePath)}\n`,
+        "utf8",
+    );
+}
+
+function createTempDir() {
+    const directoryPath = fs.mkdtempSync(
+        path.join(os.tmpdir(), "comando-release-assets-test-"),
+    );
+    temporaryDirectories.add(directoryPath);
+    return directoryPath;
+}


### PR DESCRIPTION
## Summary

- Adds tag-aware release preparation and a dedicated release gate with native checks.
- Stages platform artifacts before publishing, validates full release asset coverage, and publishes the GitHub Release only after every target passes.
- Reorders Linux repository publication after release assets, adds a published DNF smoke test with retry, and scopes release workflow permissions by job.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/validate-release-metadata.yml"); puts "YAML OK"'`
- `git diff --check`
- `pnpm exec vitest run scripts/*.test.mjs`

## Notes

- Windows packaging remains unsigned intentionally.
- Platform build jobs no longer create or upload directly to a GitHub Release.