### PR TITLE
Harden Windows batch script launching

### DIFF
--- a/scripts/ai/_shared.mjs
+++ b/scripts/ai/_shared.mjs
@@ -173,6 +173,12 @@ export function prepareCommandForSpawnSync(
         };
     }
 
+    if (path.win32.isAbsolute(command)) {
+        throw new Error(
+            `Refusing to prepare an absolute Windows batch command: ${command}`,
+        );
+    }
+
     return {
         args: [
             "/d",
@@ -181,7 +187,7 @@ export function prepareCommandForSpawnSync(
             "/c",
             buildWindowsBatchCommandLine(command, args),
         ],
-        command: launchOptions.comSpec ?? "cmd.exe",
+        command: "cmd.exe",
         options: withWindowsVerbatimArguments(options),
     };
 }
@@ -196,11 +202,10 @@ export function spawnPreparedSync(command, args = [], options = {}, launchOption
     // Windows batch commands must go through cmd.exe; prepareCommandForSpawnSync quotes every argument first.
     const prepared = prepareCommandForSpawnSync(command, args, options, {
         ...launchOptions,
-        comSpec: "cmd.exe",
         platform,
     });
 
-    return spawnSync("cmd.exe", prepared.args, prepared.options);
+    return spawnSync(prepared.command, prepared.args, prepared.options);
 }
 
 export function isWindowsBatchCommand(command) {

--- a/scripts/ai/_shared.mjs
+++ b/scripts/ai/_shared.mjs
@@ -178,6 +178,7 @@ export function prepareCommandForSpawnSync(
             `Refusing to prepare an absolute Windows batch command: ${command}`,
         );
     }
+    const batchCommand = resolveKnownWindowsBatchCommand(command);
 
     return {
         args: [
@@ -185,7 +186,7 @@ export function prepareCommandForSpawnSync(
             "/s",
             "/v:off",
             "/c",
-            buildWindowsBatchCommandLine(command, args),
+            buildWindowsBatchCommandLine(batchCommand, args),
         ],
         command: "cmd.exe",
         options: withWindowsVerbatimArguments(options),
@@ -205,12 +206,23 @@ export function spawnPreparedSync(command, args = [], options = {}, launchOption
         platform,
     });
 
-    return spawnSync(prepared.command, prepared.args, prepared.options);
+    return spawnSync("cmd.exe", prepared.args, prepared.options);
 }
 
 export function isWindowsBatchCommand(command) {
     const extension = path.win32.extname(command).toLowerCase();
     return extension === ".cmd" || extension === ".bat";
+}
+
+function resolveKnownWindowsBatchCommand(command) {
+    switch (command.toLowerCase()) {
+        case "npm.cmd":
+            return "npm.cmd";
+        case "pnpm.cmd":
+            return "pnpm.cmd";
+        default:
+            throw new Error(`Unsupported Windows batch command: ${command}`);
+    }
 }
 
 function buildWindowsBatchCommandLine(command, args) {

--- a/scripts/ai/_shared.test.mjs
+++ b/scripts/ai/_shared.test.mjs
@@ -64,14 +64,14 @@ describe("script command launch helpers", () => {
     it("quotes cmd metacharacters before launching a batch command", () => {
         // Keep this mirrored with src/main/shell/command-launch.test.ts so runtime and packaging quoting stay aligned.
         const prepared = prepareCommandForSpawnSync(
-            "run.cmd",
+            "npm.cmd",
             ["A&B", "(group)", "100%", "has^caret", "say \"hi\""],
             undefined,
             { platform: "win32" },
         );
 
         expect(prepared.args[4]).toBe(
-            '""run.cmd" "A&B" "(group)" "100"^%"" "has^caret" "say \\"hi\\"""',
+            '""npm.cmd" "A&B" "(group)" "100"^%"" "has^caret" "say \\"hi\\"""',
         );
         expect(prepared.options.windowsVerbatimArguments).toBe(true);
     });
@@ -100,6 +100,14 @@ describe("script command launch helpers", () => {
                 { platform: "win32" },
             ),
         ).toThrow(/absolute Windows batch command/);
+    });
+
+    it("rejects unsupported Windows batch commands", () => {
+        expect(() =>
+            prepareCommandForSpawnSync("run.cmd", [], undefined, {
+                platform: "win32",
+            }),
+        ).toThrow(/Unsupported Windows batch command/);
     });
 
     it("rejects absolute Windows batch commands before spawning", () => {

--- a/scripts/ai/_shared.test.mjs
+++ b/scripts/ai/_shared.test.mjs
@@ -3,13 +3,13 @@ import { describe, expect, it } from "vitest";
 import {
     isWindowsBatchCommand,
     prepareCommandForSpawnSync,
+    spawnPreparedSync,
 } from "./_shared.mjs";
 
 describe("script command launch helpers", () => {
     it.each(["pnpm.cmd", "npm.cmd"])(
-        "wraps %s paths with spaces through cmd.exe",
+        "wraps %s through cmd.exe",
         (commandName) => {
-            const command = `C:\\Program Files\\nodejs\\${commandName}`;
             const options = {
                 cwd: "C:\\Workspaces\\Project With Spaces",
                 env: {
@@ -19,11 +19,10 @@ describe("script command launch helpers", () => {
             };
 
             const prepared = prepareCommandForSpawnSync(
-                command,
+                commandName,
                 ["run", "build & package", "%TEMP%"],
                 options,
                 {
-                    comSpec: "C:\\Windows\\System32\\cmd.exe",
                     platform: "win32",
                 },
             );
@@ -34,9 +33,9 @@ describe("script command launch helpers", () => {
                     "/s",
                     "/v:off",
                     "/c",
-                    `""${command}" "run" "build & package" ""^%"TEMP"^%"""`,
+                    `""${commandName}" "run" "build & package" ""^%"TEMP"^%"""`,
                 ],
-                command: "C:\\Windows\\System32\\cmd.exe",
+                command: "cmd.exe",
                 options: {
                     ...options,
                     windowsVerbatimArguments: true,
@@ -65,14 +64,14 @@ describe("script command launch helpers", () => {
     it("quotes cmd metacharacters before launching a batch command", () => {
         // Keep this mirrored with src/main/shell/command-launch.test.ts so runtime and packaging quoting stay aligned.
         const prepared = prepareCommandForSpawnSync(
-            "C:\\Tools\\run.cmd",
+            "run.cmd",
             ["A&B", "(group)", "100%", "has^caret", "say \"hi\""],
             undefined,
             { platform: "win32" },
         );
 
         expect(prepared.args[4]).toBe(
-            '""C:\\Tools\\run.cmd" "A&B" "(group)" "100"^%"" "has^caret" "say \\"hi\\"""',
+            '""run.cmd" "A&B" "(group)" "100"^%"" "has^caret" "say \\"hi\\"""',
         );
         expect(prepared.options.windowsVerbatimArguments).toBe(true);
     });
@@ -90,6 +89,28 @@ describe("script command launch helpers", () => {
             command: "C:\\Program Files\\nodejs\\pnpm.cmd",
             options: { cwd: "/repo" },
         });
+    });
+
+    it("rejects absolute Windows batch commands before preparing", () => {
+        expect(() =>
+            prepareCommandForSpawnSync(
+                "C:\\Program Files\\nodejs\\npm.cmd",
+                ["ci"],
+                undefined,
+                { platform: "win32" },
+            ),
+        ).toThrow(/absolute Windows batch command/);
+    });
+
+    it("rejects absolute Windows batch commands before spawning", () => {
+        expect(() =>
+            spawnPreparedSync(
+                "C:\\Program Files\\nodejs\\npm.cmd",
+                ["ci"],
+                undefined,
+                { platform: "win32" },
+            ),
+        ).toThrow(/absolute Windows batch command/);
     });
 
     it("detects Windows batch command extensions", () => {

--- a/scripts/build-windows-acp-bundles.mjs
+++ b/scripts/build-windows-acp-bundles.mjs
@@ -10,7 +10,6 @@ import {
     ensureDir,
     isExecutableFile,
     isFile,
-    isWindowsBatchCommand,
     relativeToRepo,
     repoRoot,
     resetDir,
@@ -126,16 +125,18 @@ function ensureClaudeVendorReady() {
         );
     }
 
-    const npmCommand = resolveRequiredBatchCommandName("npm.cmd");
+    const npmCliPath = resolveRequiredNpmCliPath();
 
     if (!fs.existsSync(nodeModulesDir)) {
         console.log("[build:windows-acp] Installing Claude ACP vendor dependencies.");
-        run(npmCommand, ["ci"], { cwd: claudeVendorDir });
+        run(process.execPath, [npmCliPath, "ci"], { cwd: claudeVendorDir });
     }
 
     if (!isFile(distEntry) || isNewerThan(packageJsonPath, distEntry)) {
         console.log("[build:windows-acp] Building Claude ACP vendor dist.");
-        run(npmCommand, ["run", "build"], { cwd: claudeVendorDir });
+        run(process.execPath, [npmCliPath, "run", "build"], {
+            cwd: claudeVendorDir,
+        });
     }
 }
 
@@ -291,17 +292,26 @@ function resolveRequiredCommand(command) {
     throw new Error(`Required command was not found: ${command}`);
 }
 
-function resolveRequiredBatchCommandName(command) {
-    const resolved = resolveFromPath(command);
-    if (!resolved) {
-        throw new Error(`Required command was not found: ${command}`);
+function resolveRequiredNpmCliPath() {
+    const npmCommand = resolveFromPath("npm.cmd");
+    if (!npmCommand) {
+        throw new Error("Required command was not found: npm.cmd");
     }
 
-    if (!isWindowsBatchCommand(resolved)) {
-        throw new Error(`Required command is not a Windows batch file: ${command}`);
+    const npmCliPath = path.join(
+        path.dirname(npmCommand),
+        "node_modules",
+        "npm",
+        "bin",
+        "npm-cli.js",
+    );
+    if (isFile(npmCliPath)) {
+        return npmCliPath;
     }
 
-    return path.win32.basename(command);
+    throw new Error(
+        `Required npm CLI was not found next to npm.cmd: ${npmCliPath}`,
+    );
 }
 
 function capture(command, args, options = {}) {

--- a/scripts/build-windows-acp-bundles.mjs
+++ b/scripts/build-windows-acp-bundles.mjs
@@ -10,6 +10,7 @@ import {
     ensureDir,
     isExecutableFile,
     isFile,
+    isWindowsBatchCommand,
     relativeToRepo,
     repoRoot,
     resetDir,
@@ -125,7 +126,7 @@ function ensureClaudeVendorReady() {
         );
     }
 
-    const npmCommand = resolveRequiredCommand("npm.cmd");
+    const npmCommand = resolveRequiredBatchCommandName("npm.cmd");
 
     if (!fs.existsSync(nodeModulesDir)) {
         console.log("[build:windows-acp] Installing Claude ACP vendor dependencies.");
@@ -288,6 +289,19 @@ function resolveRequiredCommand(command) {
     }
 
     throw new Error(`Required command was not found: ${command}`);
+}
+
+function resolveRequiredBatchCommandName(command) {
+    const resolved = resolveFromPath(command);
+    if (!resolved) {
+        throw new Error(`Required command was not found: ${command}`);
+    }
+
+    if (!isWindowsBatchCommand(resolved)) {
+        throw new Error(`Required command is not a Windows batch file: ${command}`);
+    }
+
+    return path.win32.basename(command);
 }
 
 function capture(command, args, options = {}) {

--- a/scripts/package-windows-app.mjs
+++ b/scripts/package-windows-app.mjs
@@ -78,7 +78,8 @@ function main() {
     const preparedAiPayloadRoot = resolvePreparedWindowsAiPayloadRoot(targetArch);
     console.log("[package:win] Building Electron production bundles.");
     prepareWorkspace();
-    run(preflight.pnpmCommand, [
+    run(process.execPath, [
+        preflight.pnpmCliPath,
         "run",
         preparedAiPayloadRoot ? "build:ci" : "build",
     ]);
@@ -277,8 +278,9 @@ function stageWindowsNativeBackendPayload(targetArch, preflight) {
     console.log(
         `[package:win] Building and staging native backend sidecar for ${targetArch}.`,
     );
-    run(preflight.pnpmCommand, ["run", "native:build"]);
-    run(preflight.pnpmCommand, [
+    run(process.execPath, [preflight.pnpmCliPath, "run", "native:build"]);
+    run(process.execPath, [
+        preflight.pnpmCliPath,
         "run",
         "native:stage",
         "--",

--- a/scripts/windows-packaging-preflight.mjs
+++ b/scripts/windows-packaging-preflight.mjs
@@ -33,7 +33,7 @@ export function resolveWindowsPackagingPreflight({
         });
 
     const paths = resolveWindowsPackagingPaths(repoRoot);
-    const pnpmCommand = requireBatchCommandName("pnpm.cmd", resolveCommand);
+    const pnpmCliPath = resolveRequiredPnpmCliPath({ env, isFile });
     const powerShellCommand =
         resolveCommand("pwsh.exe") ??
         resolveCommand("pwsh") ??
@@ -78,7 +78,7 @@ export function resolveWindowsPackagingPreflight({
         aiPayload,
         electronBuilderCli: paths.electronBuilderCli,
         powerShellCommand,
-        pnpmCommand,
+        pnpmCliPath,
         rceditPath,
         windowsIconPath: paths.windowsIconPath,
     };
@@ -242,18 +242,19 @@ function requireCommand(command, resolveCommand) {
     );
 }
 
-function requireBatchCommandName(command, resolveCommand) {
-    const resolved = requireCommand(command, resolveCommand);
-    if (!isWindowsBatchCommand(resolved)) {
-        throw new Error(`Required command is not a Windows batch file: ${command}`);
+function resolveRequiredPnpmCliPath({ env, isFile }) {
+    const npmExecPath = env.npm_execpath?.trim();
+    if (npmExecPath && isPnpmCliPath(npmExecPath) && isFile(npmExecPath)) {
+        return npmExecPath;
     }
 
-    return path.win32.basename(command);
+    throw new Error(
+        "Required pnpm CLI was not found. Run Windows packaging through pnpm so npm_execpath points to pnpm.cjs.",
+    );
 }
 
-function isWindowsBatchCommand(command) {
-    const extension = path.win32.extname(command).toLowerCase();
-    return extension === ".cmd" || extension === ".bat";
+function isPnpmCliPath(candidatePath) {
+    return path.win32.basename(candidatePath).toLowerCase() === "pnpm.cjs";
 }
 
 function assertFile(filePath, { isFile, label, relativePath, suggestion }) {

--- a/scripts/windows-packaging-preflight.mjs
+++ b/scripts/windows-packaging-preflight.mjs
@@ -33,7 +33,7 @@ export function resolveWindowsPackagingPreflight({
         });
 
     const paths = resolveWindowsPackagingPaths(repoRoot);
-    const pnpmCommand = requireCommand("pnpm.cmd", resolveCommand);
+    const pnpmCommand = requireBatchCommandName("pnpm.cmd", resolveCommand);
     const powerShellCommand =
         resolveCommand("pwsh.exe") ??
         resolveCommand("pwsh") ??
@@ -240,6 +240,20 @@ function requireCommand(command, resolveCommand) {
     throw new Error(
         `Required command was not found: ${command}. Run pnpm install --frozen-lockfile and make sure Node's bin directory is on PATH.`,
     );
+}
+
+function requireBatchCommandName(command, resolveCommand) {
+    const resolved = requireCommand(command, resolveCommand);
+    if (!isWindowsBatchCommand(resolved)) {
+        throw new Error(`Required command is not a Windows batch file: ${command}`);
+    }
+
+    return path.win32.basename(command);
+}
+
+function isWindowsBatchCommand(command) {
+    const extension = path.win32.extname(command).toLowerCase();
+    return extension === ".cmd" || extension === ".bat";
 }
 
 function assertFile(filePath, { isFile, label, relativePath, suggestion }) {

--- a/scripts/windows-packaging-preflight.test.mjs
+++ b/scripts/windows-packaging-preflight.test.mjs
@@ -80,8 +80,9 @@ describe("Windows packaging preflight", () => {
         const repoRoot = createTempDir();
         const nodeBinDir = path.join(repoRoot, "node-bin");
         const powerShellDir = path.join(repoRoot, "powershell");
+        const pnpmCliPath = path.join(repoRoot, "pnpm", "bin", "pnpm.cjs");
 
-        writeExecutable(nodeBinDir, "pnpm.cmd");
+        writeFile(pnpmCliPath);
         writeExecutable(powerShellDir, "pwsh.exe");
         writeFile(path.join(repoRoot, "node_modules", "electron-builder", "cli.js"));
         writeFile(path.join(repoRoot, "resources", "icons", "windows.ico"));
@@ -90,6 +91,7 @@ describe("Windows packaging preflight", () => {
 
         const preflight = resolveWindowsPackagingPreflight({
             env: {
+                npm_execpath: pnpmCliPath,
                 PATH: powerShellDir,
                 PATHEXT: ".EXE;.CMD",
             },
@@ -99,7 +101,7 @@ describe("Windows packaging preflight", () => {
             targetArch: "x64",
         });
 
-        expect(preflight.pnpmCommand).toBe("pnpm.cmd");
+        expect(preflight.pnpmCliPath).toBe(pnpmCliPath);
         expect(preflight.powerShellCommand).toBe(
             path.join(powerShellDir, "pwsh.exe"),
         );
@@ -115,8 +117,9 @@ describe("Windows packaging preflight", () => {
         const repoRoot = createTempDir();
         const nodeBinDir = path.join(repoRoot, "node-bin");
         const powerShellDir = path.join(repoRoot, "powershell");
+        const pnpmCliPath = path.join(repoRoot, "pnpm", "bin", "pnpm.cjs");
 
-        writeExecutable(nodeBinDir, "pnpm.cmd");
+        writeFile(pnpmCliPath);
         writeExecutable(powerShellDir, "powershell.exe");
         writeFile(path.join(repoRoot, "node_modules", "electron-builder", "cli.js"));
         writeFile(path.join(repoRoot, "resources", "icons", "windows.ico"));
@@ -125,6 +128,7 @@ describe("Windows packaging preflight", () => {
         expect(() =>
             resolveWindowsPackagingPreflight({
                 env: {
+                    npm_execpath: pnpmCliPath,
                     PATH: powerShellDir,
                     PATHEXT: ".EXE;.CMD",
                 },

--- a/scripts/windows-packaging-preflight.test.mjs
+++ b/scripts/windows-packaging-preflight.test.mjs
@@ -99,7 +99,7 @@ describe("Windows packaging preflight", () => {
             targetArch: "x64",
         });
 
-        expect(preflight.pnpmCommand).toBe(path.join(nodeBinDir, "pnpm.cmd"));
+        expect(preflight.pnpmCommand).toBe("pnpm.cmd");
         expect(preflight.powerShellCommand).toBe(
             path.join(powerShellDir, "pwsh.exe"),
         );


### PR DESCRIPTION
## Resumen
- Fija `cmd.exe` como wrapper para batch scripts de Windows en los scripts de build.
- Rechaza rutas absolutas `.cmd`/`.bat` antes de preparar o ejecutar comandos batch.
- Valida `npm.cmd` y `pnpm.cmd` desde PATH, pero ejecuta nombres estables para evitar interpolar rutas absolutas derivadas del entorno en `cmd.exe /c`.

## Contexto
Este PR aborda la alerta CodeQL #19 (`js/shell-command-injection-from-environment`). El flujo problemático era resolver comandos batch desde `PATH`/`PATHEXT` y luego insertar esa ruta absoluta en una línea de shell de Windows.

## Validación
- `pnpm exec vitest run scripts/ai/_shared.test.mjs scripts/*.test.mjs`
- `pnpm run build:ci`