### PR TITLE
Preserve tool activity timeline anchors

### DIFF
--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -789,6 +789,7 @@ describe("ai-store queue", () => {
             updatedAt: "2026-04-14T00:00:01.000Z",
         });
         const updatedTool = createToolActivity({
+            createdAt: "2026-04-14T00:00:20.000Z",
             id: "tool-1",
             status: "completed",
             summary: "Tests passed",
@@ -826,7 +827,12 @@ describe("ai-store queue", () => {
             useAiStore.getState().sessions[TAB.sessionId]?.snapshot ?? null;
         expect(resyncAiSession).toHaveBeenCalledWith(TAB.sessionId);
         expect(snapshot?.status).toBe("idle");
-        expect(snapshot?.toolActivity).toEqual([updatedTool]);
+        expect(snapshot?.toolActivity).toEqual([
+            {
+                ...updatedTool,
+                createdAt: "2026-04-14T00:00:00.000Z",
+            },
+        ]);
     });
 
     it("applies a prepared runtime session snapshot from the backend", async () => {

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -2679,6 +2679,7 @@ function upsertToolActivity(
     const nextActivities = [...activity];
     nextActivities[index] = {
         ...nextActivity,
+        createdAt: existing.createdAt,
         exitCode: nextActivity.exitCode ?? existing.exitCode,
         terminalOutput: nextActivity.terminalOutput ?? existing.terminalOutput,
     };
@@ -2795,16 +2796,20 @@ function resolveIncomingSessionSnapshot(
               currentSnapshot,
           )
         : normalizedIncomingSnapshot;
+    const anchoredIncomingSnapshot = preserveCurrentToolActivityAnchors(
+        effectiveIncomingSnapshot,
+        currentSnapshot,
+    );
     const incomingTranscript =
-        buildAiSessionTranscriptModelFromSnapshot(effectiveIncomingSnapshot);
+        buildAiSessionTranscriptModelFromSnapshot(anchoredIncomingSnapshot);
     if (
         !session ||
         !currentSnapshot ||
-        currentSnapshot.sessionId !== effectiveIncomingSnapshot.sessionId
+        currentSnapshot.sessionId !== anchoredIncomingSnapshot.sessionId
     ) {
         return {
             snapshot: writeAiSessionTranscriptToSnapshot(
-                effectiveIncomingSnapshot,
+                anchoredIncomingSnapshot,
                 incomingTranscript,
             ),
             transcript: incomingTranscript,
@@ -2833,7 +2838,7 @@ function resolveIncomingSessionSnapshot(
             snapshot: writeAiSessionTranscriptToSnapshot(
                 mergeHydrationMetadataIntoCurrent(
                     currentSnapshot,
-                    effectiveIncomingSnapshot,
+                    anchoredIncomingSnapshot,
                 ),
                 currentTranscript,
             ),
@@ -2848,7 +2853,7 @@ function resolveIncomingSessionSnapshot(
     if (!shouldPreserveCurrent) {
         return {
             snapshot: writeAiSessionTranscriptToSnapshot(
-                effectiveIncomingSnapshot,
+                anchoredIncomingSnapshot,
                 incomingTranscript,
             ),
             transcript: incomingTranscript,
@@ -2863,7 +2868,7 @@ function resolveIncomingSessionSnapshot(
         );
         return {
             snapshot: writeAiSessionTranscriptToSnapshot(
-                effectiveIncomingSnapshot,
+                anchoredIncomingSnapshot,
                 nextTranscript,
             ),
             transcript: nextTranscript,
@@ -2874,12 +2879,48 @@ function resolveIncomingSessionSnapshot(
         snapshot: writeAiSessionTranscriptToSnapshot(
             mergeHydrationMetadataIntoCurrent(
                 currentSnapshot,
-                effectiveIncomingSnapshot,
+                anchoredIncomingSnapshot,
             ),
             currentTranscript,
         ),
         transcript: currentTranscript,
     };
+}
+
+function preserveCurrentToolActivityAnchors(
+    incomingSnapshot: AiSessionSnapshot,
+    currentSnapshot: AiSessionSnapshot | null,
+): AiSessionSnapshot {
+    if (!currentSnapshot || incomingSnapshot.toolActivity.length === 0) {
+        return incomingSnapshot;
+    }
+
+    const currentCreatedAtByToolId = new Map(
+        currentSnapshot.toolActivity.map((activity) => [
+            activity.id,
+            activity.createdAt,
+        ]),
+    );
+    let changed = false;
+    const toolActivity = incomingSnapshot.toolActivity.map((activity) => {
+        const currentCreatedAt = currentCreatedAtByToolId.get(activity.id);
+        if (!currentCreatedAt || currentCreatedAt === activity.createdAt) {
+            return activity;
+        }
+
+        changed = true;
+        return {
+            ...activity,
+            createdAt: currentCreatedAt,
+        };
+    });
+
+    return changed
+        ? {
+              ...incomingSnapshot,
+              toolActivity,
+          }
+        : incomingSnapshot;
 }
 
 function normalizeIncomingActivePromptEcho(


### PR DESCRIPTION
## Summary
- Preserve the original `createdAt` when an existing tool activity receives live updates.
- Normalize incoming snapshots/resyncs so known tool activities keep their first timeline anchor.
- Keep `updatedAt` as the progress/update timestamp while timeline order remains stable.

## Root cause
Tool activity payloads derive `createdAt` from `updatedAt`. The first fix covered direct live upserts, but resynced snapshots could still rebuild the transcript with a newer `createdAt`, making terminal and progressively updated tools look newer and move lower in the chat timeline.

## Validation
- `pnpm exec vitest run src/renderer/src/app/store/ai-store.test.ts`

Fixes #96