### PR TITLE
Relax Linux AppImage blockmap validation

### DIFF
--- a/scripts/linux-release-metadata.mjs
+++ b/scripts/linux-release-metadata.mjs
@@ -134,7 +134,6 @@ export function verifyLinuxReleaseArtifacts({
         version,
     });
 
-    assertFile(artifacts.appImageBlockmapPath, relativePath);
     assertFile(artifacts.metadataPath, relativePath);
 
     if (fs.existsSync(artifacts.forbiddenSharedMetadataPath)) {

--- a/scripts/linux-release-metadata.test.mjs
+++ b/scripts/linux-release-metadata.test.mjs
@@ -247,7 +247,7 @@ describe("Linux updater metadata", () => {
                 targetArch: "x64",
                 version: "1.2.3",
             }),
-        ).toThrow(/AppImage\.blockmap/u);
+        ).toThrow(/latest-x64-linux\.yml/u);
     });
 
     it("rejects shared Linux updater metadata", () => {
@@ -309,8 +309,6 @@ function writeReleaseArtifactSet(
     ]) {
         fs.writeFileSync(filePath, "", "utf8");
     }
-
-    fs.writeFileSync(artifacts.appImageBlockmapPath, "", "utf8");
 
     const appImageName = metadataAppImageName ?? path.basename(artifacts.appImagePath);
     fs.writeFileSync(

--- a/scripts/release-target-metadata.mjs
+++ b/scripts/release-target-metadata.mjs
@@ -108,7 +108,6 @@ export function resolveReleaseTargetArtifacts({
             artifactName: target.artifactName,
             files: [
                 artifacts.appImagePath,
-                artifacts.appImageBlockmapPath,
                 artifacts.debPath,
                 artifacts.rpmPath,
                 artifacts.metadataPath,

--- a/scripts/validate-release-assets.test.mjs
+++ b/scripts/validate-release-assets.test.mjs
@@ -213,7 +213,6 @@ function writeLinuxAssets(distDir, targetArch) {
     });
 
     fs.writeFileSync(artifacts.appImagePath, "", "utf8");
-    fs.writeFileSync(artifacts.appImageBlockmapPath, "", "utf8");
     fs.writeFileSync(artifacts.debPath, "", "utf8");
     fs.writeFileSync(artifacts.rpmPath, "", "utf8");
     fs.writeFileSync(


### PR DESCRIPTION
## Summary

- Stop requiring standalone Linux `.AppImage.blockmap` files in staged release assets.
- Keep Linux AppImage, deb, rpm, and architecture-specific updater metadata required.
- Update release metadata tests and validate-release-assets fixtures for both Linux architectures.

## Root cause

The `v0.1.0` release reached `Validate release assets` after all platform builds passed, but failed because Linux AppImage blockmap files were expected as standalone artifacts. The actual Linux artifacts include AppImage/deb/rpm plus updater metadata; the `.AppImage.blockmap` files are not present in the uploaded artifacts.

## Validation

- node --check scripts/release-target-metadata.mjs
- node --check scripts/linux-release-metadata.mjs
- node --check scripts/validate-release-assets.mjs
- pnpm exec vitest run scripts/linux-release-metadata.test.mjs scripts/validate-release-assets.test.mjs
- pnpm exec vitest run scripts/*.test.mjs
