### PR TITLE
Add Claude Agent ACP upstream watcher

### DIFF
--- a/.github/workflows/watch-claude-agent-acp-upstream.yml
+++ b/.github/workflows/watch-claude-agent-acp-upstream.yml
@@ -1,0 +1,34 @@
+name: Watch Claude Agent ACP Upstream
+
+on:
+    schedule:
+        - cron: "0 9 * * *"
+    workflow_dispatch:
+
+concurrency:
+    group: watch-claude-agent-acp-upstream
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+    issues: write
+
+jobs:
+    watch:
+        name: Check upstream tag
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 22
+
+            - name: Check upstream tag
+              run: node scripts/watch-claude-agent-acp-upstream.mjs
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/watch-claude-agent-acp-upstream.mjs
+++ b/scripts/watch-claude-agent-acp-upstream.mjs
@@ -1,0 +1,309 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+const UPSTREAM_OWNER = "agentclientprotocol";
+const UPSTREAM_REPO = "claude-agent-acp";
+const UPSTREAM_NAME = `${UPSTREAM_OWNER}/${UPSTREAM_REPO}`;
+const VENDORED_PACKAGE_PATH = "vendor/Claude-agent-acp-upstream/package.json";
+const VENDORED_PACKAGE_JSON_PATH = path.join(REPO_ROOT, VENDORED_PACKAGE_PATH);
+const ISSUE_LABEL = "upstream-update";
+const ISSUE_LABEL_COLOR = "0e8a16";
+const ISSUE_LABEL_DESCRIPTION = "Tracks vendored upstream dependency updates.";
+
+function parseArgs(argv) {
+    const args = { dryRun: false };
+
+    for (const arg of argv) {
+        if (arg === "--dry-run") {
+            args.dryRun = true;
+            continue;
+        }
+
+        throw new Error(`Unknown argument "${arg}". Supported args: --dry-run`);
+    }
+
+    return args;
+}
+
+function readJsonFile(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function parseSemver(value) {
+    const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(value);
+    if (!match) {
+        return null;
+    }
+
+    return {
+        major: Number(match[1]),
+        minor: Number(match[2]),
+        patch: Number(match[3]),
+        version: `${match[1]}.${match[2]}.${match[3]}`,
+    };
+}
+
+function compareSemver(left, right) {
+    for (const key of ["major", "minor", "patch"]) {
+        if (left[key] !== right[key]) {
+            return left[key] - right[key];
+        }
+    }
+
+    return 0;
+}
+
+function getGitHubRepo() {
+    const repository = process.env.GITHUB_REPOSITORY;
+    if (!repository || !repository.includes("/")) {
+        throw new Error("GITHUB_REPOSITORY must be set to owner/repo.");
+    }
+
+    const [owner, repo] = repository.split("/");
+    return { owner, repo };
+}
+
+function getGitHubToken() {
+    const token = process.env.GITHUB_TOKEN;
+    if (!token) {
+        throw new Error("GITHUB_TOKEN must be set.");
+    }
+
+    return token;
+}
+
+async function githubRequest(pathname, options = {}) {
+    const token = options.token;
+    const response = await fetch(`https://api.github.com${pathname}`, {
+        method: options.method ?? "GET",
+        headers: {
+            Accept: "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+            ...(options.body ? { "Content-Type": "application/json" } : {}),
+        },
+        body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+    const allowedStatuses = options.allowedStatuses ?? [200];
+
+    if (!allowedStatuses.includes(response.status)) {
+        throw new Error(
+            `GitHub API request failed: ${response.status} ${response.statusText} ${pathname}\n${text}`,
+        );
+    }
+
+    return { response, data };
+}
+
+async function fetchUpstreamTags() {
+    const tags = [];
+
+    for (let page = 1; page <= 10; page += 1) {
+        const { data } = await githubRequest(
+            `/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tags?per_page=100&page=${page}`,
+            { allowedStatuses: [200] },
+        );
+
+        tags.push(...data);
+
+        if (data.length < 100) {
+            break;
+        }
+    }
+
+    return tags;
+}
+
+async function getLatestStableUpstreamTag() {
+    const tags = await fetchUpstreamTags();
+    const stableTags = tags
+        .map((tag) => ({ name: tag.name, semver: parseSemver(tag.name) }))
+        .filter((tag) => tag.semver);
+
+    if (stableTags.length === 0) {
+        throw new Error(`No stable semver tags found in ${UPSTREAM_NAME}.`);
+    }
+
+    stableTags.sort((left, right) => compareSemver(right.semver, left.semver));
+    return stableTags[0];
+}
+
+function buildIssueTitle(latestTag) {
+    return `Upstream claude-agent-acp released ${latestTag.name}`;
+}
+
+function buildIssueBody(latestTag, vendoredVersion) {
+    return [
+        "A new upstream tag is available.",
+        "",
+        `- Upstream: ${UPSTREAM_NAME}`,
+        `- Latest tag: ${latestTag.name}`,
+        `- Vendored version: ${vendoredVersion}`,
+        `- Vendored package: \`${VENDORED_PACKAGE_PATH}\``,
+        "",
+        "Review and update the vendored upstream package when convenient.",
+    ].join("\n");
+}
+
+function issueMatchesUpstream(issue) {
+    return (
+        !issue.pull_request &&
+        issue.body?.includes(`- Upstream: ${UPSTREAM_NAME}`) &&
+        issue.body?.includes(`- Vendored package: \`${VENDORED_PACKAGE_PATH}\``)
+    );
+}
+
+async function findOpenIssueForUpstream(owner, repo, token) {
+    const query = new URLSearchParams({
+        state: "open",
+        labels: ISSUE_LABEL,
+        per_page: "100",
+    });
+    const { data } = await githubRequest(
+        `/repos/${owner}/${repo}/issues?${query}`,
+        { token },
+    );
+
+    return data.find(issueMatchesUpstream);
+}
+
+async function ensureIssueLabel(owner, repo, token) {
+    const labelPath = `/repos/${owner}/${repo}/labels/${encodeURIComponent(ISSUE_LABEL)}`;
+    const existing = await githubRequest(labelPath, {
+        token,
+        allowedStatuses: [200, 404],
+    });
+
+    if (existing.response.status === 200) {
+        return;
+    }
+
+    await githubRequest(`/repos/${owner}/${repo}/labels`, {
+        method: "POST",
+        token,
+        allowedStatuses: [201],
+        body: {
+            name: ISSUE_LABEL,
+            color: ISSUE_LABEL_COLOR,
+            description: ISSUE_LABEL_DESCRIPTION,
+        },
+    });
+}
+
+async function createIssue(owner, repo, token, latestTag, vendoredVersion) {
+    const { data } = await githubRequest(`/repos/${owner}/${repo}/issues`, {
+        method: "POST",
+        token,
+        allowedStatuses: [201],
+        body: {
+            title: buildIssueTitle(latestTag),
+            body: buildIssueBody(latestTag, vendoredVersion),
+            labels: [ISSUE_LABEL],
+        },
+    });
+
+    return data;
+}
+
+async function updateIssue(owner, repo, token, issue, latestTag, vendoredVersion) {
+    const title = buildIssueTitle(latestTag);
+    const body = buildIssueBody(latestTag, vendoredVersion);
+
+    if (issue.title === title && issue.body === body) {
+        return { updated: false, issue };
+    }
+
+    const { data } = await githubRequest(
+        `/repos/${owner}/${repo}/issues/${issue.number}`,
+        {
+            method: "PATCH",
+            token,
+            allowedStatuses: [200],
+            body: { title, body },
+        },
+    );
+
+    if (issue.title !== title) {
+        await githubRequest(`/repos/${owner}/${repo}/issues/${issue.number}/comments`, {
+            method: "POST",
+            token,
+            allowedStatuses: [201],
+            body: {
+                body: `Upstream is now ${latestTag.name}; vendored version is still ${vendoredVersion}.`,
+            },
+        });
+    }
+
+    return { updated: true, issue: data };
+}
+
+async function main() {
+    const { dryRun } = parseArgs(process.argv.slice(2));
+    const vendoredPackageJson = readJsonFile(VENDORED_PACKAGE_JSON_PATH);
+    const vendoredSemver = parseSemver(vendoredPackageJson.version);
+
+    if (!vendoredSemver) {
+        throw new Error(
+            `Vendored package version "${vendoredPackageJson.version}" is not strict semver.`,
+        );
+    }
+
+    const latestTag = await getLatestStableUpstreamTag();
+
+    if (compareSemver(latestTag.semver, vendoredSemver) <= 0) {
+        console.log(
+            `Vendored ${UPSTREAM_REPO} is current: ${vendoredPackageJson.version}. Latest upstream tag is ${latestTag.name}.`,
+        );
+        return;
+    }
+
+    if (dryRun) {
+        console.log(
+            `Dry run: upstream ${latestTag.name} is newer than vendored ${vendoredPackageJson.version}.`,
+        );
+        return;
+    }
+
+    const { owner, repo } = getGitHubRepo();
+    const token = getGitHubToken();
+    await ensureIssueLabel(owner, repo, token);
+
+    const existingIssue = await findOpenIssueForUpstream(owner, repo, token);
+
+    if (existingIssue) {
+        const { updated, issue } = await updateIssue(
+            owner,
+            repo,
+            token,
+            existingIssue,
+            latestTag,
+            vendoredPackageJson.version,
+        );
+        console.log(
+            updated
+                ? `Updated issue: ${issue.html_url}`
+                : `Issue already up to date: ${issue.html_url}`,
+        );
+        return;
+    }
+
+    const issue = await createIssue(
+        owner,
+        repo,
+        token,
+        latestTag,
+        vendoredPackageJson.version,
+    );
+
+    console.log(`Created issue: ${issue.html_url}`);
+}
+
+await main();


### PR DESCRIPTION
## Summary
- Add a scheduled GitHub Actions workflow that checks the vendored Claude Agent ACP package against upstream tags.
- Add a Node script that opens or updates a single tracking issue when the vendored package falls behind.
- Keep one open upstream-update issue per upstream/vendor pair, updating it instead of creating duplicates as upstream advances.

## Validation
- `node --check scripts/watch-claude-agent-acp-upstream.mjs`
- `node scripts/watch-claude-agent-acp-upstream.mjs --dry-run`
