### PR TITLE
Fix AI session selection preferences

### DIFF
--- a/src/main/ai/contracts.ts
+++ b/src/main/ai/contracts.ts
@@ -191,7 +191,6 @@ export interface AiDesiredSelections {
     readonly configOptions: readonly AiSessionConfigOption[];
     readonly modeId: string | null;
     readonly modelId: string | null;
-    readonly preferredConfigOptions: Record<string, boolean | string>;
 }
 
 export interface AiRuntimeSessionMapping {

--- a/src/main/ai/service.codex.test.ts
+++ b/src/main/ai/service.codex.test.ts
@@ -917,7 +917,7 @@ describe("AiService Codex branch", () => {
         expect(secretValues.size).toBe(0);
     });
 
-    it("updates stored session options without changing runtime defaults", async () => {
+    it("updates stored session options and remembers the runtime selection", async () => {
         const saveRuntimeSelectionPreferenceOption = vi.fn();
         const saveSessionSnapshot = vi.fn();
         const persistedSnapshot: AiSessionSnapshot = {
@@ -1022,11 +1022,15 @@ describe("AiService Codex branch", () => {
             value: "high",
         });
 
-        expect(saveRuntimeSelectionPreferenceOption).not.toHaveBeenCalled();
+        expect(saveRuntimeSelectionPreferenceOption).toHaveBeenCalledWith(
+            "codex",
+            "thought_level",
+            "high",
+        );
         expect(saveSessionSnapshot).toHaveBeenCalled();
     });
 
-    it("updates stored model config options without changing runtime defaults", async () => {
+    it("updates stored model config options and remembers the runtime model", async () => {
         const saveRuntimeModelPreference = vi.fn();
         const saveRuntimeSelectionPreferenceOption = vi.fn();
         const saveSessionSnapshot = vi.fn();
@@ -1132,8 +1136,15 @@ describe("AiService Codex branch", () => {
             value: "gpt-5.5",
         });
 
-        expect(saveRuntimeSelectionPreferenceOption).not.toHaveBeenCalled();
-        expect(saveRuntimeModelPreference).not.toHaveBeenCalled();
+        expect(saveRuntimeSelectionPreferenceOption).toHaveBeenCalledWith(
+            "codex",
+            "model",
+            "gpt-5.5",
+        );
+        expect(saveRuntimeModelPreference).toHaveBeenCalledWith(
+            "codex",
+            "gpt-5.5",
+        );
         expect(saveSessionSnapshot).toHaveBeenCalled();
     });
 });

--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -620,7 +620,7 @@ describe("AiService prepareSession", () => {
                 sessionId: "session-1",
             }),
         );
-        expect(saveRuntimeModePreference).not.toHaveBeenCalled();
+        expect(saveRuntimeModePreference).toHaveBeenCalledWith("codex", "agent");
     });
 
     it("routes live renames through the native backend and updates the cached snapshot", async () => {
@@ -965,7 +965,11 @@ describe("AiService prepareSession", () => {
             )?.value,
         ).toBe("medium");
         expect(updatedSnapshot?.reasoningEffort).toBe("medium");
-        expect(saveRuntimeSelectionPreferenceOption).not.toHaveBeenCalled();
+        expect(saveRuntimeSelectionPreferenceOption).toHaveBeenCalledWith(
+            "codex",
+            "reasoning_effort",
+            "medium",
+        );
         expect(saveRuntimeModePreference).not.toHaveBeenCalled();
         expect(saveRuntimeModelPreference).not.toHaveBeenCalled();
     });
@@ -980,6 +984,9 @@ describe("AiService prepareSession", () => {
         const setSessionConfigOption = vi.fn<
             NativeAiGateway["setSessionConfigOption"]
         >(() => Promise.resolve());
+        const saveRuntimeSelectionPreferenceOption = vi.fn();
+        const saveRuntimeModePreference = vi.fn();
+        const saveRuntimeModelPreference = vi.fn();
         const service = createPrepareService({
             nativeAi: createNativeAi({
                 prepareSession,
@@ -995,9 +1002,9 @@ describe("AiService prepareSession", () => {
                     modelId: null,
                 })),
                 loadSessionSnapshot: vi.fn(() => null),
-                saveRuntimeSelectionPreferenceOption: vi.fn(),
-                saveRuntimeModePreference: vi.fn(),
-                saveRuntimeModelPreference: vi.fn(),
+                saveRuntimeSelectionPreferenceOption,
+                saveRuntimeModePreference,
+                saveRuntimeModelPreference,
                 saveSessionSnapshot: vi.fn(),
             } as never,
         });
@@ -1027,6 +1034,9 @@ describe("AiService prepareSession", () => {
                 (option) => option.id === "reasoning_effort",
             )?.value,
         ).toBe("medium");
+        expect(saveRuntimeSelectionPreferenceOption).not.toHaveBeenCalled();
+        expect(saveRuntimeModePreference).not.toHaveBeenCalled();
+        expect(saveRuntimeModelPreference).not.toHaveBeenCalled();
     });
 
     it("keeps existing reasoning selections over runtime defaults when preparing", async () => {
@@ -1195,6 +1205,139 @@ describe("AiService prepareSession", () => {
         ).toBe("low");
     });
 
+    it("uses preferences captured at launch when a new session discovers config later", async () => {
+        const prepareSession = vi.fn<NativeAiGateway["prepareSession"]>(
+            ({ launch }) => Promise.resolve(launch.persistedSnapshot),
+        );
+        const setSessionConfigOption = vi.fn<
+            NativeAiGateway["setSessionConfigOption"]
+        >(() => Promise.resolve());
+        const loadRuntimeSelectionPreferences = vi.fn(() => ({
+            configOptions: {
+                reasoning_effort: "low",
+            },
+            modeId: null,
+            modelId: null,
+        }));
+        const service = createPrepareService({
+            nativeAi: createNativeAi({
+                prepareSession,
+                setSessionConfigOption,
+            }),
+            persistence: {
+                loadLatestRuntimeCatalog: vi.fn(() => null),
+                loadRuntimeSelectionPreferences,
+                loadSessionSnapshot: vi.fn(() => null),
+                saveRuntimeSelectionPreferenceOption: vi.fn(),
+                saveRuntimeModePreference: vi.fn(),
+                saveRuntimeModelPreference: vi.fn(),
+                saveSessionSnapshot: vi.fn(),
+            } as never,
+        });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-1",
+                title: "Codex 1",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+        loadRuntimeSelectionPreferences.mockReturnValue({
+            configOptions: {
+                reasoning_effort: "high",
+            },
+            modeId: null,
+            modelId: null,
+        });
+
+        service.handleNativeSessionCatalogPatch(
+            "window-1",
+            "session-1",
+            {
+                configOptions: [createReasoningConfig("medium")],
+            },
+            "2026-04-15T22:24:13.719838Z",
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(setSessionConfigOption).toHaveBeenCalledWith({
+            optionId: "reasoning_effort",
+            sessionId: "session-1",
+            value: "low",
+        });
+        expect(loadRuntimeSelectionPreferences).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not apply runtime preferences to restored sessions without their own selections", async () => {
+        const runtimeCatalog = createSnapshot({
+            configOptions: [createReasoningConfig("medium")],
+        });
+        const restoredSnapshot = createSnapshot({
+            configOptions: [],
+            sessionId: "session-1",
+        });
+        const prepareSession = vi.fn<NativeAiGateway["prepareSession"]>(
+            ({ launch }) => Promise.resolve(launch.persistedSnapshot),
+        );
+        const setSessionConfigOption = vi.fn<
+            NativeAiGateway["setSessionConfigOption"]
+        >(() => Promise.resolve());
+        const service = createPrepareService({
+            nativeAi: createNativeAi({
+                loadSessionSnapshot: vi.fn(() =>
+                    Promise.resolve(restoredSnapshot),
+                ),
+                prepareSession,
+                setSessionConfigOption,
+            }),
+            persistence: {
+                loadLatestRuntimeCatalog: vi.fn(() => ({
+                    availableCommands: runtimeCatalog.availableCommands,
+                    configOptions: runtimeCatalog.configOptions,
+                    modeId: runtimeCatalog.modeId,
+                    modes: runtimeCatalog.modes,
+                    modelId: runtimeCatalog.modelId,
+                    models: runtimeCatalog.models,
+                })),
+                loadRuntimeSelectionPreferences: vi.fn(() => ({
+                    configOptions: {
+                        reasoning_effort: "low",
+                    },
+                    modeId: null,
+                    modelId: null,
+                })),
+                loadSessionSnapshot: vi.fn(() => restoredSnapshot),
+                saveRuntimeSelectionPreferenceOption: vi.fn(),
+                saveRuntimeModePreference: vi.fn(),
+                saveRuntimeModelPreference: vi.fn(),
+                saveSessionSnapshot: vi.fn(),
+            } as never,
+        });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-1",
+                title: "Codex 1",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+
+        const desiredSelections =
+            prepareSession.mock.calls[0]?.[0].launch.desiredSelections;
+        expect(
+            desiredSelections?.configOptions.find(
+                (option) => option.id === "reasoning_effort",
+            )?.value,
+        ).toBe("medium");
+        expect(setSessionConfigOption).not.toHaveBeenCalled();
+    });
+
     it("keeps authoritative subagent reasoning effort over runtime defaults", async () => {
         const runtimeCatalog = createSnapshot({
             configOptions: [createReasoningConfig("medium")],
@@ -1257,6 +1400,75 @@ describe("AiService prepareSession", () => {
                 (option) => option.id === "reasoning_effort",
             )?.value,
         ).toBe("high");
+    });
+
+    it("keeps Codex subagents on inherited config instead of runtime preferences", async () => {
+        const runtimeCatalog = createSnapshot({
+            configOptions: [createReasoningConfig("medium")],
+        });
+        const persistedSnapshot = createSnapshot({
+            configOptions: [],
+            parentSessionId: "session-parent",
+            reasoningEffort: null,
+            sessionId: "session-parent:subagent:runtime-child",
+        });
+        const prepareSession = vi.fn<NativeAiGateway["prepareSession"]>(
+            ({ launch }) => Promise.resolve(launch.persistedSnapshot),
+        );
+        const setSessionConfigOption = vi.fn<
+            NativeAiGateway["setSessionConfigOption"]
+        >(() => Promise.resolve());
+        const service = createPrepareService({
+            nativeAi: createNativeAi({
+                loadSessionSnapshot: vi.fn(() =>
+                    Promise.resolve(persistedSnapshot),
+                ),
+                prepareSession,
+                setSessionConfigOption,
+            }),
+            persistence: {
+                loadLatestRuntimeCatalog: vi.fn(() => ({
+                    availableCommands: runtimeCatalog.availableCommands,
+                    configOptions: runtimeCatalog.configOptions,
+                    modeId: runtimeCatalog.modeId,
+                    modes: runtimeCatalog.modes,
+                    modelId: runtimeCatalog.modelId,
+                    models: runtimeCatalog.models,
+                })),
+                loadRuntimeSelectionPreferences: vi.fn(() => ({
+                    configOptions: {
+                        reasoning_effort: "low",
+                    },
+                    modeId: null,
+                    modelId: null,
+                })),
+                loadSessionSnapshot: vi.fn(() => persistedSnapshot),
+                saveRuntimeSelectionPreferenceOption: vi.fn(),
+                saveRuntimeModePreference: vi.fn(),
+                saveRuntimeModelPreference: vi.fn(),
+                saveSessionSnapshot: vi.fn(),
+            } as never,
+        });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-parent:subagent:runtime-child",
+                title: "Child",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+
+        const desiredSelections =
+            prepareSession.mock.calls[0]?.[0].launch.desiredSelections;
+        expect(
+            desiredSelections?.configOptions.find(
+                (option) => option.id === "reasoning_effort",
+            )?.value,
+        ).toBe("medium");
+        expect(setSessionConfigOption).not.toHaveBeenCalled();
     });
 
     it("does not restore persisted review files before native prepare", async () => {

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -442,7 +442,10 @@ export class AiService {
             readonly order: number;
         }
     >();
-    readonly #sessionsWithoutOwnSelections = new Set<string>();
+    readonly #runtimeDefaultPreferencesBySessionId = new Map<
+        string,
+        RuntimeSelectionPreferences
+    >();
     #nativeAi: NativeAiGateway | null;
     readonly #nativeAuthMigratedRuntimeIds = new Set<AiRuntimeId>();
     readonly #nativeChildParentSessionIds = new Map<string, string>();
@@ -1431,46 +1434,81 @@ export class AiService {
     }
 
     async setSessionMode(input: AiSessionModeMutationInput): Promise<void> {
+        await this.#setSessionMode(input, { rememberPreference: true });
+    }
+
+    async #setSessionMode(
+        input: AiSessionModeMutationInput,
+        options: { readonly rememberPreference: boolean },
+    ): Promise<void> {
         if (!this.#liveSessionContexts.has(input.sessionId)) {
-            await this.#updateSessionSnapshot(
+            const snapshot = await this.#updateSessionSnapshot(
                 input.sessionId,
                 (currentSnapshot) =>
                     setModeOnSnapshot(currentSnapshot, input.modeId),
             );
+            if (options.rememberPreference) {
+                this.#rememberRuntimeModePreference(snapshot, input.modeId);
+            }
             return;
         }
 
         await this.#requireNativeAiGateway().setSessionMode(input);
-        await this.#updateSessionSnapshot(
+        const snapshot = await this.#updateSessionSnapshot(
             input.sessionId,
             (currentSnapshot) =>
                 setModeOnSnapshot(currentSnapshot, input.modeId),
         );
+        if (options.rememberPreference) {
+            this.#rememberRuntimeModePreference(snapshot, input.modeId);
+        }
     }
 
     async setSessionModel(input: AiSessionModelMutationInput): Promise<void> {
+        await this.#setSessionModel(input, { rememberPreference: true });
+    }
+
+    async #setSessionModel(
+        input: AiSessionModelMutationInput,
+        options: { readonly rememberPreference: boolean },
+    ): Promise<void> {
         if (!this.#liveSessionContexts.has(input.sessionId)) {
-            await this.#updateSessionSnapshot(
+            const snapshot = await this.#updateSessionSnapshot(
                 input.sessionId,
                 (currentSnapshot) =>
                     setModelOnSnapshot(currentSnapshot, input.modelId),
             );
+            if (options.rememberPreference) {
+                this.#rememberRuntimeModelPreference(snapshot, input.modelId);
+            }
             return;
         }
 
         await this.#requireNativeAiGateway().setSessionModel(input);
-        await this.#updateSessionSnapshot(
+        const snapshot = await this.#updateSessionSnapshot(
             input.sessionId,
             (currentSnapshot) =>
                 setModelOnSnapshot(currentSnapshot, input.modelId),
         );
+        if (options.rememberPreference) {
+            this.#rememberRuntimeModelPreference(snapshot, input.modelId);
+        }
     }
 
     async setSessionConfigOption(
         input: AiSessionConfigOptionMutationInput,
     ): Promise<void> {
+        await this.#setSessionConfigOption(input, {
+            rememberPreference: true,
+        });
+    }
+
+    async #setSessionConfigOption(
+        input: AiSessionConfigOptionMutationInput,
+        options: { readonly rememberPreference: boolean },
+    ): Promise<void> {
         if (!this.#liveSessionContexts.has(input.sessionId)) {
-            await this.#updateSessionSnapshot(
+            const snapshot = await this.#updateSessionSnapshot(
                 input.sessionId,
                 (currentSnapshot) =>
                     setConfigOptionOnSnapshot(
@@ -1479,11 +1517,18 @@ export class AiService {
                         input.value,
                     ),
             );
+            if (options.rememberPreference) {
+                this.#rememberRuntimeConfigPreference(
+                    snapshot,
+                    input.optionId,
+                    input.value,
+                );
+            }
             return;
         }
 
         await this.#requireNativeAiGateway().setSessionConfigOption(input);
-        await this.#updateSessionSnapshot(
+        const snapshot = await this.#updateSessionSnapshot(
             input.sessionId,
             (currentSnapshot) =>
                 setConfigOptionOnSnapshot(
@@ -1491,6 +1536,79 @@ export class AiService {
                     input.optionId,
                     input.value,
                 ),
+        );
+        if (options.rememberPreference) {
+            this.#rememberRuntimeConfigPreference(
+                snapshot,
+                input.optionId,
+                input.value,
+            );
+        }
+    }
+
+    #rememberRuntimeModePreference(
+        snapshot: AiSessionSnapshot,
+        modeId: string,
+    ): void {
+        if (
+            snapshot.modeId !== modeId ||
+            shouldSkipRuntimeSelectionPreference(snapshot)
+        ) {
+            return;
+        }
+
+        this.#persistence.saveRuntimeModePreference(snapshot.runtimeId, modeId);
+    }
+
+    #rememberRuntimeModelPreference(
+        snapshot: AiSessionSnapshot,
+        modelId: string,
+    ): void {
+        if (
+            snapshot.modelId !== modelId ||
+            shouldSkipRuntimeSelectionPreference(snapshot)
+        ) {
+            return;
+        }
+
+        this.#persistence.saveRuntimeModelPreference(snapshot.runtimeId, modelId);
+    }
+
+    #rememberRuntimeConfigPreference(
+        snapshot: AiSessionSnapshot,
+        optionId: string,
+        value: boolean | string,
+    ): void {
+        if (shouldSkipRuntimeSelectionPreference(snapshot)) {
+            return;
+        }
+
+        const option =
+            snapshot.configOptions.find((candidate) => candidate.id === optionId) ??
+            null;
+        if (!option || option.value !== value) {
+            return;
+        }
+
+        if (option.type === "select" && typeof value === "string") {
+            if (isModelConfigOption(option)) {
+                this.#persistence.saveRuntimeModelPreference(
+                    snapshot.runtimeId,
+                    value,
+                );
+            }
+            if (isModeConfigOption(option)) {
+                this.#persistence.saveRuntimeModePreference(
+                    snapshot.runtimeId,
+                    value,
+                );
+            }
+        }
+
+        this.#persistence.saveRuntimeSelectionPreferenceOption(
+            snapshot.runtimeId,
+            optionId,
+            value,
         );
     }
 
@@ -2425,38 +2543,44 @@ export class AiService {
             return snapshot;
         }
 
-        const preferences = this.#persistence.loadRuntimeSelectionPreferences(
-            snapshot.runtimeId,
-        );
+        const preferences =
+            this.#runtimeDefaultPreferencesBySessionId.get(sessionId) ??
+            EMPTY_RUNTIME_SELECTION_PREFERENCES;
         const allowRuntimeDefaults =
-            this.#sessionsWithoutOwnSelections.has(sessionId);
+            this.#runtimeDefaultPreferencesBySessionId.has(sessionId);
         const modelConfig = getModelConfigOption(snapshot.configOptions);
         if (
             !modelConfig &&
-            (allowRuntimeDefaults || !snapshot.modelId) &&
+            allowRuntimeDefaults &&
             preferences.modelId &&
             preferences.modelId !== snapshot.modelId &&
             snapshot.models.some((model) => model.id === preferences.modelId)
         ) {
-            await this.setSessionModel({
-                modelId: preferences.modelId,
-                sessionId,
-            });
+            await this.#setSessionModel(
+                {
+                    modelId: preferences.modelId,
+                    sessionId,
+                },
+                { rememberPreference: false },
+            );
             snapshot = this.#liveSnapshots.get(sessionId) ?? snapshot;
         }
 
         const modeConfig = getModeConfigOption(snapshot.configOptions);
         if (
             !modeConfig &&
-            (allowRuntimeDefaults || !snapshot.modeId) &&
+            allowRuntimeDefaults &&
             preferences.modeId &&
             preferences.modeId !== snapshot.modeId &&
             snapshot.modes.some((mode) => mode.id === preferences.modeId)
         ) {
-            await this.setSessionMode({
-                modeId: preferences.modeId,
-                sessionId,
-            });
+            await this.#setSessionMode(
+                {
+                    modeId: preferences.modeId,
+                    sessionId,
+                },
+                { rememberPreference: false },
+            );
             snapshot = this.#liveSnapshots.get(sessionId) ?? snapshot;
         }
 
@@ -2468,11 +2592,14 @@ export class AiService {
             },
         );
         for (const mutation of mutations) {
-            await this.setSessionConfigOption({
-                optionId: mutation.optionId,
-                sessionId,
-                value: mutation.value,
-            });
+            await this.#setSessionConfigOption(
+                {
+                    optionId: mutation.optionId,
+                    sessionId,
+                    value: mutation.value,
+                },
+                { rememberPreference: false },
+            );
             snapshot = this.#liveSnapshots.get(sessionId) ?? snapshot;
         }
 
@@ -2480,7 +2607,7 @@ export class AiService {
             allowRuntimeDefaults &&
             snapshotHasEffectiveSelections(snapshot)
         ) {
-            this.#sessionsWithoutOwnSelections.delete(sessionId);
+            this.#runtimeDefaultPreferencesBySessionId.delete(sessionId);
         }
 
         return snapshot;
@@ -3338,10 +3465,15 @@ export class AiService {
             );
         }
 
+        const liveSnapshot = this.#liveSnapshots.get(input.sessionId) ?? null;
+        const storedSnapshot =
+            !snapshotOverride && !liveSnapshot
+                ? await this.#loadPersistedSessionSnapshot(input.sessionId)
+                : null;
         const sourceSnapshot =
             snapshotOverride ??
-            this.#liveSnapshots.get(input.sessionId) ??
-            (await this.#loadPersistedSessionSnapshot(input.sessionId)) ??
+            liveSnapshot ??
+            storedSnapshot ??
             createEmptyAiSessionSnapshot({
                 projectId: input.projectId,
                 runtimeId: input.runtimeId,
@@ -3351,10 +3483,26 @@ export class AiService {
             });
         const persistedSnapshot =
             this.#hydrateSnapshotRuntimeCatalog(sourceSnapshot);
-        if (hasAnySessionSelectionValue(sourceSnapshot)) {
-            this.#sessionsWithoutOwnSelections.delete(input.sessionId);
+        const shouldUseRuntimeDefaults =
+            !snapshotOverride &&
+            !liveSnapshot &&
+            !storedSnapshot &&
+            !sourceSnapshot.parentSessionId &&
+            !hasAnySessionSelectionValue(sourceSnapshot);
+        const runtimeDefaultPreferences = shouldUseRuntimeDefaults
+            ? cloneRuntimeSelectionPreferences(
+                  this.#persistence.loadRuntimeSelectionPreferences(
+                      input.runtimeId,
+                  ),
+              )
+            : EMPTY_RUNTIME_SELECTION_PREFERENCES;
+        if (shouldUseRuntimeDefaults) {
+            this.#runtimeDefaultPreferencesBySessionId.set(
+                input.sessionId,
+                runtimeDefaultPreferences,
+            );
         } else {
-            this.#sessionsWithoutOwnSelections.add(input.sessionId);
+            this.#runtimeDefaultPreferencesBySessionId.delete(input.sessionId);
         }
         const persistedSubagentSessionMappings =
             await this.#listPersistedRuntimeMappingsForParent(
@@ -3365,9 +3513,9 @@ export class AiService {
             additionalRoots,
             cwd: projectRoot ?? process.cwd(),
             desiredSelections: this.#resolveDesiredSelections(
-                input.runtimeId,
                 persistedSnapshot,
                 sourceSnapshot,
+                { runtimePreferences: runtimeDefaultPreferences },
             ),
             input: {
                 ...input,
@@ -4289,20 +4437,23 @@ export class AiService {
     }
 
     #resolveDesiredSelections(
-        runtimeId: AiRuntimeId,
         persistedSnapshot: Pick<
             AiSessionSnapshot,
             "configOptions" | "modeId" | "modelId"
         >,
         sourceSnapshot: Pick<
             AiSessionSnapshot,
-            "configOptions" | "modeId" | "modelId" | "reasoningEffort"
+            | "configOptions"
+            | "modeId"
+            | "modelId"
+            | "parentSessionId"
+            | "reasoningEffort"
         >,
+        options: { readonly runtimePreferences: RuntimeSelectionPreferences },
     ): Pick<AiSessionSnapshot, "configOptions" | "modeId" | "modelId"> & {
         readonly preferredConfigOptions: Record<string, boolean | string>;
     } {
-        const preferences =
-            this.#persistence.loadRuntimeSelectionPreferences(runtimeId);
+        const preferences = options.runtimePreferences;
         const sessionSelections = getSessionSelectionValues(sourceSnapshot);
         const preferredModeId =
             sessionSelections.modeId ??
@@ -5132,6 +5283,12 @@ interface SessionSelectionValues {
     readonly reasoningEffort: string | null;
 }
 
+interface RuntimeSelectionPreferences {
+    readonly configOptions: Record<string, boolean | string>;
+    readonly modeId: string | null;
+    readonly modelId: string | null;
+}
+
 const EMPTY_SESSION_SELECTION_VALUES: SessionSelectionValues = {
     configOptions: {},
     modeId: null,
@@ -5139,16 +5296,28 @@ const EMPTY_SESSION_SELECTION_VALUES: SessionSelectionValues = {
     reasoningEffort: null,
 };
 
+const EMPTY_RUNTIME_SELECTION_PREFERENCES: RuntimeSelectionPreferences = {
+    configOptions: {},
+    modeId: null,
+    modelId: null,
+};
+
+function cloneRuntimeSelectionPreferences(
+    preferences: RuntimeSelectionPreferences,
+): RuntimeSelectionPreferences {
+    return {
+        configOptions: { ...preferences.configOptions },
+        modeId: preferences.modeId,
+        modelId: preferences.modelId,
+    };
+}
+
 function getPreferredConfigOptionMutations(
     snapshot: Pick<
         AiSessionSnapshot,
         "configOptions" | "modeId" | "modelId" | "reasoningEffort"
     >,
-    preferences: {
-        readonly configOptions: Record<string, boolean | string>;
-        readonly modeId: string | null;
-        readonly modelId: string | null;
-    },
+    preferences: RuntimeSelectionPreferences,
     options: { readonly applyRuntimeDefaults?: boolean } = {},
 ): readonly PreferredConfigOptionMutation[] {
     const sessionSelections = options.applyRuntimeDefaults
@@ -5336,6 +5505,12 @@ function isModeConfigOption(option: AiSessionConfigOption): boolean {
 
 function isModelConfigOption(option: AiSessionConfigOption): boolean {
     return option.category === "model" || option.id.toLowerCase() === "model";
+}
+
+function shouldSkipRuntimeSelectionPreference(
+    snapshot: Pick<AiSessionSnapshot, "parentSessionId" | "runtimeId">,
+): boolean {
+    return snapshot.runtimeId === "codex" && Boolean(snapshot.parentSessionId);
 }
 
 function clearRestoredSnapshotReviewState(

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -442,9 +442,9 @@ export class AiService {
             readonly order: number;
         }
     >();
-    readonly #runtimeDefaultPreferencesBySessionId = new Map<
+    readonly #capturedRuntimeDefaultsBySessionId = new Map<
         string,
-        RuntimeSelectionPreferences
+        CapturedRuntimeDefaults
     >();
     #nativeAi: NativeAiGateway | null;
     readonly #nativeAuthMigratedRuntimeIds = new Set<AiRuntimeId>();
@@ -781,7 +781,7 @@ export class AiService {
             updatedAt,
             { emitUpdate: true },
         );
-        this.#scheduleLiveSelectionPreferenceReconciliation(
+        this.#scheduleCapturedRuntimeDefaultsApplication(
             ownerWindowId,
             sessionId,
         );
@@ -1258,7 +1258,7 @@ export class AiService {
                 ownerWindowId,
             );
             const reconciledSnapshot =
-                await this.#reconcileLiveSelectionPreferences(
+                await this.#applyCapturedRuntimeDefaults(
                     acceptedSnapshot.sessionId,
                     ownerWindowId,
                 );
@@ -1356,7 +1356,7 @@ export class AiService {
                             snapshot,
                             ownerWindowId,
                         );
-                        await this.#reconcileLiveSelectionPreferences(
+                        await this.#applyCapturedRuntimeDefaults(
                             snapshot.sessionId,
                             ownerWindowId,
                         );
@@ -1434,12 +1434,12 @@ export class AiService {
     }
 
     async setSessionMode(input: AiSessionModeMutationInput): Promise<void> {
-        await this.#setSessionMode(input, { rememberPreference: true });
+        await this.#setSessionMode(input, { rememberRuntimePreference: true });
     }
 
     async #setSessionMode(
         input: AiSessionModeMutationInput,
-        options: { readonly rememberPreference: boolean },
+        options: { readonly rememberRuntimePreference: boolean },
     ): Promise<void> {
         if (!this.#liveSessionContexts.has(input.sessionId)) {
             const snapshot = await this.#updateSessionSnapshot(
@@ -1447,7 +1447,7 @@ export class AiService {
                 (currentSnapshot) =>
                     setModeOnSnapshot(currentSnapshot, input.modeId),
             );
-            if (options.rememberPreference) {
+            if (options.rememberRuntimePreference) {
                 this.#rememberRuntimeModePreference(snapshot, input.modeId);
             }
             return;
@@ -1459,18 +1459,18 @@ export class AiService {
             (currentSnapshot) =>
                 setModeOnSnapshot(currentSnapshot, input.modeId),
         );
-        if (options.rememberPreference) {
+        if (options.rememberRuntimePreference) {
             this.#rememberRuntimeModePreference(snapshot, input.modeId);
         }
     }
 
     async setSessionModel(input: AiSessionModelMutationInput): Promise<void> {
-        await this.#setSessionModel(input, { rememberPreference: true });
+        await this.#setSessionModel(input, { rememberRuntimePreference: true });
     }
 
     async #setSessionModel(
         input: AiSessionModelMutationInput,
-        options: { readonly rememberPreference: boolean },
+        options: { readonly rememberRuntimePreference: boolean },
     ): Promise<void> {
         if (!this.#liveSessionContexts.has(input.sessionId)) {
             const snapshot = await this.#updateSessionSnapshot(
@@ -1478,7 +1478,7 @@ export class AiService {
                 (currentSnapshot) =>
                     setModelOnSnapshot(currentSnapshot, input.modelId),
             );
-            if (options.rememberPreference) {
+            if (options.rememberRuntimePreference) {
                 this.#rememberRuntimeModelPreference(snapshot, input.modelId);
             }
             return;
@@ -1490,7 +1490,7 @@ export class AiService {
             (currentSnapshot) =>
                 setModelOnSnapshot(currentSnapshot, input.modelId),
         );
-        if (options.rememberPreference) {
+        if (options.rememberRuntimePreference) {
             this.#rememberRuntimeModelPreference(snapshot, input.modelId);
         }
     }
@@ -1499,13 +1499,13 @@ export class AiService {
         input: AiSessionConfigOptionMutationInput,
     ): Promise<void> {
         await this.#setSessionConfigOption(input, {
-            rememberPreference: true,
+            rememberRuntimePreference: true,
         });
     }
 
     async #setSessionConfigOption(
         input: AiSessionConfigOptionMutationInput,
-        options: { readonly rememberPreference: boolean },
+        options: { readonly rememberRuntimePreference: boolean },
     ): Promise<void> {
         if (!this.#liveSessionContexts.has(input.sessionId)) {
             const snapshot = await this.#updateSessionSnapshot(
@@ -1517,7 +1517,7 @@ export class AiService {
                         input.value,
                     ),
             );
-            if (options.rememberPreference) {
+            if (options.rememberRuntimePreference) {
                 this.#rememberRuntimeConfigPreference(
                     snapshot,
                     input.optionId,
@@ -1537,7 +1537,7 @@ export class AiService {
                     input.value,
                 ),
         );
-        if (options.rememberPreference) {
+        if (options.rememberRuntimePreference) {
             this.#rememberRuntimeConfigPreference(
                 snapshot,
                 input.optionId,
@@ -2533,7 +2533,7 @@ export class AiService {
         return cachedSnapshot;
     }
 
-    async #reconcileLiveSelectionPreferences(
+    async #applyCapturedRuntimeDefaults(
         sessionId: string,
         ownerWindowId: string,
     ): Promise<AiSessionSnapshot | null> {
@@ -2543,25 +2543,25 @@ export class AiService {
             return snapshot;
         }
 
-        const preferences =
-            this.#runtimeDefaultPreferencesBySessionId.get(sessionId) ??
-            EMPTY_RUNTIME_SELECTION_PREFERENCES;
-        const allowRuntimeDefaults =
-            this.#runtimeDefaultPreferencesBySessionId.has(sessionId);
+        const capturedDefaults =
+            this.#capturedRuntimeDefaultsBySessionId.get(sessionId) ??
+            EMPTY_CAPTURED_RUNTIME_DEFAULTS;
+        const canApplyCapturedDefaults =
+            this.#capturedRuntimeDefaultsBySessionId.has(sessionId);
         const modelConfig = getModelConfigOption(snapshot.configOptions);
         if (
             !modelConfig &&
-            allowRuntimeDefaults &&
-            preferences.modelId &&
-            preferences.modelId !== snapshot.modelId &&
-            snapshot.models.some((model) => model.id === preferences.modelId)
+            canApplyCapturedDefaults &&
+            capturedDefaults.modelId &&
+            capturedDefaults.modelId !== snapshot.modelId &&
+            snapshot.models.some((model) => model.id === capturedDefaults.modelId)
         ) {
             await this.#setSessionModel(
                 {
-                    modelId: preferences.modelId,
+                    modelId: capturedDefaults.modelId,
                     sessionId,
                 },
-                { rememberPreference: false },
+                { rememberRuntimePreference: false },
             );
             snapshot = this.#liveSnapshots.get(sessionId) ?? snapshot;
         }
@@ -2569,26 +2569,26 @@ export class AiService {
         const modeConfig = getModeConfigOption(snapshot.configOptions);
         if (
             !modeConfig &&
-            allowRuntimeDefaults &&
-            preferences.modeId &&
-            preferences.modeId !== snapshot.modeId &&
-            snapshot.modes.some((mode) => mode.id === preferences.modeId)
+            canApplyCapturedDefaults &&
+            capturedDefaults.modeId &&
+            capturedDefaults.modeId !== snapshot.modeId &&
+            snapshot.modes.some((mode) => mode.id === capturedDefaults.modeId)
         ) {
             await this.#setSessionMode(
                 {
-                    modeId: preferences.modeId,
+                    modeId: capturedDefaults.modeId,
                     sessionId,
                 },
-                { rememberPreference: false },
+                { rememberRuntimePreference: false },
             );
             snapshot = this.#liveSnapshots.get(sessionId) ?? snapshot;
         }
 
-        const mutations = getPreferredConfigOptionMutations(
+        const mutations = getCapturedRuntimeDefaultMutations(
             snapshot,
-            preferences,
+            capturedDefaults,
             {
-                applyRuntimeDefaults: allowRuntimeDefaults,
+                applyCapturedDefaults: canApplyCapturedDefaults,
             },
         );
         for (const mutation of mutations) {
@@ -2598,30 +2598,30 @@ export class AiService {
                     sessionId,
                     value: mutation.value,
                 },
-                { rememberPreference: false },
+                { rememberRuntimePreference: false },
             );
             snapshot = this.#liveSnapshots.get(sessionId) ?? snapshot;
         }
 
         if (
-            allowRuntimeDefaults &&
+            canApplyCapturedDefaults &&
             snapshotHasEffectiveSelections(snapshot)
         ) {
-            this.#runtimeDefaultPreferencesBySessionId.delete(sessionId);
+            this.#capturedRuntimeDefaultsBySessionId.delete(sessionId);
         }
 
         return snapshot;
     }
 
-    #scheduleLiveSelectionPreferenceReconciliation(
+    #scheduleCapturedRuntimeDefaultsApplication(
         ownerWindowId: string,
         sessionId: string,
     ): void {
-        void this.#reconcileLiveSelectionPreferences(
+        void this.#applyCapturedRuntimeDefaults(
             sessionId,
             ownerWindowId,
         ).catch((error: unknown) => {
-            debugBenignError("ai.service.selectionPreferenceReconcile", error);
+            debugBenignError("ai.service.capturedRuntimeDefaults", error);
         });
     }
 
@@ -3483,26 +3483,26 @@ export class AiService {
             });
         const persistedSnapshot =
             this.#hydrateSnapshotRuntimeCatalog(sourceSnapshot);
-        const shouldUseRuntimeDefaults =
+        const shouldCaptureRuntimeDefaults =
             !snapshotOverride &&
             !liveSnapshot &&
             !storedSnapshot &&
             !sourceSnapshot.parentSessionId &&
             !hasAnySessionSelectionValue(sourceSnapshot);
-        const runtimeDefaultPreferences = shouldUseRuntimeDefaults
-            ? cloneRuntimeSelectionPreferences(
+        const capturedRuntimeDefaults = shouldCaptureRuntimeDefaults
+            ? cloneCapturedRuntimeDefaults(
                   this.#persistence.loadRuntimeSelectionPreferences(
                       input.runtimeId,
                   ),
               )
-            : EMPTY_RUNTIME_SELECTION_PREFERENCES;
-        if (shouldUseRuntimeDefaults) {
-            this.#runtimeDefaultPreferencesBySessionId.set(
+            : EMPTY_CAPTURED_RUNTIME_DEFAULTS;
+        if (shouldCaptureRuntimeDefaults) {
+            this.#capturedRuntimeDefaultsBySessionId.set(
                 input.sessionId,
-                runtimeDefaultPreferences,
+                capturedRuntimeDefaults,
             );
         } else {
-            this.#runtimeDefaultPreferencesBySessionId.delete(input.sessionId);
+            this.#capturedRuntimeDefaultsBySessionId.delete(input.sessionId);
         }
         const persistedSubagentSessionMappings =
             await this.#listPersistedRuntimeMappingsForParent(
@@ -3515,7 +3515,7 @@ export class AiService {
             desiredSelections: this.#resolveDesiredSelections(
                 persistedSnapshot,
                 sourceSnapshot,
-                { runtimePreferences: runtimeDefaultPreferences },
+                { capturedDefaults: capturedRuntimeDefaults },
             ),
             input: {
                 ...input,
@@ -4449,40 +4449,37 @@ export class AiService {
             | "parentSessionId"
             | "reasoningEffort"
         >,
-        options: { readonly runtimePreferences: RuntimeSelectionPreferences },
-    ): Pick<AiSessionSnapshot, "configOptions" | "modeId" | "modelId"> & {
-        readonly preferredConfigOptions: Record<string, boolean | string>;
-    } {
-        const preferences = options.runtimePreferences;
+        options: { readonly capturedDefaults: CapturedRuntimeDefaults },
+    ): Pick<AiSessionSnapshot, "configOptions" | "modeId" | "modelId"> {
+        const capturedDefaults = options.capturedDefaults;
         const sessionSelections = getSessionSelectionValues(sourceSnapshot);
         const preferredModeId =
             sessionSelections.modeId ??
-            preferences.modeId ??
+            capturedDefaults.modeId ??
             getPreferredConfigSelectionId(
-                preferences.configOptions,
+                capturedDefaults.configOptions,
                 persistedSnapshot.configOptions,
                 isModeConfigOption,
             );
         const preferredModelId =
             sessionSelections.modelId ??
-            preferences.modelId ??
+            capturedDefaults.modelId ??
             getPreferredConfigSelectionId(
-                preferences.configOptions,
+                capturedDefaults.configOptions,
                 persistedSnapshot.configOptions,
                 isModelConfigOption,
             );
 
         return {
-            configOptions: applyRuntimeSelectionPreferencesToConfigOptions(
+            configOptions: applyCapturedRuntimeDefaultsToConfigOptions(
                 persistedSnapshot.configOptions,
-                preferences.configOptions,
+                capturedDefaults.configOptions,
                 preferredModeId,
                 preferredModelId,
                 sessionSelections,
             ),
             modeId: preferredModeId ?? persistedSnapshot.modeId,
             modelId: preferredModelId ?? persistedSnapshot.modelId,
-            preferredConfigOptions: preferences.configOptions,
         };
     }
 
@@ -5201,9 +5198,9 @@ function trimRetentionRecords<T>(records: T[]): void {
     }
 }
 
-function applyRuntimeSelectionPreferencesToConfigOptions(
+function applyCapturedRuntimeDefaultsToConfigOptions(
     configOptions: readonly AiSessionConfigOption[],
-    preferences: Record<string, boolean | string>,
+    capturedDefaults: Record<string, boolean | string>,
     preferredModeId: string | null,
     preferredModelId: string | null,
     sessionSelections: SessionSelectionValues = EMPTY_SESSION_SELECTION_VALUES,
@@ -5215,7 +5212,7 @@ function applyRuntimeSelectionPreferencesToConfigOptions(
         );
         const savedValue =
             sessionValue ??
-            getRuntimeSelectionPreferenceValue(preferences, option.id);
+            getRuntimeSelectionPreferenceValue(capturedDefaults, option.id);
         const preferredValue =
             savedValue ??
             getTopLevelSelectionPreference(
@@ -5283,7 +5280,7 @@ interface SessionSelectionValues {
     readonly reasoningEffort: string | null;
 }
 
-interface RuntimeSelectionPreferences {
+interface CapturedRuntimeDefaults {
     readonly configOptions: Record<string, boolean | string>;
     readonly modeId: string | null;
     readonly modelId: string | null;
@@ -5296,15 +5293,15 @@ const EMPTY_SESSION_SELECTION_VALUES: SessionSelectionValues = {
     reasoningEffort: null,
 };
 
-const EMPTY_RUNTIME_SELECTION_PREFERENCES: RuntimeSelectionPreferences = {
+const EMPTY_CAPTURED_RUNTIME_DEFAULTS: CapturedRuntimeDefaults = {
     configOptions: {},
     modeId: null,
     modelId: null,
 };
 
-function cloneRuntimeSelectionPreferences(
-    preferences: RuntimeSelectionPreferences,
-): RuntimeSelectionPreferences {
+function cloneCapturedRuntimeDefaults(
+    preferences: CapturedRuntimeDefaults,
+): CapturedRuntimeDefaults {
     return {
         configOptions: { ...preferences.configOptions },
         modeId: preferences.modeId,
@@ -5312,15 +5309,15 @@ function cloneRuntimeSelectionPreferences(
     };
 }
 
-function getPreferredConfigOptionMutations(
+function getCapturedRuntimeDefaultMutations(
     snapshot: Pick<
         AiSessionSnapshot,
         "configOptions" | "modeId" | "modelId" | "reasoningEffort"
     >,
-    preferences: RuntimeSelectionPreferences,
-    options: { readonly applyRuntimeDefaults?: boolean } = {},
+    capturedDefaults: CapturedRuntimeDefaults,
+    options: { readonly applyCapturedDefaults?: boolean } = {},
 ): readonly PreferredConfigOptionMutation[] {
-    const sessionSelections = options.applyRuntimeDefaults
+    const sessionSelections = options.applyCapturedDefaults
         ? EMPTY_SESSION_SELECTION_VALUES
         : getSessionSelectionValues(snapshot);
 
@@ -5331,13 +5328,13 @@ function getPreferredConfigOptionMutations(
             }
 
             const savedValue = getRuntimeSelectionPreferenceValue(
-                preferences.configOptions,
+                capturedDefaults.configOptions,
                 option.id,
             );
             const preferredValue = savedValue ?? getTopLevelSelectionPreference(
                 option,
-                preferences.modeId,
-                preferences.modelId,
+                capturedDefaults.modeId,
+                capturedDefaults.modelId,
             );
             if (
                 preferredValue === undefined ||

--- a/src/main/native-backend/ai.test.ts
+++ b/src/main/native-backend/ai.test.ts
@@ -1071,7 +1071,6 @@ function createLaunch(): AiSessionLaunchInput {
             ],
             modeId: "build",
             modelId: "gpt-5",
-            preferredConfigOptions: {},
         },
         input: {
             additionalRoots: ["/workspace/other"],


### PR DESCRIPTION
## Summary

Fixes AI session model, mode, and config-option selection persistence so new sessions open with the last explicit settings used for that runtime, while existing sessions keep their own selections.

## Details

- Saves runtime selection preferences when the user explicitly changes model, mode, or config options.
- Captures runtime defaults at session launch time so late catalog hydration applies the launch-time defaults instead of newer global preferences.
- Avoids applying runtime defaults to restored sessions or sessions that already carry their own selections.
- Preserves inherited Codex subagent configuration from the parent launch context.
- Cleans up internal naming around captured defaults and removes an unused desired-selection field.

## Validation

- `pnpm exec vitest run src/main/ai/service.prepare.test.ts src/main/ai/service.codex.test.ts src/main/native-backend/ai.test.ts`
- `pnpm exec vitest run src/main/ai`
- `pnpm exec eslint src/main/ai/service.ts src/main/ai/contracts.ts src/main/ai/service.prepare.test.ts src/main/ai/service.codex.test.ts src/main/native-backend/ai.test.ts`
- `pnpm run typecheck`
- `git diff --check`
