### PR TITLE
Avoid cmd.exe for Windows package scripts

### DIFF
--- a/scripts/ai/_shared.mjs
+++ b/scripts/ai/_shared.mjs
@@ -173,23 +173,12 @@ export function prepareCommandForSpawnSync(
         };
     }
 
-    if (path.win32.isAbsolute(command)) {
-        throw new Error(
-            `Refusing to prepare an absolute Windows batch command: ${command}`,
-        );
-    }
-    const batchCommand = resolveKnownWindowsBatchCommand(command);
+    const cli = resolveKnownWindowsNodeCli(command, options, launchOptions);
 
     return {
-        args: [
-            "/d",
-            "/s",
-            "/v:off",
-            "/c",
-            buildWindowsBatchCommandLine(batchCommand, args),
-        ],
-        command: "cmd.exe",
-        options: withWindowsVerbatimArguments(options),
+        args: [cli.entrypointPath, ...args],
+        command: cli.nodeCommand,
+        options,
     };
 }
 
@@ -200,13 +189,12 @@ export function spawnPreparedSync(command, args = [], options = {}, launchOption
         return spawnSync(command, args, options);
     }
 
-    // Windows batch commands must go through cmd.exe; prepareCommandForSpawnSync quotes every argument first.
     const prepared = prepareCommandForSpawnSync(command, args, options, {
         ...launchOptions,
         platform,
     });
 
-    return spawnSync("cmd.exe", prepared.args, prepared.options);
+    return spawnSync(prepared.command, prepared.args, prepared.options);
 }
 
 export function isWindowsBatchCommand(command) {
@@ -214,59 +202,138 @@ export function isWindowsBatchCommand(command) {
     return extension === ".cmd" || extension === ".bat";
 }
 
-function resolveKnownWindowsBatchCommand(command) {
-    switch (command.toLowerCase()) {
-        case "npm.cmd":
-            return "npm.cmd";
-        case "pnpm.cmd":
-            return "pnpm.cmd";
-        default:
-            throw new Error(`Unsupported Windows batch command: ${command}`);
-    }
-}
-
-function buildWindowsBatchCommandLine(command, args) {
-    const innerCommandLine = [command, ...args]
-        .map(quoteWindowsCmdArgument)
-        .join(" ");
-
-    return `"${innerCommandLine}"`;
-}
-
-function quoteWindowsCmdArgument(value) {
-    let escapedValue = "";
-    let backslashCount = 0;
-
-    for (const character of String(value)) {
-        if (character === "\\") {
-            backslashCount += 1;
-            continue;
-        }
-
-        if (character === '"') {
-            escapedValue += `${"\\".repeat(backslashCount * 2 + 1)}"`;
-            backslashCount = 0;
-            continue;
-        }
-
-        if (character === "%") {
-            escapedValue += `${"\\".repeat(backslashCount)}"^%"`;
-            backslashCount = 0;
-            continue;
-        }
-
-        escapedValue += `${"\\".repeat(backslashCount)}${character}`;
-        backslashCount = 0;
+function resolveKnownWindowsNodeCli(command, options = {}, launchOptions = {}) {
+    if (path.win32.isAbsolute(command)) {
+        throw new Error(
+            `Refusing to prepare an absolute Windows batch command: ${command}`,
+        );
     }
 
-    escapedValue += "\\".repeat(backslashCount * 2);
+    const commandName = command.toLowerCase();
+    const commandPath =
+        launchOptions.commandPath ??
+        resolveFromPathForPlatform(command, {
+            env: options.env,
+            platform: "win32",
+        });
 
-    return `"${escapedValue}"`;
-}
+    if (!commandPath) {
+        throw new Error(
+            `Required Windows batch command was not found on PATH: ${command}`,
+        );
+    }
 
-function withWindowsVerbatimArguments(options) {
+    const entrypointPath = resolveKnownWindowsNodeCliEntrypoint(
+        commandName,
+        commandPath,
+        launchOptions,
+    );
+
     return {
-        ...options,
-        windowsVerbatimArguments: true,
+        entrypointPath,
+        nodeCommand: launchOptions.nodeCommand ?? process.execPath,
     };
+}
+
+function resolveKnownWindowsNodeCliEntrypoint(
+    commandName,
+    commandPath,
+    launchOptions = {},
+) {
+    switch (commandName) {
+        case "npm.cmd":
+            return resolveExistingFile(
+                [
+                    launchOptions.npmCliPath,
+                    path.win32.join(
+                        path.win32.dirname(commandPath),
+                        "node_modules",
+                        "npm",
+                        "bin",
+                        "npm-cli.js",
+                    ),
+                ],
+                "npm CLI",
+            );
+        case "pnpm.cmd":
+            return resolveExistingFile(
+                [
+                    launchOptions.pnpmCliPath,
+                    path.win32.join(
+                        path.win32.dirname(commandPath),
+                        "node_modules",
+                        "pnpm",
+                        "bin",
+                        "pnpm.cjs",
+                    ),
+                    path.win32.join(
+                        path.win32.dirname(commandPath),
+                        "node_modules",
+                        "pnpm",
+                        "bin",
+                        "pnpm.js",
+                    ),
+                    parseWindowsCmdNodeEntrypoint(commandPath),
+                ],
+                "pnpm CLI",
+            );
+        default:
+            throw new Error(`Unsupported Windows batch command: ${commandName}`);
+    }
+}
+
+function resolveFromPathForPlatform(command, { env = process.env, platform }) {
+    const pathValue = env?.PATH ?? env?.Path ?? env?.path ?? "";
+    const pathEntries = pathValue
+        .split(platform === "win32" ? path.win32.delimiter : path.delimiter)
+        .filter(Boolean);
+    const pathextEntries =
+        platform === "win32"
+            ? (env?.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+                  .split(";")
+                  .filter(Boolean)
+            : [""];
+
+    for (const entry of pathEntries) {
+        for (const ext of pathextEntries) {
+            const candidate = path.win32.join(
+                entry,
+                platform === "win32" &&
+                    !command.toLowerCase().endsWith(ext.toLowerCase())
+                    ? `${command}${ext}`
+                    : command,
+            );
+
+            if (isFile(candidate)) {
+                return candidate;
+            }
+        }
+    }
+
+    return null;
+}
+
+function resolveExistingFile(candidates, label) {
+    const candidate = candidates
+        .filter(Boolean)
+        .find((filePath) => isFile(filePath));
+    if (!candidate) {
+        throw new Error(`Required ${label} entrypoint was not found.`);
+    }
+    return candidate;
+}
+
+function parseWindowsCmdNodeEntrypoint(commandPath) {
+    if (!isFile(commandPath)) {
+        return null;
+    }
+
+    const content = fs.readFileSync(commandPath, "utf8");
+    const commandDir = path.win32.dirname(commandPath);
+    const match = content.match(/"%dp0%\\([^"]+\.(?:cjs|js))"/iu);
+    if (!match) {
+        return null;
+    }
+
+    return path.win32.join(commandDir, match[1]);
 }

--- a/scripts/ai/_shared.test.mjs
+++ b/scripts/ai/_shared.test.mjs
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
     isWindowsBatchCommand,
@@ -6,45 +10,65 @@ import {
     spawnPreparedSync,
 } from "./_shared.mjs";
 
+const temporaryDirectories = new Set();
+
+afterEach(() => {
+    for (const directoryPath of temporaryDirectories) {
+        fs.rmSync(directoryPath, {
+            force: true,
+            recursive: true,
+        });
+    }
+    temporaryDirectories.clear();
+});
+
 describe("script command launch helpers", () => {
-    it.each(["pnpm.cmd", "npm.cmd"])(
-        "wraps %s through cmd.exe",
-        (commandName) => {
-            const options = {
-                cwd: "C:\\Workspaces\\Project With Spaces",
-                env: {
-                    PATH: "C:\\Program Files\\nodejs",
-                },
-                stdio: "inherit",
-            };
-
-            const prepared = prepareCommandForSpawnSync(
-                commandName,
-                ["run", "build & package", "%TEMP%"],
-                options,
-                {
-                    platform: "win32",
-                },
-            );
-
-            expect(prepared).toEqual({
-                args: [
-                    "/d",
-                    "/s",
-                    "/v:off",
-                    "/c",
-                    `""${commandName}" "run" "build & package" ""^%"TEMP"^%"""`,
-                ],
-                command: "cmd.exe",
-                options: {
-                    ...options,
-                    windowsVerbatimArguments: true,
-                },
-            });
-            expect(prepared.options).not.toBe(options);
-            expect(options.windowsVerbatimArguments).toBeUndefined();
+    it.each([
+        {
+            cliFileName: "pnpm.cjs",
+            commandName: "pnpm.cmd",
+            cliOptionName: "pnpmCliPath",
         },
-    );
+        {
+            cliFileName: "npm-cli.js",
+            commandName: "npm.cmd",
+            cliOptionName: "npmCliPath",
+        },
+    ])("runs $commandName through node instead of cmd.exe", (fixture) => {
+        const tempDir = createTempDir();
+        const commandPath = path.join(tempDir, fixture.commandName);
+        const cliPath = path.join(tempDir, fixture.cliFileName);
+        fs.writeFileSync(commandPath, "", "utf8");
+        fs.writeFileSync(cliPath, "", "utf8");
+
+        const options = {
+            cwd: "C:\\Workspaces\\Project With Spaces",
+            env: {
+                PATH: tempDir,
+                PATHEXT: ".CMD",
+            },
+            stdio: "inherit",
+        };
+
+        const prepared = prepareCommandForSpawnSync(
+            fixture.commandName,
+            ["run", "build & package", "%TEMP%"],
+            options,
+            {
+                [fixture.cliOptionName]: cliPath,
+                commandPath,
+                nodeCommand: "node.exe",
+                platform: "win32",
+            },
+        );
+
+        expect(prepared).toEqual({
+            args: [cliPath, "run", "build & package", "%TEMP%"],
+            command: "node.exe",
+            options,
+        });
+        expect(prepared.options).toBe(options);
+    });
 
     it("does not wrap Windows non-batch executables", () => {
         const prepared = prepareCommandForSpawnSync(
@@ -61,19 +85,30 @@ describe("script command launch helpers", () => {
         });
     });
 
-    it("quotes cmd metacharacters before launching a batch command", () => {
-        // Keep this mirrored with src/main/shell/command-launch.test.ts so runtime and packaging quoting stay aligned.
+    it("passes cmd metacharacters as node CLI arguments", () => {
+        const tempDir = createTempDir();
+        const commandPath = path.join(tempDir, "npm.cmd");
+        const npmCliPath = path.join(tempDir, "npm-cli.js");
+        fs.writeFileSync(commandPath, "", "utf8");
+        fs.writeFileSync(npmCliPath, "", "utf8");
+
         const prepared = prepareCommandForSpawnSync(
             "npm.cmd",
             ["A&B", "(group)", "100%", "has^caret", "say \"hi\""],
-            undefined,
-            { platform: "win32" },
+            { env: { PATH: tempDir, PATHEXT: ".CMD" } },
+            {
+                commandPath,
+                nodeCommand: "node.exe",
+                npmCliPath,
+                platform: "win32",
+            },
         );
 
-        expect(prepared.args[4]).toBe(
-            '""npm.cmd" "A&B" "(group)" "100"^%"" "has^caret" "say \\"hi\\"""',
-        );
-        expect(prepared.options.windowsVerbatimArguments).toBe(true);
+        expect(prepared).toEqual({
+            args: [npmCliPath, "A&B", "(group)", "100%", "has^caret", "say \"hi\""],
+            command: "node.exe",
+            options: { env: { PATH: tempDir, PATHEXT: ".CMD" } },
+        });
     });
 
     it("does not wrap batch commands outside Windows", () => {
@@ -103,8 +138,13 @@ describe("script command launch helpers", () => {
     });
 
     it("rejects unsupported Windows batch commands", () => {
+        const tempDir = createTempDir();
+        const commandPath = path.join(tempDir, "run.cmd");
+        fs.writeFileSync(commandPath, "", "utf8");
+
         expect(() =>
             prepareCommandForSpawnSync("run.cmd", [], undefined, {
+                commandPath,
                 platform: "win32",
             }),
         ).toThrow(/Unsupported Windows batch command/);
@@ -128,3 +168,11 @@ describe("script command launch helpers", () => {
         expect(isWindowsBatchCommand("pnpm")).toBe(false);
     });
 });
+
+function createTempDir() {
+    const directoryPath = fs.mkdtempSync(
+        path.join(os.tmpdir(), "comando-command-launch-test-"),
+    );
+    temporaryDirectories.add(directoryPath);
+    return directoryPath;
+}


### PR DESCRIPTION
## Summary

- Stops launching `npm.cmd` and `pnpm.cmd` through `cmd.exe /c` in packaging scripts.
- Resolves the underlying Node CLI entrypoint and invokes it with `node` plus argv instead.
- Updates launch helper tests to cover metacharacter arguments without shell interpretation.

## Why

This addresses the CodeQL warning about shell commands built from environment-derived paths by removing the dynamic shell command path entirely for supported Windows package scripts.

## Validation

- `node --check scripts/ai/_shared.mjs`
- `node --check scripts/ai/_shared.test.mjs`
- `pnpm exec vitest run scripts/ai/_shared.test.mjs scripts/*.test.mjs`
- `git diff --check`