### PR TITLE
Update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/electron-package-smoke.yml
+++ b/.github/workflows/electron-package-smoke.yml
@@ -117,7 +117,7 @@ jobs:
 
             - name: Upload macOS package artifacts
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: macos-universal-smoke-dist
                   path: build/macos-package/project/dist/*
@@ -166,7 +166,7 @@ jobs:
 
             - name: Upload Windows package artifacts
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: windows-x64-smoke-dist
                   path: dist/*
@@ -215,7 +215,7 @@ jobs:
 
             - name: Upload Windows arm64 package artifacts
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: windows-arm64-smoke-dist
                   path: dist/*
@@ -281,7 +281,7 @@ jobs:
 
             - name: Upload Linux package artifacts
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: linux-${{ matrix.arch }}-smoke-dist
                   path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,12 @@ jobs:
         env:
             NODE_OPTIONS: --max-old-space-size=8192
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
 
@@ -83,16 +83,16 @@ jobs:
         env:
             NODE_OPTIONS: --max-old-space-size=8192
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@v6
               with:
                   version: 10.33.0
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm
@@ -191,16 +191,16 @@ jobs:
             CSC_LINK: ${{ secrets.CSC_LINK }}
             NODE_OPTIONS: --max-old-space-size=8192
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@v6
               with:
                   version: 10.33.0
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm
@@ -299,16 +299,16 @@ jobs:
             CSC_IDENTITY_AUTO_DISCOVERY: "false"
             NODE_OPTIONS: --max-old-space-size=8192
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@v6
               with:
                   version: 10.33.0
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm
@@ -342,16 +342,16 @@ jobs:
             CSC_IDENTITY_AUTO_DISCOVERY: "false"
             NODE_OPTIONS: --max-old-space-size=8192
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@v6
               with:
                   version: 10.33.0
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm
@@ -397,16 +397,16 @@ jobs:
             LINUX_REPO_GPG_KEY_ID: ${{ secrets.LINUX_REPO_GPG_KEY_ID || secrets.APT_REPO_GPG_KEY_ID }}
             NODE_OPTIONS: --max-old-space-size=8192
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@v6
               with:
                   version: 10.33.0
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm
@@ -488,12 +488,12 @@ jobs:
             - build-linux
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
 
@@ -525,7 +525,7 @@ jobs:
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
@@ -579,12 +579,12 @@ jobs:
             LINUX_REPO_GPG_KEY_ID: ${{ secrets.LINUX_REPO_GPG_KEY_ID || secrets.APT_REPO_GPG_KEY_ID }}
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
 
@@ -795,12 +795,12 @@ jobs:
             LINUX_REPO_GPG_PASSPHRASE: ${{ secrets.LINUX_REPO_GPG_PASSPHRASE || secrets.APT_REPO_GPG_PASSPHRASE }}
             LINUX_REPO_GPG_KEY_ID: ${{ secrets.LINUX_REPO_GPG_KEY_ID || secrets.APT_REPO_GPG_KEY_ID }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
                   test -s release-body.md
 
             - name: Upload release body
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: release-body-${{ env.RELEASE_TAG }}
                   path: release-body.md
@@ -281,7 +281,7 @@ jobs:
               run: pnpm run package:mac -- --config.forceCodeSigning=true
 
             - name: Stage macOS release assets
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: release-assets-macos-universal
                   path: |
@@ -325,7 +325,7 @@ jobs:
               run: pnpm run package:win:x64 -- --publish never
 
             - name: Stage Windows x64 release assets
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: release-assets-windows-x64
                   path: |
@@ -368,7 +368,7 @@ jobs:
               run: pnpm run package:win:arm64 -- --publish never
 
             - name: Stage Windows arm64 release assets
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: release-assets-windows-arm64
                   path: |
@@ -455,7 +455,7 @@ jobs:
                     --require-signature
 
             - name: Stage Linux release assets
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: release-assets-linux-${{ matrix.arch }}
                   path: |
@@ -468,7 +468,7 @@ jobs:
 
             - name: Upload Linux package artifacts on failure
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: release-linux-${{ matrix.arch }}-failure-dist
                   path: |
@@ -498,7 +498,7 @@ jobs:
                   node-version: 22
 
             - name: Download staged release assets
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   pattern: release-assets-*
                   path: .artifacts/release-assets
@@ -531,13 +531,13 @@ jobs:
                   ref: ${{ env.RELEASE_TAG }}
 
             - name: Download release body
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   name: release-body-${{ needs.prepare.outputs.tag }}
                   path: .release
 
             - name: Download staged release assets
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   pattern: release-assets-*
                   path: .artifacts/release-assets
@@ -594,7 +594,7 @@ jobs:
                   sudo apt-get install -y ca-certificates dpkg gnupg gzip
 
             - name: Download staged Linux release assets
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   pattern: release-assets-linux-*
                   path: .artifacts/linux
@@ -810,7 +810,7 @@ jobs:
                   sudo apt-get install -y createrepo-c gnupg gzip rpm
 
             - name: Download staged Linux release assets
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   pattern: release-assets-linux-*
                   path: .artifacts/linux

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,6 +305,8 @@ pnpm release:win:arm64
 pnpm release:linux
 ```
 
+GitHub-hosted release and package smoke workflows use JavaScript actions that require runners compatible with the GitHub Actions Node 24 runtime.
+
 ## Versioning
 
 Comando follows Semantic Versioning. During the `0.x` phase, minor bumps may include breaking changes.


### PR DESCRIPTION
## Summary

- Update release workflow setup actions to Node 24-compatible majors.
- Update release and package smoke artifact actions to Node 24-compatible majors.
- Document the GitHub Actions Node 24 runner compatibility expectation for release/package smoke workflows.

## Why

Closes #84.

GitHub Actions is moving JavaScript actions off the Node 20 runtime. The project already installs Node 22 for its own build scripts; this PR updates the action versions themselves so their internal runtime is Node 24-compatible.

## Validation

- `rg -n "node-version: 20|node20|@v4|@v5" .github/workflows .github/actions`
- `rg -n "actions/(checkout|setup-node|upload-artifact|download-artifact)@v4|pnpm/action-setup@v4|node20|node-version: 20" .github/workflows .github/actions`
- Reviewed artifact action inputs after the version updates.
- Confirmed no workflows under `vendor/` were modified.

