### PR TITLE
Adjust editor line number spacing

### DIFF
--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -134,7 +134,7 @@ import { persistChatDraftForTab } from "@renderer/components/workspace/chatDraft
 import {
     GIT_GUTTER_LINE_DECORATIONS_WIDTH,
     GitGutterDecorator,
-    getGitGutterLineNumbersMinChars,
+    getEditorLineNumbersMinChars,
     hasRenderableGitGutterChange,
 } from "@renderer/components/workspace/gitGutter";
 import { buildLiveGitGutterDiff } from "@renderer/components/workspace/gitGutterLiveDiff";
@@ -3959,8 +3959,8 @@ function FileTabView({
             : gitGutterLiveState?.status === "unavailable"
               ? null
               : (gitGutterSource?.diff ?? null);
-    const gitGutterLineNumbersMinChars = useMemo(
-        () => getGitGutterLineNumbersMinChars(countTextLines(tab.draftContent)),
+    const editorLineNumbersMinChars = useMemo(
+        () => getEditorLineNumbersMinChars(countTextLines(tab.draftContent)),
         [tab.draftContent],
     );
     const canShowInlineReview = isInlineReviewSupported(trackedFile);
@@ -5625,9 +5625,7 @@ function FileTabView({
             lineHeight: editorLineHeightPx,
             lineDecorationsWidth: GIT_GUTTER_LINE_DECORATIONS_WIDTH,
             lineNumbers: editorLineNumbers,
-            lineNumbersMinChars: shouldShowGitGutter
-                ? gitGutterLineNumbersMinChars
-                : 4,
+            lineNumbersMinChars: editorLineNumbersMinChars,
             minimap: {
                 enabled: editorSettings.minimapEnabled,
             },
@@ -5656,10 +5654,9 @@ function FileTabView({
         editorFontFamily,
         editorLineHeightPx,
         editorLineNumbers,
+        editorLineNumbersMinChars,
         editorSettings.fontSize,
         editorSettings.minimapEnabled,
-        gitGutterLineNumbersMinChars,
-        shouldShowGitGutter,
     ]);
 
     useEffect(() => {
@@ -5733,9 +5730,7 @@ function FileTabView({
             lineHeight: editorLineHeightPx,
             lineDecorationsWidth: GIT_GUTTER_LINE_DECORATIONS_WIDTH,
             lineNumbers: editorLineNumbers,
-            lineNumbersMinChars: shouldShowGitGutter
-                ? gitGutterLineNumbersMinChars
-                : 4,
+            lineNumbersMinChars: editorLineNumbersMinChars,
             ...createComandoEditorFeatureOptions(),
             largeFileOptimizations: true,
             maxTokenizationLineLength: MONACO_MAX_TOKENIZATION_LINE_LENGTH,
@@ -5773,10 +5768,9 @@ function FileTabView({
             editorFontFamily,
             editorLineHeightPx,
             editorLineNumbers,
+            editorLineNumbersMinChars,
             editorSettings.fontSize,
             editorSettings.minimapEnabled,
-            gitGutterLineNumbersMinChars,
-            shouldShowGitGutter,
         ],
     );
 

--- a/src/renderer/src/components/workspace/gitGutter.test.ts
+++ b/src/renderer/src/components/workspace/gitGutter.test.ts
@@ -677,12 +677,12 @@ describe("GitGutterDecorator", () => {
 });
 
 describe("getGitGutterLineNumbersMinChars", () => {
-    it("keeps line-number width independent from git marker space", () => {
+    it("keeps left breathing room independent from git marker space", () => {
         expect(getGitGutterLineNumbersMinChars(9)).toBe(4);
         expect(getGitGutterLineNumbersMinChars(87)).toBe(4);
         expect(getGitGutterLineNumbersMinChars(120)).toBe(4);
-        expect(getGitGutterLineNumbersMinChars(2048)).toBe(4);
-        expect(getGitGutterLineNumbersMinChars(10000)).toBe(5);
+        expect(getGitGutterLineNumbersMinChars(2048)).toBe(5);
+        expect(getGitGutterLineNumbersMinChars(10000)).toBe(6);
     });
 });
 

--- a/src/renderer/src/components/workspace/gitGutter.ts
+++ b/src/renderer/src/components/workspace/gitGutter.ts
@@ -5,6 +5,7 @@ import type { GitFileDiff } from "@shared/ipc";
 import {
     computeGitGutterMarkers,
     type GitGutterChangeType,
+    getEditorLineNumbersMinChars,
     getGitGutterLineNumbersMinChars,
     hasRenderableGitGutterChange,
     type GitGutterMarker,
@@ -12,6 +13,7 @@ import {
 
 export {
     computeGitGutterMarkers,
+    getEditorLineNumbersMinChars,
     getGitGutterLineNumbersMinChars,
     hasRenderableGitGutterChange,
 };

--- a/src/renderer/src/components/workspace/gitGutterModel.ts
+++ b/src/renderer/src/components/workspace/gitGutterModel.ts
@@ -32,10 +32,20 @@ export function computeGitGutterMarkers(
     return dedupeMarkers(markers);
 }
 
-export function getGitGutterLineNumbersMinChars(lineCount: number): number {
+const MIN_EDITOR_LINE_NUMBER_CHARS = 4;
+const EDITOR_LINE_NUMBER_LEFT_PADDING_CHARS = 1;
+
+export function getEditorLineNumbersMinChars(lineCount: number): number {
     const digits = String(Math.max(1, lineCount)).length;
 
-    return Math.max(4, digits);
+    return Math.max(
+        MIN_EDITOR_LINE_NUMBER_CHARS,
+        digits + EDITOR_LINE_NUMBER_LEFT_PADDING_CHARS,
+    );
+}
+
+export function getGitGutterLineNumbersMinChars(lineCount: number): number {
+    return getEditorLineNumbersMinChars(lineCount);
 }
 
 function computeHunkMarkers(


### PR DESCRIPTION
## Summary

Adjusts the editor line-number column so long documents keep one extra character of breathing room on the left side of the gutter.

The git decoration lane remains unchanged, so existing git gutter markers keep their current spacing and rendering behavior.

## Validation

- `pnpm exec vitest run src/renderer/src/components/workspace/gitGutter.test.ts src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx`
- `pnpm run typecheck`
- `git diff --check`