### PR TITLE
Fix Windows release publish mode

### DIFF
--- a/scripts/package-windows-app.mjs
+++ b/scripts/package-windows-app.mjs
@@ -146,7 +146,7 @@ function packageWindowsApp(
             unpackedAppDir,
         ],
         {
-        env: process.env,
+            env: process.env,
         },
     );
 
@@ -168,10 +168,23 @@ function prepareWorkspace() {
 }
 
 function resolveElectronBuilderArgs(rawArgs) {
-    const hasArchFlag = rawArgs.some((arg) =>
+    const normalizedArgs = rawArgs.filter(
+        (arg) => !["--", "--win"].includes(arg),
+    );
+    const hasArchFlag = normalizedArgs.some((arg) =>
         ["--x64", "--arm64", "--ia32", "--universal"].includes(arg),
     );
-    const args = ["--win", ...rawArgs.filter((arg) => arg !== "--win")];
+    const hasPublishFlag = normalizedArgs.some(
+        (arg) =>
+            ["--publish", "-p"].includes(arg) ||
+            arg.startsWith("--publish=") ||
+            arg.startsWith("-p="),
+    );
+    const args = ["--win", ...normalizedArgs];
+
+    if (!hasPublishFlag) {
+        args.push("--publish", "never");
+    }
 
     if (hasArchFlag) {
         return args;


### PR DESCRIPTION
## Summary

- Normalize Windows electron-builder args by removing the npm `--` separator before invoking electron-builder.
- Default Windows packaging to `--publish never` unless a publish mode is explicitly provided.
- Preserve explicit publish modes such as `--publish always` for release helper scripts.

## Root cause

The `v0.1.0` release failed in both Windows jobs after NSIS installers were built and signed. Because electron-builder was running under the release tag and did not receive `--publish never` correctly, it enabled implicit GitHub publishing and failed with `GH_TOKEN` missing.

## Validation

- node --check scripts/package-windows-app.mjs
- pnpm run lint
