### PR TITLE
Use terminal status colors for command tools

### DIFF
--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
@@ -1219,6 +1219,108 @@ describe("ToolActivityItem", () => {
         expect(markup).not.toContain("cm-static-code");
     });
 
+    it("colors successful terminal cards green without rendering an exit badge", () => {
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivityItem, {
+                activity: createActivity({
+                    exitCode: 0,
+                    kind: "shell",
+                    locations: [],
+                    rawInputJson: JSON.stringify({ command: "echo ok" }),
+                    status: "completed",
+                    summary: null,
+                    terminalOutput: null,
+                    title: "Run echo ok",
+                }),
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                trackedFiles: [],
+                worktreeId: null,
+            }),
+        );
+
+        expect(markup).toContain("Run echo ok");
+        expect(markup).toContain("var(--diff-add)");
+        expect(markup).not.toContain("exit 0");
+    });
+
+    it("colors non-zero terminal exits red without rendering an exit badge", () => {
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivityItem, {
+                activity: createActivity({
+                    exitCode: 1,
+                    kind: "shell",
+                    locations: [],
+                    rawInputJson: JSON.stringify({ command: "false" }),
+                    status: "completed",
+                    summary: null,
+                    terminalOutput: null,
+                    title: "Run false",
+                }),
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                trackedFiles: [],
+                worktreeId: null,
+            }),
+        );
+
+        expect(markup).toContain("Run false");
+        expect(markup).toContain("#ef4444");
+        expect(markup).not.toContain("exit 1");
+    });
+
+    it("keeps in-progress terminal cards neutral and shows the live indicator", () => {
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivityItem, {
+                activity: createActivity({
+                    exitCode: null,
+                    kind: "shell",
+                    locations: [],
+                    rawInputJson: JSON.stringify({ command: "pnpm dev" }),
+                    status: "in_progress",
+                    summary: null,
+                    terminalOutput: null,
+                    title: "Run pnpm dev",
+                }),
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                trackedFiles: [],
+                worktreeId: null,
+            }),
+        );
+
+        expect(markup).toContain("Run pnpm dev");
+        expect(markup).toContain("#6b7280");
+        expect(markup).toContain("animate-pulse");
+    });
+
+    it("treats terminal output as danger when exit code is non-zero", () => {
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivityItem, {
+                activity: createActivity({
+                    exitCode: 1,
+                    kind: "shell",
+                    locations: [],
+                    rawInputJson: JSON.stringify({ command: "pnpm test" }),
+                    status: "completed",
+                    summary: null,
+                    terminalOutput: "Tests failed\n",
+                    title: "Run pnpm test",
+                }),
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                trackedFiles: [],
+                worktreeId: null,
+            }),
+        );
+
+        expect(markup).toContain("Tests failed");
+        expect(markup).toContain(
+            "color-mix(in srgb, #ef4444 6%, var(--color-bg-tertiary))",
+        );
+        expect(markup).toContain("color:#ef4444");
+    });
+
     it("does not repeat duplicated terminal commands in expanded output", () => {
         const markup = renderToStaticMarkup(
             createElement(ToolActivityItem, {

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
@@ -1214,7 +1214,7 @@ describe("ToolActivityItem", () => {
         );
 
         expect(markup).toContain("Run pnpm run typecheck");
-        expect(markup).toContain("exit 1");
+        expect(markup).not.toContain("exit 1");
         expect(markup).not.toContain("space-y-1");
         expect(markup).not.toContain("cm-static-code");
     });

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
@@ -1515,13 +1515,11 @@ function TerminalToolMessage({
 }: {
     readonly activity: AiToolActivity;
 }) {
-    const isFailed = activity.status === "failed";
-    const hasNonZeroExit =
-        activity.exitCode !== null && activity.exitCode !== 0;
     const isInProgress = activity.status === "in_progress";
     const isCompleted = activity.status === "completed";
 
     const terminalTone = getTerminalToolTone(activity);
+    const isDangerTone = terminalTone === "danger";
     const accent = getTerminalToolToneColor(terminalTone);
     const command = extractCommand(activity.rawInputJson);
     const shouldShowCommand =
@@ -1530,7 +1528,7 @@ function TerminalToolMessage({
     const hasDetail = shouldShowCommand || hasTerminalOutput;
     const [expanded, setExpanded] = usePersistentToolExpansion(
         `${activity.id}:terminal`,
-        (isFailed || hasNonZeroExit) && hasTerminalOutput,
+        isDangerTone && hasTerminalOutput,
     );
 
     return (
@@ -1576,23 +1574,6 @@ function TerminalToolMessage({
                         style={{ backgroundColor: "var(--color-accent)" }}
                     />
                 ) : null}
-                {activity.exitCode !== null ? (
-                    <span
-                        className="rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.12em]"
-                        style={{
-                            backgroundColor:
-                                activity.exitCode === 0
-                                    ? "color-mix(in srgb, var(--diff-add) 10%, transparent)"
-                                    : "color-mix(in srgb, var(--diff-remove) 10%, transparent)",
-                            color:
-                                activity.exitCode === 0
-                                    ? "var(--diff-add)"
-                                    : "var(--diff-remove)",
-                        }}
-                    >
-                        exit {activity.exitCode}
-                    </span>
-                ) : null}
                 {hasDetail ? (
                     <span className="shrink-0">
                         <Chevron expanded={expanded} />
@@ -1608,17 +1589,17 @@ function TerminalToolMessage({
                     {activity.terminalOutput ? (
                         <ToolDetailCodeBlock
                             accentBorder={
-                                isFailed
+                                isDangerTone
                                     ? "1px solid color-mix(in srgb, #ef4444 20%, var(--color-border))"
                                     : "1px solid var(--color-border)"
                             }
                             backgroundColor={
-                                isFailed
+                                isDangerTone
                                     ? "color-mix(in srgb, #ef4444 6%, var(--color-bg-tertiary))"
                                     : "var(--color-bg-tertiary)"
                             }
                             color={
-                                isFailed
+                                isDangerTone
                                     ? "#ef4444"
                                     : "var(--color-text-secondary)"
                             }

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
@@ -1481,6 +1481,35 @@ function isCommandDuplicatedByTitle(title: string, command: string): boolean {
     );
 }
 
+type TerminalToolTone = "neutral" | "success" | "danger";
+
+function getTerminalToolTone(activity: AiToolActivity): TerminalToolTone {
+    if (
+        activity.status === "failed" ||
+        (activity.exitCode !== null && activity.exitCode !== 0)
+    ) {
+        return "danger";
+    }
+
+    if (activity.status === "completed" && activity.exitCode === 0) {
+        return "success";
+    }
+
+    return "neutral";
+}
+
+function getTerminalToolToneColor(tone: TerminalToolTone): string {
+    if (tone === "danger") {
+        return "#ef4444";
+    }
+
+    if (tone === "success") {
+        return "var(--diff-add)";
+    }
+
+    return "#6b7280";
+}
+
 function TerminalToolMessage({
     activity,
 }: {
@@ -1492,7 +1521,8 @@ function TerminalToolMessage({
     const isInProgress = activity.status === "in_progress";
     const isCompleted = activity.status === "completed";
 
-    const accent = isFailed || hasNonZeroExit ? "#ef4444" : "#6b7280";
+    const terminalTone = getTerminalToolTone(activity);
+    const accent = getTerminalToolToneColor(terminalTone);
     const command = extractCommand(activity.rawInputJson);
     const shouldShowCommand =
         !!command && !isCommandDuplicatedByTitle(activity.title, command);


### PR DESCRIPTION
## Summary

- derive terminal tool tone from status and exit code
- color successful terminal tool cards green and failed ones red
- remove visible `exit N` badges so the card color carries the state
- cover success, danger, neutral, and non-zero output behavior in tests

## Validation

- `pnpm exec vitest run src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts`