### PR TITLE
Fix session core lint warning

### DIFF
--- a/src/main/ai/session-core.ts
+++ b/src/main/ai/session-core.ts
@@ -821,7 +821,7 @@ export function setConfigOptionOnSnapshot(
                 : snapshot.modelId,
         reasoningEffort:
             hasUpdatedOptionValue &&
-            updatedOption?.type === "select" &&
+            updatedOption.type === "select" &&
             isReasoningEffortConfigOption(updatedOption) &&
             typeof value === "string"
                 ? value


### PR DESCRIPTION
## Summary

- remove a redundant optional chain in `setConfigOptionOnSnapshot`
- keep the existing `hasUpdatedOptionValue` short-circuit narrowing intact
- clean up the remaining ESLint warning in `session-core.ts`

## Why

`hasUpdatedOptionValue` already guarantees `updatedOption !== null` before the reasoning effort branch evaluates `updatedOption.type`, so `updatedOption?.type` was unnecessary and flagged by `@typescript-eslint/no-unnecessary-condition`.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm vitest run src/main/ai/session-core.test.ts`
