### PR TITLE
Address code scanning alerts

### DIFF
--- a/scripts/ai/_shared.mjs
+++ b/scripts/ai/_shared.mjs
@@ -187,16 +187,20 @@ export function prepareCommandForSpawnSync(
 }
 
 export function spawnPreparedSync(command, args = [], options = {}, launchOptions = {}) {
-    const prepared = prepareCommandForSpawnSync(
-        command,
-        args,
-        options,
-        launchOptions,
-    );
+    const platform = launchOptions.platform ?? process.platform;
 
-    // codeql[js/shell-command-injection-from-environment]
+    if (platform !== "win32" || !isWindowsBatchCommand(command)) {
+        return spawnSync(command, args, options);
+    }
+
     // Windows batch commands must go through cmd.exe; prepareCommandForSpawnSync quotes every argument first.
-    return spawnSync(prepared.command, prepared.args, prepared.options);
+    const prepared = prepareCommandForSpawnSync(command, args, options, {
+        ...launchOptions,
+        comSpec: "cmd.exe",
+        platform,
+    });
+
+    return spawnSync("cmd.exe", prepared.args, prepared.options);
 }
 
 export function isWindowsBatchCommand(command) {

--- a/scripts/ai/_shared.mjs
+++ b/scripts/ai/_shared.mjs
@@ -181,7 +181,7 @@ export function prepareCommandForSpawnSync(
             "/c",
             buildWindowsBatchCommandLine(command, args),
         ],
-        command: launchOptions.comSpec ?? process.env.ComSpec ?? "cmd.exe",
+        command: launchOptions.comSpec ?? "cmd.exe",
         options: withWindowsVerbatimArguments(options),
     };
 }

--- a/scripts/ai/_shared.mjs
+++ b/scripts/ai/_shared.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = fileURLToPath(new URL(".", import.meta.url));
@@ -183,6 +184,19 @@ export function prepareCommandForSpawnSync(
         command: launchOptions.comSpec ?? process.env.ComSpec ?? "cmd.exe",
         options: withWindowsVerbatimArguments(options),
     };
+}
+
+export function spawnPreparedSync(command, args = [], options = {}, launchOptions = {}) {
+    const prepared = prepareCommandForSpawnSync(
+        command,
+        args,
+        options,
+        launchOptions,
+    );
+
+    // codeql[js/shell-command-injection-from-environment]
+    // Windows batch commands must go through cmd.exe; prepareCommandForSpawnSync quotes every argument first.
+    return spawnSync(prepared.command, prepared.args, prepared.options);
 }
 
 export function isWindowsBatchCommand(command) {

--- a/scripts/build-windows-acp-bundles.mjs
+++ b/scripts/build-windows-acp-bundles.mjs
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
 import {
@@ -11,11 +10,11 @@ import {
     ensureDir,
     isExecutableFile,
     isFile,
-    prepareCommandForSpawnSync,
     relativeToRepo,
     repoRoot,
     resetDir,
     resolveFromPath,
+    spawnPreparedSync,
 } from "./ai/_shared.mjs";
 
 const supportedTargets = new Map([
@@ -302,12 +301,7 @@ function capture(command, args, options = {}) {
         stdio: ["ignore", "pipe", "inherit"],
         ...options,
     };
-    const prepared = prepareCommandForSpawnSync(command, args, spawnOptions);
-    const result = spawnSync(
-        prepared.command,
-        prepared.args,
-        prepared.options,
-    );
+    const result = spawnPreparedSync(command, args, spawnOptions);
 
     if (result.error) {
         throw result.error;
@@ -330,12 +324,7 @@ function run(command, args, options = {}) {
         stdio: "inherit",
         ...options,
     };
-    const prepared = prepareCommandForSpawnSync(command, args, spawnOptions);
-    const result = spawnSync(
-        prepared.command,
-        prepared.args,
-        prepared.options,
-    );
+    const result = spawnPreparedSync(command, args, spawnOptions);
 
     if (result.error) {
         throw result.error;

--- a/scripts/native/build-native-backend.mjs
+++ b/scripts/native/build-native-backend.mjs
@@ -1,8 +1,6 @@
-import { spawnSync } from "node:child_process";
-
 import {
-    prepareCommandForSpawnSync,
     repoRoot,
+    spawnPreparedSync,
 } from "../ai/_shared.mjs";
 
 const args = parseArgs(process.argv.slice(2));
@@ -23,16 +21,11 @@ console.log(
 run("cargo", cargoArgs);
 
 function run(command, commandArgs) {
-    const prepared = prepareCommandForSpawnSync(command, commandArgs, {
+    const result = spawnPreparedSync(command, commandArgs, {
         cwd: repoRoot,
         env: process.env,
         stdio: "inherit",
     });
-    const result = spawnSync(
-        prepared.command,
-        prepared.args,
-        prepared.options,
-    );
 
     if (result.error) {
         throw result.error;

--- a/scripts/package-macos-app.mjs
+++ b/scripts/package-macos-app.mjs
@@ -15,11 +15,11 @@ import {
     ensureDir,
     isExecutableFile,
     isFile,
-    prepareCommandForSpawnSync,
     relativeToRepo,
     repoRoot,
     resolveFromPath,
     resetDir,
+    spawnPreparedSync,
 } from "./ai/_shared.mjs";
 
 const buildRoot = path.join(repoRoot, "build");
@@ -1281,7 +1281,7 @@ function run(command, args, options = {}) {
     ]
         .filter(Boolean)
         .join(path.delimiter);
-    const prepared = prepareCommandForSpawnSync(command, args, {
+    const result = spawnPreparedSync(command, args, {
         cwd: repoRoot,
         env: {
             ...process.env,
@@ -1291,11 +1291,6 @@ function run(command, args, options = {}) {
         stdio: "inherit",
         ...spawnOptions,
     });
-    const result = spawnSync(
-        prepared.command,
-        prepared.args,
-        prepared.options,
-    );
 
     if (result.error) {
         throw result.error;

--- a/scripts/package-windows-app.mjs
+++ b/scripts/package-windows-app.mjs
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 
 import {
     buildRceditExecutableMetadataArgs,
@@ -23,10 +22,10 @@ import {
     ensureDir,
     isExecutableFile,
     isFile,
-    prepareCommandForSpawnSync,
     relativeToRepo,
     repoRoot,
     resetDir,
+    spawnPreparedSync,
 } from "./ai/_shared.mjs";
 
 const buildRoot = path.join(repoRoot, "build");
@@ -462,12 +461,7 @@ function run(command, args, options = {}) {
         stdio: "inherit",
         ...options,
     };
-    const prepared = prepareCommandForSpawnSync(command, args, spawnOptions);
-    const result = spawnSync(
-        prepared.command,
-        prepared.args,
-        prepared.options,
-    );
+    const result = spawnPreparedSync(command, args, spawnOptions);
 
     if (result.error) {
         throw result.error;
@@ -492,12 +486,7 @@ function runCaptured(command, args, options = {}) {
         maxBuffer: 1024 * 1024,
         ...options,
     };
-    const prepared = prepareCommandForSpawnSync(command, args, spawnOptions);
-    const result = spawnSync(
-        prepared.command,
-        prepared.args,
-        prepared.options,
-    );
+    const result = spawnPreparedSync(command, args, spawnOptions);
 
     if (result.error) {
         throw result.error;

--- a/src/renderer/src/app/editor/codeLanguage.ts
+++ b/src/renderer/src/app/editor/codeLanguage.ts
@@ -456,7 +456,7 @@ async function loadVueLanguage(): Promise<LanguageSupport | Language> {
     return StreamLanguage.define(
         simpleMode({
             start: [
-                { regex: /<!--.*?-->/, token: "comment" },
+                { regex: /<!--/, token: "comment", next: "comment" },
                 { regex: /\/\/.*/, token: "comment" },
                 { regex: /\/\*.*?\*\//, token: "comment" },
                 { regex: /<\/?[A-Za-z][\w:-]*/, token: "tag" },
@@ -477,6 +477,10 @@ async function loadVueLanguage(): Promise<LanguageSupport | Language> {
                 { regex: /\b[A-Z][A-Za-z0-9_]*\b/, token: "typeName" },
                 { regex: /\b[A-Za-z_$][\w$-]*\b/, token: "variableName" },
             ],
+            comment: [
+                { regex: /.*?-->/, token: "comment", next: "start" },
+                { regex: /.*/, token: "comment" },
+            ],
         }),
     );
 }
@@ -488,7 +492,7 @@ async function loadSvelteLanguage(): Promise<LanguageSupport | Language> {
     return StreamLanguage.define(
         simpleMode({
             start: [
-                { regex: /<!--.*?-->/, token: "comment" },
+                { regex: /<!--/, token: "comment", next: "comment" },
                 { regex: /\/\/.*/, token: "comment" },
                 { regex: /\/\*.*?\*\//, token: "comment" },
                 { regex: /<\/?[A-Za-z][\w:-]*/, token: "tag" },
@@ -512,6 +516,10 @@ async function loadSvelteLanguage(): Promise<LanguageSupport | Language> {
                 { regex: /\b[A-Z][A-Za-z0-9_]*\b/, token: "typeName" },
                 { regex: /\b[A-Za-z_$][\w$-]*\b/, token: "variableName" },
             ],
+            comment: [
+                { regex: /.*?-->/, token: "comment", next: "start" },
+                { regex: /.*/, token: "comment" },
+            ],
         }),
     );
 }
@@ -524,7 +532,7 @@ async function loadAstroLanguage(): Promise<LanguageSupport | Language> {
         simpleMode({
             start: [
                 { regex: /^---$/, token: "meta" },
-                { regex: /<!--.*?-->/, token: "comment" },
+                { regex: /<!--/, token: "comment", next: "comment" },
                 { regex: /\/\/.*/, token: "comment" },
                 { regex: /\/\*.*?\*\//, token: "comment" },
                 { regex: /<\/?[A-Za-z][\w:-]*/, token: "tag" },
@@ -543,6 +551,10 @@ async function loadAstroLanguage(): Promise<LanguageSupport | Language> {
                 },
                 { regex: /\b[A-Z][A-Za-z0-9_]*\b/, token: "typeName" },
                 { regex: /\b[A-Za-z_$][\w$-]*\b/, token: "variableName" },
+            ],
+            comment: [
+                { regex: /.*?-->/, token: "comment", next: "start" },
+                { regex: /.*/, token: "comment" },
             ],
         }),
     );
@@ -631,7 +643,7 @@ async function loadNixLanguage(): Promise<LanguageSupport | Language> {
                     token: "function",
                 },
                 { regex: /''(?:[^']|'(?!'))*''/, token: "string" },
-                { regex: /"(?:[^"\\]|\\"|\\.)*"/, token: "string" },
+                { regex: /"(?:[^"\\]|\\.)*"/, token: "string" },
                 { regex: /\$\{[^}]*\}/, token: "meta" },
                 { regex: /\b(?:true|false|null)\b/, token: "atom" },
                 { regex: /\b\d+(?:\.\d+)?\b/, token: "number" },

--- a/src/renderer/src/app/editor/codeLanguage.ts
+++ b/src/renderer/src/app/editor/codeLanguage.ts
@@ -478,8 +478,9 @@ async function loadVueLanguage(): Promise<LanguageSupport | Language> {
                 { regex: /\b[A-Za-z_$][\w$-]*\b/, token: "variableName" },
             ],
             comment: [
-                { regex: /.*?-->/, token: "comment", next: "start" },
-                { regex: /.*/, token: "comment" },
+                { regex: /-->/, token: "comment", next: "start" },
+                { regex: /[^-]+/, token: "comment" },
+                { regex: /-/, token: "comment" },
             ],
         }),
     );
@@ -517,8 +518,9 @@ async function loadSvelteLanguage(): Promise<LanguageSupport | Language> {
                 { regex: /\b[A-Za-z_$][\w$-]*\b/, token: "variableName" },
             ],
             comment: [
-                { regex: /.*?-->/, token: "comment", next: "start" },
-                { regex: /.*/, token: "comment" },
+                { regex: /-->/, token: "comment", next: "start" },
+                { regex: /[^-]+/, token: "comment" },
+                { regex: /-/, token: "comment" },
             ],
         }),
     );
@@ -553,8 +555,9 @@ async function loadAstroLanguage(): Promise<LanguageSupport | Language> {
                 { regex: /\b[A-Za-z_$][\w$-]*\b/, token: "variableName" },
             ],
             comment: [
-                { regex: /.*?-->/, token: "comment", next: "start" },
-                { regex: /.*/, token: "comment" },
+                { regex: /-->/, token: "comment", next: "start" },
+                { regex: /[^-]+/, token: "comment" },
+                { regex: /-/, token: "comment" },
             ],
         }),
     );

--- a/src/renderer/src/app/editor/codeLanguage.ts
+++ b/src/renderer/src/app/editor/codeLanguage.ts
@@ -478,7 +478,7 @@ async function loadVueLanguage(): Promise<LanguageSupport | Language> {
                 { regex: /\b[A-Za-z_$][\w$-]*\b/, token: "variableName" },
             ],
             comment: [
-                { regex: /-->/, token: "comment", next: "start" },
+                { regex: /--!?>/, token: "comment", next: "start" },
                 { regex: /[^-]+/, token: "comment" },
                 { regex: /-/, token: "comment" },
             ],
@@ -518,7 +518,7 @@ async function loadSvelteLanguage(): Promise<LanguageSupport | Language> {
                 { regex: /\b[A-Za-z_$][\w$-]*\b/, token: "variableName" },
             ],
             comment: [
-                { regex: /-->/, token: "comment", next: "start" },
+                { regex: /--!?>/, token: "comment", next: "start" },
                 { regex: /[^-]+/, token: "comment" },
                 { regex: /-/, token: "comment" },
             ],
@@ -555,7 +555,7 @@ async function loadAstroLanguage(): Promise<LanguageSupport | Language> {
                 { regex: /\b[A-Za-z_$][\w$-]*\b/, token: "variableName" },
             ],
             comment: [
-                { regex: /-->/, token: "comment", next: "start" },
+                { regex: /--!?>/, token: "comment", next: "start" },
                 { regex: /[^-]+/, token: "comment" },
                 { regex: /-/, token: "comment" },
             ],

--- a/src/shared/path-identity.ts
+++ b/src/shared/path-identity.ts
@@ -196,7 +196,9 @@ function formatDisplayPath(parts: NormalizedPathParts): string {
     }
 
     if (parts.root.endsWith("/")) {
-        return `${parts.root}${parts.segments.join("/")}`.replace(/\/$/, "/");
+        return parts.segments.length > 0
+            ? `${parts.root}${parts.segments.join("/")}`
+            : parts.root;
     }
 
     return parts.segments.length > 0


### PR DESCRIPTION
## Summary

- Replace fragile editor regex patterns that CodeQL flagged with safer tokenizer states.
- Remove a no-op path replacement.
- Centralize prepared process spawning for packaging/build scripts.

## Validation

- pnpm run typecheck
- pnpm run lint
- pnpm run test

## Notes

- This PR addresses Code Scanning alerts only. Dependency vulnerabilities are intentionally out of scope.
