### PR TITLE
Test updater runtime events

### DIFF
--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -48,12 +48,15 @@ function createPackagedResourcesPath(): string {
 
 async function importUpdaterWithMocks(options?: {
     readonly autoUpdater?: MockAutoUpdater;
+    readonly showMessageBoxResponse?: number;
 }) {
     vi.resetModules();
 
     const autoUpdater = options?.autoUpdater ?? createMockAutoUpdater();
     const sendToWindow = vi.fn();
-    const showMessageBox = vi.fn().mockResolvedValue({ response: 1 });
+    const showMessageBox = vi
+        .fn()
+        .mockResolvedValue({ response: options?.showMessageBoxResponse ?? 1 });
     const getFocusedMainWindow = vi.fn().mockReturnValue(null);
     const getMostRecentMainWindow = vi.fn().mockReturnValue(null);
 
@@ -393,5 +396,90 @@ describe("auto updater download events", () => {
             status: "downloaded",
         });
         expect(showMessageBox).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("auto updater install and failure paths", () => {
+    it("does not install before an update has downloaded", async () => {
+        const { autoUpdater, updater } = await importUpdaterWithMocks();
+        initializeSupportedAutoUpdates(updater);
+
+        updater.installAppUpdateAndRestart();
+
+        expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+    });
+
+    it("installs after an update has downloaded", async () => {
+        const { autoUpdater, updater } = await importUpdaterWithMocks();
+        initializeSupportedAutoUpdates(updater);
+
+        autoUpdater.emit("update-downloaded", { version: "2.0.0" });
+        updater.installAppUpdateAndRestart();
+
+        expect(autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("installs when the restart prompt is accepted", async () => {
+        const { autoUpdater, updater } = await importUpdaterWithMocks({
+            showMessageBoxResponse: 0,
+        });
+        initializeSupportedAutoUpdates(updater);
+
+        autoUpdater.emit("update-downloaded", { version: "2.0.0" });
+        await vi.waitFor(() => {
+            expect(autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it("keeps the downloaded update pending when the restart prompt is dismissed", async () => {
+        const { autoUpdater, showMessageBox, updater } =
+            await importUpdaterWithMocks({
+                showMessageBoxResponse: 1,
+            });
+        initializeSupportedAutoUpdates(updater);
+
+        autoUpdater.emit("update-downloaded", { version: "2.0.0" });
+        await vi.waitFor(() => {
+            expect(showMessageBox).toHaveBeenCalledTimes(1);
+        });
+
+        expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+    });
+
+    it("stores a recoverable error when update checks fail", async () => {
+        const autoUpdater = createMockAutoUpdater();
+        autoUpdater.checkForUpdates.mockRejectedValue(
+            new Error("GitHub update metadata is unavailable"),
+        );
+        const { updater } = await importUpdaterWithMocks({ autoUpdater });
+
+        initializeSupportedAutoUpdates(updater);
+        await vi.waitFor(() => {
+            expect(updater.getAppUpdateState().status).toBe("error");
+        });
+
+        expect(updater.getAppUpdateState()).toMatchObject({
+            canCheckForUpdates: true,
+            message: "GitHub update metadata is unavailable",
+            status: "error",
+        });
+        expect(updater.getAppUpdateState().lastCheckedAt).toEqual(
+            expect.any(String),
+        );
+    });
+
+    it("marks the app current when no update is available", async () => {
+        const { autoUpdater, updater } = await importUpdaterWithMocks();
+        initializeSupportedAutoUpdates(updater);
+
+        autoUpdater.emit("update-available", { version: "2.0.0" });
+        autoUpdater.emit("update-not-available");
+
+        expect(updater.getAppUpdateState()).toMatchObject({
+            availableVersion: null,
+            canCheckForUpdates: true,
+            message: "You're already on the latest version.",
+            status: "not-available",
+        });
     });
 });

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -5,6 +5,8 @@ import { EventEmitter } from "node:events";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { IPC_EVENTS, type AppUpdateState } from "@shared/ipc";
+
 import {
     hasPackagedUpdateConfig,
     isLinuxAppImageEnvironment,
@@ -53,7 +55,9 @@ async function importUpdaterWithMocks(options?: {
     vi.resetModules();
 
     const autoUpdater = options?.autoUpdater ?? createMockAutoUpdater();
-    const sendToWindow = vi.fn();
+    const sendToWindow = vi.fn<
+        (eventName: string, payload: AppUpdateState) => void
+    >();
     const showMessageBox = vi
         .fn()
         .mockResolvedValue({ response: options?.showMessageBoxResponse ?? 1 });
@@ -481,5 +485,78 @@ describe("auto updater install and failure paths", () => {
             message: "You're already on the latest version.",
             status: "not-available",
         });
+    });
+});
+
+describe("auto updater state broadcasting", () => {
+    it("broadcasts relevant state transitions with the current app version", async () => {
+        const { autoUpdater, sendToWindow, updater } =
+            await importUpdaterWithMocks();
+        initializeSupportedAutoUpdates(updater);
+
+        autoUpdater.emit("update-available", { version: "2.0.0" });
+        autoUpdater.emit("download-progress", { percent: 42 });
+        autoUpdater.emit("update-downloaded", { version: "2.0.0" });
+
+        const broadcasts = sendToWindow.mock.calls.map(([eventName, payload]) => ({
+            eventName,
+            payload,
+        }));
+
+        expect(broadcasts.map(({ eventName }) => eventName)).toEqual(
+            expect.arrayContaining([
+                IPC_EVENTS.appUpdateState,
+                IPC_EVENTS.appUpdateState,
+                IPC_EVENTS.appUpdateState,
+                IPC_EVENTS.appUpdateState,
+                IPC_EVENTS.appUpdateState,
+            ]),
+        );
+        expect(broadcasts.map(({ payload }) => payload.status)).toEqual(
+            expect.arrayContaining([
+                "idle",
+                "checking",
+                "available",
+                "downloading",
+                "downloaded",
+            ]),
+        );
+        for (const { payload } of broadcasts) {
+            expect(payload.currentVersion).toBe("1.2.3");
+        }
+    });
+
+    it("reuses the active update check instead of starting concurrent checks", async () => {
+        const autoUpdater = createMockAutoUpdater();
+        let resolveCheck!: () => void;
+        autoUpdater.checkForUpdates.mockReturnValue(
+            new Promise<void>((resolve) => {
+                resolveCheck = resolve;
+            }),
+        );
+        const { updater } = await importUpdaterWithMocks({ autoUpdater });
+        initializeSupportedAutoUpdates(updater);
+
+        const firstCheck = updater.checkForAppUpdates();
+        const secondCheck = updater.checkForAppUpdates();
+
+        expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+        await expect(secondCheck).resolves.toMatchObject({
+            status: "checking",
+        });
+
+        resolveCheck();
+        await firstCheck;
+    });
+
+    it("shows the downloaded update prompt only once", async () => {
+        const { autoUpdater, showMessageBox, updater } =
+            await importUpdaterWithMocks();
+        initializeSupportedAutoUpdates(updater);
+
+        autoUpdater.emit("update-downloaded", { version: "2.0.0" });
+        autoUpdater.emit("update-downloaded", { version: "2.0.0" });
+
+        expect(showMessageBox).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { EventEmitter } from "node:events";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
     hasPackagedUpdateConfig,
@@ -14,6 +15,98 @@ import {
 
 const temporaryDirectories = new Set<string>();
 
+type MockAutoUpdater = EventEmitter & {
+    allowPrerelease: boolean;
+    autoDownload: boolean;
+    autoInstallOnAppQuit: boolean;
+    checkForUpdates: ReturnType<typeof vi.fn>;
+    quitAndInstall: ReturnType<typeof vi.fn>;
+};
+
+function createMockAutoUpdater(): MockAutoUpdater {
+    const autoUpdater = new EventEmitter() as MockAutoUpdater;
+    autoUpdater.allowPrerelease = true;
+    autoUpdater.autoDownload = false;
+    autoUpdater.autoInstallOnAppQuit = false;
+    autoUpdater.checkForUpdates = vi.fn().mockResolvedValue(undefined);
+    autoUpdater.quitAndInstall = vi.fn();
+    return autoUpdater;
+}
+
+function createPackagedResourcesPath(): string {
+    const resourcesPath = fs.mkdtempSync(
+        path.join(os.tmpdir(), "comando-updater-runtime-test-"),
+    );
+    temporaryDirectories.add(resourcesPath);
+    fs.writeFileSync(
+        resolvePackagedUpdateConfigPath(resourcesPath),
+        "provider: github\n",
+        "utf8",
+    );
+    return resourcesPath;
+}
+
+async function importUpdaterWithMocks(options?: {
+    readonly autoUpdater?: MockAutoUpdater;
+}) {
+    vi.resetModules();
+
+    const autoUpdater = options?.autoUpdater ?? createMockAutoUpdater();
+    const sendToWindow = vi.fn();
+    const showMessageBox = vi.fn().mockResolvedValue({ response: 1 });
+    const getFocusedMainWindow = vi.fn().mockReturnValue(null);
+    const getMostRecentMainWindow = vi.fn().mockReturnValue(null);
+
+    vi.doMock("electron", () => ({
+        app: {
+            getVersion: vi.fn(() => "1.2.3"),
+        },
+        BrowserWindow: {
+            getFocusedWindow: vi.fn(() => null),
+        },
+        dialog: {
+            showMessageBox,
+        },
+    }));
+    vi.doMock("electron-updater", () => ({
+        default: {
+            autoUpdater,
+        },
+    }));
+    vi.doMock("./window", () => ({
+        forEachLiveWindow: vi.fn(
+            (
+                callback: (window: {
+                    webContents: { send: typeof sendToWindow };
+                }) => void,
+            ) => {
+                callback({ webContents: { send: sendToWindow } });
+            },
+        ),
+    }));
+    vi.doMock("./windows/registry", () => ({
+        windowRegistry: {
+            getFocusedMainWindow,
+            getMostRecentMainWindow,
+        },
+    }));
+
+    const updater = await import("./updater");
+
+    return {
+        autoUpdater,
+        getFocusedMainWindow,
+        getMostRecentMainWindow,
+        sendToWindow,
+        showMessageBox,
+        updater,
+    };
+}
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+});
+
 afterEach(() => {
     for (const directoryPath of temporaryDirectories) {
         fs.rmSync(directoryPath, {
@@ -22,6 +115,8 @@ afterEach(() => {
         });
     }
     temporaryDirectories.clear();
+    vi.resetModules();
+    vi.clearAllMocks();
 });
 
 describe("shouldEnableAutoUpdates", () => {
@@ -177,6 +272,73 @@ describe("resolveAutoUpdateSupportState", () => {
             enabled: true,
             message:
                 "Automatic updates are enabled for this packaged release build.",
+        });
+    });
+});
+
+describe("initializeAutoUpdates", () => {
+    it("configures the updater and starts checking in supported builds", async () => {
+        const { autoUpdater, updater } = await importUpdaterWithMocks();
+        const resourcesPath = createPackagedResourcesPath();
+
+        updater.initializeAutoUpdates({
+            appChannel: "release",
+            isLinuxAppImage: true,
+            isPackaged: true,
+            platform: "linux",
+            resourcesPath,
+        });
+
+        expect(autoUpdater.autoDownload).toBe(true);
+        expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
+        expect(autoUpdater.allowPrerelease).toBe(false);
+        expect(autoUpdater.listenerCount("error")).toBe(1);
+        expect(autoUpdater.listenerCount("update-available")).toBe(1);
+        expect(autoUpdater.listenerCount("download-progress")).toBe(1);
+        expect(autoUpdater.listenerCount("update-not-available")).toBe(1);
+        expect(autoUpdater.listenerCount("update-downloaded")).toBe(1);
+        expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+        expect(updater.getAppUpdateState()).toMatchObject({
+            autoUpdatesEnabled: true,
+            canCheckForUpdates: false,
+            canInstallUpdate: false,
+            currentVersion: "1.2.3",
+            status: "checking",
+        });
+
+        updater.initializeAutoUpdates({
+            appChannel: "release",
+            isLinuxAppImage: true,
+            isPackaged: true,
+            platform: "linux",
+            resourcesPath,
+        });
+
+        expect(autoUpdater.listenerCount("error")).toBe(1);
+        expect(autoUpdater.listenerCount("update-available")).toBe(1);
+    });
+
+    it("leaves unsupported builds disabled without registering updater handlers", async () => {
+        const { autoUpdater, updater } = await importUpdaterWithMocks();
+
+        updater.initializeAutoUpdates({
+            appChannel: "dev",
+            isPackaged: false,
+            platform: "darwin",
+            resourcesPath: "/tmp/comando",
+        });
+
+        expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+        expect(autoUpdater.eventNames()).toEqual([]);
+        expect(updater.getAppUpdateState()).toMatchObject({
+            autoUpdatesEnabled: false,
+            availableVersion: null,
+            canCheckForUpdates: false,
+            canInstallUpdate: false,
+            downloadedVersion: null,
+            lastCheckedAt: null,
+            progressPercent: null,
+            status: "unsupported",
         });
     });
 });

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -103,6 +103,18 @@ async function importUpdaterWithMocks(options?: {
     };
 }
 
+function initializeSupportedAutoUpdates(
+    updater: Awaited<ReturnType<typeof importUpdaterWithMocks>>["updater"],
+) {
+    updater.initializeAutoUpdates({
+        appChannel: "release",
+        isLinuxAppImage: true,
+        isPackaged: true,
+        platform: "linux",
+        resourcesPath: createPackagedResourcesPath(),
+    });
+}
+
 beforeEach(() => {
     vi.restoreAllMocks();
 });
@@ -279,15 +291,7 @@ describe("resolveAutoUpdateSupportState", () => {
 describe("initializeAutoUpdates", () => {
     it("configures the updater and starts checking in supported builds", async () => {
         const { autoUpdater, updater } = await importUpdaterWithMocks();
-        const resourcesPath = createPackagedResourcesPath();
-
-        updater.initializeAutoUpdates({
-            appChannel: "release",
-            isLinuxAppImage: true,
-            isPackaged: true,
-            platform: "linux",
-            resourcesPath,
-        });
+        initializeSupportedAutoUpdates(updater);
 
         expect(autoUpdater.autoDownload).toBe(true);
         expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
@@ -306,13 +310,7 @@ describe("initializeAutoUpdates", () => {
             status: "checking",
         });
 
-        updater.initializeAutoUpdates({
-            appChannel: "release",
-            isLinuxAppImage: true,
-            isPackaged: true,
-            platform: "linux",
-            resourcesPath,
-        });
+        initializeSupportedAutoUpdates(updater);
 
         expect(autoUpdater.listenerCount("error")).toBe(1);
         expect(autoUpdater.listenerCount("update-available")).toBe(1);
@@ -340,5 +338,60 @@ describe("initializeAutoUpdates", () => {
             progressPercent: null,
             status: "unsupported",
         });
+    });
+});
+
+describe("auto updater download events", () => {
+    it("marks a discovered update as available and starts progress at zero", async () => {
+        const { autoUpdater, updater } = await importUpdaterWithMocks();
+        initializeSupportedAutoUpdates(updater);
+
+        autoUpdater.emit("update-available", { version: "2.0.0" });
+
+        expect(updater.getAppUpdateState()).toMatchObject({
+            availableVersion: "2.0.0",
+            canInstallUpdate: false,
+            progressPercent: 0,
+            status: "available",
+        });
+    });
+
+    it("clamps download progress and includes the available version in messages", async () => {
+        const { autoUpdater, updater } = await importUpdaterWithMocks();
+        initializeSupportedAutoUpdates(updater);
+
+        autoUpdater.emit("update-available", { version: "2.0.0" });
+        autoUpdater.emit("download-progress", { percent: -12 });
+
+        expect(updater.getAppUpdateState()).toMatchObject({
+            message: "Downloading version 2.0.0 (0%).",
+            progressPercent: 0,
+            status: "downloading",
+        });
+
+        autoUpdater.emit("download-progress", { percent: 175.4 });
+
+        expect(updater.getAppUpdateState()).toMatchObject({
+            message: "Downloading version 2.0.0 (100%).",
+            progressPercent: 100,
+            status: "downloading",
+        });
+    });
+
+    it("marks downloaded updates installable and prompts for restart", async () => {
+        const { autoUpdater, showMessageBox, updater } =
+            await importUpdaterWithMocks();
+        initializeSupportedAutoUpdates(updater);
+
+        autoUpdater.emit("update-downloaded", { version: "2.0.0" });
+
+        expect(updater.getAppUpdateState()).toMatchObject({
+            availableVersion: "2.0.0",
+            canInstallUpdate: true,
+            downloadedVersion: "2.0.0",
+            progressPercent: 100,
+            status: "downloaded",
+        });
+        expect(showMessageBox).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
## Summary

- Adds runtime coverage for Electron auto-updater initialization, gating, download states, install paths, failures, and state broadcasts.
- Verifies supported builds configure electron-updater correctly and unsupported builds remain disabled.
- Covers restart prompt behavior, recoverable check failures, no-update states, concurrent checks, and duplicate downloaded events.

## Validation

- `pnpm exec vitest run src/main/updater.test.ts`
- `pnpm exec vitest run scripts/mac-release-metadata.test.mjs scripts/windows-release-metadata.test.mjs scripts/linux-release-metadata.test.mjs scripts/validate-release-assets.test.mjs`
- `pnpm run typecheck`
- `pnpm run lint`
