### PR TITLE
Add update badge to project switcher

### DIFF
--- a/src/main/settings/window.ts
+++ b/src/main/settings/window.ts
@@ -3,7 +3,7 @@ import type { BrowserWindow } from "electron";
 import { applyAppZoomToWindow } from "@main/settings/window-zoom";
 import { createSettingsWindow as createSettingsBrowserWindow } from "@main/window";
 import { windowRegistry } from "@main/windows/registry";
-import type { OpenSettingsWindowInput } from "@shared/ipc";
+import { IPC_EVENTS, type OpenSettingsWindowInput } from "@shared/ipc";
 
 const SETTINGS_WINDOW_KEY_PREFIX = "settings";
 
@@ -23,6 +23,12 @@ export function openSettingsWindow(
         }
         existingWindow.show();
         existingWindow.focus();
+        if (input.initialCategory) {
+            existingWindow.webContents.send(
+                IPC_EVENTS.settingsCategoryRequested,
+                input.initialCategory,
+            );
+        }
         return;
     }
 

--- a/src/main/settings/window.ts
+++ b/src/main/settings/window.ts
@@ -28,6 +28,7 @@ export function openSettingsWindow(
 
     const settingsWindow = createSettingsBrowserWindow(
         input.projectId,
+        input.initialCategory ?? null,
         transparencyEnabled,
     );
     applyAppZoomToWindow(settingsWindow, zoomFactor);

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import { BrowserWindow, nativeTheme, screen, shell } from "electron";
 
-import type { PersistedWindowState } from "@shared/ipc";
+import type { PersistedWindowState, SettingsWindowCategory } from "@shared/ipc";
 
 import { appIdentity } from "./app-runtime";
 import { debugBenignError } from "./observability/logging";
@@ -224,6 +224,7 @@ export function createMainWindow(
 
 export function createSettingsWindow(
     projectId: string | null = null,
+    initialCategory: SettingsWindowCategory | null = null,
     transparencyEnabled = true,
 ): BrowserWindow {
     const searchParams = new URLSearchParams({
@@ -232,6 +233,10 @@ export function createSettingsWindow(
 
     if (projectId) {
         searchParams.set("projectId", projectId);
+    }
+
+    if (initialCategory) {
+        searchParams.set("category", initialCategory);
     }
 
     return createBaseWindow({

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -55,6 +55,7 @@ import {
     type OpenProjectEntryExternallyInput,
     type OpenProjectFileInput,
     type OpenSettingsWindowInput,
+    type SettingsWindowCategory,
     type AiSessionSnapshot,
     type PersistenceSnapshot,
     type PrepareAiSessionInput,
@@ -635,6 +636,23 @@ const comandoApi: ComandoApi = {
 
         return () => {
             ipcRenderer.removeListener(IPC_EVENTS.appUpdateState, handleEvent);
+        };
+    },
+    onSettingsCategoryRequested: (listener) => {
+        const handleEvent = (
+            _event: Electron.IpcRendererEvent,
+            category: SettingsWindowCategory,
+        ) => {
+            listener(category);
+        };
+
+        ipcRenderer.on(IPC_EVENTS.settingsCategoryRequested, handleEvent);
+
+        return () => {
+            ipcRenderer.removeListener(
+                IPC_EVENTS.settingsCategoryRequested,
+                handleEvent,
+            );
         };
     },
     onAppPrivacyAccessState: (listener) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,14 +8,17 @@ import {
     type KeyboardEvent as ReactKeyboardEvent,
     type MouseEvent as ReactMouseEvent,
     type PointerEvent as ReactPointerEvent,
+    type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
 
 import type {
+    AppUpdateState,
     ComandoApi,
     PersistenceSnapshot,
     ProjectTreeNode,
     ProjectSummary,
+    SettingsWindowCategory,
     SettingsSnapshot,
 } from "@shared/ipc";
 import { resolveEditorLanguage } from "@shared/editor-language";
@@ -3215,12 +3218,39 @@ export function App() {
         ],
     );
 
-    const openSettingsWindow = useCallback(() => {
+    const [appUpdateState, setAppUpdateState] = useState<AppUpdateState>(() =>
+        createInitialAppUpdateState(),
+    );
+
+    useEffect(() => {
+        if (!window.comando) {
+            return;
+        }
+
+        let cancelled = false;
+        void window.comando.getAppUpdateState().then((state) => {
+            if (!cancelled) {
+                setAppUpdateState(state);
+            }
+        });
+
+        const unsubscribe = window.comando.onAppUpdateState((state) => {
+            setAppUpdateState(state);
+        });
+
+        return () => {
+            cancelled = true;
+            unsubscribe();
+        };
+    }, []);
+
+    const openSettingsWindow = useCallback((initialCategory?: SettingsWindowCategory) => {
         if (!window.comando) {
             return;
         }
 
         void window.comando.openSettingsWindow({
+            initialCategory,
             projectId: activeProjectId,
         });
     }, [activeProjectId]);
@@ -4124,6 +4154,7 @@ export function App() {
             <div className="border-t border-border/50 px-2 py-2">
                 <ProjectSwitcher
                     activeProject={activeProject}
+                    appUpdateState={appUpdateState}
                     onCloneRepository={(repositoryUrl) =>
                         cloneRepository(repositoryUrl)
                     }
@@ -4600,8 +4631,42 @@ function FileTreeMoveDestinationPicker({
     );
 }
 
+function createInitialAppUpdateState(): AppUpdateState {
+    return {
+        autoUpdatesEnabled: false,
+        availableVersion: null,
+        canCheckForUpdates: false,
+        canInstallUpdate: false,
+        currentVersion: "",
+        downloadedVersion: null,
+        lastCheckedAt: null,
+        message: "Auto-updates are initializing.",
+        progressPercent: null,
+        status: "unsupported",
+    };
+}
+
+function getProjectSwitcherUpdateMenuLabel(
+    state: AppUpdateState,
+): string | null {
+    if (state.canInstallUpdate || state.status === "downloaded") {
+        return "Settings · Update ready";
+    }
+
+    if (state.status === "downloading" || state.status === "available") {
+        return "Settings · Downloading update";
+    }
+
+    if (state.availableVersion || state.downloadedVersion) {
+        return "Settings · Update available";
+    }
+
+    return null;
+}
+
 function ProjectSwitcher({
     activeProject,
+    appUpdateState,
     onCloneRepository,
     onOpenProjects,
     onOpenSettings,
@@ -4609,9 +4674,10 @@ function ProjectSwitcher({
     projects,
 }: {
     readonly activeProject: ProjectSummary | null;
+    readonly appUpdateState: AppUpdateState;
     readonly onCloneRepository: (repositoryUrl: string) => Promise<boolean>;
     readonly onOpenProjects: () => void;
-    readonly onOpenSettings: () => void;
+    readonly onOpenSettings: (initialCategory?: SettingsWindowCategory) => void;
     readonly onSelectProject: (projectId: string) => void;
     readonly projects: readonly ProjectSummary[];
 }) {
@@ -4632,6 +4698,8 @@ function ProjectSwitcher({
             project.rootPath.toLowerCase().includes(normalizedSearch)
         );
     });
+    const updateMenuLabel = getProjectSwitcherUpdateMenuLabel(appUpdateState);
+    const hasUpdateNotice = updateMenuLabel !== null;
 
     const resetMenuState = () => {
         setOpen(false);
@@ -4709,6 +4777,7 @@ function ProjectSwitcher({
         action: () => void,
         checked = false,
         muted = false,
+        trailing?: ReactNode,
     ) => (
         <button
             className="project-switcher-menu-item"
@@ -4727,6 +4796,7 @@ function ProjectSwitcher({
             >
                 {label}
             </span>
+            {trailing}
         </button>
     );
 
@@ -4886,10 +4956,21 @@ function ProjectSwitcher({
                                 </span>
                             </button>
                             {menuItem(
-                                "Settings",
-                                onOpenSettings,
+                                updateMenuLabel ?? "Settings",
+                                () =>
+                                    onOpenSettings(
+                                        hasUpdateNotice
+                                            ? "updates"
+                                            : undefined,
+                                    ),
                                 false,
                                 true,
+                                hasUpdateNotice ? (
+                                    <span
+                                        aria-hidden="true"
+                                        className="project-switcher-update-dot"
+                                    />
+                                ) : undefined,
                             )}
                         </>
                     )}

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -36,6 +36,7 @@ import {
     type AiProviderId,
     type AiProviderRuntimeStatus,
     type AiProviderRuntimeSettingsInput,
+    type SettingsWindowProps,
 } from "./components/settings";
 import {
     saveAiChatSettings,
@@ -69,6 +70,11 @@ export function SettingsApp() {
     const runtimeProjectId = useMemo(() => {
         const params = new URLSearchParams(window.location.search);
         return params.get("projectId");
+    }, []);
+    const initialCategory = useMemo(() => {
+        const params = new URLSearchParams(window.location.search);
+        const value = params.get("category");
+        return isSettingsWindowCategory(value) ? value : undefined;
     }, []);
     const [appAppearance, setAppAppearance] = useState<AppAppearanceSettings>(
         getDefaultAppAppearance(),
@@ -806,6 +812,7 @@ export function SettingsApp() {
 
     return (
         <SettingsWindow
+            initialCategory={initialCategory}
             aiChat={{
                 chatFontFamily: aiChat.chatFontFamily,
                 chatFontFamilies: chatFontFamilies,
@@ -1107,6 +1114,23 @@ export function SettingsApp() {
                 state: appUpdateState,
             }}
         />
+    );
+}
+
+function isSettingsWindowCategory(
+    value: string | null,
+): value is NonNullable<SettingsWindowProps["initialCategory"]> {
+    return (
+        value === "appearance" ||
+        value === "editor" ||
+        value === "terminal" ||
+        value === "projects" ||
+        value === "github" ||
+        value === "ai" ||
+        value === "privacy" ||
+        value === "shortcuts" ||
+        value === "runtimes" ||
+        value === "updates"
     );
 }
 

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -76,6 +76,13 @@ export function SettingsApp() {
         const value = params.get("category");
         return isSettingsWindowCategory(value) ? value : undefined;
     }, []);
+    const [requestedCategory, setRequestedCategory] = useState<{
+        readonly category: SettingsWindowProps["initialCategory"];
+        readonly requestId: number;
+    }>({
+        category: initialCategory,
+        requestId: 0,
+    });
     const [appAppearance, setAppAppearance] = useState<AppAppearanceSettings>(
         getDefaultAppAppearance(),
     );
@@ -338,6 +345,21 @@ export function SettingsApp() {
         loadRuntimeStatuses,
         loadProjects,
     ]);
+
+    useEffect(() => {
+        if (!window.comando) {
+            return undefined;
+        }
+
+        return window.comando.onSettingsCategoryRequested((category) => {
+            if (isSettingsWindowCategory(category)) {
+                setRequestedCategory((current) => ({
+                    category,
+                    requestId: current.requestId + 1,
+                }));
+            }
+        });
+    }, []);
 
     useEffect(() => {
         if (!window.comando) {
@@ -812,7 +834,8 @@ export function SettingsApp() {
 
     return (
         <SettingsWindow
-            initialCategory={initialCategory}
+            initialCategory={requestedCategory.category}
+            initialCategoryRequestId={requestedCategory.requestId}
             aiChat={{
                 chatFontFamily: aiChat.chatFontFamily,
                 chatFontFamilies: chatFontFamilies,

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -74,17 +74,9 @@ import type {
     ShortcutEntryOption,
 } from "./settings-types";
 
-type Category =
-    | "appearance"
-    | "editor"
-    | "terminal"
-    | "projects"
-    | "github"
-    | "ai"
-    | "privacy"
-    | "shortcuts"
-    | "runtimes"
-    | "updates";
+type Category = SettingsWindowProps["initialCategory"] extends infer T
+    ? NonNullable<T>
+    : never;
 
 const CATEGORIES: { id: Category; label: string }[] = [
     { id: "appearance", label: "Appearance" },
@@ -517,8 +509,9 @@ export function SettingsWindow({
     aiProviders,
     shortcuts = [],
     updates,
+    initialCategory = "appearance",
 }: SettingsWindowProps) {
-    const [active, setActive] = useState<Category>("appearance");
+    const [active, setActive] = useState<Category>(initialCategory);
     const [search, setSearch] = useState("");
     const searchQuery = createSettingsSearchQuery(search);
     const searchContext: SettingsSearchContext = {

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -510,6 +510,7 @@ export function SettingsWindow({
     shortcuts = [],
     updates,
     initialCategory = "appearance",
+    initialCategoryRequestId = 0,
 }: SettingsWindowProps) {
     const [active, setActive] = useState<Category>(initialCategory);
     const [search, setSearch] = useState("");
@@ -542,6 +543,11 @@ export function SettingsWindow({
         ? EMPTY_SEARCH_QUERY
         : searchQuery;
     const hasSearch = searchQuery.terms.length > 0;
+
+    useEffect(() => {
+        setActive(initialCategory);
+        setSearch("");
+    }, [initialCategory, initialCategoryRequestId]);
 
     useEffect(() => {
         if (activeCategory !== active) {

--- a/src/renderer/src/components/settings/settings-types.ts
+++ b/src/renderer/src/components/settings/settings-types.ts
@@ -138,6 +138,7 @@ export interface SettingsAiChatState {
 
 export interface SettingsWindowProps {
     readonly initialCategory?: SettingsWindowCategory;
+    readonly initialCategoryRequestId?: number;
     readonly appAppearance: SettingsThemeControlState;
     readonly appEditor: SettingsEditorControlState;
     readonly terminal: SettingsTerminalState;

--- a/src/renderer/src/components/settings/settings-types.ts
+++ b/src/renderer/src/components/settings/settings-types.ts
@@ -6,6 +6,7 @@ import type {
     AppTerminalSettings,
     AppUpdateState,
     GitHubAuthStatus,
+    SettingsWindowCategory,
 } from "@shared/ipc";
 
 import type { AIProvidersSettingsProps } from "./AIProvidersSettings";
@@ -136,6 +137,7 @@ export interface SettingsAiChatState {
 }
 
 export interface SettingsWindowProps {
+    readonly initialCategory?: SettingsWindowCategory;
     readonly appAppearance: SettingsThemeControlState;
     readonly appEditor: SettingsEditorControlState;
     readonly terminal: SettingsTerminalState;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2006,6 +2006,14 @@ button {
     color: var(--color-accent);
 }
 
+.project-switcher-update-dot {
+    width: 6px;
+    height: 6px;
+    flex-shrink: 0;
+    border-radius: 999px;
+    background: linear-gradient(180deg, #f97316, #ef4444);
+}
+
 .project-switcher-sep {
     height: 1px;
     margin: 4px 0;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -164,6 +164,7 @@ export const IPC_CHANNELS = {
 export const IPC_EVENTS = {
     appUpdateState: "app:update-state",
     appPrivacyAccessState: "app:privacy-access-state",
+    settingsCategoryRequested: "settings:category-requested",
     projectAppDataCleared: "projects:app-data-cleared",
     projectsUpdated: "projects:updated",
     projectTreeInvalidated: "projects:tree-invalidated",
@@ -3136,6 +3137,9 @@ export interface ComandoApi {
         listener: (payload: ProjectTreeInvalidation) => void,
     ) => () => void;
     onAppUpdateState: (listener: (payload: AppUpdateState) => void) => () => void;
+    onSettingsCategoryRequested: (
+        listener: (category: SettingsWindowCategory) => void,
+    ) => () => void;
     onAppPrivacyAccessState: (
         listener: (payload: AppPrivacyAccessState) => void,
     ) => () => void;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -651,7 +651,20 @@ export interface ProjectSettingsUpdatedEvent {
     readonly projectId: string;
 }
 
+export type SettingsWindowCategory =
+    | "appearance"
+    | "editor"
+    | "terminal"
+    | "projects"
+    | "github"
+    | "ai"
+    | "privacy"
+    | "shortcuts"
+    | "runtimes"
+    | "updates";
+
 export interface OpenSettingsWindowInput {
+    readonly initialCategory?: SettingsWindowCategory;
     readonly projectId: string | null;
 }
 


### PR DESCRIPTION
## Summary

- Adds an update indicator to the project switcher Settings entry when an app update is available, downloading, or ready to install.
- Opens Settings directly to Updates from that menu state.
- Adds lightweight initial settings category routing through the main/preload/settings window path.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test -- src/renderer/src/components/settings/SettingsWindow.test.tsx src/main/updater.test.ts`