### PR TITLE
Fix Monaco inline review scroll handoff

### DIFF
--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -1606,6 +1606,86 @@ describe("WorkspaceFileEditorHost", () => {
         ).toHaveBeenCalledWith("file-1", null);
     });
 
+    it("preserves the normal editor viewport when new inline review changes arrive", async () => {
+        const content = [
+            "const first = 1;",
+            "const second = 2;",
+            "const third = 3;",
+            "const fourth = 4;",
+            "",
+        ].join("\n");
+        const updatedContent = [
+            "const first = 1;",
+            "const second = 22;",
+            "const third = 3;",
+            "const fourth = 4;",
+            "",
+        ].join("\n");
+        const fileTab = createFileTab("file-1", "src/app.ts", content);
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: fileTab,
+                    fileTabs: [fileTab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const normalEditor = monacoHarness.codeEditors.find((editor) =>
+            editor.name.startsWith("editor-"),
+        );
+        expect(normalEditor).toBeDefined();
+        if (!normalEditor) {
+            throw new Error("Expected normal file editor to mount.");
+        }
+
+        normalEditor.setPosition({ column: 7, lineNumber: 3 });
+        normalEditor.setScrollLeft(13);
+        normalEditor.setScrollTop(360);
+
+        mockAiStoreState.current.sessions = {
+            "session-1": {
+                snapshot: {
+                    trackedFiles: [
+                        {
+                            ...createTrackedFile(),
+                            newText: updatedContent,
+                            oldText: content,
+                        },
+                    ],
+                },
+            },
+        };
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: fileTab,
+                    fileTabs: [fileTab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const diffEditor = monacoHarness.diffEditors[0];
+        expect(diffEditor).toBeDefined();
+        if (!diffEditor) {
+            throw new Error("Expected inline review diff editor to mount.");
+        }
+
+        const modifiedEditor = diffEditor.getModifiedEditor();
+        expect(modifiedEditor.getPosition()).toEqual({
+            column: 7,
+            lineNumber: 3,
+        });
+        expect(modifiedEditor.getScrollLeft()).toBe(13);
+        expect(modifiedEditor.getScrollTop()).toBe(360);
+        expect(diffEditor.getOriginalEditor().getScrollLeft()).toBe(13);
+        expect(diffEditor.getOriginalEditor().getScrollTop()).toBe(360);
+    });
+
     it("applies a pending file open range that arrives after inline review mounts", async () => {
         const tab = createFileTab("file-1");
         mockAiStoreState.current.sessions = {

--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -146,12 +146,14 @@ const monacoHarness = vi.hoisted(() => {
         readonly hasTextFocus: () => boolean;
         readonly hasWidgetFocus: () => boolean;
         readonly layout: () => void;
-        readonly onDidChangeCursorSelection: () => Disposable;
+        readonly onDidChangeCursorSelection: (
+            listener: () => void,
+        ) => Disposable;
         readonly onDidChangeHiddenAreas: () => Disposable;
         readonly onDidChangeModel: (listener: () => void) => Disposable;
         readonly onDidDispose: (listener: () => void) => Disposable;
         readonly onDidLayoutChange: () => Disposable;
-        readonly onDidScrollChange: () => Disposable;
+        readonly onDidScrollChange: (listener: () => void) => Disposable;
         readonly onWillChangeModel: (listener: () => void) => Disposable;
         readonly onMouseLeave: () => Disposable;
         readonly onMouseMove: () => Disposable;
@@ -332,6 +334,8 @@ const monacoHarness = vi.hoisted(() => {
         const disposeListeners = new Set<() => void>();
         const modelChangeListeners = new Set<() => void>();
         const modelWillChangeListeners = new Set<() => void>();
+        const cursorSelectionListeners = new Set<() => void>();
+        const scrollListeners = new Set<() => void>();
         const editor: FakeCodeEditor = {
             createDecorationsCollection: vi.fn(
                 (decorations: readonly unknown[] = []) => {
@@ -392,7 +396,14 @@ const monacoHarness = vi.hoisted(() => {
             layout: vi.fn(),
             model: null,
             name,
-            onDidChangeCursorSelection: () => createDisposable(),
+            onDidChangeCursorSelection: (listener) => {
+                cursorSelectionListeners.add(listener);
+                return {
+                    dispose: () => {
+                        cursorSelectionListeners.delete(listener);
+                    },
+                };
+            },
             onDidChangeHiddenAreas: () => createDisposable(),
             onDidChangeModel: (listener) => {
                 modelChangeListeners.add(listener);
@@ -411,7 +422,14 @@ const monacoHarness = vi.hoisted(() => {
                 };
             },
             onDidLayoutChange: () => createDisposable(),
-            onDidScrollChange: () => createDisposable(),
+            onDidScrollChange: (listener) => {
+                scrollListeners.add(listener);
+                return {
+                    dispose: () => {
+                        scrollListeners.delete(listener);
+                    },
+                };
+            },
             onWillChangeModel: (listener) => {
                 modelWillChangeListeners.add(listener);
                 return {
@@ -457,14 +475,23 @@ const monacoHarness = vi.hoisted(() => {
                     readonly lineNumber: number;
                 }) => {
                     editor.position = position;
+                    for (const listener of cursorSelectionListeners) {
+                        listener();
+                    }
                 },
             ),
             setSelection: vi.fn(),
             setScrollLeft: vi.fn((scrollLeft: number) => {
                 editor.scrollLeft = scrollLeft;
+                for (const listener of scrollListeners) {
+                    listener();
+                }
             }),
             setScrollTop: vi.fn((scrollTop: number) => {
                 editor.scrollTop = scrollTop;
+                for (const listener of scrollListeners) {
+                    listener();
+                }
             }),
             updateOptions: vi.fn(),
         };

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -3878,6 +3878,7 @@ function FileTabView({
         readonly state: PortableEditorRestoreState;
         readonly tabId: string;
     } | null>(null);
+    const previousInlineReviewSignatureRef = useRef<string | null>(null);
     const fileTabIdRef = useRef(tab.id);
     const latestDraftContentRef = useRef(tab.draftContent);
     const gitGutterDecoratorRef = useRef<GitGutterDecorator | null>(null);
@@ -4318,6 +4319,17 @@ function FileTabView({
             pendingEditorViewStateTabIdRef.current = fileTabIdRef.current;
         }
     }, []);
+
+    useLayoutEffect(() => {
+        const previousSignature = previousInlineReviewSignatureRef.current;
+        previousInlineReviewSignatureRef.current = reviewSignature;
+
+        if (previousSignature || !reviewSignature || !editorRef.current) {
+            return;
+        }
+
+        captureEditorStateForInlineReview(editorRef.current);
+    }, [captureEditorStateForInlineReview, reviewSignature]);
 
     const handleKeepInlineReviewFile = useCallback(() => {
         if (!inlineReviewTrackedFile) {
@@ -5208,6 +5220,11 @@ function FileTabView({
                 value: trackedFile.newText ?? "",
             });
 
+            if (!currentReviewModels.revision && editorRef.current) {
+                // Capture the live editor position before the diff editor replaces the surface.
+                captureEditorStateForInlineReview(editorRef.current);
+            }
+
             const pendingInlineReviewRestoreState =
                 pendingEditorInlineReviewRestoreStateRef.current?.tabId ===
                 tab.id
@@ -5301,6 +5318,7 @@ function FileTabView({
             restoreInlineReviewScrollState,
             restoreInlineReviewViewState,
             restorePortableInlineReviewState,
+            captureEditorStateForInlineReview,
             tab.id,
             tab.viewState,
         ],

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -140,7 +140,10 @@ import {
 import { buildLiveGitGutterDiff } from "@renderer/components/workspace/gitGutterLiveDiff";
 import { buildInlineReviewDecorations } from "@renderer/components/workspace/inlineReviewDecorations";
 import { buildInlineReviewDiffEditorOptions } from "@renderer/components/workspace/inlineReviewDiffEditorOptions";
-import { resolveInlineReviewRestoreCandidate } from "@renderer/components/workspace/inlineReviewRestorePriority";
+import {
+    resolveInlineReviewRestoreCandidate,
+    resolvePendingEditorInlineReviewRestoreState,
+} from "@renderer/components/workspace/inlineReviewRestorePriority";
 import {
     acquireWorkspaceFileModel,
     buildWorkspaceEditorModelPath,
@@ -5232,21 +5235,15 @@ function FileTabView({
 
             const pendingInlineReviewRestoreState =
                 pendingEditorInlineReviewRestoreStateRef.current;
-            if (
-                pendingInlineReviewRestoreState?.tabId === tab.id &&
-                pendingInlineReviewRestoreState.reviewSignature !== null &&
-                pendingInlineReviewRestoreState.reviewSignature !==
-                    reviewSignature
-            ) {
+            const pendingInlineReviewRestoreResolution =
+                resolvePendingEditorInlineReviewRestoreState({
+                    pendingState: pendingInlineReviewRestoreState,
+                    reviewSignature,
+                    tabId: tab.id,
+                });
+            if (pendingInlineReviewRestoreResolution.shouldClear) {
                 pendingEditorInlineReviewRestoreStateRef.current = null;
             }
-            const pendingInlineReviewPortableState =
-                pendingInlineReviewRestoreState?.tabId === tab.id &&
-                (pendingInlineReviewRestoreState.reviewSignature === null ||
-                    pendingInlineReviewRestoreState.reviewSignature ===
-                        reviewSignature)
-                    ? pendingInlineReviewRestoreState.state
-                    : null;
 
             try {
                 inlineReviewDecorationsRef.current?.clear();
@@ -5268,7 +5265,7 @@ function FileTabView({
                     didConsumePendingOpenLocation:
                         consumePendingInlineReviewOpenLocation(diffEditor),
                     pendingEditorInlineReviewRestoreState:
-                        pendingInlineReviewPortableState,
+                        pendingInlineReviewRestoreResolution.state,
                     persistedInlineReviewViewState,
                     scrollState,
                 });

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -5330,6 +5330,7 @@ function FileTabView({
             restoreInlineReviewScrollState,
             restoreInlineReviewViewState,
             restorePortableInlineReviewState,
+            reviewSignature,
             tab.id,
             tab.viewState,
         ],

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -140,6 +140,7 @@ import {
 import { buildLiveGitGutterDiff } from "@renderer/components/workspace/gitGutterLiveDiff";
 import { buildInlineReviewDecorations } from "@renderer/components/workspace/inlineReviewDecorations";
 import { buildInlineReviewDiffEditorOptions } from "@renderer/components/workspace/inlineReviewDiffEditorOptions";
+import { resolveInlineReviewRestoreCandidate } from "@renderer/components/workspace/inlineReviewRestorePriority";
 import {
     acquireWorkspaceFileModel,
     buildWorkspaceEditorModelPath,
@@ -5228,28 +5229,47 @@ function FileTabView({
                     modified: nextModifiedModel,
                     original: nextOriginalModel,
                 };
-                if (consumePendingInlineReviewOpenLocation(diffEditor)) {
-                    // Explicit file reference navigation wins over review view state.
-                } else if (currentInlineReviewRestoreState) {
-                    restorePortableInlineReviewState(
-                        diffEditor,
-                        currentInlineReviewRestoreState,
-                    );
-                } else if (pendingInlineReviewRestoreState) {
-                    restorePortableInlineReviewState(
-                        diffEditor,
+                const restoreCandidate = resolveInlineReviewRestoreCandidate({
+                    currentInlineReviewRestoreState,
+                    didConsumePendingOpenLocation:
+                        consumePendingInlineReviewOpenLocation(diffEditor),
+                    pendingEditorInlineReviewRestoreState:
                         pendingInlineReviewRestoreState,
-                    );
-                    pendingEditorInlineReviewRestoreStateRef.current = null;
-                } else if (persistedInlineReviewViewState) {
-                    restoreInlineReviewViewState(
-                        diffEditor,
-                        persistedInlineReviewViewState,
-                    );
-                    pendingEditorViewStateRef.current =
-                        persistedInlineReviewViewState;
-                } else {
-                    restoreInlineReviewScrollState(diffEditor, scrollState);
+                    persistedInlineReviewViewState,
+                    scrollState,
+                });
+
+                switch (restoreCandidate.kind) {
+                    case "openLocation":
+                        // Explicit file reference navigation wins over review view state.
+                        break;
+                    case "currentInlineReviewState":
+                        restorePortableInlineReviewState(
+                            diffEditor,
+                            restoreCandidate.state,
+                        );
+                        break;
+                    case "portableEditorState":
+                        restorePortableInlineReviewState(
+                            diffEditor,
+                            restoreCandidate.state,
+                        );
+                        pendingEditorInlineReviewRestoreStateRef.current = null;
+                        break;
+                    case "viewState":
+                        restoreInlineReviewViewState(
+                            diffEditor,
+                            restoreCandidate.state,
+                        );
+                        pendingEditorViewStateRef.current =
+                            restoreCandidate.state;
+                        break;
+                    case "diffScrollState":
+                        restoreInlineReviewScrollState(
+                            diffEditor,
+                            restoreCandidate.state,
+                        );
+                        break;
                 }
             } catch (error) {
                 if (!isMonacoDisposedError(error)) {

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -3882,8 +3882,8 @@ function FileTabView({
         readonly state: PortableEditorRestoreState;
         readonly tabId: string;
     } | null>(null);
-    const previousInlineReviewSignatureRef = useRef<string | null>(null);
     const fileTabIdRef = useRef(tab.id);
+    const inlineReviewActiveRef = useRef(false);
     const inlineReviewSignatureRef = useRef<string | null>(null);
     const latestDraftContentRef = useRef(tab.draftContent);
     const gitGutterDecoratorRef = useRef<GitGutterDecorator | null>(null);
@@ -4292,6 +4292,10 @@ function FileTabView({
 
     const captureEditorStateForInlineReview = useCallback(
         (editor: MonacoEditor.IStandaloneCodeEditor | null) => {
+            if (inlineReviewActiveRef.current) {
+                return;
+            }
+
             const state = capturePortableEditorRestoreState(editor);
             if (!state) {
                 return;
@@ -4327,17 +4331,9 @@ function FileTabView({
     }, []);
 
     useLayoutEffect(() => {
+        inlineReviewActiveRef.current = isInlineReviewActive;
         inlineReviewSignatureRef.current = reviewSignature;
-
-        const previousSignature = previousInlineReviewSignatureRef.current;
-        previousInlineReviewSignatureRef.current = reviewSignature;
-
-        if (previousSignature || !reviewSignature || !editorRef.current) {
-            return;
-        }
-
-        captureEditorStateForInlineReview(editorRef.current);
-    }, [captureEditorStateForInlineReview, reviewSignature]);
+    }, [isInlineReviewActive, reviewSignature]);
 
     const handleKeepInlineReviewFile = useCallback(() => {
         if (!inlineReviewTrackedFile) {
@@ -5228,11 +5224,6 @@ function FileTabView({
                 value: trackedFile.newText ?? "",
             });
 
-            if (!currentReviewModels.revision && editorRef.current) {
-                // Capture the live editor position before the diff editor replaces the surface.
-                captureEditorStateForInlineReview(editorRef.current);
-            }
-
             const pendingInlineReviewRestoreState =
                 pendingEditorInlineReviewRestoreStateRef.current;
             const pendingInlineReviewRestoreResolution =
@@ -5338,7 +5329,6 @@ function FileTabView({
             restoreInlineReviewScrollState,
             restoreInlineReviewViewState,
             restorePortableInlineReviewState,
-            captureEditorStateForInlineReview,
             tab.id,
             tab.viewState,
         ],

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -3871,6 +3871,7 @@ function FileTabView({
         ReturnType<typeof captureDiffEditorScrollState>
     >(captureDiffEditorScrollState(null));
     const pendingEditorInlineReviewRestoreStateRef = useRef<{
+        readonly reviewSignature: string | null;
         readonly state: PortableEditorRestoreState;
         readonly tabId: string;
     } | null>(null);
@@ -3880,6 +3881,7 @@ function FileTabView({
     } | null>(null);
     const previousInlineReviewSignatureRef = useRef<string | null>(null);
     const fileTabIdRef = useRef(tab.id);
+    const inlineReviewSignatureRef = useRef<string | null>(null);
     const latestDraftContentRef = useRef(tab.draftContent);
     const gitGutterDecoratorRef = useRef<GitGutterDecorator | null>(null);
     const inlineReviewDecorationsRef =
@@ -4293,6 +4295,7 @@ function FileTabView({
             }
 
             pendingEditorInlineReviewRestoreStateRef.current = {
+                reviewSignature: inlineReviewSignatureRef.current,
                 state,
                 tabId: fileTabIdRef.current,
             };
@@ -4321,6 +4324,8 @@ function FileTabView({
     }, []);
 
     useLayoutEffect(() => {
+        inlineReviewSignatureRef.current = reviewSignature;
+
         const previousSignature = previousInlineReviewSignatureRef.current;
         previousInlineReviewSignatureRef.current = reviewSignature;
 
@@ -5226,9 +5231,21 @@ function FileTabView({
             }
 
             const pendingInlineReviewRestoreState =
-                pendingEditorInlineReviewRestoreStateRef.current?.tabId ===
-                tab.id
-                    ? pendingEditorInlineReviewRestoreStateRef.current.state
+                pendingEditorInlineReviewRestoreStateRef.current;
+            if (
+                pendingInlineReviewRestoreState?.tabId === tab.id &&
+                pendingInlineReviewRestoreState.reviewSignature !== null &&
+                pendingInlineReviewRestoreState.reviewSignature !==
+                    reviewSignature
+            ) {
+                pendingEditorInlineReviewRestoreStateRef.current = null;
+            }
+            const pendingInlineReviewPortableState =
+                pendingInlineReviewRestoreState?.tabId === tab.id &&
+                (pendingInlineReviewRestoreState.reviewSignature === null ||
+                    pendingInlineReviewRestoreState.reviewSignature ===
+                        reviewSignature)
+                    ? pendingInlineReviewRestoreState.state
                     : null;
 
             try {
@@ -5251,7 +5268,7 @@ function FileTabView({
                     didConsumePendingOpenLocation:
                         consumePendingInlineReviewOpenLocation(diffEditor),
                     pendingEditorInlineReviewRestoreState:
-                        pendingInlineReviewRestoreState,
+                        pendingInlineReviewPortableState,
                     persistedInlineReviewViewState,
                     scrollState,
                 });
@@ -5271,7 +5288,13 @@ function FileTabView({
                             diffEditor,
                             restoreCandidate.state,
                         );
-                        pendingEditorInlineReviewRestoreStateRef.current = null;
+                        if (
+                            pendingEditorInlineReviewRestoreStateRef.current ===
+                            pendingInlineReviewRestoreState
+                        ) {
+                            pendingEditorInlineReviewRestoreStateRef.current =
+                                null;
+                        }
                         break;
                     case "viewState":
                         restoreInlineReviewViewState(

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -4292,6 +4292,7 @@ function FileTabView({
 
     const captureEditorStateForInlineReview = useCallback(
         (editor: MonacoEditor.IStandaloneCodeEditor | null) => {
+            // Once inline review is active, the hidden editor may report stale layout scroll.
             if (inlineReviewActiveRef.current) {
                 return;
             }

--- a/src/renderer/src/components/workspace/inlineReviewRestorePriority.test.ts
+++ b/src/renderer/src/components/workspace/inlineReviewRestorePriority.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveInlineReviewRestoreCandidate } from "./inlineReviewRestorePriority";
+import {
+    resolveInlineReviewRestoreCandidate,
+    resolvePendingEditorInlineReviewRestoreState,
+} from "./inlineReviewRestorePriority";
 
 describe("resolveInlineReviewRestoreCandidate", () => {
     const scrollState = { scrollTop: 10 };
@@ -77,6 +80,27 @@ describe("resolveInlineReviewRestoreCandidate", () => {
         ).toEqual({
             kind: "diffScrollState",
             state: scrollState,
+        });
+    });
+});
+
+describe("resolvePendingEditorInlineReviewRestoreState", () => {
+    const portableEditorState = { lineNumber: 30, source: "editor" };
+
+    it("ignores stale portable state from a different review signature", () => {
+        expect(
+            resolvePendingEditorInlineReviewRestoreState({
+                pendingState: {
+                    reviewSignature: "review:v1",
+                    state: portableEditorState,
+                    tabId: "file-1",
+                },
+                reviewSignature: "review:v2",
+                tabId: "file-1",
+            }),
+        ).toEqual({
+            shouldClear: true,
+            state: null,
         });
     });
 });

--- a/src/renderer/src/components/workspace/inlineReviewRestorePriority.test.ts
+++ b/src/renderer/src/components/workspace/inlineReviewRestorePriority.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInlineReviewRestoreCandidate } from "./inlineReviewRestorePriority";
+
+describe("resolveInlineReviewRestoreCandidate", () => {
+    const scrollState = { scrollTop: 10 };
+    const viewState = { cursor: "persisted" };
+    const currentInlineState = { lineNumber: 20, source: "current-inline" };
+    const portableEditorState = { lineNumber: 30, source: "editor" };
+
+    it("prioritizes explicit open location navigation", () => {
+        expect(
+            resolveInlineReviewRestoreCandidate({
+                currentInlineReviewRestoreState: currentInlineState,
+                didConsumePendingOpenLocation: true,
+                pendingEditorInlineReviewRestoreState: portableEditorState,
+                persistedInlineReviewViewState: viewState,
+                scrollState,
+            }),
+        ).toEqual({ kind: "openLocation" });
+    });
+
+    it("keeps the current inline review position across model refreshes", () => {
+        expect(
+            resolveInlineReviewRestoreCandidate({
+                currentInlineReviewRestoreState: currentInlineState,
+                didConsumePendingOpenLocation: false,
+                pendingEditorInlineReviewRestoreState: portableEditorState,
+                persistedInlineReviewViewState: viewState,
+                scrollState,
+            }),
+        ).toEqual({
+            kind: "currentInlineReviewState",
+            state: currentInlineState,
+        });
+    });
+
+    it("uses the portable editor state before persisted view state", () => {
+        expect(
+            resolveInlineReviewRestoreCandidate({
+                currentInlineReviewRestoreState: null,
+                didConsumePendingOpenLocation: false,
+                pendingEditorInlineReviewRestoreState: portableEditorState,
+                persistedInlineReviewViewState: viewState,
+                scrollState,
+            }),
+        ).toEqual({
+            kind: "portableEditorState",
+            state: portableEditorState,
+        });
+    });
+
+    it("falls back to persisted view state before diff scroll state", () => {
+        expect(
+            resolveInlineReviewRestoreCandidate({
+                currentInlineReviewRestoreState: null,
+                didConsumePendingOpenLocation: false,
+                pendingEditorInlineReviewRestoreState: null,
+                persistedInlineReviewViewState: viewState,
+                scrollState,
+            }),
+        ).toEqual({
+            kind: "viewState",
+            state: viewState,
+        });
+    });
+
+    it("uses previous diff scroll state as the final fallback", () => {
+        expect(
+            resolveInlineReviewRestoreCandidate({
+                currentInlineReviewRestoreState: null,
+                didConsumePendingOpenLocation: false,
+                pendingEditorInlineReviewRestoreState: null,
+                persistedInlineReviewViewState: null,
+                scrollState,
+            }),
+        ).toEqual({
+            kind: "diffScrollState",
+            state: scrollState,
+        });
+    });
+});

--- a/src/renderer/src/components/workspace/inlineReviewRestorePriority.ts
+++ b/src/renderer/src/components/workspace/inlineReviewRestorePriority.ts
@@ -1,0 +1,64 @@
+export type InlineReviewRestoreCandidate<
+    TPortableState,
+    TViewState,
+    TScrollState,
+> =
+    | { readonly kind: "openLocation" }
+    | {
+          readonly kind: "currentInlineReviewState";
+          readonly state: TPortableState;
+      }
+    | {
+          readonly kind: "portableEditorState";
+          readonly state: TPortableState;
+      }
+    | {
+          readonly kind: "viewState";
+          readonly state: TViewState;
+      }
+    | {
+          readonly kind: "diffScrollState";
+          readonly state: TScrollState;
+      };
+
+export function resolveInlineReviewRestoreCandidate<
+    TPortableState,
+    TViewState,
+    TScrollState,
+>(input: {
+    readonly currentInlineReviewRestoreState: TPortableState | null;
+    readonly didConsumePendingOpenLocation: boolean;
+    readonly pendingEditorInlineReviewRestoreState: TPortableState | null;
+    readonly persistedInlineReviewViewState: TViewState | null;
+    readonly scrollState: TScrollState;
+}): InlineReviewRestoreCandidate<TPortableState, TViewState, TScrollState> {
+    if (input.didConsumePendingOpenLocation) {
+        return { kind: "openLocation" };
+    }
+
+    if (input.currentInlineReviewRestoreState) {
+        return {
+            kind: "currentInlineReviewState",
+            state: input.currentInlineReviewRestoreState,
+        };
+    }
+
+    if (input.pendingEditorInlineReviewRestoreState) {
+        return {
+            kind: "portableEditorState",
+            state: input.pendingEditorInlineReviewRestoreState,
+        };
+    }
+
+    if (input.persistedInlineReviewViewState) {
+        return {
+            kind: "viewState",
+            state: input.persistedInlineReviewViewState,
+        };
+    }
+
+    return {
+        kind: "diffScrollState",
+        state: input.scrollState,
+    };
+}

--- a/src/renderer/src/components/workspace/inlineReviewRestorePriority.ts
+++ b/src/renderer/src/components/workspace/inlineReviewRestorePriority.ts
@@ -21,6 +21,12 @@ export type InlineReviewRestoreCandidate<
           readonly state: TScrollState;
       };
 
+export type PendingEditorInlineReviewRestoreState<TPortableState> = {
+    readonly reviewSignature: string | null;
+    readonly state: TPortableState;
+    readonly tabId: string;
+};
+
 export function resolveInlineReviewRestoreCandidate<
     TPortableState,
     TViewState,
@@ -60,5 +66,38 @@ export function resolveInlineReviewRestoreCandidate<
     return {
         kind: "diffScrollState",
         state: input.scrollState,
+    };
+}
+
+export function resolvePendingEditorInlineReviewRestoreState<TPortableState>(
+    input: {
+        readonly pendingState: PendingEditorInlineReviewRestoreState<TPortableState> | null;
+        readonly reviewSignature: string | null;
+        readonly tabId: string;
+    },
+): {
+    readonly shouldClear: boolean;
+    readonly state: TPortableState | null;
+} {
+    if (!input.pendingState || input.pendingState.tabId !== input.tabId) {
+        return {
+            shouldClear: false,
+            state: null,
+        };
+    }
+
+    if (
+        input.pendingState.reviewSignature !== null &&
+        input.pendingState.reviewSignature !== input.reviewSignature
+    ) {
+        return {
+            shouldClear: true,
+            state: null,
+        };
+    }
+
+    return {
+        shouldClear: false,
+        state: input.pendingState.state,
     };
 }


### PR DESCRIPTION
## Summary

- preserve the normal Monaco editor viewport when new inline review changes arrive
- make inline review restore priority explicit and covered by unit tests
- avoid capturing scroll from the normal editor after it has already been hidden
- add regression coverage for editable-to-inline-review viewport handoff and stale restore signatures

## Root cause

When a file moved from editable Monaco to inline review, the normal editor could still be queried after React had hidden that surface. In real Monaco, that hidden/layout-changing editor can report a bad scroll position, including a position near the end of the document. That late capture could overwrite the good viewport state captured while the editor was still visible.

## Validation

- `pnpm vitest run src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx src/renderer/src/components/workspace/inlineReviewRestorePriority.test.ts`
- `pnpm typecheck`
