### PR TITLE
Fix Linux RPM signing key import

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,6 +439,7 @@ jobs:
                   printf '%s' "$LINUX_REPO_GPG_PRIVATE_KEY" | gpg --batch --import
                   gpg --batch --list-secret-keys "$LINUX_REPO_GPG_KEY_ID" >/dev/null
                   gpg --batch --armor --export "$LINUX_REPO_GPG_KEY_ID" > "$RUNNER_TEMP/comando-rpm-signing-key.asc"
+                  rpm --import "$RUNNER_TEMP/comando-rpm-signing-key.asc"
                   sudo rpm --import "$RUNNER_TEMP/comando-rpm-signing-key.asc"
 
                   node scripts/sign-rpm-packages.mjs \


### PR DESCRIPTION
## Summary

- Import the Linux repository GPG public key into the runner user RPM keyring before signing RPMs.
- Keep the existing sudo import so root-owned RPM checks still have the same key available.

## Root cause

The `v0.1.0` release failed in `Linux arm64` during `Sign Linux RPM package`. The package was signed, but `rpm -Kv` ran as the normal runner user and reported `NOKEY` because the workflow had only imported the public key with `sudo rpm --import`.

## Validation

- Cancelled the failed tag workflow run: https://github.com/jsgrrchg/Comando/actions/runs/28707698197
- Parsed `.github/workflows/release.yml` with Ruby YAML loader.
- Local RPM tooling is not installed on this machine, so the full RPM signing path remains verified by rerunning the release workflow.
