### PR TITLE
refine(chat): consolidate activity rails, mentions, and agent sidebar

### DIFF
--- a/src/main/ai/service.history.test.ts
+++ b/src/main/ai/service.history.test.ts
@@ -96,6 +96,39 @@ describe("AiService history", () => {
         expect(deleteSession).toHaveBeenCalledWith("session-1");
     });
 
+    it("deletes every persisted descendant from leaf to root", async () => {
+        const deleteSession = vi.fn();
+        const listSessionRuntimeMappingsForParent = vi.fn(() => [
+            {
+                appSessionId: "session-child",
+                parentAppSessionId: "session-parent",
+                parentRuntimeSessionId: "runtime-parent",
+                runtimeSessionId: "runtime-child",
+            },
+            {
+                appSessionId: "session-grandchild",
+                parentAppSessionId: "session-child",
+                parentRuntimeSessionId: "runtime-child",
+                runtimeSessionId: "runtime-grandchild",
+            },
+        ]);
+        const service = createService({
+            deleteSession,
+            listSessionRuntimeMappingsForParent,
+        });
+
+        await service.deleteSession("session-parent");
+
+        expect(listSessionRuntimeMappingsForParent).toHaveBeenCalledWith(
+            "session-parent",
+        );
+        expect(deleteSession.mock.calls).toEqual([
+            ["session-grandchild"],
+            ["session-child"],
+            ["session-parent"],
+        ]);
+    });
+
     it("ignores late worker snapshots after deleting a session", async () => {
         const deleteSession = vi.fn();
         const onSessionSnapshot = vi.fn();
@@ -732,6 +765,7 @@ function createService(overrides: {
     readonly deleteSession?: ReturnType<typeof vi.fn>;
     readonly loadLatestRuntimeCatalog?: ReturnType<typeof vi.fn>;
     readonly listSessionHistory?: ReturnType<typeof vi.fn>;
+    readonly listSessionRuntimeMappingsForParent?: ReturnType<typeof vi.fn>;
     readonly loadSessionSnapshot?: ReturnType<typeof vi.fn>;
     readonly loadSessionTranscriptPage?: ReturnType<typeof vi.fn>;
     readonly onSessionSnapshot?: (
@@ -763,6 +797,8 @@ function createService(overrides: {
             loadSessionSnapshot: overrides.loadSessionSnapshot ?? vi.fn(() => null),
             loadSessionTranscriptPage:
                 overrides.loadSessionTranscriptPage ?? vi.fn(() => null),
+            listSessionRuntimeMappingsForParent:
+                overrides.listSessionRuntimeMappingsForParent ?? vi.fn(() => []),
             saveRuntimeSelectionPreferenceOption: vi.fn(),
             saveRuntimeModePreference: vi.fn(),
             saveRuntimeModelPreference: vi.fn(),

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -1746,32 +1746,53 @@ export class AiService {
         }
 
         await this.#requireNativeAiGateway().closeSession(sessionId);
+        if (this.#nativeChildParentSessionIds.has(sessionId)) {
+            this.#detachLiveSession(sessionId);
+            return;
+        }
         this.#clearLiveSession(sessionId);
     }
 
     async deleteSession(sessionId: string): Promise<void> {
-        this.#deletedSessionIds.add(sessionId);
+        const subtreeSessionIds = await this.#collectSessionSubtreeIds(sessionId);
+        for (const subtreeSessionId of subtreeSessionIds) {
+            this.#deletedSessionIds.add(subtreeSessionId);
+        }
         try {
-            if (this.#liveSessionContexts.has(sessionId)) {
+            for (const subtreeSessionId of [...subtreeSessionIds].reverse()) {
+                if (!this.#liveSessionContexts.has(subtreeSessionId)) {
+                    continue;
+                }
                 try {
-                    await this.cancelSession(sessionId);
+                    await this.cancelSession(subtreeSessionId);
                 } catch (error) {
-                    // Closing and deleting the local session state is still safe.
+                    // Deleting the persisted session tree is still safe after an interrupt failure.
                     debugBenignError("ai.service.deleteSession.cancel", error);
                 }
+            }
 
+            if (
+                this.#liveSessionContexts.has(sessionId) &&
+                !this.#nativeChildParentSessionIds.has(sessionId)
+            ) {
                 await this.closeSession(sessionId);
             }
 
             this.#clearLiveSession(sessionId);
-            this.#promptQueue.deleteSession(sessionId);
+            for (const subtreeSessionId of subtreeSessionIds) {
+                this.#promptQueue.deleteSession(subtreeSessionId);
+            }
             if (this.#nativeAi?.shouldHandleHistory()) {
                 await this.#nativeAi.deleteSession(sessionId);
                 return;
             }
-            await this.#persistence.deleteSession(sessionId);
+            for (const subtreeSessionId of [...subtreeSessionIds].reverse()) {
+                await this.#persistence.deleteSession(subtreeSessionId);
+            }
         } catch (error) {
-            this.#deletedSessionIds.delete(sessionId);
+            for (const subtreeSessionId of subtreeSessionIds) {
+                this.#deletedSessionIds.delete(subtreeSessionId);
+            }
             throw error;
         }
     }
@@ -2371,6 +2392,19 @@ export class AiService {
         this.#scheduleSessionRetentionTimer();
     }
 
+    #detachLiveSession(sessionId: string): void {
+        this.#liveSnapshots.delete(sessionId);
+        this.#liveSessionContexts.delete(sessionId);
+        this.#liveSessionTouches.delete(sessionId);
+        this.#freezingSessionIds.delete(sessionId);
+        this.#nativeReviewBaselines.delete(sessionId);
+        this.#recentNativeReviewContexts.delete(sessionId);
+        this.#resolvedReviewVersions.delete(sessionId);
+        this.#reviewMutationChains.delete(sessionId);
+        // Keep the child-to-parent mapping so future runtime events retain their owner.
+        this.#scheduleSessionRetentionTimer();
+    }
+
     #touchLiveSession(sessionId: string): void {
         if (!this.#liveSessionContexts.has(sessionId)) {
             return;
@@ -2479,9 +2513,8 @@ export class AiService {
 
         this.#freezingSessionIds.add(sessionId);
         try {
-            await this.#requireNativeAiGateway().closeSession(sessionId);
+            await this.closeSession(sessionId);
             this.#recordRetentionClose(sessionId, reason);
-            this.#clearLiveSession(sessionId);
         } catch (error) {
             this.#deferSessionRetentionRetry(sessionId);
             debugBenignError("ai.service.freezeNativeSession", error);
@@ -3511,6 +3544,35 @@ export class AiService {
         );
 
         return mappings;
+    }
+
+    async #collectSessionSubtreeIds(sessionId: string): Promise<readonly string[]> {
+        const sessionIds = new Set<string>([sessionId]);
+        const pendingSessionIds = [sessionId];
+        while (pendingSessionIds.length > 0) {
+            const currentSessionId = pendingSessionIds.shift();
+            if (!currentSessionId) {
+                continue;
+            }
+            for (const [childSessionId, parentSessionId] of this
+                .#nativeChildParentSessionIds) {
+                if (
+                    parentSessionId === currentSessionId &&
+                    !sessionIds.has(childSessionId)
+                ) {
+                    sessionIds.add(childSessionId);
+                    pendingSessionIds.push(childSessionId);
+                }
+            }
+        }
+
+        for (const mapping of await this.#listPersistedRuntimeMappingsForParent(
+            sessionId,
+        )) {
+            sessionIds.add(mapping.appSessionId);
+        }
+
+        return [...sessionIds];
     }
 
     async #buildNativePrepareLaunchForSession(

--- a/src/main/ai/session-core.test.ts
+++ b/src/main/ai/session-core.test.ts
@@ -11,10 +11,54 @@ import {
     normalizeAiSessionHierarchy,
     normalizeRestoredAiSessionSnapshot,
     resolveSessionScopedPath,
+    serializeComposerPartsForDisplay,
     setConfigOptionOnSnapshot,
     setManualTitleOnSnapshot,
     setRuntimeTitleOnSnapshot,
 } from "./session-core";
+
+describe("composer display serialization", () => {
+    it("preserves file mention paths for the user timeline", () => {
+        const serialized = serializeComposerPartsForDisplay(
+            [
+                {
+                    label: "thread.rs",
+                    languageId: "rust",
+                    path: "/workspace/vendor/codex-acp/src/thread.rs",
+                    relativePath: "vendor/codex-acp/src/thread.rs",
+                    type: "file_mention",
+                },
+            ],
+            "fallback",
+        );
+
+        expect(serialized).toContain(
+            "file|vendor%2Fcodex-acp%2Fsrc%2Fthread.rs|thread.rs",
+        );
+        expect(serialized).not.toContain("/workspace");
+    });
+
+    it("preserves selection paths and line ranges for the user timeline", () => {
+        const serialized = serializeComposerPartsForDisplay(
+            [
+                {
+                    endLine: 14,
+                    label: "(8:14) - selected code",
+                    path: "src/elicitation.ts",
+                    selectedText: "selected code",
+                    startLine: 8,
+                    type: "selection_mention",
+                },
+            ],
+            "fallback",
+        );
+
+        expect(serialized).toContain(
+            "selection|src%2Felicitation.ts|8|14|(8%3A14)%20-%20selected%20code",
+        );
+        expect(serialized).not.toContain("selected code selected code");
+    });
+});
 
 describe("restored Codex activity normalization", () => {
     it("repairs a self-referential root snapshot without preserving its derived close state", () => {

--- a/src/main/ai/session-core.ts
+++ b/src/main/ai/session-core.ts
@@ -11,6 +11,9 @@ import {
     applyReasoningEffortToConfigOptions,
     isReasoningEffortConfigOption,
 } from "@shared/ai-config-options";
+import {
+    serializeComposerMessagePartsForDisplay,
+} from "@shared/composer-display-markers";
 import type {
     AiAvailableCommand,
     AiRuntimeId,
@@ -981,46 +984,11 @@ export function setConfigOptionOnSnapshot(
     };
 }
 
-const PILL_OPEN = "\u200B\u00AB";
-const PILL_CLOSE = "\u00BB\u200B";
-
 export function serializeComposerPartsForDisplay(
     parts: SendAiPromptInput["composerParts"] | undefined,
     fallback: string,
 ): string {
-    if (!parts || parts.length === 0) {
-        return fallback;
-    }
-
-    return parts
-        .map((part) => {
-            switch (part.type) {
-                case "text":
-                    return part.text;
-                case "file_mention":
-                    return `${PILL_OPEN}@${part.label}${PILL_CLOSE}`;
-                case "folder_mention":
-                    return `${PILL_OPEN}@${part.label}${PILL_CLOSE}`;
-                case "fetch_mention":
-                    return `${PILL_OPEN}@fetch${PILL_CLOSE}`;
-                case "plan_mention":
-                    return `${PILL_OPEN}/plan${PILL_CLOSE}`;
-                case "selection_mention":
-                    return `${PILL_OPEN}${part.label}${PILL_CLOSE}`;
-                case "file_attachment":
-                    return `${PILL_OPEN}📎${part.label}${PILL_CLOSE}`;
-                case "git_commit_mention":
-                    return `${PILL_OPEN}commit: ${part.label}${PILL_CLOSE}`;
-                case "github_issue_mention":
-                    return `${PILL_OPEN}${part.label}${PILL_CLOSE}`;
-                case "github_pull_request_mention":
-                    return `${PILL_OPEN}${part.label}${PILL_CLOSE}`;
-                default:
-                    return "";
-            }
-        })
-        .join("")
-        .trim();
+    return serializeComposerMessagePartsForDisplay(parts, fallback);
 }
 
 export function normalizeAdditionalRoots(

--- a/src/main/native-backend/ai.test.ts
+++ b/src/main/native-backend/ai.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type {
-    AiSessionClosedEvent,
     AiSessionSnapshot,
     AiTrackedFile,
     AiRuntimeStatus,
@@ -414,32 +413,17 @@ describe("NativeAiGateway", () => {
         });
 
         client.request.mockClear();
+        onSessionEvent.mockClear();
         await gateway.closeSession("session-1:subagent:runtime-child-1");
+        expect(client.request).not.toHaveBeenCalled();
+        expect(onSessionEvent).not.toHaveBeenCalled();
+
+        await gateway.cancelSession("session-1:subagent:runtime-child-1");
         expect(client.request).toHaveBeenCalledWith("ai_cancel_session", {
             runtimeSessionId: "runtime-child-1",
             sessionId: "session-1",
             targetSessionId: "session-1:subagent:runtime-child-1",
         });
-        expect(onSessionEvent).toHaveBeenCalledWith(
-            "window-1",
-            expect.objectContaining({
-                kind: "session-closed",
-                parentSessionId: "session-1",
-                runtimeId: "opencode",
-                runtimeSessionId: "runtime-child-1",
-                sessionId: "session-1:subagent:runtime-child-1",
-            }),
-        );
-        const closedEvent = onSessionEvent.mock.calls
-            .map(([, event]) => event)
-            .find(
-                (event): event is AiSessionClosedEvent =>
-                    event.kind === "session-closed" &&
-                    event.sessionId === "session-1:subagent:runtime-child-1",
-            );
-        expect(closedEvent?.kind).toBe("session-closed");
-        expect(typeof closedEvent?.closedAt).toBe("string");
-        expect(typeof closedEvent?.updatedAt).toBe("string");
     });
 
     it("hydrates persisted subagent mappings before child events arrive", async () => {
@@ -580,33 +564,17 @@ describe("NativeAiGateway", () => {
         });
 
         client.request.mockClear();
+        onSessionEvent.mockClear();
         await gateway.closeSession(childSessionId);
-        expect(client.request.mock.calls).toEqual([
-            [
-                "ai_cancel_session",
-                {
-                    runtimeSessionId: "runtime-grandchild",
-                    sessionId: "session-1",
-                    targetSessionId: grandchildSessionId,
-                },
-            ],
-            [
-                "ai_cancel_session",
-                {
-                    runtimeSessionId: "runtime-child",
-                    sessionId: "session-1",
-                    targetSessionId: childSessionId,
-                },
-            ],
-        ]);
-        const closedSessionIds = onSessionEvent.mock.calls
-            .map(([, event]) => event)
-            .filter((event) => event.kind === "session-closed")
-            .map((event) => event.sessionId);
-        expect(closedSessionIds).toEqual([
-            grandchildSessionId,
-            childSessionId,
-        ]);
+        expect(client.request).not.toHaveBeenCalled();
+        expect(onSessionEvent).not.toHaveBeenCalled();
+
+        await gateway.cancelSession(grandchildSessionId);
+        expect(client.request).toHaveBeenCalledWith("ai_cancel_session", {
+            runtimeSessionId: "runtime-grandchild",
+            sessionId: "session-1",
+            targetSessionId: grandchildSessionId,
+        });
     });
 
     it("requests and adapts native history payloads when history is enabled", async () => {
@@ -958,8 +926,8 @@ describe("NativeAiGateway", () => {
             "window-1",
             expect.objectContaining({
                 kind: "message-delta",
-                content: "Review \u200B«@new-note.md»\u200B",
-                delta: "Review \u200B«@new-note.md»\u200B",
+                content: "Review \u200B«file|new-note.md|new-note.md»\u200B",
+                delta: "Review \u200B«file|new-note.md|new-note.md»\u200B",
                 messageId: "user-message-1",
                 messageKind: "user",
             }),
@@ -968,7 +936,8 @@ describe("NativeAiGateway", () => {
             messageId: "user-message-1",
             prompt: {
                 attachments: [attachment],
-                displayText: "Review \u200B«@new-note.md»\u200B",
+                displayText:
+                    "Review \u200B«file|new-note.md|new-note.md»\u200B",
                 text: "Implement the feature.",
             },
             runtimeSessionId: null,

--- a/src/main/native-backend/ai.ts
+++ b/src/main/native-backend/ai.ts
@@ -387,6 +387,7 @@ export class NativeAiGateway implements NativeAiGatewayContract {
             return;
         }
         await this.#client.request("ai_delete_session", { sessionId });
+        this.#forgetSession(sessionId);
     }
 
     async renameSession(input: AiSessionRenameMutationInput): Promise<void> {
@@ -542,20 +543,7 @@ export class NativeAiGateway implements NativeAiGatewayContract {
         }
 
         if (this.#subagentParentSessionIds.has(sessionId)) {
-            const subtreeSessionIds = this.#collectSessionSubtreeIds(sessionId);
-            for (const descendantSessionId of [...subtreeSessionIds].reverse()) {
-                try {
-                    await this.cancelSession(descendantSessionId);
-                } catch (error) {
-                    if (!isCleanupSessionNotFoundError(error)) {
-                        throw error;
-                    }
-                }
-            }
-            for (const descendantSessionId of [...subtreeSessionIds].reverse()) {
-                this.#emitLocalSubagentClosed(descendantSessionId);
-            }
-            this.#forgetSession(sessionId);
+            // A child close is a view detach. ACP has no target-aware close primitive.
             return;
         }
 
@@ -936,27 +924,6 @@ export class NativeAiGateway implements NativeAiGatewayContract {
             ...event,
             parentSessionId,
         };
-    }
-
-    #emitLocalSubagentClosed(sessionId: string): void {
-        const parentSessionId = this.#subagentParentSessionIds.get(sessionId);
-        const ownerWindowId = this.#sessionOwners.get(sessionId);
-        const runtimeId = this.#sessionRuntimeIds.get(sessionId);
-        if (!parentSessionId || !ownerWindowId || !runtimeId) {
-            return;
-        }
-
-        const closedAt = new Date().toISOString();
-        this.#onSessionEvent(ownerWindowId, {
-            closedAt,
-            kind: "session-closed",
-            origin: "live",
-            parentSessionId,
-            runtimeId,
-            runtimeSessionId: this.#runtimeSessionIds.get(sessionId) ?? null,
-            sessionId,
-            updatedAt: closedAt,
-        });
     }
 
     #restoreOwner(sessionId: string, previousOwner: string | undefined): void {

--- a/src/main/native-backend/app-data.ts
+++ b/src/main/native-backend/app-data.ts
@@ -21,7 +21,6 @@ import {
     EDITOR_FONT_FAMILY_IDS,
 } from "@shared/typography";
 import type {
-    AiToolCardExpansionMode,
     AiPromptQueueSnapshot,
     AiHistorySessionSummary,
     AiRuntimeId,
@@ -1138,13 +1137,6 @@ function createLegacySettingsSnapshot(
                     settings,
                     "ai.composer.screenshot_retention_seconds",
                 ) ?? defaults.aiChat.screenshotRetentionSeconds,
-            toolCardExpansionMode:
-                parseLegacyToolCardExpansionMode(
-                    readLegacyStringSetting(
-                        settings,
-                        "ai.chat.tool_card_expansion_mode",
-                    ),
-                ) ?? defaults.aiChat.toolCardExpansionMode,
         },
         appearance: {
             ...defaults.appearance,
@@ -1658,15 +1650,6 @@ function parseLegacyThemePreset(
         : null;
 }
 
-function parseLegacyToolCardExpansionMode(
-    value: string | null | undefined,
-): AiToolCardExpansionMode | null {
-    if (value === "collapsed" || value === "latest" || value === "expanded") {
-        return value;
-    }
-    return null;
-}
-
 function normalizeLegacyFontFamily(
     value: string | null | undefined,
 ): (typeof EDITOR_FONT_FAMILY_IDS)[number] | null {
@@ -1792,7 +1775,7 @@ function createDefaultSettingsSnapshot(): CompleteSettingsSnapshot {
             requireCmdEnterToSend: false,
             reviewDiffZoom: 0.96,
             screenshotRetentionSeconds: 0,
-            toolCardExpansionMode: "collapsed",
+            toolActivityDefaultExpansion: "collapsed",
         },
         appearance: {
             agentsSidebarScale: AGENTS_SIDEBAR_SCALE_DEFAULT,
@@ -1821,9 +1804,23 @@ function createDefaultSettingsSnapshot(): CompleteSettingsSnapshot {
 
 function normalizeSettingsSnapshot(snapshot: SettingsSnapshot): SettingsSnapshot {
     const defaults = createDefaultSettingsSnapshot();
+    const persistedAiChat = snapshot.aiChat as
+        | (Partial<AppAiChatSettings> & {
+              readonly toolCardExpansionMode?: unknown;
+          })
+        | undefined;
+    const { toolCardExpansionMode: _legacyToolCardExpansionMode, ...aiChat } =
+        persistedAiChat ?? {};
     return {
         ai: snapshot.ai ?? defaults.ai,
-        aiChat: snapshot.aiChat ?? defaults.aiChat,
+        aiChat: {
+            ...defaults.aiChat,
+            ...aiChat,
+            toolActivityDefaultExpansion:
+                persistedAiChat?.toolActivityDefaultExpansion === "expanded"
+                    ? "expanded"
+                    : "collapsed",
+        },
         appearance: {
             ...defaults.appearance,
             ...(snapshot.appearance ?? {}),

--- a/src/main/native-backend/app-data.ts
+++ b/src/main/native-backend/app-data.ts
@@ -1809,8 +1809,8 @@ function normalizeSettingsSnapshot(snapshot: SettingsSnapshot): SettingsSnapshot
               readonly toolCardExpansionMode?: unknown;
           })
         | undefined;
-    const { toolCardExpansionMode: _legacyToolCardExpansionMode, ...aiChat } =
-        persistedAiChat ?? {};
+    const aiChat = { ...(persistedAiChat ?? {}) };
+    delete aiChat.toolCardExpansionMode;
     return {
         ai: snapshot.ai ?? defaults.ai,
         aiChat: {

--- a/src/main/settings/window-zoom.test.ts
+++ b/src/main/settings/window-zoom.test.ts
@@ -58,7 +58,7 @@ describe("broadcastSettingsUpdated", () => {
                 requireCmdEnterToSend: false,
                 reviewDiffZoom: 0.96,
                 screenshotRetentionSeconds: 0,
-                toolCardExpansionMode: "collapsed",
+                toolActivityDefaultExpansion: "collapsed",
             },
             DEFAULT_APP_TERMINAL_SETTINGS,
         );
@@ -74,7 +74,7 @@ describe("broadcastSettingsUpdated", () => {
                 requireCmdEnterToSend: false,
                 reviewDiffZoom: 0.96,
                 screenshotRetentionSeconds: 0,
-                toolCardExpansionMode: "collapsed",
+                toolActivityDefaultExpansion: "collapsed",
             },
             appearance: {
                 agentsSidebarScale: 1,

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -834,7 +834,8 @@ export function SettingsApp() {
                 screenshotRetentionSeconds: aiChat.screenshotRetentionSeconds,
                 historyRetentionDays: aiChat.historyRetentionDays,
                 contextUsageBarEnabled: aiChat.contextUsageBarEnabled,
-                toolCardExpansionMode: aiChat.toolCardExpansionMode,
+                toolActivityDefaultExpansion:
+                    aiChat.toolActivityDefaultExpansion,
                 onChatFontFamilyChange: (id) =>
                     updateAiChat({
                         chatFontFamily: id as ChatFontFamily,
@@ -855,8 +856,8 @@ export function SettingsApp() {
                     updateAiChat({ historyRetentionDays: days }),
                 onContextUsageBarEnabledChange: (value) =>
                     updateAiChat({ contextUsageBarEnabled: value }),
-                onToolCardExpansionModeChange: (value) =>
-                    updateAiChat({ toolCardExpansionMode: value }),
+                onToolActivityDefaultExpansionChange: (value) =>
+                    updateAiChat({ toolActivityDefaultExpansion: value }),
             }}
             appAppearance={{
                 agentsSidebarScale: appAppearance.agentsSidebarScale,

--- a/src/renderer/src/app/ai/sessionReviewContracts.ts
+++ b/src/renderer/src/app/ai/sessionReviewContracts.ts
@@ -2,6 +2,7 @@ import type {
     AiComposerMessagePart,
     AiFileContextAttachment,
     AiImageAttachment,
+    AiQueuedPromptStatus,
 } from "@shared/ipc";
 
 export const DEFAULT_AI_DIFF_ZOOM = 0.96;
@@ -10,13 +11,7 @@ export const FIXED_PENDING_REVIEW_CARD_TEXT_ZOOM = 1.25;
 // Fase 0 / Ruta B: el undo de reject queda fuera del alcance inicial.
 export const AI_REVIEW_UNDO_ENABLED = false;
 
-export type AiQueuedPromptStatus =
-    | "editing"
-    | "failed"
-    | "pending_dispatch"
-    | "queued"
-    | "running"
-    | "sending";
+export type { AiQueuedPromptStatus };
 
 export type AiComposerDraftPart = AiComposerMessagePart;
 
@@ -48,11 +43,9 @@ export function buildSelectionMentionLabel(
     endLine: number,
 ): string {
     const preview = selectedText.replace(/\s+/g, " ").trim();
-    const truncated =
-        preview.length > 20 ? `${preview.slice(0, 20).trimEnd()}...` : preview;
     const range =
         startLine === endLine ? `(${startLine})` : `(${startLine}:${endLine})`;
-    return truncated ? `${range} - ${truncated}` : range;
+    return preview ? `${range} - ${preview}` : range;
 }
 
 function ensureTrailingSpace(

--- a/src/renderer/src/app/ai/transcriptModel.test.ts
+++ b/src/renderer/src/app/ai/transcriptModel.test.ts
@@ -134,6 +134,30 @@ describe("transcriptModel", () => {
         expect(transcript.lastTurnStartedMessageId).toBe("status:active-turn");
     });
 
+    it("keeps repeated tool ids distinct across sessions", () => {
+        const transcript = buildAiSessionTranscriptModel({
+            messages: [],
+            toolActivity: [
+                createToolActivity(),
+                createToolActivity({
+                    createdAt: "2026-04-14T00:00:02.000Z",
+                    sessionId: "session-2",
+                    updatedAt: "2026-04-14T00:00:02.000Z",
+                }),
+            ],
+        });
+
+        expect(transcript.messageOrder).toEqual([
+            "tool:session-1:tool-1",
+            "tool:session-2:tool-1",
+        ]);
+        expect(
+            getAiSessionTranscriptToolActivity(transcript).map(
+                (activity) => activity.sessionId,
+            ),
+        ).toEqual(["session-1", "session-2"]);
+    });
+
     it("hides persisted encrypted inter-agent transport payloads", () => {
         const encryptedPayload =
             "gAAAAABqUCwGM4iUSPpzoPf1Tn5y6lh72L_8dnVbmdOR42YZ9KRaUwUBCY14DMmdBOIOmjd2HW3l6SSCckLSjJ6KebNzsXzG9m8pajAOwQ2UxYazsFGhYP6jzx7KqOsnwWhMaOxcXDla5KQQwB66JlYo6rFxvUoIfpBeLEJY6ErSJ_KAjNlUkoU=";

--- a/src/renderer/src/app/settings/theme.ts
+++ b/src/renderer/src/app/settings/theme.ts
@@ -1786,7 +1786,7 @@ export function getDefaultAiChatSettings(): AppAiChatSettings {
         screenshotRetentionSeconds: 0,
         historyRetentionDays: 0,
         contextUsageBarEnabled: true,
-        toolCardExpansionMode: "collapsed",
+        toolActivityDefaultExpansion: "collapsed",
     };
 }
 

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -38,6 +38,7 @@ import type {
     OpenCodeRuntimeSettingsInput,
     SecretValuePatch,
 } from "@shared/ipc";
+import { serializeComposerMessagePartsForDisplay } from "@shared/composer-display-markers";
 import {
     deriveTrackedFilesFromActionLog,
     isReviewTargetVersionCurrent,
@@ -2917,19 +2918,29 @@ function normalizeIncomingActivePromptEcho(
     const messages: AiMessage[] = [];
 
     for (const message of incomingSnapshot.messages) {
+        const isCanonicalOptimisticMessage =
+            message.kind === "user" && message.id === optimisticMessageId;
         const isActivePromptEcho =
             message.kind === "user" &&
             message.id !== optimisticMessageId &&
             isTimestampAtOrAfter(message.createdAt, activeQueuedPrompt.createdAt) &&
             message.content === promptContent;
-        const nextMessage = isActivePromptEcho
+        const nextMessage = isCanonicalOptimisticMessage
+            ? {
+                  ...message,
+                  content: promptContent,
+              }
+            : isActivePromptEcho
             ? {
                   ...message,
                   id: optimisticMessageId,
               }
             : message;
 
-        if (isActivePromptEcho) {
+        if (
+            isActivePromptEcho ||
+            (isCanonicalOptimisticMessage && message.content !== promptContent)
+        ) {
             changed = true;
         }
 
@@ -3014,8 +3025,17 @@ function normalizeIncomingActivePromptEvent(
             };
         case "message-delta":
             if (
+                event.messageKind === "user" &&
+                event.messageId === optimisticMessageId
+            ) {
+                return {
+                    ...event,
+                    content: promptContent,
+                    delta: promptContent,
+                };
+            }
+            if (
                 event.messageKind !== "user" ||
-                event.messageId === optimisticMessageId ||
                 !isActivePromptEchoContent(event, promptContent)
             ) {
                 return event;
@@ -3480,31 +3500,10 @@ function completeLocalStreamingMessages(
 }
 
 function getQueuedPromptDisplayContent(queuedPrompt: QueuedPrompt): string {
-    if (queuedPrompt.prompt.trim()) {
-        return queuedPrompt.prompt.trim();
-    }
-
-    return queuedPrompt.composerPartsSnapshot
-        .map((part) => {
-            switch (part.type) {
-                case "text":
-                    return part.text;
-                case "file_mention":
-                case "folder_mention":
-                case "file_attachment":
-                case "git_commit_mention":
-                case "github_issue_mention":
-                case "github_pull_request_mention":
-                case "selection_mention":
-                    return part.label;
-                case "fetch_mention":
-                    return "@fetch";
-                case "plan_mention":
-                    return "/plan";
-            }
-        })
-        .join("")
-        .trim();
+    return serializeComposerMessagePartsForDisplay(
+        queuedPrompt.composerPartsSnapshot,
+        queuedPrompt.prompt,
+    );
 }
 
 function createQueuedPromptEditState(input: {

--- a/src/renderer/src/app/store/settings-store.test.ts
+++ b/src/renderer/src/app/store/settings-store.test.ts
@@ -60,7 +60,7 @@ function createAiChatSettings(
         requireCmdEnterToSend: false,
         reviewDiffZoom: 1,
         screenshotRetentionSeconds: 300,
-        toolCardExpansionMode: "collapsed",
+        toolActivityDefaultExpansion: "collapsed",
         ...overrides,
     };
 }

--- a/src/renderer/src/components/icons/createFileTypeIconElement.test.ts
+++ b/src/renderer/src/components/icons/createFileTypeIconElement.test.ts
@@ -1,0 +1,14 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it } from "vitest";
+
+import { createFileTypeIconElement } from "./createFileTypeIconElement";
+
+describe("createFileTypeIconElement", () => {
+    it("creates a themed Catppuccin SVG for composer mentions", () => {
+        const icon = createFileTypeIconElement("src/thread.rs", 13);
+
+        expect(icon?.dataset.composerFileIcon).toBe("true");
+        expect(icon?.getAttribute("height")).toBe("13");
+        expect(icon?.innerHTML).toContain("var(--catppuccin-icon-");
+    });
+});

--- a/src/renderer/src/components/icons/createFileTypeIconElement.ts
+++ b/src/renderer/src/components/icons/createFileTypeIconElement.ts
@@ -1,0 +1,31 @@
+import { resolveCatppuccinFileIcon } from "./FileTypeIcon";
+import {
+    getCatppuccinIcon,
+    getCatppuccinViewBox,
+    getThemedCatppuccinIconBody,
+} from "./catppuccin-icons";
+
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+
+export function createFileTypeIconElement(
+    fileName: string,
+    size: number,
+): SVGSVGElement | null {
+    const { iconName } = resolveCatppuccinFileIcon(fileName);
+    const icon = getCatppuccinIcon(iconName);
+    if (!icon) {
+        return null;
+    }
+
+    const svg = document.createElementNS(SVG_NAMESPACE, "svg");
+    svg.setAttribute("aria-hidden", "true");
+    svg.setAttribute("focusable", "false");
+    svg.setAttribute("height", String(size));
+    svg.setAttribute("viewBox", getCatppuccinViewBox(icon));
+    svg.setAttribute("width", String(size));
+    svg.dataset.composerFileIcon = "true";
+    svg.style.display = "block";
+    svg.style.flexShrink = "0";
+    svg.innerHTML = getThemedCatppuccinIconBody(icon.body);
+    return svg;
+}

--- a/src/renderer/src/components/icons/createFolderTypeIconElement.ts
+++ b/src/renderer/src/components/icons/createFolderTypeIconElement.ts
@@ -1,0 +1,31 @@
+import { resolveCatppuccinFolderIcon } from "./FolderTypeIcon";
+import {
+    getCatppuccinIcon,
+    getCatppuccinViewBox,
+    getThemedCatppuccinIconBody,
+} from "./catppuccin-icons";
+
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+
+export function createFolderTypeIconElement(
+    folderName: string,
+    size: number,
+): SVGSVGElement | null {
+    const { iconName } = resolveCatppuccinFolderIcon(folderName, false);
+    const icon = getCatppuccinIcon(iconName);
+    if (!icon) {
+        return null;
+    }
+
+    const svg = document.createElementNS(SVG_NAMESPACE, "svg");
+    svg.setAttribute("aria-hidden", "true");
+    svg.setAttribute("focusable", "false");
+    svg.setAttribute("height", String(size));
+    svg.setAttribute("viewBox", getCatppuccinViewBox(icon));
+    svg.setAttribute("width", String(size));
+    svg.dataset.composerFolderIcon = "true";
+    svg.style.display = "block";
+    svg.style.flexShrink = "0";
+    svg.innerHTML = getThemedCatppuccinIconBody(icon.body);
+    return svg;
+}

--- a/src/renderer/src/components/settings/SettingsWindow.test.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.test.tsx
@@ -43,7 +43,7 @@ function createSettingsWindowProps(
             historyRetentionDays: 0,
             requireCmdEnterToSend: false,
             screenshotRetentionSeconds: 0,
-            toolCardExpansionMode: "collapsed",
+            toolActivityDefaultExpansion: "collapsed",
         },
         aiProviders: {
             runtimeStatuses: {},
@@ -139,6 +139,29 @@ describe("SettingsWindow terminal settings", () => {
         );
 
         expect(markup).toContain("Terminal");
+    });
+
+    it("renders the default tool activity expansion preference in AI settings", () => {
+        const props = createSettingsWindowProps({ initialCategory: "ai" });
+        const markup = renderToStaticMarkup(
+            <SettingsWindow {...props} />,
+        );
+        const expandedMarkup = renderToStaticMarkup(
+            <SettingsWindow
+                {...props}
+                aiChat={{
+                    ...props.aiChat,
+                    toolActivityDefaultExpansion: "expanded",
+                }}
+            />,
+        );
+
+        expect(markup).toContain("Tool activity");
+        expect(markup).toContain(
+            "Choose whether tool activity starts collapsed or expanded.",
+        );
+        expect(markup).toContain("Collapsed");
+        expect(expandedMarkup).toContain("Expanded");
     });
 
     it("renders a release notes action in the Updates category", () => {

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -238,12 +238,10 @@ const STATIC_CATEGORY_SEARCH_VALUES: Record<Category, readonly SearchValue[]> = 
         "Font used for messages in the chat.",
         "Chat font size",
         "Font size of messages in the chat.",
-        "Edited file cards",
-        "Choose when edited-file tool cards open automatically.",
-        "Normal",
-        "Latest expanded",
-        "Always expanded",
-        "collapsed expanded streaming tools",
+        "Tool activity",
+        "Choose whether tool activity starts collapsed or expanded.",
+        "Collapsed",
+        "Expanded",
         "Review",
         "Chat history retention",
         "How long saved chat histories stay on disk before automatic deletion.",
@@ -2446,12 +2444,11 @@ function AiChatContent({
         ],
         ["Chat font size", "Font size of messages in the chat, in pixels."],
         [
-            "Edited file cards",
-            "Choose when edited-file tool cards open automatically.",
-            "Normal",
-            "Latest expanded",
-            "Always expanded",
-            "collapsed expanded streaming tools",
+            "Tool activity",
+            "Choose whether tool activity starts collapsed or expanded.",
+            "Collapsed",
+            "Expanded",
+            "tools default disclosure",
         ],
     ]);
     const showReview = sectionHasMatches(searchQuery, "Review", [
@@ -2531,33 +2528,24 @@ function AiChatContent({
             <SearchableRow
                 searchQuery={searchQuery}
                 section="Chat"
-                label="Edited file cards"
-                description="Choose when edited-file tool cards open automatically."
+                label="Tool activity"
+                description="Choose whether tool activity starts collapsed or expanded."
                 keywords={[
-                    "Normal",
-                    "Latest expanded",
-                    "Always expanded",
-                    "edited files",
-                    "collapsed",
-                    "expanded",
-                    "streaming tools",
+                    "Collapsed",
+                    "Expanded",
+                    "tools",
+                    "default",
+                    "disclosure",
                 ]}
                 control={
                     <SelectField
-                        value={state.toolCardExpansionMode}
+                        value={state.toolActivityDefaultExpansion}
                         options={[
-                            { value: "collapsed", label: "Normal" },
-                            {
-                                value: "latest",
-                                label: "Latest expanded",
-                            },
-                            {
-                                value: "expanded",
-                                label: "Always expanded",
-                            },
+                            { value: "collapsed", label: "Collapsed" },
+                            { value: "expanded", label: "Expanded" },
                         ]}
-                        onChange={(v) =>
-                            state.onToolCardExpansionModeChange?.(v)
+                        onChange={(value) =>
+                            state.onToolActivityDefaultExpansionChange?.(value)
                         }
                     />
                 }

--- a/src/renderer/src/components/settings/settings-types.ts
+++ b/src/renderer/src/components/settings/settings-types.ts
@@ -1,5 +1,5 @@
 import type {
-    AiToolCardExpansionMode,
+    AiToolActivityDefaultExpansion,
     ProjectAppDataSummary,
     AppPrivacyAccessState,
     AppTerminalSettings,
@@ -121,7 +121,7 @@ export interface SettingsAiChatState {
     readonly screenshotRetentionSeconds: number;
     readonly historyRetentionDays: number;
     readonly contextUsageBarEnabled: boolean;
-    readonly toolCardExpansionMode: AiToolCardExpansionMode;
+    readonly toolActivityDefaultExpansion: AiToolActivityDefaultExpansion;
     readonly onChatFontFamilyChange?: (id: string) => void;
     readonly onChatFontSizeChange?: (size: number) => void;
     readonly onComposerFontFamilyChange?: (id: string) => void;
@@ -130,8 +130,8 @@ export interface SettingsAiChatState {
     readonly onScreenshotRetentionChange?: (seconds: number) => void;
     readonly onHistoryRetentionChange?: (days: number) => void;
     readonly onContextUsageBarEnabledChange?: (value: boolean) => void;
-    readonly onToolCardExpansionModeChange?: (
-        value: AiToolCardExpansionMode,
+    readonly onToolActivityDefaultExpansionChange?: (
+        value: AiToolActivityDefaultExpansion,
     ) => void;
 }
 

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
@@ -158,6 +158,31 @@ describe("SidebarAgentsPanel history cache", () => {
         expect(markup).not.toContain("Loading...");
     });
 
+    it("renders title-only rows with provider icons", () => {
+        const fullTitle =
+            "Investigate the model selector behavior without shortening this title";
+        writeSidebarAgentsHistoryCache(
+            "project-1",
+            "worktree-1",
+            [createSummary({ title: fullTitle })],
+            100,
+        );
+        const markup = renderToStaticMarkup(
+            <SidebarAgentsPanel
+                projectId="project-1"
+                worktreeId="worktree-1"
+            />,
+        );
+
+        expect(markup).not.toContain("Use compact thread rows");
+        expect(markup).not.toContain("Show thread details");
+        expect(markup).toContain('data-provider-icon="codex"');
+        expect(markup).toContain(fullTitle);
+        expect(markup).not.toContain("Assistant returns a concise answer.");
+        expect(markup).toContain("sidebar-agents-compact-relative-time");
+        expect(markup).not.toContain("1 message");
+    });
+
     it("does not render cached sessions from another worktree scope", () => {
         writeSidebarAgentsHistoryCache(
             "project-1",
@@ -214,10 +239,10 @@ describe("SidebarAgentsPanel history cache", () => {
             markup.indexOf("Galileo"),
         );
         expect(markup).toContain('data-subagent="true"');
-        expect(markup).toContain("Agent");
+        expect(markup).toContain('data-provider-icon="codex"');
     });
 
-    it("shows Working only for child agents with a busy normalized snapshot", () => {
+    it("shows an activity dot only for working child agents", () => {
         const sessions = [
             createSummary({
                 runtimeSessionId: "runtime-parent",
@@ -297,9 +322,15 @@ describe("SidebarAgentsPanel history cache", () => {
             item.textContent?.includes("Running Child"),
         );
 
-        expect(container.textContent?.match(/Working…/g)).toHaveLength(1);
-        expect(finishedItem?.textContent).not.toContain("Working…");
-        expect(runningItem?.textContent).toContain("Working…");
+        expect(
+            container.querySelectorAll(".sidebar-agents-activity-dot"),
+        ).toHaveLength(1);
+        expect(
+            finishedItem?.querySelector(".sidebar-agents-activity-dot"),
+        ).toBeNull();
+        expect(
+            runningItem?.querySelector(".sidebar-agents-activity-dot"),
+        ).not.toBeNull();
     });
 
     it("renders live Claude Code terminal agents alongside real history", () => {
@@ -335,7 +366,7 @@ describe("SidebarAgentsPanel history cache", () => {
         expect(markup).toContain("Claude Thread");
         expect(markup).toContain("Claude Code 1");
         expect(markup).toContain("Claude Code");
-        expect(markup).toContain("Terminal");
+        expect(markup).toContain('data-provider-icon="claude"');
     });
 });
 

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -19,7 +19,6 @@ import {
     ACTIVE_AI_RUNTIME_IDS,
     type ActiveAiRuntimeId,
 } from "@shared/ai-runtimes";
-import { truncateChatTitle } from "@shared/chatTitle";
 
 import { useAiStore } from "@renderer/app/store/ai-store";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
@@ -48,11 +47,9 @@ import {
     type ContextMenuState,
 } from "@renderer/components/context-menu/ContextMenu";
 import {
-    formatHistoryMessageCount,
     formatHistoryRelativeDateCompact,
     getHistoryRuntimeLabel,
 } from "@renderer/components/workspace/chat-history/historyPresentation";
-import { getHistoryPreviewText } from "@renderer/components/workspace/chat-history/historyPreview";
 import {
     buildAiSessionHierarchyGroups,
     countAiHistorySessionChildren,
@@ -65,6 +62,7 @@ import {
     resolveWorkspaceChatTabActivityIndicator,
     type WorkspaceChatTabActivityIndicator,
 } from "@renderer/components/workspace/workspaceTabActivity";
+import { ProviderIcon } from "@renderer/components/workspace/ProviderIcon";
 
 import {
     applySessionUpdateToSidebarHistory,
@@ -98,7 +96,6 @@ type SidebarAgentDragPreview = {
     readonly y: number;
 };
 
-const SIDEBAR_AGENTS_TITLE_MAX_CHARS = 48;
 const SIDEBAR_AGENTS_REFRESH_DEBOUNCE_MS = 800;
 const EMPTY_AGENTS_SESSIONS: readonly AiHistorySessionSummary[] = [];
 const EMPTY_COLLAPSED_IDS: ReadonlySet<string> = new Set();
@@ -1104,7 +1101,7 @@ export function SidebarAgentsPanel({
                     onClose={() => setNewAgentMenu(null)}
                 />
             ) : null}
-        </div>
+            </div>
     );
 }
 
@@ -1285,21 +1282,10 @@ function SidebarAgentsItem({
     const [dragPreview, setDragPreview] =
         useState<SidebarAgentDragPreview | null>(null);
     const [isPointerTracking, setIsPointerTracking] = useState(false);
-    const preview = getHistoryPreviewText(session);
-    const title = truncateChatTitle(session.title, SIDEBAR_AGENTS_TITLE_MAX_CHARS);
+    const title = session.title.trim();
     const isPinned = isSessionPinned(session);
     const isTerminalAgent = isClaudeCodeSidebarSession(session);
     const activity = useAgentActivityIndicator(session.sessionId);
-    const timestampLabel = activity
-        ? activity.tone === "danger"
-            ? "Error"
-            : "Working…"
-        : formatHistoryRelativeDateCompact(session.updatedAt);
-    const timestampClassName = activity
-        ? activity.tone === "danger"
-            ? "text-rose-500"
-            : "text-(--diff-warn)"
-        : "text-text-secondary";
     const indentStyle =
         depth > 0
             ? { paddingLeft: `${8 + Math.min(depth, 4) * 14}px` }
@@ -1560,6 +1546,16 @@ function SidebarAgentsItem({
                         <ChevronIcon collapsed={isCollapsed} />
                     </button>
                 ) : null}
+                <ProviderIcon
+                    className="sidebar-agents-provider-icon shrink-0 text-text-secondary"
+                    opacity={0.72}
+                    runtimeId={
+                        isTerminalAgent
+                            ? "claude"
+                            : (session.runtimeId as AiRuntimeId)
+                    }
+                    size={12}
+                />
                 <SidebarAgentActivityDot indicator={activity} />
                 {isRenaming ? (
                     <input
@@ -1616,46 +1612,10 @@ function SidebarAgentsItem({
                     </button>
                 )}
                 {isRenaming ? null : (
-                    <span
-                        className={`sidebar-agents-timestamp shrink-0 text-[10px] ${timestampClassName}`}
-                        title={activity?.title}
-                    >
-                        {timestampLabel}
+                    <span className="sidebar-agents-compact-relative-time shrink-0 text-[10px] text-text-secondary">
+                        {formatHistoryRelativeDateCompact(session.updatedAt)}
                     </span>
                 )}
-            </div>
-            <p className="sidebar-agents-preview line-clamp-1 w-full text-left text-[10.5px] leading-[1.35] text-text-secondary">
-                {preview}
-            </p>
-            <div className="sidebar-agents-meta flex w-full min-w-0 items-center gap-1.5 text-[10px] text-text-secondary">
-                {isSubagent ? (
-                    <>
-                        <span
-                            className="shrink-0 rounded-[3px] px-1 text-[9px] font-medium"
-                            style={{
-                                color: "var(--color-accent)",
-                                background:
-                                    "color-mix(in srgb, var(--color-accent) 14%, transparent)",
-                            }}
-                        >
-                            Agent
-                        </span>
-                        <span aria-hidden="true" className="shrink-0">
-                            ·
-                        </span>
-                    </>
-                ) : null}
-                <span className="shrink-0">
-                    {getSidebarAgentRuntimeLabel(session)}
-                </span>
-                <span aria-hidden="true" className="shrink-0">
-                    ·
-                </span>
-                <span className="shrink-0">
-                    {isTerminalAgent
-                        ? "Terminal"
-                        : formatHistoryMessageCount(session.messageCount)}
-                </span>
             </div>
             </div>
             {dragPreview && typeof document !== "undefined"

--- a/src/renderer/src/components/workspace/AIChatAgentControls.test.tsx
+++ b/src/renderer/src/components/workspace/AIChatAgentControls.test.tsx
@@ -60,6 +60,43 @@ const SUBAGENT_CONFIG_OPTIONS: readonly AiSessionConfigOption[] = [
     },
 ];
 
+const GPT_5_6_MODEL_CONFIG_OPTIONS: readonly AiSessionConfigOption[] = [
+    {
+        category: "model",
+        description: null,
+        id: "model",
+        label: "Model",
+        options: [
+            {
+                description: null,
+                groupLabel: "GPT 5.6",
+                label: "Sol",
+                value: "gpt-5.6-sol",
+            },
+            {
+                description: null,
+                groupLabel: "GPT 5.6",
+                label: "Terra",
+                value: "gpt-5.6-terra",
+            },
+            {
+                description: null,
+                groupLabel: "GPT 5.6",
+                label: "Luna",
+                value: "gpt-5.6-luna",
+            },
+            {
+                description: null,
+                groupLabel: "Other models",
+                label: "gpt-5.5",
+                value: "gpt-5.5",
+            },
+        ],
+        type: "select",
+        value: "gpt-5.6-terra",
+    },
+];
+
 function mountControls(
     overrides: Partial<Parameters<typeof AIChatAgentControls>[0]> = {},
 ) {
@@ -179,6 +216,33 @@ describe("AIChatAgentControls", () => {
         expect(onConfigOptionChange).toHaveBeenCalledWith(
             "codex-reasoning-effort",
             "low",
+        );
+    });
+
+    it("expands GPT-5.6 variants and shows the selected variant label", () => {
+        const onConfigOptionChange = vi.fn();
+        const { container } = mountControls({
+            configOptions: GPT_5_6_MODEL_CONFIG_OPTIONS,
+            modelId: "gpt-5.6-terra",
+            onConfigOptionChange,
+        });
+
+        const modelButton = getButtonByTitle(container, "Model");
+        expect(modelButton.textContent).toContain("Terra");
+        expect(modelButton.textContent).not.toContain("GPT 5.6");
+
+        click(modelButton);
+        const groupButton = getButtonByText(document.body, "GPT 5.6");
+        expect(groupButton.getAttribute("aria-expanded")).toBe("false");
+        expect(() => getButtonByText(document.body, "Sol")).toThrow();
+
+        click(groupButton);
+        expect(groupButton.getAttribute("aria-expanded")).toBe("true");
+
+        click(getButtonByText(document.body, "Sol"));
+        expect(onConfigOptionChange).toHaveBeenCalledWith(
+            "model",
+            "gpt-5.6-sol",
         );
     });
 });

--- a/src/renderer/src/components/workspace/AIChatAgentControls.tsx
+++ b/src/renderer/src/components/workspace/AIChatAgentControls.tsx
@@ -40,8 +40,14 @@ interface DropdownOption {
     readonly value: string;
 }
 
+interface DropdownOptionGroup {
+    readonly label: string | null;
+    readonly options: readonly DropdownOption[];
+}
+
 interface DropdownFieldProps {
     readonly buttonLabel?: string;
+    readonly collapsibleGroupLabels?: readonly string[];
     readonly disabled?: boolean;
     readonly emptySearchMessage?: string;
     readonly label: string;
@@ -57,6 +63,8 @@ interface DropdownMenuPosition {
     readonly x: number;
     readonly y: number;
 }
+
+const GPT_5_6_MODEL_GROUP = "GPT 5.6";
 
 function formatFallbackLabel(value: string): string {
     if (value.trim().includes(" ")) {
@@ -75,6 +83,24 @@ function formatFallbackLabel(value: string): string {
             return token.charAt(0).toUpperCase() + token.slice(1);
         })
         .join(" ");
+}
+
+function groupDropdownOptions(
+    options: readonly DropdownOption[],
+): readonly DropdownOptionGroup[] {
+    const groups: Array<{ label: string | null; options: DropdownOption[] }> = [];
+
+    for (const option of options) {
+        const label = option.groupLabel?.trim() || null;
+        const group = groups.find((candidate) => candidate.label === label);
+        if (group) {
+            group.options.push(option);
+        } else {
+            groups.push({ label, options: [option] });
+        }
+    }
+
+    return groups;
 }
 
 function ChevronIcon({ open }: { readonly open: boolean }) {
@@ -101,6 +127,7 @@ function ChevronIcon({ open }: { readonly open: boolean }) {
 
 function DropdownField({
     buttonLabel,
+    collapsibleGroupLabels = [],
     disabled = false,
     emptySearchMessage = "No matches found.",
     label,
@@ -112,6 +139,9 @@ function DropdownField({
 }: DropdownFieldProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [query, setQuery] = useState("");
+    const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
+        () => new Set(),
+    );
     const containerRef = useRef<HTMLDivElement | null>(null);
     const buttonRef = useRef<HTMLButtonElement | null>(null);
     const menuRef = useRef<HTMLDivElement | null>(null);
@@ -137,6 +167,37 @@ function DropdownField({
             return haystack.includes(normalizedQuery);
         });
     }, [options, query, searchable]);
+    const collapsibleGroupKey = collapsibleGroupLabels.join("\u0000");
+    const collapsibleGroups = useMemo(
+        () =>
+            new Set(collapsibleGroupKey.split("\u0000").filter(Boolean)),
+        [collapsibleGroupKey],
+    );
+    const hasActiveSearch = searchable && query.trim().length > 0;
+    const optionGroups = useMemo(
+        () =>
+            collapsibleGroups.size > 0
+                ? groupDropdownOptions(filteredOptions)
+                : [{ label: null, options: filteredOptions }],
+        [collapsibleGroups, filteredOptions],
+    );
+    const visibleRowCount = useMemo(
+        () =>
+            optionGroups.reduce((count, group) => {
+                const isCollapsible =
+                    group.label !== null && collapsibleGroups.has(group.label);
+                const isExpanded =
+                    !isCollapsible ||
+                    hasActiveSearch ||
+                    expandedGroups.has(group.label ?? "");
+                return (
+                    count +
+                    (group.label === null ? 0 : 1) +
+                    (isExpanded ? group.options.length : 0)
+                );
+            }, 0),
+        [collapsibleGroups, expandedGroups, hasActiveSearch, optionGroups],
+    );
 
     const updateMenuPosition = useCallback(() => {
         const button = buttonRef.current;
@@ -151,7 +212,7 @@ function DropdownField({
         );
         const estimatedHeight = Math.min(
             288,
-            filteredOptions.length * 32 + (searchable ? 52 : 0) + 8,
+            visibleRowCount * 32 + (searchable ? 52 : 0) + 8,
         );
         const height = Math.ceil(measuredMenuRect?.height ?? estimatedHeight);
         const spaceAbove = buttonRect.top - 8;
@@ -173,7 +234,7 @@ function DropdownField({
             x: safePosition.x,
             y: safePosition.y,
         });
-    }, [filteredOptions.length, searchable]);
+    }, [searchable, visibleRowCount]);
 
     useEffect(() => {
         if (!isOpen) return;
@@ -183,6 +244,7 @@ function DropdownField({
             if (menuRef.current?.contains(target)) return;
             setIsOpen(false);
             setQuery("");
+            setExpandedGroups(new Set());
         };
         document.addEventListener("mousedown", handlePointerDown);
         return () =>
@@ -224,8 +286,12 @@ function DropdownField({
                 ref={buttonRef}
                 onClick={() => {
                     if (isDisabled) return;
-                    setIsOpen((current) => !current);
+                    const nextIsOpen = !isOpen;
+                    setIsOpen(nextIsOpen);
                     setQuery("");
+                    if (nextIsOpen) {
+                        setExpandedGroups(new Set());
+                    }
                 }}
                 onMouseEnter={(e) => {
                     if (!isDisabled) {
@@ -311,53 +377,157 @@ function DropdownField({
                                       {emptySearchMessage}
                                   </div>
                               ) : (
-                                  filteredOptions.map((option) => (
-                                      <button
-                                          className="app-no-drag flex min-w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-xs transition"
-                                          key={`${option.groupLabel ?? "default"}:${option.value}`}
-                                          onClick={() => {
-                                              onChange(option.value);
-                                              setIsOpen(false);
-                                              setQuery("");
-                                          }}
-                                          onMouseEnter={(e) => {
-                                              e.currentTarget.style.backgroundColor =
-                                                  "var(--color-bg-tertiary)";
-                                          }}
-                                          onMouseLeave={(e) => {
-                                              e.currentTarget.style.backgroundColor =
-                                                  "transparent";
-                                          }}
-                                          style={{
-                                              backgroundColor: "transparent",
-                                              border: "none",
-                                              color:
-                                                  option.value === value
-                                                      ? "var(--color-accent)"
-                                                      : "var(--color-text-primary)",
-                                              width: "max-content",
-                                              transition:
-                                                  "background-color 100ms ease",
-                                          }}
-                                          type="button"
-                                      >
-                                          <div className="whitespace-nowrap">
-                                              <div>
-                                                  {option.groupLabel ? (
-                                                      <span
+                                  optionGroups.map((group) => {
+                                      const isCollapsible =
+                                          group.label !== null &&
+                                          collapsibleGroups.has(group.label);
+                                      const isExpanded =
+                                          !isCollapsible ||
+                                          hasActiveSearch ||
+                                          expandedGroups.has(group.label ?? "");
+
+                                      return (
+                                          <div
+                                              key={group.label ?? "ungrouped"}
+                                          >
+                                              {group.label ? (
+                                                  isCollapsible ? (
+                                                      <button
+                                                          aria-expanded={isExpanded}
+                                                          className="app-no-drag flex min-w-full items-center justify-between gap-2 rounded-md px-3 py-1.5 text-left text-xs transition"
+                                                          onClick={() => {
+                                                              setExpandedGroups(
+                                                                  (current) => {
+                                                                      const next =
+                                                                          new Set(
+                                                                              current,
+                                                                          );
+                                                                      if (
+                                                                          next.has(
+                                                                              group.label ??
+                                                                                  "",
+                                                                          )
+                                                                      ) {
+                                                                          next.delete(
+                                                                              group.label ??
+                                                                                  "",
+                                                                          );
+                                                                      } else {
+                                                                          next.add(
+                                                                              group.label ??
+                                                                                  "",
+                                                                          );
+                                                                      }
+                                                                      return next;
+                                                                  },
+                                                              );
+                                                          }}
+                                                          onMouseEnter={(e) => {
+                                                              e.currentTarget.style.backgroundColor =
+                                                                  "var(--color-bg-tertiary)";
+                                                          }}
+                                                          onMouseLeave={(e) => {
+                                                              e.currentTarget.style.backgroundColor =
+                                                                  "transparent";
+                                                          }}
+                                                          style={{
+                                                              backgroundColor:
+                                                                  "transparent",
+                                                              border: "none",
+                                                              color: "var(--color-text-primary)",
+                                                              transition:
+                                                                  "background-color 100ms ease",
+                                                          }}
+                                                          type="button"
+                                                      >
+                                                          <span className="whitespace-nowrap">
+                                                              {group.label}
+                                                          </span>
+                                                          <ChevronIcon
+                                                              open={isExpanded}
+                                                          />
+                                                      </button>
+                                                  ) : (
+                                                      <div
+                                                          className="px-3 pb-1 pt-2 text-[11px]"
                                                           style={{
                                                               color: "var(--color-text-secondary)",
                                                           }}
                                                       >
-                                                          {option.groupLabel}{" "}
-                                                          /{" "}
-                                                      </span>
-                                                  ) : null}
-                                                  <span>{option.label}</span>
-                                              </div>
+                                                          {group.label}
+                                                      </div>
+                                                  )
+                                              ) : null}
+
+                                              {isExpanded
+                                                  ? group.options.map((option) => (
+                                                        <button
+                                                            className={`app-no-drag flex min-w-full items-center gap-2 rounded-md py-1.5 text-left text-xs transition ${
+                                                                isCollapsible
+                                                                    ? "pl-7 pr-3"
+                                                                    : "px-3"
+                                                            }`}
+                                                            key={`${option.groupLabel ?? "default"}:${option.value}`}
+                                                            onClick={() => {
+                                                                onChange(
+                                                                    option.value,
+                                                                );
+                                                                setIsOpen(false);
+                                                                setQuery("");
+                                                                setExpandedGroups(
+                                                                    new Set(),
+                                                                );
+                                                            }}
+                                                            onMouseEnter={(e) => {
+                                                                e.currentTarget.style.backgroundColor =
+                                                                    "var(--color-bg-tertiary)";
+                                                            }}
+                                                            onMouseLeave={(e) => {
+                                                                e.currentTarget.style.backgroundColor =
+                                                                    "transparent";
+                                                            }}
+                                                            style={{
+                                                                backgroundColor:
+                                                                    "transparent",
+                                                                border: "none",
+                                                                color:
+                                                                    option.value ===
+                                                                    value
+                                                                        ? "var(--color-accent)"
+                                                                        : "var(--color-text-primary)",
+                                                                width: "max-content",
+                                                                transition:
+                                                                    "background-color 100ms ease",
+                                                            }}
+                                                            type="button"
+                                                        >
+                                                            <div className="whitespace-nowrap">
+                                                                <div>
+                                                                    {collapsibleGroups.size ===
+                                                                        0 &&
+                                                                    option.groupLabel ? (
+                                                                        <span
+                                                                            style={{
+                                                                                color: "var(--color-text-secondary)",
+                                                                            }}
+                                                                        >
+                                                                            {
+                                                                                option.groupLabel
+                                                                            }{" "}
+                                                                            /{" "}
+                                                                        </span>
+                                                                    ) : null}
+                                                                    <span>
+                                                                        {option.label}
+                                                                    </span>
+                                                                </div>
+                                                            </div>
+                                                        </button>
+                                                    ))
+                                                  : null}
                                           </div>
-                                      </button>
-                                  ))
+                                      );
+                                  })
                               )}
                           </div>
                       </div>,
@@ -570,6 +740,7 @@ export function AIChatAgentControls({
 
             {visibleModels.length > 0 ? (
                 <DropdownField
+                    collapsibleGroupLabels={[GPT_5_6_MODEL_GROUP]}
                     disabled={disabled}
                     emptySearchMessage={`No ${runtimeId} models match that search.`}
                     label="Model"

--- a/src/renderer/src/components/workspace/ChatHistoryTabView.test.tsx
+++ b/src/renderer/src/components/workspace/ChatHistoryTabView.test.tsx
@@ -423,7 +423,6 @@ describe("ChatHistoryTabLayout", () => {
                 totalMessages: 1,
             },
             sessions: [session],
-            toolCardExpansionMode: "expanded",
             transcriptMessages: [
                 {
                     attachments: [],
@@ -435,6 +434,15 @@ describe("ChatHistoryTabLayout", () => {
                 },
             ],
         });
+        const groupButton = container.querySelector<HTMLButtonElement>(
+            'button[aria-label^="Show full activity:"]',
+        );
+        expect(groupButton).not.toBeNull();
+
+        act(() => {
+            groupButton?.click();
+        });
+
         const expandButton = container.querySelector<HTMLButtonElement>(
             'button[aria-label="Expand details"]',
         );

--- a/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
@@ -17,7 +17,6 @@ import type {
     AiMessage,
     AiSessionSnapshot,
     AiSessionStatus,
-    AiToolCardExpansionMode,
 } from "@shared/ipc";
 import {
     CHAT_TITLE_HISTORY_MAX_CHARS,
@@ -48,6 +47,7 @@ import {
 import { ChatContentColumn } from "./chat/ChatContentColumn";
 import { ChatMessageRow } from "./chat/ChatMessageRow";
 import { PlanMessage } from "./chat/PlanMessage";
+import { ToolActivitySegment } from "./chat/ToolActivitySegment";
 import { ToolActivityItem } from "./chat/ToolActivityItem";
 import {
     reconcileChatTimelineModel,
@@ -117,7 +117,6 @@ export interface ChatHistoryTabLayoutProps {
     ) => boolean;
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
-    readonly toolCardExpansionMode?: AiToolCardExpansionMode;
     readonly isSidebarCollapsed?: boolean;
     readonly historyScrollRef?: RefCallback<HTMLDivElement>;
     readonly transcriptScrollRef?: RefCallback<HTMLDivElement>;
@@ -913,7 +912,6 @@ export function ChatHistoryTabView({ tab }: ChatHistoryTabViewProps) {
         <ChatHistoryTabLayout
             chatFontFamily={chatFontFamily}
             chatFontSize={aiChatSettings.chatFontSize}
-            toolCardExpansionMode={aiChatSettings.toolCardExpansionMode}
             canRenderFileReference={canRenderFileReference}
             handleDelete={handleDelete}
             handleOpenFile={handleOpenFile}
@@ -963,7 +961,6 @@ export function ChatHistoryTabLayout({
     canRenderFileReference,
     chatFontFamily,
     chatFontSize,
-    toolCardExpansionMode = "collapsed",
     handleDelete,
     handleOpenFile,
     handleOpenImage,
@@ -1741,9 +1738,6 @@ export function ChatHistoryTabLayout({
                                             transcriptMessages={
                                                 displayedTranscriptMessages
                                             }
-                                            toolCardExpansionMode={
-                                                toolCardExpansionMode
-                                            }
                                             worktreeId={
                                                 selectedSession.worktreeId ??
                                                 null
@@ -1844,7 +1838,6 @@ interface HistoryTimelineHandlers {
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
     readonly highlightQuery?: string;
-    readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly onOpenFile: (
         projectId: string,
         relativePath: string,
@@ -1874,7 +1867,6 @@ function HistoryTranscriptTimeline({
     projectId,
     resolveFileReference,
     snapshot,
-    toolCardExpansionMode,
     transcriptMessages,
     worktreeId,
 }: {
@@ -1902,7 +1894,6 @@ function HistoryTranscriptTimeline({
         reference: string,
     ) => ResolvedProjectFileReference | null;
     readonly snapshot: AiSessionSnapshot | null;
-    readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly transcriptMessages: readonly AiMessage[];
     readonly worktreeId: string | null;
 }) {
@@ -1913,7 +1904,7 @@ function HistoryTranscriptTimeline({
             toolActivity: snapshot?.toolActivity ?? [],
             trackedFiles: snapshot?.trackedFiles ?? [],
         });
-        return model.orderedAtomicRows;
+        return model.orderedRows;
     }, [
         snapshot?.toolActivity,
         snapshot?.trackedFiles,
@@ -1926,7 +1917,6 @@ function HistoryTranscriptTimeline({
             chatFontFamily,
             chatFontSize,
             highlightQuery,
-            toolCardExpansionMode,
             onOpenFile: onOpenFile ?? NOOP_OPEN_FILE,
             onOpenImage: onOpenImage ?? NOOP_OPEN_IMAGE,
             onOpenResolvedFileReference,
@@ -1939,7 +1929,6 @@ function HistoryTranscriptTimeline({
             chatFontFamily,
             chatFontSize,
             highlightQuery,
-            toolCardExpansionMode,
             onOpenFile,
             onOpenImage,
             onOpenResolvedFileReference,
@@ -1993,15 +1982,24 @@ function HistoryTimelineRow({
     }
 
     if (row.kind === "activity-segment") {
-        return null;
+        return (
+            <ToolActivitySegment
+                canRenderFileReference={handlers.canRenderFileReference}
+                onOpenFile={handlers.onOpenFile}
+                onOpenFileReference={handlers.onOpenResolvedFileReference}
+                onOpenSession={handlers.onOpenSession}
+                projectId={projectId}
+                resolveFileReference={handlers.resolveFileReference}
+                segment={row}
+                worktreeId={worktreeId}
+            />
+        );
     }
 
     return (
         <ToolActivityItem
             activity={row.reviewEntry.activity}
             canRenderFileReference={handlers.canRenderFileReference}
-            expansionMode={handlers.toolCardExpansionMode}
-            isLatestStreamingTool={false}
             onOpenFile={handlers.onOpenFile}
             onOpenFileReference={handlers.onOpenResolvedFileReference}
             onOpenSession={handlers.onOpenSession}

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -17,7 +17,6 @@ import type {
     AiImageAttachment,
     AiUserInputRequest,
     AiSessionSnapshot,
-    AiToolCardExpansionMode,
     ProjectTreeNode,
 } from "@shared/ipc";
 import {
@@ -101,8 +100,8 @@ import {
     serializePromptWithContexts,
 } from "./chat/promptContextReferences";
 import { QueuedMessagesPanel } from "./chat/QueuedMessagesPanel";
+import { ToolActivitySegment } from "./chat/ToolActivitySegment";
 import { ToolActivityItem } from "./chat/ToolActivityItem";
-import { isEditedFileToolActivity } from "./chat/toolActivityKinds";
 import { requestStopAgentSession } from "./chat/aiSessionLifecycle";
 import {
     collectProjectFileRoots,
@@ -497,7 +496,9 @@ export const ChatTabView = memo(function ChatTabView({
         : null;
     const runtimeDisplayName = getRuntimeDisplayName(tab.runtimeId);
     const closedSubagentMessage =
-        snapshot.parentSessionId && snapshot.closedAt
+        snapshot.parentSessionId &&
+        snapshot.parentSessionId !== snapshot.sessionId &&
+        snapshot.closedAt
             ? CLOSED_SUBAGENT_MESSAGE
             : null;
     const parentSessionId =
@@ -848,7 +849,7 @@ export const ChatTabView = memo(function ChatTabView({
         pendingReviewCount,
         queuedPrompts: queuedPrompts.length,
         sessionId: tab.sessionId,
-        timelineRows: timelineModel.orderedAtomicRows.length,
+        timelineRows: timelineModel.orderedRows.length,
     });
 
     const isNearBottom = useCallback((el: HTMLDivElement) => {
@@ -1836,10 +1837,9 @@ export const ChatTabView = memo(function ChatTabView({
                     chatFontSize={aiChatSettings.chatFontSize}
                     elapsed={elapsed}
                     covered={composerExpanded}
-                    historyRows={timelineModel.atomicHistoryRows}
+                    historyRows={timelineModel.historyRows}
                     isStreaming={isStreaming}
-                    liveTailRow={timelineModel.atomicLiveTailRow}
-                    toolCardExpansionMode={aiChatSettings.toolCardExpansionMode}
+                    liveTailRow={timelineModel.liveTailRow}
                     onAddFileReferenceToChat={
                         handleAddResolvedFileReferenceToChat
                     }
@@ -1910,6 +1910,7 @@ export const ChatTabView = memo(function ChatTabView({
 
                             {pendingReviewCount > 0 ? (
                                 <EditedFilesBufferPanel
+                                    defaultCollapsed
                                     diffZoom={diffZoom}
                                     items={pendingReviewItems}
                                     onKeepAll={handleKeepAllPendingReview}
@@ -2305,34 +2306,6 @@ function ImageAttachmentChip(props: {
     );
 }
 
-function isEditedFileToolRow(row: ChatTimelineRow): boolean {
-    return (
-        row.kind === "tool" &&
-        isEditedFileToolActivity(
-            row.reviewEntry.activity,
-            row.reviewEntry.trackedFiles,
-        )
-    );
-}
-
-function getLatestEditedFileToolRowId(
-    historyRows: readonly ChatTimelineRow[],
-    liveTailRow: ChatTimelineRow | null,
-): string | null {
-    if (liveTailRow && isEditedFileToolRow(liveTailRow)) {
-        return liveTailRow.id;
-    }
-
-    for (let index = historyRows.length - 1; index >= 0; index -= 1) {
-        const row = historyRows[index];
-        if (row && isEditedFileToolRow(row)) {
-            return row.id;
-        }
-    }
-
-    return null;
-}
-
 type ChatTimelineProps = {
     readonly canRenderFileReference?: (
         rawReference: string,
@@ -2379,7 +2352,6 @@ type ChatTimelineProps = {
     readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
     readonly timelineContentRef: RefObject<HTMLDivElement | null>;
-    readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
 };
 
@@ -2412,17 +2384,8 @@ const ChatTimeline = memo(function ChatTimeline({
     shouldPreserveVirtualMeasureAnchor,
     shouldPreserveVirtualResizeAnchor,
     timelineContentRef,
-    toolCardExpansionMode,
     worktreeId,
 }: ChatTimelineProps) {
-    const latestStreamingEditedFileToolRowId = useMemo(
-        () =>
-            isStreaming
-                ? getLatestEditedFileToolRowId(historyRows, liveTailRow)
-                : null,
-        [historyRows, isStreaming, liveTailRow],
-    );
-
     useRenderProbe("ChatTimeline", {
         historyRows: historyRows.length,
         isStreaming,
@@ -2478,9 +2441,6 @@ const ChatTimeline = memo(function ChatTimeline({
                             onVirtualResizeStart={onVirtualResizeStart}
                             projectId={projectId}
                             resolveFileReference={resolveFileReference}
-                            latestStreamingEditedFileToolRowId={
-                                latestStreamingEditedFileToolRowId
-                            }
                             scrollRef={scrollRef}
                             shouldPreserveVirtualMeasureAnchor={
                                 shouldPreserveVirtualMeasureAnchor
@@ -2488,7 +2448,6 @@ const ChatTimeline = memo(function ChatTimeline({
                             shouldPreserveVirtualResizeAnchor={
                                 shouldPreserveVirtualResizeAnchor
                             }
-                            toolCardExpansionMode={toolCardExpansionMode}
                             worktreeId={worktreeId}
                         />
                         <ChatTimelineLiveTail
@@ -2510,10 +2469,6 @@ const ChatTimeline = memo(function ChatTimeline({
                             projectId={projectId}
                             resolveFileReference={resolveFileReference}
                             row={liveTailRow}
-                            latestStreamingEditedFileToolRowId={
-                                latestStreamingEditedFileToolRowId
-                            }
-                            toolCardExpansionMode={toolCardExpansionMode}
                             worktreeId={worktreeId}
                         />
                         {isStreaming ? (
@@ -2610,11 +2565,9 @@ type ChatTimelineHistoryProps = {
     readonly resolveFileReference: (
         reference: string,
     ) => ResolvedProjectFileReference | null;
-    readonly latestStreamingEditedFileToolRowId: string | null;
     readonly scrollRef: RefObject<HTMLDivElement | null>;
     readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
-    readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
 };
 
@@ -2635,21 +2588,13 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
     onVirtualResizeStart,
     projectId,
     resolveFileReference,
-    latestStreamingEditedFileToolRowId,
     scrollRef,
     shouldPreserveVirtualMeasureAnchor,
     shouldPreserveVirtualResizeAnchor,
-    toolCardExpansionMode,
     worktreeId,
 }: ChatTimelineHistoryProps) {
     const renderRow = useCallback(
-        ({
-            isLatestStreamingTool,
-            row,
-        }: {
-            readonly isLatestStreamingTool: boolean;
-            readonly row: ChatTimelineRow;
-        }) => (
+        ({ row }: { readonly row: ChatTimelineRow }) => (
             // The list `key` is owned by each call site (the virtual list keys
             // its row wrapper; the non-virtual path keys via Fragment), so this
             // renderer only describes a row's content.
@@ -2666,8 +2611,6 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
                 projectId={projectId}
                 resolveFileReference={resolveFileReference}
                 row={row}
-                isLatestStreamingTool={isLatestStreamingTool}
-                toolCardExpansionMode={toolCardExpansionMode}
                 worktreeId={worktreeId}
             />
         ),
@@ -2683,7 +2626,6 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
             onRevealFileReference,
             projectId,
             resolveFileReference,
-            toolCardExpansionMode,
             worktreeId,
         ],
     );
@@ -2693,9 +2635,6 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
             chatFontFamily={chatFontFamily}
             chatFontSize={chatFontSize}
             historyRows={historyRows}
-            latestStreamingEditedFileToolRowId={
-                latestStreamingEditedFileToolRowId
-            }
             onVirtualRangeChange={onVirtualRangeChange}
             onVirtualResizeEnd={onVirtualResizeEnd}
             onVirtualResizeAutoFollow={onVirtualResizeAutoFollow}
@@ -2708,7 +2647,6 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
             shouldPreserveVirtualResizeAnchor={
                 shouldPreserveVirtualResizeAnchor
             }
-            toolCardExpansionMode={toolCardExpansionMode}
         />
     );
 });
@@ -2745,8 +2683,6 @@ type ChatTimelineLiveTailProps = {
         reference: string,
     ) => ResolvedProjectFileReference | null;
     readonly row: ChatTimelineRow | null;
-    readonly latestStreamingEditedFileToolRowId: string | null;
-    readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
 };
 
@@ -2763,8 +2699,6 @@ const ChatTimelineLiveTail = memo(function ChatTimelineLiveTail({
     projectId,
     resolveFileReference,
     row,
-    latestStreamingEditedFileToolRowId,
-    toolCardExpansionMode,
     worktreeId,
 }: ChatTimelineLiveTailProps) {
     if (!row) {
@@ -2785,11 +2719,8 @@ const ChatTimelineLiveTail = memo(function ChatTimelineLiveTail({
             onRevealFileReference={onRevealFileReference}
             projectId={projectId}
             resolveFileReference={resolveFileReference}
+            isCurrentTurnTail={true}
             row={row}
-            isLatestStreamingTool={
-                row.id === latestStreamingEditedFileToolRowId
-            }
-            toolCardExpansionMode={toolCardExpansionMode}
             worktreeId={worktreeId}
         />
     );
@@ -2804,6 +2735,7 @@ type ChatTimelineRowViewProps = {
     ) => boolean;
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
+    readonly isCurrentTurnTail?: boolean;
     readonly onAddFileReferenceToChat?: (
         reference: ResolvedProjectFileReference,
     ) => void;
@@ -2827,8 +2759,6 @@ type ChatTimelineRowViewProps = {
         reference: string,
     ) => ResolvedProjectFileReference | null;
     readonly row: ChatTimelineRow;
-    readonly isLatestStreamingTool: boolean;
-    readonly toolCardExpansionMode: AiToolCardExpansionMode;
     readonly worktreeId: string | null;
 };
 
@@ -2836,6 +2766,7 @@ const ChatTimelineRowView = memo(function ChatTimelineRowView({
     canRenderFileReference,
     chatFontFamily,
     chatFontSize,
+    isCurrentTurnTail = false,
     onAddFileReferenceToChat,
     onOpenFile,
     onOpenImage,
@@ -2845,8 +2776,6 @@ const ChatTimelineRowView = memo(function ChatTimelineRowView({
     projectId,
     resolveFileReference,
     row,
-    isLatestStreamingTool,
-    toolCardExpansionMode,
     worktreeId,
 }: ChatTimelineRowViewProps) {
     if (row.kind === "message") {
@@ -2868,7 +2797,21 @@ const ChatTimelineRowView = memo(function ChatTimelineRowView({
     }
 
     if (row.kind === "activity-segment") {
-        return null;
+        return (
+            <div className="min-w-0 w-full">
+                <ToolActivitySegment
+                    canRenderFileReference={canRenderFileReference}
+                    isCurrentTurnTail={isCurrentTurnTail}
+                    onOpenFile={onOpenFile}
+                    onOpenFileReference={onOpenResolvedFileReference}
+                    onOpenSession={onOpenSession}
+                    projectId={projectId}
+                    resolveFileReference={resolveFileReference}
+                    segment={row}
+                    worktreeId={worktreeId}
+                />
+            </div>
+        );
     }
 
     return (
@@ -2876,8 +2819,6 @@ const ChatTimelineRowView = memo(function ChatTimelineRowView({
             <ToolActivityItem
                 activity={row.reviewEntry.activity}
                 canRenderFileReference={canRenderFileReference}
-                expansionMode={toolCardExpansionMode}
-                isLatestStreamingTool={isLatestStreamingTool}
                 onOpenFile={onOpenFile}
                 onOpenFileReference={onOpenResolvedFileReference}
                 onOpenSession={onOpenSession}

--- a/src/renderer/src/components/workspace/MarkdownCodeFrame.tsx
+++ b/src/renderer/src/components/workspace/MarkdownCodeFrame.tsx
@@ -1,0 +1,206 @@
+import {
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    type ReactNode,
+} from "react";
+
+const markdownCodeLanguageLabels: Record<string, string> = {
+    bash: "Bash",
+    c: "C",
+    "c++": "C++",
+    cpp: "C++",
+    cs: "C#",
+    csharp: "C#",
+    css: "CSS",
+    diff: "Diff",
+    docker: "Dockerfile",
+    dockerfile: "Dockerfile",
+    gql: "GraphQL",
+    graphql: "GraphQL",
+    html: "HTML",
+    java: "Java",
+    javascript: "JavaScript",
+    js: "JavaScript",
+    json: "JSON",
+    jsonc: "JSONC",
+    jsx: "JSX",
+    make: "Makefile",
+    makefile: "Makefile",
+    markdown: "Markdown",
+    md: "Markdown",
+    mdx: "MDX",
+    php: "PHP",
+    powershell: "PowerShell",
+    ps1: "PowerShell",
+    pwsh: "PowerShell",
+    py: "Python",
+    python: "Python",
+    rb: "Ruby",
+    rs: "Rust",
+    ruby: "Ruby",
+    rust: "Rust",
+    scss: "SCSS",
+    sh: "Shell",
+    shell: "Shell",
+    sql: "SQL",
+    text: "Text",
+    ts: "TypeScript",
+    tsx: "TSX",
+    typescript: "TypeScript",
+    xml: "XML",
+    yaml: "YAML",
+    yml: "YAML",
+    zsh: "Zsh",
+};
+
+function formatMarkdownCodeLanguageLabel(language: string): string {
+    const normalizedLanguage = language.trim().toLowerCase();
+    const mappedLabel = markdownCodeLanguageLabels[normalizedLanguage];
+    if (mappedLabel) {
+        return mappedLabel;
+    }
+
+    return normalizedLanguage
+        .split(/[-_]+/)
+        .filter(Boolean)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(" ");
+}
+
+async function writeCodeBlockClipboardText(text: string): Promise<void> {
+    if (window.comando?.writeClipboardText) {
+        try {
+            await window.comando.writeClipboardText(text);
+            return;
+        } catch {
+            // Fall through to the Web Clipboard API when the native bridge is unavailable.
+        }
+    }
+
+    if (navigator.clipboard?.writeText) {
+        try {
+            await navigator.clipboard.writeText(text);
+        } catch {
+            // Copy actions should stay quiet if clipboard access is denied.
+        }
+    }
+}
+
+function MarkdownCodeCopyIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.6"
+            viewBox="0 0 14 14"
+            width="12"
+        >
+            <rect x="5" y="3" width="6" height="8" rx="1.2" />
+            <path d="M3.5 9.5H3A1 1 0 0 1 2 8.5v-5A1.5 1.5 0 0 1 3.5 2H8" />
+        </svg>
+    );
+}
+
+function MarkdownCodeCheckIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.7"
+            viewBox="0 0 14 14"
+            width="12"
+        >
+            <path d="M3 7l2.2 2.2L11 3.8" />
+        </svg>
+    );
+}
+
+function MarkdownCodeCopyButton({ codeText }: { readonly codeText: string }) {
+    const [copied, setCopied] = useState(false);
+    const resetTimeoutRef = useRef<number | null>(null);
+
+    useEffect(
+        () => () => {
+            if (resetTimeoutRef.current) {
+                window.clearTimeout(resetTimeoutRef.current);
+            }
+        },
+        [],
+    );
+
+    const handleCopy = useCallback(() => {
+        void writeCodeBlockClipboardText(codeText).then(() => {
+            setCopied(true);
+            if (resetTimeoutRef.current) {
+                window.clearTimeout(resetTimeoutRef.current);
+            }
+            resetTimeoutRef.current = window.setTimeout(() => {
+                setCopied(false);
+                resetTimeoutRef.current = null;
+            }, 1200);
+        });
+    }, [codeText]);
+
+    return (
+        <button
+            aria-label="Copy code block"
+            className="markdown-code-copy-button"
+            data-copied={copied ? "true" : undefined}
+            onClick={handleCopy}
+            title={copied ? "Copied" : "Copy"}
+            type="button"
+        >
+            {copied ? <MarkdownCodeCheckIcon /> : <MarkdownCodeCopyIcon />}
+        </button>
+    );
+}
+
+export function MarkdownCodeFrame({
+    children,
+    className,
+    codeText,
+    language,
+}: {
+    readonly children: ReactNode;
+    readonly className?: string;
+    readonly codeText: string;
+    readonly language?: string | null;
+}) {
+    const normalizedLanguage = language?.trim() || null;
+
+    return (
+        <div
+            className={[
+                "markdown-code-frame",
+                normalizedLanguage ? null : "markdown-code-frame--unlabeled",
+                className,
+            ]
+                .filter(Boolean)
+                .join(" ")}
+        >
+            {normalizedLanguage ? (
+                <div className="markdown-code-header">
+                    <span>
+                        {formatMarkdownCodeLanguageLabel(normalizedLanguage)}
+                    </span>
+                    <MarkdownCodeCopyButton codeText={codeText} />
+                </div>
+            ) : (
+                <div className="markdown-code-copy-overlay">
+                    <MarkdownCodeCopyButton codeText={codeText} />
+                </div>
+            )}
+            {children}
+        </div>
+    );
+}

--- a/src/renderer/src/components/workspace/MarkdownContent.test.ts
+++ b/src/renderer/src/components/workspace/MarkdownContent.test.ts
@@ -5,6 +5,12 @@ import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import {
+    serializeComposerDisplayFileMention,
+    serializeComposerDisplayFolderMention,
+    serializeComposerDisplaySelectionMention,
+} from "@shared/composer-display-markers";
+
 import { MarkdownContent } from "./MarkdownContent";
 import { resolveProjectFileReference } from "./projectFileReferences";
 
@@ -44,6 +50,21 @@ function renderInteractiveMarkdownContent(
 }
 
 describe("MarkdownContent", () => {
+    it("renders serialized folder mentions as Catppuccin links", () => {
+        const markup = renderToStaticMarkup(
+            createElement(MarkdownContent, {
+                content: serializeComposerDisplayFolderMention({
+                    folderPath: "src/components",
+                    label: "components",
+                }),
+            }),
+        );
+
+        expect(markup).toContain("@components");
+        expect(markup).toContain("src/components");
+        expect(markup).toContain("<svg");
+    });
+
     it("renders diff blocks with DiffLineView", () => {
         const markup = renderToStaticMarkup(
             createElement(MarkdownContent, {
@@ -55,7 +76,9 @@ describe("MarkdownContent", () => {
         expect(markup).toContain('data-diff-line="true"');
         expect(markup).toContain('data-line-type="remove"');
         expect(markup).toContain('data-line-type="add"');
-        expect(markup).toContain(">diff<");
+        expect(markup).toContain(">Diff<");
+        expect(markup).toContain("markdown-code-frame");
+        expect(markup).toContain("markdown-code-header");
     });
 
     it("keeps normal rendering for non-diff code blocks", () => {
@@ -65,9 +88,24 @@ describe("MarkdownContent", () => {
             }),
         );
 
-        expect(markup).toContain(">ts<");
+        expect(markup).toContain(">TypeScript<");
+        expect(markup).toContain("markdown-code-block");
         expect(markup).toContain("cm-static-code");
         expect(markup).not.toContain("markdown-diff-block");
+    });
+
+    it("uses the shared preview chrome for text fences", () => {
+        const markup = renderToStaticMarkup(
+            createElement(MarkdownContent, {
+                content: "```text\nprepare root\n```",
+            }),
+        );
+
+        expect(markup).toContain("markdown-code-frame");
+        expect(markup).toContain("markdown-code-header");
+        expect(markup).toContain(">Text</span>");
+        expect(markup).toContain('aria-label="Copy code block"');
+        expect(markup).toContain("prepare root");
     });
 
     it("renders tilde fenced code blocks", () => {
@@ -77,7 +115,7 @@ describe("MarkdownContent", () => {
             }),
         );
 
-        expect(markup).toContain(">python<");
+        expect(markup).toContain(">Python<");
         expect(markup).toContain("cm-static-code");
         expect(markup).toContain("print");
     });
@@ -89,7 +127,7 @@ describe("MarkdownContent", () => {
             }),
         );
 
-        expect(markup).toContain(">zig<");
+        expect(markup).toContain(">Zig<");
         expect(markup).toContain("cm-static-code");
         expect(markup).toContain("value");
     });
@@ -106,9 +144,9 @@ describe("MarkdownContent", () => {
             }),
         );
 
-        expect(tomlMarkup).toContain(">toml<");
+        expect(tomlMarkup).toContain(">Toml<");
         expect(tomlMarkup).toContain("cm-static-code");
-        expect(graphqlMarkup).toContain(">graphql<");
+        expect(graphqlMarkup).toContain(">GraphQL<");
         expect(graphqlMarkup).toContain("cm-static-code");
     });
 
@@ -144,6 +182,110 @@ describe("MarkdownContent", () => {
 
         expect(markup).toContain("(8:14) - Si ves que un");
         expect(markup).toContain("expande");
+    });
+
+    it("renders serialized user file mentions as openable icon links", () => {
+        const relativePath = "vendor/codex-acp/src/thread.rs";
+        const markup = renderToStaticMarkup(
+            createElement(MarkdownContent, {
+                canRenderFileReference: () => true,
+                content: serializeComposerDisplayFileMention({
+                    label: "thread.rs",
+                    relativePath,
+                }),
+                onOpenFile: () => undefined,
+                resolveFileReference: (reference) =>
+                    resolveProjectFileReference(reference, {
+                        projectRoots: ["/Users/test/workspace/comando"],
+                    }),
+            }),
+        );
+
+        expect(markup).toContain(">@thread.rs<");
+        expect(markup).toContain(`title="${relativePath}"`);
+        expect(markup).toContain("catppuccin-icon");
+    });
+
+    it("modernizes legacy user file mentions when the file is unambiguous", () => {
+        const fileName = "@02-pr-code-mode-host-packaging-por-commits.md";
+        const markup = renderToStaticMarkup(
+            createElement(MarkdownContent, {
+                canRenderFileReference: () => true,
+                content: `\u200B\u00AB${fileName}\u00BB\u200B create this`,
+                onOpenFile: () => undefined,
+                resolveFileReference: (reference) =>
+                    resolveProjectFileReference(reference, { projectRoots: [] }),
+            }),
+        );
+
+        expect(markup).toContain(`>${fileName}<`);
+        expect(markup).toContain(
+            'title="02-pr-code-mode-host-packaging-por-commits.md"',
+        );
+        expect(markup).toContain("catppuccin-icon");
+        expect(markup).toContain("background:transparent");
+    });
+
+    it("renders serialized selections as links to their exact line range", () => {
+        const relativePath = "src/elicitation.ts";
+        const markup = renderToStaticMarkup(
+            createElement(MarkdownContent, {
+                canRenderFileReference: () => true,
+                content: serializeComposerDisplaySelectionMention({
+                    endLine: 14,
+                    label: "(8:14) - selected code",
+                    path: relativePath,
+                    startLine: 8,
+                }),
+                onOpenFile: () => undefined,
+                resolveFileReference: (reference) =>
+                    resolveProjectFileReference(reference, {
+                        projectRoots: ["/Users/test/workspace/comando"],
+                    }),
+            }),
+        );
+
+        expect(markup).toContain(
+            ">elicitation.ts (lines 8–14)<",
+        );
+        expect(markup).not.toContain("selected code</span>");
+        expect(markup).toContain('title="src/elicitation.ts:8-14"');
+        expect(markup).toContain("catppuccin-icon");
+    });
+
+    it("keeps unresolved legacy user file mentions in the new icon link style", () => {
+        const fileName = "@03-pr-turntime-activities-deduplicacion-por-commits.md";
+        const markup = renderToStaticMarkup(
+            createElement(MarkdownContent, {
+                content: `\u200B\u00AB${fileName}\u00BB\u200B create a branch`,
+            }),
+        );
+
+        expect(markup).toContain(`>${fileName}<`);
+        expect(markup).toContain("catppuccin-icon");
+        expect(markup).toContain("background:transparent");
+    });
+
+    it("keeps trusted composer selections styled while the file index loads", () => {
+        const markup = renderToStaticMarkup(
+            createElement(MarkdownContent, {
+                canRenderFileReference: () => false,
+                content: serializeComposerDisplaySelectionMention({
+                    endLine: 3,
+                    label: "(1:3) - interesting",
+                    path: "archive-2.txt",
+                    startLine: 1,
+                }),
+                onOpenFile: () => undefined,
+                resolveFileReference: (reference) =>
+                    resolveProjectFileReference(reference, { projectRoots: [] }),
+            }),
+        );
+
+        expect(markup).toContain(">archive-2.txt (lines 1–3)<");
+        expect(markup).toContain('title="archive-2.txt:1-3"');
+        expect(markup).toContain("catppuccin-icon");
+        expect(markup).toContain("background:transparent");
     });
 
     it("renders long inline file reference pills without shortening the label", () => {
@@ -203,6 +345,7 @@ describe("MarkdownContent", () => {
         expect(markup).not.toContain('title="TCP/IP"');
         expect(markup).not.toContain('title="2024/Q1"');
         expect(markup).not.toContain('title="/LinkedIn"');
+        expect(markup.match(/class="chat-inline-code"/g)?.length).toBe(4);
         expect(markup).toContain(
             'title="src/renderer/src/components/workspace/MarkdownContent.tsx"',
         );
@@ -239,6 +382,30 @@ describe("MarkdownContent", () => {
         );
         expect(markup).toContain(
             'title="file:///Users/test/workspace/comando/src/app.ts#L9-L14"',
+        );
+    });
+
+    it("renders natural line references with Catppuccin file icons", () => {
+        const content =
+            "See manage_profiles_modal.rs (line 790) and src/profile_selector.rs (lines 177-184).";
+        const markup = renderToStaticMarkup(
+            createElement(MarkdownContent, {
+                canRenderFileReference: () => true,
+                content,
+                onOpenFile: () => undefined,
+                resolveFileReference: (reference) =>
+                    resolveProjectFileReference(reference, {
+                        projectRoots: ["/Users/test/workspace/comando"],
+                    }),
+            }),
+        );
+
+        expect(markup.match(/<button/g)?.length).toBe(2);
+        expect(markup).toContain("manage_profiles_modal.rs (line 790)");
+        expect(markup).toContain("profile_selector.rs (lines 177-184)");
+        expect(markup).toContain("transform:translateY(2px)");
+        expect(markup.match(/catppuccin-icon/g)?.length).toBeGreaterThanOrEqual(
+            2,
         );
     });
 

--- a/src/renderer/src/components/workspace/MarkdownContent.tsx
+++ b/src/renderer/src/components/workspace/MarkdownContent.tsx
@@ -8,6 +8,13 @@ import {
     type ReactElement,
 } from "react";
 
+import {
+    formatComposerDisplaySelectionLabel,
+    parseComposerDisplayFileMention,
+    parseComposerDisplayFolderMention,
+    parseComposerDisplaySelectionMention,
+} from "@shared/composer-display-markers";
+
 import { extractFenceLanguageToken } from "../../app/editor/codeLanguage";
 import { openExternalUrl } from "../../app/utils/external-url";
 import {
@@ -22,19 +29,20 @@ import {
     type ContextMenuState,
 } from "../context-menu/ContextMenu";
 import { useTextContextMenu } from "../context-menu/useTextContextMenu";
+import { FileTypeIcon } from "../icons/FileTypeIcon";
+import { FolderTypeIcon } from "../icons/FolderTypeIcon";
 import { DiffLineView } from "./review/DiffLineView";
 import {
     DIFF_PANEL_MAX_HEIGHT,
     computeUnifiedDiffLines,
 } from "./review/reviewDiff";
-import {
-    getChatCodeBlockFontSize,
-    getChatCodeLabelFontSize,
-} from "./chat/chatCodeSizing";
+import { getChatCodeBlockFontSize } from "./chat/chatCodeSizing";
 import { ChatInlinePill } from "./chat/ChatInlinePill";
 import { getChatPillMetrics } from "./chat/chatPillMetrics";
 import { type ChatPillVariant } from "./chat/chatPillPalette";
+import { MarkdownCodeFrame } from "./MarkdownCodeFrame";
 import {
+    parseProjectFileReference,
     type ResolvedProjectFileReference,
 } from "./projectFileReferences";
 
@@ -321,7 +329,7 @@ function getSerializedPillDisplayLabel(label: string): string {
 const EXPLICIT_RELATIVE_PATH_RE = /^\.{1,2}[\\/]/;
 const FILE_URL_RE = /^file:\/\//i;
 const RAW_TEXT_FILE_REFERENCE_RE =
-    /file:\/\/[^\s<>"'`()[\]{}]+|(?:[A-Za-z]:[\\/]|\\\\|\/|\.{1,2}[\\/]|[A-Za-z0-9_@.-]+[\\/])[^\s<>"'`()[\]{}]+/gi;
+    /file:\/\/[^\s<>"'`()[\]{}]+|(?:[A-Za-z]:[\\/]|\\\\|\/|\.{1,2}[\\/]|[A-Za-z0-9_@.-]+[\\/])[^\s<>"'`()[\]{}]+(?:\s*\((?:line|lines)\s+\d+(?:\s*[-–]\s*\d+)?\))?|\b[A-Za-z0-9_@.-]+\.[A-Za-z0-9]+(?:\s*\((?:line|lines)\s+\d+(?:\s*[-–]\s*\d+)?\))?/gi;
 const RAW_GIT_COMMIT_REFERENCE_RE =
     /\b(?:commit|revision|sha)\s*:?\s*([0-9a-f]{7,40})\b/gi;
 const KNOWN_EXTENSIONLESS_FILE_NAMES = new Set([
@@ -455,8 +463,62 @@ function getFileReferenceName(reference: ResolvedProjectFileReference): string {
     return reference.relativePath.split("/").pop() ?? reference.relativePath;
 }
 
+function resolveTrustedComposerReference(
+    target: string,
+    resolveFileReference: InlineOptions["resolveFileReference"],
+): ResolvedProjectFileReference | null {
+    const resolved = resolveFileReference?.(target) ?? null;
+    if (resolved) {
+        return resolved;
+    }
+
+    const parsed = parseProjectFileReference(target);
+    if (!parsed || parsed.isAbsolute) {
+        return null;
+    }
+
+    return {
+        ...parsed,
+        relativePath: parsed.path,
+    };
+}
+
+function createTrustedSelectionReference(
+    path: string,
+    startLine: number,
+    endLine: number,
+): ResolvedProjectFileReference | null {
+    const normalizedPath = path.replaceAll("\\", "/").replace(/^\.\//, "");
+    if (
+        !normalizedPath ||
+        normalizedPath === ".." ||
+        normalizedPath.startsWith("../") ||
+        normalizedPath.startsWith("/") ||
+        /^[A-Za-z]:\//.test(normalizedPath)
+    ) {
+        return null;
+    }
+
+    return {
+        endLine,
+        isAbsolute: false,
+        path: normalizedPath,
+        relativePath: normalizedPath,
+        startLine,
+    };
+}
+
 function getRawReferenceLocationSuffix(rawReference: string): string {
     const trimmedReference = rawReference.trim();
+    const naturalLineMatch = trimmedReference.match(
+        /\((line|lines)\s+(\d+)(?:\s*[-–]\s*(\d+))?\)$/i,
+    );
+    if (naturalLineMatch) {
+        return naturalLineMatch[3]
+            ? ` (lines ${naturalLineMatch[2]}-${naturalLineMatch[3]})`
+            : ` (line ${naturalLineMatch[2]})`;
+    }
+
     const trailingLineMatch = trimmedReference.match(
         /:(\d+)(?::(\d+))?(?:[.,;!?])?$/,
     );
@@ -539,9 +601,17 @@ function renderFileReferencePill({
 }): ReactElement {
     return (
         <ChatInlinePill
+            appearance="link"
             interactive
             key={key}
             label={label}
+            leadingVisual={
+                <FileTypeIcon
+                    fileName={resolvedReference.relativePath}
+                    opacity={1}
+                    size={Math.max(11, Math.min(14, metrics.fontSize))}
+                />
+            }
             metrics={metrics}
             onClick={() => onOpenFile(resolvedReference)}
             onContextMenu={(event) =>
@@ -915,18 +985,194 @@ function renderInline(
             }
 
             const pillLabel = text.slice(tokenIndex + 2, pillEndIndex);
+            const fileMention = parseComposerDisplayFileMention(pillLabel);
+            const fallbackFileMention = parseComposerDisplayFileMention(pillLabel);
+            const folderMention = parseComposerDisplayFolderMention(pillLabel);
+            const selectionMention =
+                parseComposerDisplaySelectionMention(pillLabel);
+            const legacyFileTarget =
+                !fileMention &&
+                !folderMention &&
+                !selectionMention &&
+                pillLabel.startsWith("@")
+                    ? pillLabel.slice(1).trim()
+                    : null;
             const displayLabel = getSerializedPillDisplayLabel(pillLabel);
             const variant = getPillVariant(pillLabel);
             const pillMetrics = options?.metrics ?? getChatPillMetrics(14);
-            parts.push(
-                <ChatInlinePill
-                    key={key++}
-                    label={displayLabel}
-                    metrics={pillMetrics}
-                    title={pillLabel}
-                    variant={variant}
-                />,
-            );
+            const resolvedFileMention = fileMention
+                ? resolveTrustedComposerReference(
+                      fileMention.relativePath,
+                      options?.resolveFileReference,
+                  )
+                : null;
+            const selectionTarget = selectionMention
+                ? `${selectionMention.path}:${selectionMention.startLine}-${selectionMention.endLine}`
+                : null;
+            const resolvedSelectionMention = selectionTarget
+                ? (options?.resolveFileReference?.(selectionTarget) ??
+                  (selectionMention
+                      ? createTrustedSelectionReference(
+                            selectionMention.path,
+                            selectionMention.startLine,
+                            selectionMention.endLine,
+                        )
+                      : null))
+                : null;
+            const resolvedLegacyFileMention = legacyFileTarget
+                ? (options?.resolveFileReference?.(legacyFileTarget) ?? null)
+                : null;
+            if (folderMention) {
+                parts.push(
+                    <ChatInlinePill
+                        appearance="link"
+                        key={key++}
+                        label={`@${folderMention.label}`}
+                        leadingVisual={
+                            <FolderTypeIcon
+                                folderName={folderMention.folderPath}
+                                opacity={1}
+                                open={false}
+                                size={Math.max(
+                                    11,
+                                    Math.min(14, pillMetrics.fontSize),
+                                )}
+                            />
+                        }
+                        metrics={pillMetrics}
+                        title={folderMention.folderPath}
+                        variant="folder"
+                    />,
+                );
+            } else if (
+                fileMention &&
+                resolvedFileMention &&
+                options?.onOpenFile
+            ) {
+                parts.push(
+                    renderFileReferencePill({
+                        key: key++,
+                        label: `@${fileMention.label}`,
+                        metrics: pillMetrics,
+                        onFileContextMenu: options.onFileContextMenu,
+                        onOpenFile: options.onOpenFile,
+                        rawReference: fileMention.relativePath,
+                        resolvedReference: resolvedFileMention,
+                    }),
+                );
+            } else if (
+                selectionMention &&
+                selectionTarget &&
+                resolvedSelectionMention &&
+                options?.onOpenFile
+            ) {
+                parts.push(
+                    renderFileReferencePill({
+                        key: key++,
+                        label: formatComposerDisplaySelectionLabel(
+                            selectionMention,
+                        ),
+                        metrics: pillMetrics,
+                        onFileContextMenu: options.onFileContextMenu,
+                        onOpenFile: options.onOpenFile,
+                        rawReference: selectionTarget,
+                        resolvedReference: resolvedSelectionMention,
+                    }),
+                );
+            } else if (
+                legacyFileTarget &&
+                resolvedLegacyFileMention &&
+                options?.onOpenFile &&
+                canRenderResolvedFileReferencePill(
+                    legacyFileTarget,
+                    resolvedLegacyFileMention,
+                    "markdown_link",
+                    options,
+                )
+            ) {
+                parts.push(
+                    renderFileReferencePill({
+                        key: key++,
+                        label: `@${legacyFileTarget}`,
+                        metrics: pillMetrics,
+                        onFileContextMenu: options.onFileContextMenu,
+                        onOpenFile: options.onOpenFile,
+                        rawReference: legacyFileTarget,
+                        resolvedReference: resolvedLegacyFileMention,
+                    }),
+                );
+            } else if (fallbackFileMention) {
+                parts.push(
+                    <ChatInlinePill
+                        appearance="link"
+                        key={key++}
+                        label={`@${fallbackFileMention.label}`}
+                        leadingVisual={
+                            <FileTypeIcon
+                                fileName={fallbackFileMention.relativePath}
+                                opacity={1}
+                                size={Math.max(
+                                    11,
+                                    Math.min(14, pillMetrics.fontSize),
+                                )}
+                            />
+                        }
+                        metrics={pillMetrics}
+                        title={fallbackFileMention.relativePath}
+                        variant="file"
+                    />,
+                );
+            } else if (
+                legacyFileTarget &&
+                getPillVariant(pillLabel) === "file"
+            ) {
+                parts.push(
+                    <ChatInlinePill
+                        appearance="link"
+                        key={key++}
+                        label={`@${legacyFileTarget}`}
+                        leadingVisual={
+                            <FileTypeIcon
+                                fileName={legacyFileTarget}
+                                opacity={1}
+                                size={Math.max(
+                                    11,
+                                    Math.min(14, pillMetrics.fontSize),
+                                )}
+                            />
+                        }
+                        metrics={pillMetrics}
+                        title={legacyFileTarget}
+                        variant="file"
+                    />,
+                );
+            } else {
+                parts.push(
+                    <ChatInlinePill
+                        key={key++}
+                        label={
+                            fileMention
+                                ? `@${fileMention.label}`
+                                : selectionMention
+                                  ? formatComposerDisplaySelectionLabel(
+                                        selectionMention,
+                                    )
+                                  : displayLabel
+                        }
+                        metrics={pillMetrics}
+                        title={
+                            fileMention?.relativePath ??
+                            selectionTarget ??
+                            pillLabel
+                        }
+                        variant={
+                            fileMention || selectionMention
+                                ? "file"
+                                : variant
+                        }
+                    />,
+                );
+            }
             cursor = pillEndIndex + 2;
             continue;
         }
@@ -969,14 +1215,8 @@ function renderInline(
             } else {
                 parts.push(
                     <code
+                        className="chat-inline-code"
                         key={key++}
-                        style={{
-                            backgroundColor: "var(--color-bg-tertiary)",
-                            borderRadius: 4,
-                            color: "var(--color-accent)",
-                            fontSize: "0.85em",
-                            padding: "1px 5px",
-                        }}
                     >
                         {codeText}
                     </code>,
@@ -1539,43 +1779,6 @@ function parseList(
     };
 }
 
-/* ─── Copy button SVG icons ─── */
-
-function CopyIcon() {
-    return (
-        <svg
-            fill="none"
-            height="11"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.5"
-            viewBox="0 0 14 14"
-            width="11"
-        >
-            <rect x="5" y="3" width="6" height="8" rx="1.2" />
-            <path d="M3.5 9.5H3A1 1 0 012 8.5v-5A1.5 1.5 0 013.5 2H8" />
-        </svg>
-    );
-}
-
-function CheckIcon() {
-    return (
-        <svg
-            fill="none"
-            height="11"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.5"
-            viewBox="0 0 14 14"
-            width="11"
-        >
-            <path d="M3 7l2.2 2.2L11 3.8" />
-        </svg>
-    );
-}
-
 /* ─── Code block ─── */
 
 function CodeBlock({
@@ -1585,7 +1788,6 @@ function CodeBlock({
     readonly block: Block;
     readonly chatFontSize?: number;
 }) {
-    const [copied, setCopied] = useState(false);
     const languageSupport = useMarkdownCodeLanguageSupport(block.info);
     const languageToken = extractFenceLanguageToken(block.info ?? "");
     const isDiffBlock =
@@ -1596,88 +1798,20 @@ function CodeBlock({
         [block.content, isDiffBlock],
     );
     const codeFontSize = getChatCodeBlockFontSize(chatFontSize);
-    const languageLabel =
-        languageToken?.toLowerCase() === "md"
-            ? "Markdown"
-            : (languageToken ?? block.info?.trim());
-
-    const handleCopy = useCallback(() => {
-        void navigator.clipboard.writeText(block.content).then(() => {
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1200);
-        });
-    }, [block.content]);
-
-    const copyButton = (
-        <button
-            aria-label="Copy code block"
-            onClick={handleCopy}
-            onMouseEnter={(e) => {
-                e.currentTarget.style.opacity = "1";
-            }}
-            onMouseLeave={(e) => {
-                e.currentTarget.style.opacity = "0.9";
-            }}
-            title={copied ? "Copied" : "Copy"}
-            style={{
-                alignItems: "center",
-                backgroundColor:
-                    "color-mix(in srgb, var(--color-bg-elevated) 92%, transparent)",
-                border: "1px solid var(--color-border)",
-                borderRadius: 6,
-                color: copied
-                    ? "var(--color-accent)"
-                    : "var(--color-text-secondary)",
-                cursor: "pointer",
-                display: "inline-flex",
-                height: 22,
-                justifyContent: "center",
-                opacity: 0.9,
-                transition: "opacity 100ms ease, background-color 100ms ease",
-                width: 22,
-            }}
-            type="button"
-        >
-            {copied ? <CheckIcon /> : <CopyIcon />}
-        </button>
-    );
 
     return (
-        <div
-            className="group relative my-2 min-w-0 max-w-full select-none overflow-hidden rounded-lg"
-            style={{
-                backgroundColor: "var(--color-bg-tertiary)",
-                border: "1px solid var(--color-border)",
-            }}
+        <MarkdownCodeFrame
+            className="my-1 min-w-0 max-w-full"
+            codeText={block.content}
+            language={languageToken}
         >
-            {languageLabel ? (
-                <div
-                    className="flex items-center justify-between px-3 py-2 pr-9"
-                    style={{
-                        borderBottom: "1px solid var(--color-border)",
-                        color: "var(--color-text-secondary)",
-                        fontSize: getChatCodeLabelFontSize(chatFontSize),
-                        letterSpacing: "0.06em",
-                        textTransform: "uppercase",
-                    }}
-                >
-                    <span>{languageLabel}</span>
-                </div>
-            ) : null}
-            <div
-                className="absolute right-2"
-                style={{ top: languageLabel ? 5 : 8 }}
-            >
-                {copyButton}
-            </div>
             <pre
-                className="select-text overflow-x-auto p-3"
+                className="markdown-code-block chat-markdown-code-block select-text"
                 style={{
                     color: "var(--color-text-primary)",
                     fontFamily: "var(--font-mono)",
                     fontSize: codeFontSize,
-                    lineHeight: 1.6,
-                    margin: 0,
+                    lineHeight: 1.55,
                     overflowWrap: "anywhere",
                     whiteSpace: "pre-wrap",
                     wordBreak: "break-word",
@@ -1721,7 +1855,7 @@ function CodeBlock({
                     </code>
                 )}
             </pre>
-        </div>
+        </MarkdownCodeFrame>
     );
 }
 

--- a/src/renderer/src/components/workspace/MarkdownFilePreview.test.tsx
+++ b/src/renderer/src/components/workspace/MarkdownFilePreview.test.tsx
@@ -320,10 +320,10 @@ describe("MarkdownFilePreview", () => {
         });
 
         expect(markup).toContain('data-language="ts"');
-        expect(markup).toContain("markdown-file-preview__code-frame");
-        expect(markup).toContain("markdown-file-preview__code-header");
+        expect(markup).toContain("markdown-code-frame");
+        expect(markup).toContain("markdown-code-header");
         expect(markup).toContain(">TypeScript</span>");
-        expect(markup).toContain("markdown-file-preview__code-block");
+        expect(markup).toContain("markdown-code-block");
         expect(markup).toContain("cm-static-code");
         expect(markup).toContain("const value = 1;");
     });
@@ -434,8 +434,8 @@ describe("MarkdownFilePreview", () => {
             content: "```\nplain code\n```",
         });
 
-        expect(markup).toContain("markdown-file-preview__code-block");
-        expect(markup).not.toContain("markdown-file-preview__code-header");
+        expect(markup).toContain("markdown-code-block");
+        expect(markup).not.toContain("markdown-code-header");
         expect(markup).not.toContain("data-language=");
         expect(markup).not.toContain("cm-static-code");
         expect(markup).toContain("plain code");

--- a/src/renderer/src/components/workspace/MarkdownFilePreview.tsx
+++ b/src/renderer/src/components/workspace/MarkdownFilePreview.tsx
@@ -13,17 +13,16 @@ import {
     type TableHTMLAttributes,
     type TdHTMLAttributes,
     type ThHTMLAttributes,
-    useCallback,
-    useEffect,
     useMemo,
     useRef,
-    useState,
 } from "react";
 
 import { HighlightedCodeText } from "@renderer/app/editor/staticCodeHighlight";
 import { useMarkdownCodeLanguageSupport } from "@renderer/app/editor/useCodeLanguageSupport";
 import { openExternalUrl } from "@renderer/app/utils/external-url";
 import { useTextContextMenu } from "@renderer/components/context-menu/useTextContextMenu";
+
+import { MarkdownCodeFrame } from "./MarkdownCodeFrame";
 
 interface MarkdownFilePreviewProps {
     readonly content: string;
@@ -55,25 +54,6 @@ function getSafeExternalHref(href: string | null | undefined): string | null {
     return null;
 }
 
-async function writeMarkdownPreviewClipboardText(text: string): Promise<void> {
-    if (window.comando?.writeClipboardText) {
-        try {
-            await window.comando.writeClipboardText(text);
-            return;
-        } catch {
-            // Fall through to the Web Clipboard API when the native bridge is unavailable.
-        }
-    }
-
-    if (navigator.clipboard?.writeText) {
-        try {
-            await navigator.clipboard.writeText(text);
-        } catch {
-            // Copy actions should stay quiet if clipboard access is denied.
-        }
-    }
-}
-
 function extractMarkdownCodeLanguage(
     className: string | null | undefined,
 ): string | null {
@@ -82,68 +62,6 @@ function extractMarkdownCodeLanguage(
         .find((entry) => entry.startsWith("language-"));
     const language = languageClass?.slice("language-".length).trim();
     return language || null;
-}
-
-const markdownCodeLanguageLabels: Record<string, string> = {
-    bash: "Bash",
-    c: "C",
-    "c++": "C++",
-    cpp: "C++",
-    cs: "C#",
-    csharp: "C#",
-    css: "CSS",
-    diff: "Diff",
-    docker: "Dockerfile",
-    dockerfile: "Dockerfile",
-    gql: "GraphQL",
-    graphql: "GraphQL",
-    html: "HTML",
-    java: "Java",
-    javascript: "JavaScript",
-    js: "JavaScript",
-    json: "JSON",
-    jsonc: "JSONC",
-    jsx: "JSX",
-    make: "Makefile",
-    makefile: "Makefile",
-    markdown: "Markdown",
-    md: "Markdown",
-    mdx: "MDX",
-    php: "PHP",
-    powershell: "PowerShell",
-    ps1: "PowerShell",
-    pwsh: "PowerShell",
-    py: "Python",
-    python: "Python",
-    rb: "Ruby",
-    rs: "Rust",
-    ruby: "Ruby",
-    rust: "Rust",
-    scss: "SCSS",
-    sh: "Shell",
-    shell: "Shell",
-    sql: "SQL",
-    ts: "TypeScript",
-    tsx: "TSX",
-    typescript: "TypeScript",
-    xml: "XML",
-    yaml: "YAML",
-    yml: "YAML",
-    zsh: "Zsh",
-};
-
-function formatMarkdownCodeLanguageLabel(language: string): string {
-    const normalizedLanguage = language.trim().toLowerCase();
-    const mappedLabel = markdownCodeLanguageLabels[normalizedLanguage];
-    if (mappedLabel) {
-        return mappedLabel;
-    }
-
-    return normalizedLanguage
-        .split(/[-_]+/)
-        .filter(Boolean)
-        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-        .join(" ");
 }
 
 function getMarkdownCodeLanguageFromNode(node: ReactNode): string | null {
@@ -357,90 +275,6 @@ function MarkdownPreviewInput({
     );
 }
 
-function MarkdownPreviewCopyIcon() {
-    return (
-        <svg
-            aria-hidden="true"
-            fill="none"
-            height="12"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.6"
-            viewBox="0 0 14 14"
-            width="12"
-        >
-            <rect x="5" y="3" width="6" height="8" rx="1.2" />
-            <path d="M3.5 9.5H3A1 1 0 0 1 2 8.5v-5A1.5 1.5 0 0 1 3.5 2H8" />
-        </svg>
-    );
-}
-
-function MarkdownPreviewCheckIcon() {
-    return (
-        <svg
-            aria-hidden="true"
-            fill="none"
-            height="12"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.7"
-            viewBox="0 0 14 14"
-            width="12"
-        >
-            <path d="M3 7l2.2 2.2L11 3.8" />
-        </svg>
-    );
-}
-
-function MarkdownPreviewCodeCopyButton({
-    codeText,
-}: {
-    readonly codeText: string;
-}) {
-    const [copied, setCopied] = useState(false);
-    const resetTimeoutRef = useRef<number | null>(null);
-
-    useEffect(
-        () => () => {
-            if (resetTimeoutRef.current) {
-                window.clearTimeout(resetTimeoutRef.current);
-            }
-        },
-        [],
-    );
-
-    const handleCopy = useCallback(() => {
-        void writeMarkdownPreviewClipboardText(codeText).then(() => {
-            setCopied(true);
-            if (resetTimeoutRef.current) {
-                window.clearTimeout(resetTimeoutRef.current);
-            }
-            resetTimeoutRef.current = window.setTimeout(() => {
-                setCopied(false);
-                resetTimeoutRef.current = null;
-            }, 1200);
-        });
-    }, [codeText]);
-
-    return (
-        <button
-            aria-label="Copy code block"
-            className="markdown-file-preview__copy-button"
-            onClick={handleCopy}
-            title={copied ? "Copied" : "Copy"}
-            type="button"
-        >
-            {copied ? (
-                <MarkdownPreviewCheckIcon />
-            ) : (
-                <MarkdownPreviewCopyIcon />
-            )}
-        </button>
-    );
-}
-
 function MarkdownPreviewPre({
     children,
     className,
@@ -449,10 +283,7 @@ function MarkdownPreviewPre({
 }: HTMLAttributes<HTMLPreElement> & { readonly node?: unknown }) {
     void _node;
 
-    const codeBlockClassName = [
-        "markdown-file-preview__code-block",
-        className,
-    ]
+    const codeBlockClassName = ["markdown-code-block", className]
         .filter(Boolean)
         .join(" ");
     const language = getMarkdownCodeLanguageFromNode(children);
@@ -468,13 +299,9 @@ function MarkdownPreviewPre({
     }
 
     return (
-        <div className="markdown-file-preview__code-frame">
-            <div className="markdown-file-preview__code-header">
-                <span>{formatMarkdownCodeLanguageLabel(language)}</span>
-                <MarkdownPreviewCodeCopyButton codeText={codeText} />
-            </div>
+        <MarkdownCodeFrame codeText={codeText} language={language}>
             {codeBlock}
-        </div>
+        </MarkdownCodeFrame>
     );
 }
 

--- a/src/renderer/src/components/workspace/chat/AIChatComposer.tsx
+++ b/src/renderer/src/components/workspace/chat/AIChatComposer.tsx
@@ -18,6 +18,7 @@ import type {
     ProjectTreeNode,
 } from "@shared/ipc";
 import { resolveEditorLanguage } from "@shared/editor-language";
+import { formatComposerDisplaySelectionLabel } from "@shared/composer-display-markers";
 
 import {
     COMPOSER_PROJECT_ENTRY_LIST_MIME,
@@ -31,6 +32,8 @@ import {
     type WorkspaceTabComposerDragDetail,
 } from "@renderer/app/drag-and-drop";
 import { useRenderProbe } from "@renderer/app/debug/renderProbe";
+import { createFileTypeIconElement } from "@renderer/components/icons/createFileTypeIconElement";
+import { createFolderTypeIconElement } from "@renderer/components/icons/createFolderTypeIconElement";
 import { getChatPillMetrics, type ChatPillMetrics } from "./chatPillMetrics";
 import { CHAT_PILL_VARIANTS } from "./chatPillPalette";
 import type { AIComposerPart } from "./composerParts";
@@ -185,8 +188,23 @@ function createFileMentionNode(
     el.dataset.path = part.path;
     el.dataset.relativePath = part.relativePath;
     el.dataset.languageId = part.languageId;
-    el.textContent = `@${part.label}`;
     applyComposerPillStyles(el, metrics, CHAT_PILL_VARIANTS.file);
+    el.style.padding = "0";
+    el.style.borderRadius = "2px";
+    el.style.background = "transparent";
+    el.style.color = "var(--color-accent)";
+    el.style.transform = "translateY(2px)";
+    el.style.gap = "4px";
+    const icon = createFileTypeIconElement(
+        part.relativePath,
+        Math.max(11, Math.min(14, metrics.fontSize)),
+    );
+    if (icon) {
+        el.append(icon);
+    }
+    const label = document.createElement("span");
+    label.textContent = `@${part.label}`;
+    el.append(label);
     return el;
 }
 
@@ -199,8 +217,23 @@ function createFolderMentionNode(
     el.dataset.kind = "folder_mention";
     el.dataset.folderPath = part.folderPath;
     el.dataset.label = part.label;
-    el.textContent = `@${part.label}`;
     applyComposerPillStyles(el, metrics, CHAT_PILL_VARIANTS.folder);
+    el.style.padding = "0";
+    el.style.borderRadius = "2px";
+    el.style.background = "transparent";
+    el.style.color = "var(--color-accent)";
+    el.style.transform = "translateY(2px)";
+    el.style.gap = "4px";
+    const icon = createFolderTypeIconElement(
+        part.folderPath,
+        Math.max(11, Math.min(14, metrics.fontSize)),
+    );
+    if (icon) {
+        el.append(icon);
+    }
+    const label = document.createElement("span");
+    label.textContent = `@${part.label}`;
+    el.append(label);
     return el;
 }
 
@@ -234,10 +267,28 @@ function createSelectionMentionNode(
     el.dataset.selectedText = part.selectedText;
     el.dataset.startLine = String(part.startLine);
     el.dataset.endLine = String(part.endLine);
-    el.textContent = part.label;
-    applyComposerPillStyles(el, metrics, CHAT_PILL_VARIANTS.accent, {
-        compact: true,
+    applyComposerPillStyles(el, metrics, CHAT_PILL_VARIANTS.file);
+    el.style.padding = "0";
+    el.style.borderRadius = "2px";
+    el.style.background = "transparent";
+    el.style.color = "var(--color-accent)";
+    el.style.transform = "translateY(2px)";
+    el.style.gap = "4px";
+    const icon = createFileTypeIconElement(
+        part.path,
+        Math.max(11, Math.min(14, metrics.fontSize)),
+    );
+    if (icon) {
+        el.append(icon);
+    }
+    const label = document.createElement("span");
+    label.textContent = formatComposerDisplaySelectionLabel({
+        endLine: part.endLine,
+        label: part.label,
+        path: part.path,
+        startLine: part.startLine,
     });
+    el.append(label);
     return el;
 }
 

--- a/src/renderer/src/components/workspace/chat/ChangeReviewPanel.test.ts
+++ b/src/renderer/src/components/workspace/chat/ChangeReviewPanel.test.ts
@@ -107,11 +107,10 @@ function createTrackedFile(
 }
 
 describe("ChangeReviewPanel", () => {
-    it("renders single-file case with actions and expandable diff", () => {
+    it("renders a single-file terminal row with a linked file and collapsed diff", () => {
         const markup = renderToStaticMarkup(
             createElement(ChangeReviewPanel, {
                 activity: createActivity(),
-                defaultExpanded: true,
                 onOpenFile: async () => {},
                 projectId: "project-1",
                 trackedFiles: [createTrackedFile()],
@@ -119,16 +118,19 @@ describe("ChangeReviewPanel", () => {
             }),
         );
 
-        expect(markup).toContain("Edited app.ts");
-        expect(markup).toContain("font-weight:400");
-        expect(markup).toContain("Open");
+        expect(markup).toContain(">Edited<");
+        expect(markup).toContain(">app.ts<");
+        expect(markup).toContain('data-change-review-surface="rail-row"');
+        expect(markup).toContain('aria-label="Open src/app.ts"');
+        expect(markup).toContain("ui-monospace");
+        expect(markup).not.toContain("review-text-btn");
         expect(markup).not.toContain("Accept");
         expect(markup).not.toContain("Reject");
-        expect(markup).toContain("Resize diff preview");
-        expect(markup).toContain("change-review-panel:file-1");
+        expect(markup).not.toContain("Resize diff preview");
+        expect(markup).not.toContain("change-review-panel:file-1");
         expect(markup).toContain(">+1<");
         expect(markup).toContain(">-1<");
-        expect(markup).toContain('data-line-wrapping="false"');
+        expect(markup).not.toContain('data-line-wrapping="false"');
         expect(markup).not.toContain(
             "background-color:color-mix(in srgb, var(--diff-add) 8%, var(--color-bg-secondary))",
         );
@@ -137,7 +139,7 @@ describe("ChangeReviewPanel", () => {
         );
     });
 
-    it("renders multi-file case as independent single-file cards", () => {
+    it("renders multi-file case as independent terminal rows", () => {
         const primaryDiff = createActivity().diffs[0];
         if (!primaryDiff) {
             throw new Error("Expected a primary diff for the test.");
@@ -173,8 +175,6 @@ describe("ChangeReviewPanel", () => {
         const markup = renderToStaticMarkup(
             createElement(ChangeReviewPanel, {
                 activity,
-                defaultExpanded: true,
-                defaultExpandedFileKeys: ["file-1"],
                 onOpenFile: async () => {},
                 projectId: "project-1",
                 trackedFiles: [createTrackedFile(), secondaryTrackedFile],
@@ -182,9 +182,10 @@ describe("ChangeReviewPanel", () => {
         );
 
         expect(markup).not.toContain("Edited 2 files");
-        expect(markup).toContain("Edited app.ts");
-        expect(markup).toContain("Edited secondary.ts");
-        expect(markup).toContain("change-review-panel:file-1");
+        expect(markup).toContain(">Edited<");
+        expect(markup).toContain(">app.ts<");
+        expect(markup).toContain(">secondary.ts<");
+        expect(markup).not.toContain("change-review-panel:file-1");
         expect(markup).not.toContain("change-review-panel:file-2");
     });
 
@@ -199,7 +200,6 @@ describe("ChangeReviewPanel", () => {
                         },
                     ],
                 }),
-                defaultExpanded: true,
                 onOpenFile: async () => {},
                 projectId: "project-1",
                 resolveFileReference: (reference) =>
@@ -220,7 +220,9 @@ describe("ChangeReviewPanel", () => {
             }),
         );
 
-        expect(markup).toContain("Open");
+        expect(markup).toContain(
+            'aria-label="Open /workspace/comando/src/app.ts"',
+        );
     });
 
     it("keeps the open action available for UNC tracked paths", () => {
@@ -235,7 +237,6 @@ describe("ChangeReviewPanel", () => {
                         },
                     ],
                 }),
-                defaultExpanded: true,
                 onOpenFile: async () => {},
                 projectId: "project-1",
                 resolveFileReference: (reference) =>
@@ -256,7 +257,7 @@ describe("ChangeReviewPanel", () => {
             }),
         );
 
-        expect(markup).toContain("Open");
+        expect(markup).toContain(`aria-label="Open ${uncPath}`);
     });
 
     it("keeps wrapping enabled for markdown review cards", () => {
@@ -270,7 +271,6 @@ describe("ChangeReviewPanel", () => {
                         },
                     ],
                 }),
-                defaultExpanded: true,
                 onOpenFile: async () => {},
                 projectId: "project-1",
                 trackedFiles: [
@@ -281,6 +281,6 @@ describe("ChangeReviewPanel", () => {
             }),
         );
 
-        expect(markup).toContain('data-line-wrapping="true"');
+        expect(markup).not.toContain('data-line-wrapping="true"');
     });
 });

--- a/src/renderer/src/components/workspace/chat/ChangeReviewPanel.tsx
+++ b/src/renderer/src/components/workspace/chat/ChangeReviewPanel.tsx
@@ -9,9 +9,9 @@ import type {
 
 import { DEFAULT_AI_DIFF_ZOOM } from "@renderer/app/ai/sessionReviewContracts";
 import { useRenderProbe } from "@renderer/app/debug/renderProbe";
+import { FileTypeIcon } from "@renderer/components/icons/FileTypeIcon";
 import type { ResolvedProjectFileReference } from "../projectFileReferences";
 import { EditedFileDiffPreview } from "../review/EditedFileDiffPreview";
-import { getNeutralButtonStyle } from "../review/reviewStyles";
 import { formatDiffStat, getFileNameFromPath } from "../review/reviewDiff";
 import {
     deriveChangeReviewItems,
@@ -19,20 +19,11 @@ import {
 } from "./toolActivityReviewModel";
 import { ResizableDiffContainer } from "./ResizableDiffContainer";
 import { usePersistentToolExpansion } from "./toolExpansionStore";
-import { FileTypeIcon } from "@renderer/components/icons/FileTypeIcon";
-
-const TOOL_ACTION_BUTTON_STYLE: CSSProperties = {
-    borderRadius: 8,
-    fontSize: "0.74em",
-    fontWeight: 600,
-    minHeight: 24,
-    padding: "0 10px",
-};
 
 function getFlatDiffStatStyle(color: string): CSSProperties {
     return {
         color,
-        fontSize: "0.74em",
+        fontSize: "0.9em",
         fontWeight: 700,
     };
 }
@@ -194,191 +185,134 @@ function renderStatus(activity: AiToolActivity) {
     return null;
 }
 
-function ChangeReviewFileCard({
+function ChangeReviewRailRow({
     activity,
-    defaultExpanded = false,
     diffZoom,
-    forceExpanded = false,
     item,
     onOpen,
 }: {
     readonly activity: AiToolActivity;
-    readonly defaultExpanded?: boolean;
     readonly diffZoom: number;
-    readonly forceExpanded?: boolean;
     readonly item: ChangeReviewItem;
     readonly onOpen: (() => void) | null;
 }) {
     // Persist expansion (and the diff height below) in the timeline scroller so
-    // it survives this card unmounting when its virtualized row scrolls out of
-    // view. The reset key still encodes the expansion mode, so switching modes
-    // re-hydrates to the mode's default exactly as before.
-    const resetKey = `${activity.id}:${item.key}:${
-        defaultExpanded ? "open" : "closed"
-    }:${forceExpanded ? "forced" : "free"}`;
+    // it survives this row unmounting when its virtualized entry scrolls out of
+    // view. Diffs always start collapsed; only an explicit user action opens
+    // their preview.
+    const resetKey = `${activity.id}:${item.key}`;
     const [expanded, setExpanded] = usePersistentToolExpansion(
         resetKey,
-        defaultExpanded,
+        false,
     );
-    const resolvedExpanded = forceExpanded ? true : expanded;
     const accent = getPanelAccent(activity);
     const actionLabel = getActivityActionLabel(activity.kind);
-    const summaryLabel = `${actionLabel} ${getFileNameFromPath(item.path)}`;
+    const fileName = getFileNameFromPath(item.path);
 
     return (
         <div
-            className="min-w-0 max-w-full select-none overflow-hidden rounded-lg"
+            className="min-w-0 max-w-full select-none"
+            data-change-review-surface="rail-row"
             style={{
-                backgroundColor: `color-mix(in srgb, ${accent} 4%, var(--color-bg-secondary))`,
-                border: `1px solid color-mix(in srgb, ${accent} 24%, var(--color-border))`,
+                color: "var(--color-text-secondary)",
+                fontFamily: "var(--font-mono), ui-monospace, monospace",
+                fontSize: "0.82em",
             }}
         >
-            <div
-                style={{
-                    alignItems: "center",
-                    borderBottom: resolvedExpanded
-                        ? `1px solid color-mix(in srgb, ${accent} 14%, var(--color-border))`
-                        : "1px solid transparent",
-                    display: "grid",
-                    gap: 12,
-                    gridTemplateColumns: "minmax(0, 1fr) auto",
-                    padding: "7px 12px",
-                }}
-            >
-                <button
-                    aria-label={
-                        forceExpanded
-                            ? "Inline diff review expanded"
-                            : `${resolvedExpanded ? "Collapse" : "Expand"} inline diff review`
-                    }
-                    onClick={() => {
-                        if (forceExpanded) {
-                            return;
-                        }
-
-                        setExpanded((previous) => !previous);
-                    }}
+            <div className="flex min-h-7 w-full min-w-0 items-center gap-2">
+                <span
+                    aria-hidden="true"
+                    className="shrink-0"
                     style={{
-                        alignItems: "center",
-                        background: "none",
-                        border: "none",
-                        color: "inherit",
-                        cursor: forceExpanded ? "default" : "pointer",
-                        display: "flex",
-                        gap: 10,
-                        minWidth: 0,
-                        padding: 0,
-                        textAlign: "left",
+                        color: accent,
+                        display: "inline-flex",
                     }}
-                    type="button"
                 >
-                    <span
-                        style={{
-                            color: "var(--color-text-secondary)",
-                            flexShrink: 0,
-                        }}
+                    {activity.status === "failed" ? (
+                        <WarningIcon />
+                    ) : (
+                        <FileTypeIcon
+                            fileName={item.path}
+                            opacity={0.85}
+                            size={14}
+                        />
+                    )}
+                </span>
+                <span className="shrink-0 opacity-70">{actionLabel}</span>
+                {onOpen ? (
+                    <button
+                        aria-label={`Open ${item.path}`}
+                        className="app-no-drag min-w-0 truncate text-left text-text-primary underline decoration-text-secondary/40 underline-offset-2 hover:decoration-current focus-visible:rounded-sm focus-visible:outline-none focus-visible:shadow-[0_0_0_1px_var(--color-accent)]"
+                        onClick={onOpen}
+                        title={item.path}
+                        type="button"
                     >
-                        <Chevron expanded={resolvedExpanded} />
+                        {fileName}
+                    </button>
+                ) : (
+                    <span
+                        className="min-w-0 truncate text-text-primary"
+                        title={item.path}
+                    >
+                        {fileName}
                     </span>
-                    <span className="shrink-0" style={{ color: accent }}>
-                        {activity.status === "failed" ? (
-                            <WarningIcon />
-                        ) : (
-                            <FileTypeIcon
-                                fileName={item.path}
-                                opacity={0.85}
-                                size={14}
-                            />
+                )}
+                <span className="min-w-0 flex-1" />
+                {item.tone.badge ? (
+                    <span
+                        className="shrink-0 text-[10px] font-medium"
+                        style={{ color: item.tone.accent }}
+                    >
+                        {getBadgeLabel(item)}
+                    </span>
+                ) : null}
+                {item.stats.additions > 0 ? (
+                    <span style={getFlatDiffStatStyle("var(--diff-add)")}>
+                        +
+                        {formatDiffStat(
+                            item.stats.additions,
+                            item.stats.approximate,
                         )}
                     </span>
-                    <div className="min-w-0">
-                        <div className="flex min-w-0 items-center gap-2">
-                            <span
-                                className="truncate"
-                                style={{
-                                    color: "var(--color-text-primary)",
-                                    fontSize: "0.84em",
-                                    fontWeight: 400,
-                                }}
-                            >
-                                {summaryLabel}
-                            </span>
-                            {item.tone.badge ? (
-                                <span
-                                    style={{
-                                        backgroundColor: `color-mix(in srgb, ${item.tone.accent} 10%, transparent)`,
-                                        borderRadius: 999,
-                                        color: item.tone.accent,
-                                        fontSize: "0.62em",
-                                        fontWeight: 700,
-                                        letterSpacing: "0.04em",
-                                        padding: "2px 6px",
-                                        textTransform: "uppercase",
-                                    }}
-                                >
-                                    {getBadgeLabel(item)}
-                                </span>
-                            ) : null}
-                        </div>
-                    </div>
+                ) : null}
+                {item.stats.deletions > 0 ? (
+                    <span style={getFlatDiffStatStyle("var(--diff-remove)")}>
+                        -
+                        {formatDiffStat(
+                            item.stats.deletions,
+                            item.stats.approximate,
+                        )}
+                    </span>
+                ) : null}
+                {renderStatus(activity)}
+                <button
+                    aria-label={
+                        `${expanded ? "Collapse" : "Expand"} inline diff review`
+                    }
+                    className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-secondary hover:bg-bg-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:shadow-[0_0_0_1px_var(--color-accent)]"
+                    onClick={() => setExpanded((previous) => !previous)}
+                    type="button"
+                >
+                    <Chevron expanded={expanded} />
                 </button>
-
-                <div className="flex flex-wrap items-center justify-end gap-2">
-                    {item.stats.additions > 0 ? (
-                        <span style={getFlatDiffStatStyle("var(--diff-add)")}>
-                            +
-                            {formatDiffStat(
-                                item.stats.additions,
-                                item.stats.approximate,
-                            )}
-                        </span>
-                    ) : null}
-                    {item.stats.deletions > 0 ? (
-                        <span
-                            style={getFlatDiffStatStyle("var(--diff-remove)")}
-                        >
-                            -
-                            {formatDiffStat(
-                                item.stats.deletions,
-                                item.stats.approximate,
-                            )}
-                        </span>
-                    ) : null}
-                    {onOpen ? (
-                        <button
-                            aria-label="Open File"
-                            className="review-text-btn"
-                            onClick={onOpen}
-                            style={{
-                                ...getNeutralButtonStyle(),
-                                ...TOOL_ACTION_BUTTON_STYLE,
-                                transition:
-                                    "background-color 100ms ease, opacity 100ms ease, transform 90ms ease, filter 90ms ease",
-                            }}
-                            title="Open File"
-                            type="button"
-                        >
-                            Open
-                        </button>
-                    ) : null}
-                    {renderStatus(activity)}
-                </div>
             </div>
 
-            {resolvedExpanded ? (
-                <ResizableDiffContainer
-                    accent={accent}
-                    persistKey={`${activity.id}:${item.key}:diff-height`}
-                >
-                    <EditedFileDiffPreview
-                        compactLineNumbers
-                        diff={item.diff}
-                        diffZoom={diffZoom}
-                        expanded={resolvedExpanded}
-                        file={item.file ?? undefined}
-                        testId={`change-review-panel:${item.key}`}
-                    />
-                </ResizableDiffContainer>
+            {expanded ? (
+                <div className="ml-5 mt-1 overflow-hidden border-l border-border pl-2">
+                    <ResizableDiffContainer
+                        accent={accent}
+                        persistKey={`${activity.id}:${item.key}:diff-height`}
+                    >
+                        <EditedFileDiffPreview
+                            compactLineNumbers
+                            diff={item.diff}
+                            diffZoom={diffZoom}
+                            expanded={expanded}
+                            file={item.file ?? undefined}
+                            testId={`change-review-panel:${item.key}`}
+                        />
+                    </ResizableDiffContainer>
+                </div>
             ) : null}
         </div>
     );
@@ -386,9 +320,6 @@ function ChangeReviewFileCard({
 
 export interface ChangeReviewPanelProps {
     readonly activity: AiToolActivity;
-    readonly defaultExpanded?: boolean;
-    readonly defaultExpandedFileKeys?: readonly string[];
-    readonly forceExpanded?: boolean;
     readonly onOpenFile: (
         projectId: string,
         relativePath: string,
@@ -406,9 +337,6 @@ export interface ChangeReviewPanelProps {
 
 export const ChangeReviewPanel = memo(function ChangeReviewPanel({
     activity,
-    defaultExpanded = false,
-    defaultExpandedFileKeys = [],
-    forceExpanded = false,
     onOpenFile,
     projectId,
     resolveFileReference,
@@ -463,11 +391,9 @@ export const ChangeReviewPanel = memo(function ChangeReviewPanel({
         }
 
         return (
-            <ChangeReviewFileCard
+            <ChangeReviewRailRow
                 activity={activity}
-                defaultExpanded={defaultExpanded}
                 diffZoom={diffZoom}
-                forceExpanded={forceExpanded}
                 item={singleItem}
                 onOpen={
                     canOpenItem(singleItem, projectId, resolveFileReference)
@@ -478,20 +404,12 @@ export const ChangeReviewPanel = memo(function ChangeReviewPanel({
         );
     }
 
-    const defaultExpandedKeys = new Set(defaultExpandedFileKeys);
-
     return (
-        <div className="space-y-2">
+        <div className="space-y-1">
             {items.map((item) => (
-                <ChangeReviewFileCard
+                <ChangeReviewRailRow
                     activity={activity}
-                    defaultExpanded={
-                        defaultExpandedKeys.size > 0
-                            ? defaultExpandedKeys.has(item.key)
-                            : defaultExpanded
-                    }
                     diffZoom={diffZoom}
-                    forceExpanded={forceExpanded}
                     item={item}
                     key={item.key}
                     onOpen={
@@ -513,9 +431,6 @@ function areChangeReviewPanelPropsEqual(
 ) {
     return (
         previous.activity === next.activity &&
-        previous.defaultExpanded === next.defaultExpanded &&
-        previous.defaultExpandedFileKeys === next.defaultExpandedFileKeys &&
-        previous.forceExpanded === next.forceExpanded &&
         previous.projectId === next.projectId &&
         previous.trackedFiles === next.trackedFiles &&
         previous.worktreeId === next.worktreeId

--- a/src/renderer/src/components/workspace/chat/ChatInlinePill.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatInlinePill.tsx
@@ -1,38 +1,43 @@
-import type { CSSProperties, MouseEventHandler } from "react";
+import type { CSSProperties, MouseEventHandler, ReactNode } from "react";
 
 import { type ChatPillMetrics } from "./chatPillMetrics";
 import { CHAT_PILL_VARIANTS, type ChatPillVariant } from "./chatPillPalette";
 
 interface ChatInlinePillProps {
+    readonly appearance?: "link" | "pill";
     readonly label: string;
     readonly metrics: ChatPillMetrics;
     readonly title?: string;
     readonly interactive?: boolean;
+    readonly leadingVisual?: ReactNode;
     readonly variant?: ChatPillVariant;
     readonly onClick?: () => void;
     readonly onContextMenu?: MouseEventHandler<HTMLElement>;
 }
 
 export function ChatInlinePill({
+    appearance = "pill",
     label,
     metrics,
     title,
     interactive = false,
+    leadingVisual,
     variant = "accent",
     onClick,
     onContextMenu,
 }: ChatInlinePillProps) {
     const palette = CHAT_PILL_VARIANTS[variant];
     const clickable = interactive || typeof onClick === "function";
+    const isLink = appearance === "link";
     const style: CSSProperties = {
         display: "inline-flex",
         alignItems: "center",
         margin: `0 ${metrics.gapX}px`,
-        padding: `${metrics.paddingY}px ${metrics.paddingX}px`,
+        padding: isLink ? 0 : `${metrics.paddingY}px ${metrics.paddingX}px`,
         maxInlineSize: "100%",
-        borderRadius: metrics.radius,
-        background: palette.background,
-        color: palette.color,
+        borderRadius: isLink ? 2 : metrics.radius,
+        background: isLink ? "transparent" : palette.background,
+        color: isLink ? "var(--color-accent)" : palette.color,
         fontSize: metrics.fontSize,
         lineHeight: metrics.lineHeight,
         border: "none",
@@ -40,7 +45,7 @@ export function ChatInlinePill({
         fontFamily: "inherit",
         verticalAlign: "baseline",
         overflowWrap: "anywhere",
-        transform: `translateY(${metrics.offsetY}px)`,
+        transform: `translateY(${isLink ? 2 : metrics.offsetY}px)`,
         filter: "brightness(1)",
         opacity: clickable ? 0.85 : 1,
         transition: clickable
@@ -51,15 +56,33 @@ export function ChatInlinePill({
     const content = (
         <span
             style={{
-                display: "block",
+                alignItems: "center",
+                display: "inline-flex",
+                gap: leadingVisual ? 4 : 0,
                 minWidth: 0,
                 maxWidth: "100%",
-                overflowWrap: "anywhere",
-                whiteSpace: "normal",
-                wordBreak: "break-word",
             }}
         >
-            {label}
+            {leadingVisual ? (
+                <span
+                    aria-hidden="true"
+                    style={{ display: "inline-flex", flexShrink: 0 }}
+                >
+                    {leadingVisual}
+                </span>
+            ) : null}
+            <span
+                style={{
+                    display: "block",
+                    minWidth: 0,
+                    maxWidth: "100%",
+                    overflowWrap: "anywhere",
+                    whiteSpace: "normal",
+                    wordBreak: "break-word",
+                }}
+            >
+                {label}
+            </span>
         </span>
     );
 

--- a/src/renderer/src/components/workspace/chat/ChatMessageRow.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatMessageRow.test.tsx
@@ -4,9 +4,35 @@ import { describe, expect, it } from "vitest";
 
 import type { AiMessage } from "@shared/ipc";
 
-import { ChatMessageRow } from "./ChatMessageRow";
+import { ChatMessageRow, formatChatMessageTime } from "./ChatMessageRow";
 
 describe("ChatMessageRow generated images", () => {
+    it("renders indented user messages with time and copy metadata", () => {
+        const markup = renderMessage({
+            content: "Please update the activity rail.",
+            createdAt: "2026-04-20T12:00:00",
+            kind: "user",
+        });
+
+        expect(markup).toContain('data-user-message="true"');
+        expect(markup).toContain("user-message-layout min-w-0 w-full");
+        expect(markup).toContain("user-message-bubble ml-auto");
+        expect(markup).toContain("w-[70%] max-w-full");
+        expect(markup).toContain('data-user-message-metadata="true"');
+        expect(markup).toContain("items-center justify-end gap-1.5");
+        expect(markup).toContain('dateTime="2026-04-20T12:00:00"');
+        expect(markup).toContain("12:00 PM");
+        expect(markup).toContain('aria-label="Copy message"');
+        expect(markup).toContain("var(--color-accent) 5%");
+    });
+
+    it("formats message times in the requested locale and ignores invalid dates", () => {
+        expect(
+            formatChatMessageTime("2026-04-20T12:00:00", "en-US"),
+        ).toBe("12:00 PM");
+        expect(formatChatMessageTime("invalid", "en-US")).toBeNull();
+    });
+
     it("renders assistant text in a full-width container", () => {
         const markup = renderMessage({
             content: "A normal assistant paragraph should use the available width.",

--- a/src/renderer/src/components/workspace/chat/ChatMessageRow.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatMessageRow.tsx
@@ -53,6 +53,7 @@ export const ChatMessageRow = memo(function ChatMessageRow({
                 chatFontFamily={chatFontFamily}
                 chatFontSize={chatFontSize}
                 content={message.content}
+                createdAt={message.createdAt}
                 highlightQuery={highlightQuery}
                 onAddFileReferenceToChat={onAddFileReferenceToChat}
                 onOpenFile={onOpenFile}
@@ -614,6 +615,7 @@ function UserMessage(props: {
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
     readonly content: string;
+    readonly createdAt: string;
     readonly highlightQuery?: string;
     readonly onAddFileReferenceToChat?: (
         reference: ResolvedProjectFileReference,
@@ -627,40 +629,136 @@ function UserMessage(props: {
         reference: string,
     ) => ResolvedProjectFileReference | null;
 }) {
+    const [copied, setCopied] = useState(false);
+    const formattedTime = formatChatMessageTime(props.createdAt);
+    const copyMessage = async () => {
+        if (!props.content || !window.comando) {
+            return;
+        }
+
+        await window.comando.writeClipboardText(props.content);
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+    };
+
     return (
         <div
-            className="min-w-0 max-w-full whitespace-pre-wrap rounded-lg px-3 py-2"
-            style={{
-                backgroundColor: "var(--color-bg-tertiary)",
-                border: "1px solid var(--color-border)",
-                color: "var(--color-text-primary)",
-                fontSize: props.chatFontSize,
-                lineHeight: 1.6,
-                overflowWrap: "anywhere",
-                wordBreak: "break-word",
-            }}
+            className="user-message-layout min-w-0 w-full max-w-full"
+            data-user-message="true"
         >
-            {props.content
-                ? renderHighlightableMarkdown({
-                      chatFontFamily: props.chatFontFamily,
-                      chatFontSize: props.chatFontSize,
-                      canRenderFileReference:
-                          props.canRenderFileReference,
-                      content: props.content,
-                      highlightQuery: props.highlightQuery,
-                      onAddFileReferenceToChat: props.onAddFileReferenceToChat,
-                      onOpenFile: props.onOpenFile,
-                      onRevealFileReference: props.onRevealFileReference,
-                      resolveFileReference: props.resolveFileReference,
-                  })
-                : null}
-            {props.attachments.length > 0 ? (
-                <MessageImageGrid
-                    attachments={props.attachments}
-                    onOpenImage={props.onOpenImage}
-                />
-            ) : null}
+            <div
+                className="user-message-bubble ml-auto min-w-0 w-[70%] max-w-full whitespace-pre-wrap rounded-lg px-3 py-2"
+                style={{
+                    backgroundColor:
+                        "color-mix(in srgb, var(--color-accent) 5%, var(--color-bg-tertiary))",
+                    border: "1px solid color-mix(in srgb, var(--color-accent) 16%, var(--color-border))",
+                    color: "var(--color-text-primary)",
+                    fontSize: props.chatFontSize,
+                    lineHeight: 1.6,
+                    overflowWrap: "anywhere",
+                    wordBreak: "break-word",
+                }}
+            >
+                {props.content
+                    ? renderHighlightableMarkdown({
+                          chatFontFamily: props.chatFontFamily,
+                          chatFontSize: props.chatFontSize,
+                          canRenderFileReference:
+                              props.canRenderFileReference,
+                          content: props.content,
+                          highlightQuery: props.highlightQuery,
+                          onAddFileReferenceToChat:
+                              props.onAddFileReferenceToChat,
+                          onOpenFile: props.onOpenFile,
+                          onRevealFileReference: props.onRevealFileReference,
+                          resolveFileReference: props.resolveFileReference,
+                      })
+                    : null}
+                {props.attachments.length > 0 ? (
+                    <MessageImageGrid
+                        attachments={props.attachments}
+                        onOpenImage={props.onOpenImage}
+                    />
+                ) : null}
+            </div>
+            <div
+                className="mt-1 flex min-h-5 items-center justify-end gap-1.5 px-0.5 text-text-secondary"
+                data-user-message-metadata="true"
+                style={{
+                    fontFamily: "var(--font-mono), ui-monospace, monospace",
+                    fontSize: "10px",
+                    opacity: 0.72,
+                }}
+            >
+                {formattedTime ? (
+                    <time dateTime={props.createdAt}>{formattedTime}</time>
+                ) : null}
+                {props.content ? (
+                    <button
+                        aria-label={copied ? "Message copied" : "Copy message"}
+                        className="flex h-5 w-5 items-center justify-center rounded text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:shadow-[0_0_0_1px_var(--color-accent)]"
+                        onClick={() => void copyMessage()}
+                        style={copied ? { color: "var(--diff-add)" } : undefined}
+                        title={copied ? "Copied" : "Copy message"}
+                        type="button"
+                    >
+                        {copied ? <CopySuccessIcon /> : <CopyMessageIcon />}
+                    </button>
+                ) : null}
+            </div>
         </div>
+    );
+}
+
+export function formatChatMessageTime(
+    value: string,
+    locales?: Intl.LocalesArgument,
+): string | null {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    return new Intl.DateTimeFormat(locales, {
+        hour: "numeric",
+        minute: "2-digit",
+    }).format(date);
+}
+
+function CopyMessageIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.5"
+            viewBox="0 0 24 24"
+            width="12"
+        >
+            <rect height="13" rx="2" width="13" x="8" y="8" />
+            <path d="M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3" />
+        </svg>
+    );
+}
+
+function CopySuccessIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.7"
+            viewBox="0 0 24 24"
+            width="12"
+        >
+            <path d="m5 12 4 4L19 6" />
+        </svg>
     );
 }
 

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { AiSessionSnapshot } from "@shared/ipc";
+import type { AiSessionSnapshot, AiToolActivity } from "@shared/ipc";
 import { useShellStore } from "@renderer/app/store/shell-store";
 
 import type { ChatTimelineRow } from "./chatTimelineModel";
@@ -148,17 +148,64 @@ function createRows(count: number): ChatTimelineRow[] {
     });
 }
 
+function createSegmentRow(): ChatTimelineRow {
+    const activity: AiToolActivity = {
+        action: null,
+        createdAt: "2026-04-14T00:00:00.000Z",
+        diffs: [],
+        exitCode: null,
+        id: "read-1",
+        kind: "read",
+        locations: [],
+        rawInputJson: JSON.stringify({ file_path: "src/app.ts" }),
+        rawOutputJson: null,
+        sessionId: "session-1",
+        status: "completed",
+        summary: null,
+        terminalOutput: null,
+        title: "Read src/app.ts",
+        updatedAt: "2026-04-14T00:00:00.000Z",
+    };
+
+    return {
+        entries: [
+            {
+                policy: "groupable",
+                reviewEntry: {
+                    activity,
+                    hasPendingTrackedFiles: false,
+                    pendingTrackedFiles: [],
+                    trackedFiles: [],
+                },
+            },
+        ],
+        id: "activity-segment:session-1:read-1",
+        kind: "activity-segment",
+        summary: {
+            actionCount: 1,
+            changeCount: 0,
+            changedFileCount: 0,
+            commandCount: 0,
+            failureCount: 0,
+            fileCount: 1,
+            hiddenActivityCount: 1,
+            isInProgress: false,
+            latestActivityId: "read-1",
+            latestTitle: "Read src/app.ts",
+            searchCount: 0,
+            startedAt: activity.createdAt,
+            updatedAt: activity.updatedAt,
+        },
+    };
+}
+
 function renderHistoryRows(historyRows: readonly ChatTimelineRow[]) {
     return renderToStaticMarkup(
         <ChatTimelineHistoryRows
             historyRows={historyRows}
-            latestStreamingEditedFileToolRowId={null}
             onVirtualRangeChange={() => {}}
-            renderRow={({ isLatestStreamingTool, row }) => (
+            renderRow={({ row }) => (
                 <div
-                    data-latest-streaming-tool={
-                        isLatestStreamingTool ? "true" : "false"
-                    }
                     data-row-id={row.id}
                     key={row.id}
                 >
@@ -166,7 +213,6 @@ function renderHistoryRows(historyRows: readonly ChatTimelineRow[]) {
                 </div>
             )}
             scrollRef={{ current: null }}
-            toolCardExpansionMode="collapsed"
         />,
     );
 }
@@ -198,14 +244,12 @@ function mountHistoryRows(
         root.render(
             <ChatTimelineHistoryRows
                 historyRows={historyRows}
-                latestStreamingEditedFileToolRowId={null}
                 renderRow={({ row }) => (
                     <div data-row-id={row.id} key={row.id}>
                         {row.id}
                     </div>
                 )}
                 scrollRef={scrollRef}
-                toolCardExpansionMode="collapsed"
             />,
         );
     });
@@ -322,6 +366,25 @@ describe("ChatTimelineHistoryRows", () => {
             `message:message-${CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD - 1}`,
         );
         expect(markup.match(/padding-bottom:8px/g)).toHaveLength(1);
+    });
+
+    it("passes activity segments through the virtual list with their stable id", () => {
+        const rows = [
+            createSegmentRow(),
+            ...createRows(CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD - 1),
+        ];
+        const markup = renderHistoryRows(rows);
+        const firstCall = measuredVirtualListMock.mock.calls[0]?.[0];
+
+        expect(firstCall).toMatchObject({
+            firstEstimate: 48,
+            firstKey: "activity-segment:session-1:read-1",
+            itemCount: CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
+        });
+        expect(firstCall?.firstMeasurementKey).toContain(
+            "activity-segment:session-1:read-1",
+        );
+        expect(markup).toContain("activity-segment:session-1:read-1");
     });
 
     it("freezes content width during panel resize and re-syncs on release", () => {

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -10,7 +10,7 @@ import {
     type RefObject,
 } from "react";
 
-import type { AiToolCardExpansionMode } from "@shared/ipc";
+import { useSettingsStore } from "@renderer/app/store/settings-store";
 import { useShellStore } from "@renderer/app/store/shell-store";
 import {
     MeasuredVirtualList,
@@ -41,19 +41,14 @@ interface ChatTimelineHistoryRowsProps {
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
     readonly historyRows: readonly ChatTimelineRow[];
-    readonly latestStreamingEditedFileToolRowId: string | null;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onVirtualResizeEnd?: () => void;
     readonly onVirtualResizeAutoFollow?: () => void;
     readonly onVirtualResizeStart?: () => void;
-    readonly renderRow: (params: {
-        readonly isLatestStreamingTool: boolean;
-        readonly row: ChatTimelineRow;
-    }) => ReactNode;
+    readonly renderRow: (params: { readonly row: ChatTimelineRow }) => ReactNode;
     readonly scrollRef: RefObject<HTMLElement | null>;
     readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
-    readonly toolCardExpansionMode: AiToolCardExpansionMode;
 }
 
 export function resolveChatTimelineFrozenContentWidth(input: {
@@ -80,7 +75,6 @@ export const ChatTimelineHistoryRows = memo(
         chatFontFamily,
         chatFontSize,
         historyRows,
-        latestStreamingEditedFileToolRowId,
         onVirtualRangeChange,
         onVirtualResizeEnd,
         onVirtualResizeAutoFollow,
@@ -89,9 +83,11 @@ export const ChatTimelineHistoryRows = memo(
         scrollRef,
         shouldPreserveVirtualMeasureAnchor,
         shouldPreserveVirtualResizeAnchor,
-        toolCardExpansionMode,
     }: ChatTimelineHistoryRowsProps) {
         const historyRef = useRef<HTMLDivElement | null>(null);
+        const toolActivityDefaultExpansion = useSettingsStore(
+            (state) => state.aiChat.toolActivityDefaultExpansion,
+        );
         const pendingResizeAnchorFrameRef = useRef<number | null>(null);
         const pendingResizeAnchorRef =
             useRef<MeasuredVirtualViewportAnchor | null>(null);
@@ -346,24 +342,21 @@ export const ChatTimelineHistoryRows = memo(
         // identity key simply ignores the width bucket it carries.
         const buildRowContext = useCallback(
             (
-                row: ChatTimelineRow,
+                _row: ChatTimelineRow,
                 index: number,
             ): ChatTimelineRowMeasurementContext => ({
                 chatFontFamily,
                 chatFontSize,
                 gapPx: resolveRowGapPx(index),
-                isLatestStreamingTool:
-                    row.id === latestStreamingEditedFileToolRowId,
-                toolCardExpansionMode,
+                toolActivityDefaultExpansion,
                 width: contentMeasurementWidth,
             }),
             [
                 chatFontFamily,
                 contentMeasurementWidth,
                 chatFontSize,
-                latestStreamingEditedFileToolRowId,
                 resolveRowGapPx,
-                toolCardExpansionMode,
+                toolActivityDefaultExpansion,
             ],
         );
 
@@ -407,16 +400,11 @@ export const ChatTimelineHistoryRows = memo(
                                 : undefined
                         }
                     >
-                        {renderRow({
-                            isLatestStreamingTool:
-                                item.id === latestStreamingEditedFileToolRowId,
-                            row: item,
-                        })}
+                        {renderRow({ row: item })}
                     </div>
                 );
             },
             [
-                latestStreamingEditedFileToolRowId,
                 renderRow,
                 resolveRowGapPx,
             ],
@@ -427,12 +415,7 @@ export const ChatTimelineHistoryRows = memo(
                 <>
                     {historyRows.map((row) => (
                         <Fragment key={row.id}>
-                            {renderRow({
-                                isLatestStreamingTool:
-                                    row.id ===
-                                    latestStreamingEditedFileToolRowId,
-                                row,
-                            })}
+                            {renderRow({ row })}
                         </Fragment>
                     ))}
                 </>

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
@@ -6,8 +6,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AiToolActivity, AiTrackedFile } from "@shared/ipc";
 
-import { ToolActivityItem } from "./ToolActivityItem";
-import { isFileToolActivity } from "./toolActivityKinds";
+import {
+    shouldShowCompactActivitySummary,
+    ToolActivityItem,
+} from "./ToolActivityItem";
+import {
+    isFileToolActivity,
+    isStatusToolActivity,
+} from "./toolActivityKinds";
 
 const mockAiStoreState = vi.hoisted(() => ({
     current: {
@@ -52,7 +58,6 @@ vi.mock("@renderer/app/hooks/use-ai-chat-settings", () => ({
         reviewDiffZoom: 0.72,
         screenshotRetentionSeconds: 0,
         historyRetentionDays: 0,
-        toolCardExpansionMode: "collapsed",
     }),
 }));
 
@@ -147,6 +152,7 @@ const mountedRoots: Root[] = [];
 const mountedContainers: HTMLElement[] = [];
 
 beforeEach(() => {
+    mockAiStoreState.current.sessions = {};
     mockProjectFileIndexState.paths = new Set(
         DEFAULT_PROJECT_FILE_INDEX_PATHS,
     );
@@ -182,6 +188,163 @@ function renderInteractiveToolActivityItem(
 }
 
 describe("ToolActivityItem", () => {
+    it("hides the redundant terminal output availability summary", () => {
+        expect(
+            shouldShowCompactActivitySummary(
+                "Terminal output available.",
+                "command",
+                true,
+            ),
+        ).toBe(false);
+        expect(
+            shouldShowCompactActivitySummary(
+                "Command failed before producing output.",
+                "command",
+                true,
+            ),
+        ).toBe(true);
+        expect(
+            shouldShowCompactActivitySummary(
+                "Terminal output available.",
+                "command",
+                false,
+            ),
+        ).toBe(true);
+    });
+
+    it.each(["unknown", "mcp"])(
+        "uses the hammer icon for %s tools",
+        (kind) => {
+            const markup = renderToStaticMarkup(
+                createElement(ToolActivityItem, {
+                    activity: createActivity({ kind, summary: null }),
+                    onOpenFile: async () => {},
+                    projectId: "project-1",
+                    surface: "rail-row",
+                    trackedFiles: [],
+                    worktreeId: null,
+                }),
+            );
+
+            expect(markup).toContain('data-tool-icon="hammer"');
+        },
+    );
+
+    it("renders safe file activity as a dense rail row without raw details", () => {
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivityItem, {
+                activity: createActivity({
+                    kind: "read",
+                    locations: [],
+                    rawInputJson: JSON.stringify({
+                        file_path: "src/app.ts",
+                        secret: "raw-secret",
+                    }),
+                    summary: null,
+                    title: "Read file",
+                }),
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                surface: "rail-row",
+                trackedFiles: [],
+                worktreeId: null,
+            }),
+        );
+
+        expect(markup).toContain('data-tool-activity-surface="rail-row"');
+        expect(markup).toContain("Read file");
+        expect(markup).toContain("src/app.ts");
+        expect(markup).not.toContain("raw-secret");
+        expect(markup).not.toContain("rounded-lg");
+    });
+
+    it("renders successful terminal activity as a dense completed row", () => {
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivityItem, {
+                activity: createActivity({
+                    exitCode: 0,
+                    kind: "shell",
+                    locations: [],
+                    rawInputJson: JSON.stringify({ command: "pnpm test" }),
+                    status: "completed",
+                    summary: null,
+                    terminalOutput: "Tests passed\n",
+                    title: "Run pnpm test",
+                }),
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                surface: "rail-row",
+                trackedFiles: [],
+                worktreeId: null,
+            }),
+        );
+
+        expect(markup).toContain('data-tool-activity-surface="rail-row"');
+        expect(markup).toContain("Run pnpm test");
+        expect(markup).toContain("Done");
+        expect(markup).not.toContain("Tests passed");
+        expect(markup).not.toContain("var(--diff-add)");
+    });
+
+    it("reveals dense rail row details only through its disclosure", () => {
+        const container = renderInteractiveToolActivityItem({
+            activity: createActivity({
+                kind: "search",
+                locations: [],
+                rawInputJson: JSON.stringify({ query: "activity-segment" }),
+                rawOutputJson: JSON.stringify("3 matches"),
+                summary: null,
+                title: "Search activity-segment",
+            }),
+            onOpenFile: async () => {},
+            projectId: "project-1",
+            surface: "rail-row",
+            trackedFiles: [],
+            worktreeId: null,
+        });
+        const disclosure = container.querySelector<HTMLButtonElement>(
+            'button[aria-label="Expand details"]',
+        );
+
+        expect(container.textContent).not.toContain("3 matches");
+        act(() => disclosure?.click());
+        expect(disclosure?.getAttribute("aria-expanded")).toBe("true");
+        expect(container.textContent).toContain("3 matches");
+    });
+
+    it("preserves file navigation from a dense rail row", () => {
+        const onOpenFileReference = vi.fn();
+        const reference = {
+            endLine: null,
+            isAbsolute: false,
+            path: "src/app.ts",
+            relativePath: "src/app.ts",
+            startLine: null,
+        };
+        const container = renderInteractiveToolActivityItem({
+            activity: createActivity({
+                kind: "read",
+                locations: [],
+                rawInputJson: JSON.stringify({ file_path: "src/app.ts" }),
+                summary: null,
+                title: "Read src/app.ts",
+            }),
+            onOpenFile: async () => {},
+            onOpenFileReference,
+            projectId: "project-1",
+            resolveFileReference: () => reference,
+            surface: "rail-row",
+            trackedFiles: [],
+            worktreeId: null,
+        });
+        const openButton = Array.from(
+            container.querySelectorAll<HTMLButtonElement>("button"),
+        ).find((button) => button.textContent === "Read src/app.ts");
+
+        act(() => openButton?.click());
+        expect(onOpenFileReference).toHaveBeenCalledWith(reference);
+    });
+
     it("classifies native read_file activity as a file tool card", () => {
         expect(
             isFileToolActivity(
@@ -271,8 +434,9 @@ describe("ToolActivityItem", () => {
             }),
         );
 
-        expect(markup).toContain("Edited app.ts");
-        expect(markup).toContain("font-weight:400");
+        expect(markup).toContain(">Edited<");
+        expect(markup).toContain(">app.ts<");
+        expect(markup).toContain('data-change-review-surface="rail-row"');
         expect(markup).not.toContain("Accept");
         expect(markup).not.toContain("Reject");
     });
@@ -314,7 +478,6 @@ describe("ToolActivityItem", () => {
                         },
                     ],
                 }),
-                expansionMode: "expanded",
                 onOpenFile: async () => {},
                 projectId: "project-1",
                 trackedFiles: [],
@@ -322,10 +485,11 @@ describe("ToolActivityItem", () => {
             }),
         );
 
-        expect(markup).toContain("Edited app.ts");
-        expect(markup).toContain("change-review-panel:");
-        expect(markup).toContain("const before = true;");
-        expect(markup).toContain("const after = true;");
+        expect(markup).toContain(">Edited<");
+        expect(markup).toContain(">app.ts<");
+        expect(markup).not.toContain("change-review-panel:");
+        expect(markup).not.toContain("const before = true;");
+        expect(markup).not.toContain("const after = true;");
         expect(markup).not.toContain("Updates 1 line(s).");
         expect(markup).not.toContain("Accept");
         expect(markup).not.toContain("Reject");
@@ -372,7 +536,6 @@ describe("ToolActivityItem", () => {
                     terminalOutput: "patched src/app.ts\n",
                     title: "Run node patch.js",
                 }),
-                expansionMode: "expanded",
                 onOpenFile: async () => {},
                 projectId: "project-1",
                 trackedFiles: [],
@@ -381,9 +544,9 @@ describe("ToolActivityItem", () => {
         );
 
         expect(markup).toContain("Run node patch.js");
-        expect(markup).toContain("change-review-panel:");
-        expect(markup).toContain("const before = true;");
-        expect(markup).toContain("const after = true;");
+        expect(markup).not.toContain("change-review-panel:");
+        expect(markup).not.toContain("const before = true;");
+        expect(markup).not.toContain("const after = true;");
     });
 
     it("falls back to file tool card when no reviewable preview exists", () => {
@@ -435,7 +598,6 @@ describe("ToolActivityItem", () => {
                         },
                     ],
                 }),
-                expansionMode: "expanded",
                 onOpenFile: async () => {},
                 projectId: "project-1",
                 trackedFiles: [],
@@ -443,120 +605,11 @@ describe("ToolActivityItem", () => {
             }),
         );
 
-        expect(markup).toContain("Edited app.ts");
-        expect(markup).toContain("change-review-panel:");
+        expect(markup).toContain(">Edited<");
+        expect(markup).toContain(">app.ts<");
+        expect(markup).not.toContain("change-review-panel:");
         expect(markup).not.toContain("Accept");
         expect(markup).not.toContain("Reject");
-    });
-
-    it("expands file tool details when the card policy is always expanded", () => {
-        const markup = renderToStaticMarkup(
-            createElement(ToolActivityItem, {
-                activity: createActivity(),
-                expansionMode: "expanded",
-                onOpenFile: async () => {},
-                projectId: "project-1",
-                trackedFiles: [],
-                worktreeId: null,
-            }),
-        );
-
-        expect(markup).toContain("Updated src/app.ts");
-    });
-
-    it("does not expand read tool details when the card policy is always expanded", () => {
-        const markup = renderToStaticMarkup(
-            createElement(ToolActivityItem, {
-                activity: createActivity({
-                    kind: "read",
-                    summary: "Read-only details stay collapsed.",
-                    title: "Read src/app.ts",
-                }),
-                expansionMode: "expanded",
-                onOpenFile: async () => {},
-                projectId: "project-1",
-                trackedFiles: [],
-                worktreeId: null,
-            }),
-        );
-
-        expect(markup).toContain("Read ");
-        expect(markup).toContain("src/app.ts");
-        expect(markup).not.toContain("Read-only details stay collapsed.");
-    });
-
-    it("does not expand terminal tool details when the card policy is always expanded", () => {
-        const markup = renderToStaticMarkup(
-            createElement(ToolActivityItem, {
-                activity: createActivity({
-                    kind: "shell",
-                    rawInputJson: JSON.stringify({ command: "echo hidden" }),
-                    summary: null,
-                    terminalOutput: "terminal hidden output\n",
-                    title: "Run echo",
-                }),
-                expansionMode: "expanded",
-                onOpenFile: async () => {},
-                projectId: "project-1",
-                trackedFiles: [],
-                worktreeId: null,
-            }),
-        );
-
-        expect(markup).toContain("Run echo");
-        expect(markup).not.toContain("terminal hidden output");
-    });
-
-    it("does not expand generic tool details when the card policy is always expanded", () => {
-        const markup = renderToStaticMarkup(
-            createElement(ToolActivityItem, {
-                activity: createActivity({
-                    kind: "unknown",
-                    locations: [],
-                    rawInputJson: JSON.stringify({ value: "generic hidden" }),
-                    summary: "Generic hidden summary.",
-                    title: "Run generic tool",
-                }),
-                expansionMode: "expanded",
-                onOpenFile: async () => {},
-                projectId: "project-1",
-                trackedFiles: [],
-                worktreeId: null,
-            }),
-        );
-
-        expect(markup).toContain("Run generic tool");
-        expect(markup).not.toContain("Generic hidden summary.");
-        expect(markup).not.toContain("generic hidden");
-    });
-
-    it("only expands latest live tool details for the latest policy", () => {
-        const historyMarkup = renderToStaticMarkup(
-            createElement(ToolActivityItem, {
-                activity: createActivity(),
-                expansionMode: "latest",
-                isLatestStreamingTool: false,
-                onOpenFile: async () => {},
-                projectId: "project-1",
-                trackedFiles: [],
-                worktreeId: null,
-            }),
-        );
-        const liveMarkup = renderToStaticMarkup(
-            createElement(ToolActivityItem, {
-                activity: createActivity(),
-                expansionMode: "latest",
-                isLatestStreamingTool: true,
-                onOpenFile: async () => {},
-                projectId: "project-1",
-                trackedFiles: [],
-                worktreeId: null,
-            }),
-        );
-
-        expect(historyMarkup).not.toContain("Updated src/app.ts");
-        expect(liveMarkup).toContain("Updated src/app.ts");
-        expect(liveMarkup).toContain("cursor:pointer");
     });
 
     it("renders read tool titles as clickable internal links when they target a project file", () => {
@@ -1118,7 +1171,7 @@ describe("ToolActivityItem", () => {
         expect(codeBlock?.textContent).toBe('"hello"');
     });
 
-    it("renders turn_started as a subtle Codex ACP-style divider", () => {
+    it("does not render turn_started activities", () => {
         const markup = renderToStaticMarkup(
             createElement(ToolActivityItem, {
                 activity: createActivity({
@@ -1134,9 +1187,32 @@ describe("ToolActivityItem", () => {
             }),
         );
 
-        expect(markup).toContain('data-testid="turn-start-divider"');
-        expect(markup).toContain("New turn");
-        expect(markup).not.toContain("Context window: 128000");
+        expect(markup).toBe("");
+    });
+
+    it("renders lifecycle statuses as compact rows instead of generic tools", () => {
+        const activity = createActivity({
+            id: "codex-acp:status:item:compact-1",
+            kind: "other",
+            rawInputJson: JSON.stringify({ internal: true }),
+            summary: "Context window was compacted.",
+            title: "Compacting context",
+        });
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivityItem, {
+                activity,
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                trackedFiles: [],
+                worktreeId: null,
+            }),
+        );
+
+        expect(isStatusToolActivity(activity)).toBe(true);
+        expect(markup).toContain('data-testid="status-activity-item"');
+        expect(markup).toContain("Compacting context");
+        expect(markup).toContain("Context window was compacted.");
+        expect(markup).not.toContain("internal");
     });
 
     it("renders open-session actions for subagent breadcrumbs", () => {
@@ -1155,6 +1231,7 @@ describe("ToolActivityItem", () => {
                 onOpenFile: async () => {},
                 onOpenSession: async () => {},
                 projectId: "project-1",
+                surface: "rail-row",
                 trackedFiles: [],
                 worktreeId: null,
             }),
@@ -1162,6 +1239,37 @@ describe("ToolActivityItem", () => {
 
         expect(markup).toContain("Open Galileo");
         expect(markup).toContain("app-no-drag");
+        expect(markup).toContain('data-tool-activity-surface="rail-row"');
+    });
+
+    it("uses the child session title for subagent breadcrumbs", () => {
+        mockAiStoreState.current.sessions = {
+            "child-session": {
+                snapshot: { title: "Kierkegaard" },
+            },
+        };
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivityItem, {
+                activity: createActivity({
+                    action: {
+                        kind: "open_session",
+                        sessionId: "child-session",
+                    },
+                    kind: "unknown",
+                    locations: [],
+                    summary: null,
+                    title: "Started saludo_nuevo_tres",
+                }),
+                onOpenFile: async () => {},
+                onOpenSession: async () => {},
+                projectId: "project-1",
+                trackedFiles: [],
+                worktreeId: null,
+            }),
+        );
+
+        expect(markup).toContain("Open Kierkegaard");
+        expect(markup).not.toContain("Open saludo_nuevo_tres");
     });
 
     it("highlights structured payloads and terminal output in details", () => {
@@ -1192,7 +1300,7 @@ describe("ToolActivityItem", () => {
         );
     });
 
-    it("keeps failed terminal cards compact when there is no output to show", () => {
+    it("renders failed terminals as compact rail rows without empty output", () => {
         const markup = renderToStaticMarkup(
             createElement(ToolActivityItem, {
                 activity: createActivity({
@@ -1214,12 +1322,16 @@ describe("ToolActivityItem", () => {
         );
 
         expect(markup).toContain("Run pnpm run typecheck");
-        expect(markup).not.toContain("exit 1");
+        expect(markup).toContain("exit 1");
+        expect(markup).toContain(
+            'data-terminal-activity-surface="rail-row"',
+        );
+        expect(markup).not.toContain("rounded-lg");
         expect(markup).not.toContain("space-y-1");
         expect(markup).not.toContain("cm-static-code");
     });
 
-    it("colors successful terminal cards green without rendering an exit badge", () => {
+    it("colors successful terminal rows green without rendering an exit badge", () => {
         const markup = renderToStaticMarkup(
             createElement(ToolActivityItem, {
                 activity: createActivity({
@@ -1244,7 +1356,7 @@ describe("ToolActivityItem", () => {
         expect(markup).not.toContain("exit 0");
     });
 
-    it("colors non-zero terminal exits red without rendering an exit badge", () => {
+    it("colors non-zero terminal rows red and renders the exit status", () => {
         const markup = renderToStaticMarkup(
             createElement(ToolActivityItem, {
                 activity: createActivity({
@@ -1266,10 +1378,10 @@ describe("ToolActivityItem", () => {
 
         expect(markup).toContain("Run false");
         expect(markup).toContain("#ef4444");
-        expect(markup).not.toContain("exit 1");
+        expect(markup).toContain("exit 1");
     });
 
-    it("keeps in-progress terminal cards neutral and shows the live indicator", () => {
+    it("keeps in-progress terminal rows neutral and shows the live indicator", () => {
         const markup = renderToStaticMarkup(
             createElement(ToolActivityItem, {
                 activity: createActivity({
@@ -1315,10 +1427,35 @@ describe("ToolActivityItem", () => {
         );
 
         expect(markup).toContain("Tests failed");
-        expect(markup).toContain(
-            "color-mix(in srgb, #ef4444 6%, var(--color-bg-tertiary))",
-        );
+        expect(markup).toContain("background-color:transparent");
+        expect(markup).toContain("border:none");
         expect(markup).toContain("color:#ef4444");
+    });
+
+    it("keeps failed terminal output collapsed in compact contexts", () => {
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivityItem, {
+                activity: createActivity({
+                    exitCode: 1,
+                    kind: "shell",
+                    locations: [],
+                    rawInputJson: JSON.stringify({ command: "pnpm test" }),
+                    status: "completed",
+                    summary: null,
+                    terminalOutput: "Tests failed\n",
+                    title: "Run pnpm test",
+                }),
+                compactTerminal: true,
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                trackedFiles: [],
+                worktreeId: null,
+            }),
+        );
+
+        expect(markup).toContain("Run pnpm test");
+        expect(markup).toContain("exit 1");
+        expect(markup).not.toContain("Tests failed");
     });
 
     it("does not repeat duplicated terminal commands in expanded output", () => {

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
@@ -1,13 +1,13 @@
 import { memo } from "react";
 
 import type {
-    AiToolCardExpansionMode,
     AiToolActivity,
     AiToolActivityLocation,
     AiTrackedFile,
 } from "@shared/ipc";
 import { isAiTrackedFileUnresolved } from "@shared/ai-tracked-file";
 import { FIXED_PENDING_REVIEW_CARD_TEXT_ZOOM } from "@renderer/app/ai/sessionReviewContracts";
+import { useAiStore } from "@renderer/app/store/ai-store";
 import {
     normalizeIndexPath,
     useFileReferenceValidator,
@@ -29,12 +29,13 @@ import {
 } from "../projectFileReferences";
 import { ChangeReviewPanel } from "./ChangeReviewPanel";
 import {
+    getToolActivityDescriptor,
     getStructuredToolCommand,
     getStructuredToolTarget,
 } from "./toolActivityDescriptor";
 import {
-    isEditedFileToolActivity,
     isFileToolActivity,
+    isStatusToolActivity,
     isTerminalToolActivity,
     isTurnStartedActivity,
 } from "./toolActivityKinds";
@@ -115,7 +116,41 @@ function ExecuteIcon() {
     );
 }
 
-function DefaultIcon() {
+function HammerIcon() {
+    return (
+        <svg
+            data-tool-icon="hammer"
+            fill="none"
+            height="13"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.5"
+            viewBox="0 0 24 24"
+            width="13"
+        >
+            <path d="m14 4 6 6" />
+            <path d="m12.5 5.5 3-3 6 6-3 3" />
+            <path d="m14.5 10.5-9 9a2.12 2.12 0 0 1-3-3l9-9" />
+        </svg>
+    );
+}
+
+function SubagentIcon() {
+    return (
+        <svg
+            fill="currentColor"
+            height="13"
+            stroke="none"
+            viewBox="0 0 24 24"
+            width="13"
+        >
+            <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z" />
+        </svg>
+    );
+}
+
+function StatusIcon() {
     return (
         <svg
             fill="none"
@@ -127,13 +162,28 @@ function DefaultIcon() {
             viewBox="0 0 24 24"
             width="13"
         >
-            <circle cx="12" cy="12" r="3" />
-            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            <circle cx="12" cy="12" r="9" />
+            <path d="M12 7v5l3 2" />
         </svg>
     );
 }
 
-function Chevron({ expanded }: { readonly expanded: boolean }) {
+function Chevron({
+    expanded,
+    variant = "vertical",
+}: {
+    readonly expanded: boolean;
+    readonly variant?: "disclosure" | "vertical";
+}) {
+    const transform =
+        variant === "disclosure"
+            ? expanded
+                ? "rotate(0deg)"
+                : "rotate(-90deg)"
+            : expanded
+              ? "rotate(180deg)"
+              : "rotate(0deg)";
+
     return (
         <svg
             fill="none"
@@ -144,7 +194,7 @@ function Chevron({ expanded }: { readonly expanded: boolean }) {
             strokeWidth="2"
             style={{
                 opacity: 0.6,
-                transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+                transform,
                 transition: "transform 0.15s ease",
             }}
             viewBox="0 0 24 24"
@@ -165,8 +215,9 @@ function getToolAccent(kind: string): string {
     return "#6b7280";
 }
 
-function getToolIcon(kind: string) {
-    const lk = kind.toLowerCase();
+function getToolIcon(activity: AiToolActivity) {
+    if (activity.action?.kind === "open_session") return <SubagentIcon />;
+    const lk = activity.kind.toLowerCase();
     if (lk === "read" || lk === "search") return <ReadIcon />;
     if (lk === "delete" || lk === "remove") return <DeleteIcon />;
     if (lk === "execute" || lk === "bash" || lk === "shell")
@@ -179,7 +230,7 @@ function getToolIcon(kind: string) {
         lk === "update"
     )
         return <EditIcon />;
-    return <DefaultIcon />;
+    return <HammerIcon />;
 }
 
 function summarizeDiff(oldText: string | null, newText: string | null): string {
@@ -805,113 +856,60 @@ function ToolDetailSummary({
     );
 }
 
-function TurnStartedDivider({
+function StatusActivityItem({
     activity,
 }: {
     readonly activity: AiToolActivity;
 }) {
+    const isFailed = activity.status === "failed";
+    const isInProgress = activity.status === "in_progress";
+    const isCompleted = activity.status === "completed";
+
     return (
         <div
-            className="min-w-0 max-w-full py-2"
-            data-testid="turn-start-divider"
+            className="flex min-w-0 max-w-full select-none items-center gap-2 py-0.5"
+            data-testid="status-activity-item"
+            style={{
+                color: isFailed
+                    ? "#ef4444"
+                    : "var(--color-text-secondary)",
+                fontSize: "0.82em",
+                opacity: isCompleted ? 0.72 : 0.88,
+                transition: "opacity 0.2s ease",
+            }}
         >
-            <div className="flex min-w-0 max-w-full items-center gap-3">
-                <div
-                    className="h-px flex-1"
-                    style={{
-                        backgroundColor: "var(--color-border)",
-                        opacity: 0.5,
-                    }}
-                />
-                <span
-                    className="shrink-0 uppercase tracking-[0.14em]"
-                    style={{
-                        color: "var(--color-text-secondary)",
-                        fontSize: "0.68em",
-                        opacity: 0.7,
-                    }}
-                >
-                    {activity.title}
+            <span className="shrink-0">
+                <StatusIcon />
+            </span>
+            <span
+                className="min-w-0 truncate"
+                style={{ color: "var(--color-text-primary)" }}
+            >
+                {activity.title}
+            </span>
+            {activity.summary ? (
+                <span className="min-w-0 flex-1 truncate opacity-75">
+                    {activity.summary}
                 </span>
-                <div
-                    className="h-px flex-1"
-                    style={{
-                        backgroundColor: "var(--color-border)",
-                        opacity: 0.5,
-                    }}
+            ) : (
+                <span className="min-w-0 flex-1" />
+            )}
+            {isInProgress ? (
+                <span
+                    className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full"
+                    style={{ backgroundColor: "var(--color-accent)" }}
                 />
-            </div>
+            ) : null}
         </div>
     );
 }
 
 /* ─── File tool message (card style) ─── */
 
-function getToolCardExpansionState({
-    defaultExpanded,
-    expansionMode,
-    isLatestStreamingTool,
-}: {
-    readonly defaultExpanded: boolean;
-    readonly expansionMode: AiToolCardExpansionMode;
-    readonly isLatestStreamingTool: boolean;
-}) {
-    if (expansionMode === "expanded") {
-        return { defaultExpanded: true, forceExpanded: true };
-    }
-
-    if (expansionMode === "latest") {
-        return {
-            defaultExpanded: isLatestStreamingTool,
-            forceExpanded: false,
-        };
-    }
-
-    return { defaultExpanded, forceExpanded: false };
-}
-
-function useSyncedToolExpansion({
-    defaultExpanded,
-    forceExpanded,
-    resetKey,
-}: {
-    readonly defaultExpanded: boolean;
-    readonly forceExpanded: boolean;
-    readonly resetKey: string;
-}) {
-    const [expanded, setExpanded] = usePersistentToolExpansion(
-        resetKey,
-        defaultExpanded,
-    );
-
-    return {
-        expanded: forceExpanded ? true : expanded,
-        toggleExpanded: () => {
-            if (forceExpanded) {
-                return;
-            }
-
-            setExpanded((previous) => !previous);
-        },
-    };
-}
-
-function getToolExpansionResetKey(
-    activityId: string,
-    expansionMode: AiToolCardExpansionMode,
-    isLatestStreamingTool: boolean,
-): string {
-    return `${activityId}:${expansionMode}:${
-        isLatestStreamingTool ? "latest" : "history"
-    }`;
-}
-
 function FileToolMessage({
     activity,
     canRenderFileReference,
-    expansionMode,
     fileIndex,
-    isLatestStreamingTool,
     onOpenFile,
     onOpenFileReference,
     pendingTrackedFiles,
@@ -924,9 +922,7 @@ function FileToolMessage({
         rawReference: string,
         reference: ResolvedProjectFileReference,
     ) => boolean;
-    readonly expansionMode: AiToolCardExpansionMode;
     readonly fileIndex?: ReadonlySet<string> | null;
-    readonly isLatestStreamingTool: boolean;
     readonly onOpenFile: (
         projectId: string,
         relativePath: string,
@@ -980,27 +976,16 @@ function FileToolMessage({
         activity.locations.length > 0 ||
         activity.diffs.length > 0 ||
         pendingTrackedFiles.length > 0;
-    const expansionState = getToolCardExpansionState({
-        defaultExpanded: false,
-        expansionMode,
-        isLatestStreamingTool,
-    });
-    const { expanded, toggleExpanded: toggleSyncedExpanded } =
-        useSyncedToolExpansion({
-            defaultExpanded: expansionState.defaultExpanded,
-            forceExpanded: expansionState.forceExpanded,
-            resetKey: getToolExpansionResetKey(
-                activity.id,
-                expansionMode,
-                isLatestStreamingTool,
-            ),
-        });
+    const [expanded, setExpanded] = usePersistentToolExpansion(
+        activity.id,
+        false,
+    );
     const toggleExpanded = () => {
         if (!hasDetail) {
             return;
         }
 
-        toggleSyncedExpanded();
+        setExpanded((previous) => !previous);
     };
     const openTitleReference = () => {
         if (!titleReference || !titleIsLink) {
@@ -1033,7 +1018,7 @@ function FileToolMessage({
             style={{
                 backgroundColor: `color-mix(in srgb, ${accent} 4%, var(--color-bg-secondary))`,
                 border: `1px solid color-mix(in srgb, ${accent} 25%, var(--color-border))`,
-                opacity: isCompleted ? 0.65 : 1,
+                opacity: isCompleted ? 0.72 : 1,
                 transition: "opacity 0.2s ease",
             }}
         >
@@ -1068,16 +1053,14 @@ function FileToolMessage({
                     color: accent,
                     cursor:
                         shouldOpenOnHeaderClick ||
-                        (hasDetail && !expansionState.forceExpanded)
-                            ? "pointer"
-                            : "default",
+                        hasDetail ? "pointer" : "default",
                     fontSize: "0.83em",
                 }}
                 tabIndex={
                     hasDetail || shouldOpenOnHeaderClick ? 0 : undefined
                 }
             >
-                <span className="shrink-0">{getToolIcon(activity.kind)}</span>
+                <span className="shrink-0">{getToolIcon(activity)}</span>
                 <span
                     className="flex min-w-0 flex-1 items-baseline"
                     style={{
@@ -1190,10 +1173,7 @@ function FileToolMessage({
                             background: "none",
                             border: "none",
                             color: "inherit",
-                            cursor:
-                                expansionState.forceExpanded
-                                    ? "default"
-                                    : "pointer",
+                            cursor: "pointer",
                             display: "inline-flex",
                             margin: 0,
                             padding: 0,
@@ -1431,8 +1411,10 @@ function getTerminalToolToneColor(tone: TerminalToolTone): string {
 
 function TerminalToolMessage({
     activity,
+    compactByDefault,
 }: {
     readonly activity: AiToolActivity;
+    readonly compactByDefault: boolean;
 }) {
     const isInProgress = activity.status === "in_progress";
     const isCompleted = activity.status === "completed";
@@ -1447,42 +1429,38 @@ function TerminalToolMessage({
     const hasDetail = shouldShowCommand || hasTerminalOutput;
     const [expanded, setExpanded] = usePersistentToolExpansion(
         `${activity.id}:terminal`,
-        isDangerTone && hasTerminalOutput,
+        !compactByDefault && isDangerTone && hasTerminalOutput,
     );
+    const failureLabel = isDangerTone
+        ? activity.exitCode !== null && activity.exitCode !== 0
+            ? `exit ${activity.exitCode}`
+            : "Failed"
+        : null;
 
     return (
         <div
-            className="min-w-0 max-w-full select-none overflow-hidden rounded-lg"
+            className="min-w-0 max-w-full select-none"
+            data-terminal-activity-surface="rail-row"
             style={{
-                backgroundColor: `color-mix(in srgb, ${accent} 4%, var(--color-bg-secondary))`,
-                border: `1px solid color-mix(in srgb, ${accent} 25%, var(--color-border))`,
-                opacity: isCompleted ? 0.65 : 1,
+                color: "var(--color-text-secondary)",
+                fontFamily: "var(--font-mono), ui-monospace, monospace",
+                fontSize: "0.82em",
+                opacity: isCompleted ? 0.72 : 1,
                 transition: "opacity 0.2s ease",
             }}
         >
-            <button
-                className="flex w-full items-center gap-2 px-3 py-1.5 text-left"
-                onClick={() => hasDetail && setExpanded(!expanded)}
-                style={{
-                    background: "none",
-                    border: "none",
-                    borderBottom: expanded
-                        ? `1px solid color-mix(in srgb, ${accent} 15%, var(--color-border))`
-                        : "1px solid transparent",
-                    color: accent,
-                    cursor: hasDetail ? "pointer" : "default",
-                    fontSize: "0.83em",
-                }}
-                type="button"
-            >
-                <span className="shrink-0">
+            <div className="flex min-h-7 w-full min-w-0 items-center gap-2">
+                <span
+                    aria-hidden="true"
+                    className="shrink-0"
+                    style={{ color: accent }}
+                >
                     <ExecuteIcon />
                 </span>
                 <span
                     className="min-w-0 flex-1 truncate"
                     style={{
                         color: "var(--color-text-primary)",
-                        fontWeight: 400,
                     }}
                 >
                     {activity.title}
@@ -1493,30 +1471,39 @@ function TerminalToolMessage({
                         style={{ backgroundColor: "var(--color-accent)" }}
                     />
                 ) : null}
-                {hasDetail ? (
-                    <span className="shrink-0">
-                        <Chevron expanded={expanded} />
+                {failureLabel ? (
+                    <span
+                        className="shrink-0 text-[10px] font-medium"
+                        style={{ color: accent }}
+                    >
+                        {failureLabel}
                     </span>
                 ) : null}
-            </button>
+                {hasDetail ? (
+                    <button
+                        aria-label={
+                            expanded
+                                ? "Collapse terminal output"
+                                : "Expand terminal output"
+                        }
+                        className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-secondary hover:bg-bg-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:shadow-[0_0_0_1px_var(--color-accent)]"
+                        onClick={() => setExpanded(!expanded)}
+                        type="button"
+                    >
+                        <Chevron expanded={expanded} variant="disclosure" />
+                    </button>
+                ) : null}
+            </div>
 
             {expanded && hasDetail ? (
                 <div
-                    className="space-y-1 px-3 py-1.5"
+                    className="ml-5 mt-1 space-y-1 overflow-hidden border-l border-border pl-2"
                     style={{ fontSize: "0.78em" }}
                 >
                     {activity.terminalOutput ? (
                         <ToolDetailCodeBlock
-                            accentBorder={
-                                isDangerTone
-                                    ? "1px solid color-mix(in srgb, #ef4444 20%, var(--color-border))"
-                                    : "1px solid var(--color-border)"
-                            }
-                            backgroundColor={
-                                isDangerTone
-                                    ? "color-mix(in srgb, #ef4444 6%, var(--color-bg-tertiary))"
-                                    : "var(--color-bg-tertiary)"
-                            }
+                            accentBorder="none"
+                            backgroundColor="transparent"
                             color={
                                 isDangerTone
                                     ? "#ef4444"
@@ -1528,8 +1515,8 @@ function TerminalToolMessage({
                     ) : null}
                     {shouldShowCommand ? (
                         <ToolDetailCodeBlock
-                            accentBorder={`1px solid color-mix(in srgb, ${accent} 10%, var(--color-border))`}
-                            backgroundColor={`color-mix(in srgb, ${accent} 4%, var(--color-bg-tertiary))`}
+                            accentBorder="none"
+                            backgroundColor="transparent"
                             color="var(--color-text-primary)"
                             content={command}
                             languageInfo="shell"
@@ -1553,15 +1540,23 @@ function formatRawJson(raw: string): string {
     }
 }
 
-function getOpenSessionActionLabel(activity: AiToolActivity): string {
-    const name = activity.title
-        .replace(/^(spawned|started|opened)\s+/i, "")
-        .trim();
+function getOpenSessionActionLabel(
+    activity: AiToolActivity,
+    targetSessionTitle: string | null,
+): string {
+    const name =
+        targetSessionTitle?.trim() ||
+        activity.title
+            .replace(/^(spawned|started|opened)\s+/i, "")
+            .trim();
     return name.length > 0 && name.length <= 28 ? `Open ${name}` : "Open";
 }
 
-function getOpenSessionActionTitle(activity: AiToolActivity): string {
-    const label = getOpenSessionActionLabel(activity);
+function getOpenSessionActionTitle(
+    activity: AiToolActivity,
+    targetSessionTitle: string | null,
+): string {
+    const label = getOpenSessionActionLabel(activity, targetSessionTitle);
     return label === "Open" ? "Open session" : label;
 }
 
@@ -1570,6 +1565,7 @@ function GenericToolMessage({
     canRenderFileReference,
     onOpenFileReference,
     onOpenSession,
+    openSessionTitle,
     resolveFileReference,
 }: {
     readonly activity: AiToolActivity;
@@ -1581,6 +1577,7 @@ function GenericToolMessage({
         reference: ResolvedProjectFileReference,
     ) => void;
     readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
+    readonly openSessionTitle: string | null;
     readonly resolveFileReference?: (
         reference: string,
     ) => ResolvedProjectFileReference | null;
@@ -1606,7 +1603,7 @@ function GenericToolMessage({
             style={{
                 color: isFailed ? "#ef4444" : "var(--color-text-secondary)",
                 fontSize: "0.85em",
-                opacity: isCompleted ? 0.45 : 0.7,
+                opacity: isCompleted ? 0.72 : 0.88,
                 transition: "opacity 0.2s ease",
             }}
         >
@@ -1623,7 +1620,7 @@ function GenericToolMessage({
                     type="button"
                 >
                     <span className="shrink-0">
-                        {getToolIcon(activity.kind)}
+                        {getToolIcon(activity)}
                     </span>
                     <span className="min-w-0 flex-1 truncate">
                         {activity.title}
@@ -1646,10 +1643,16 @@ function GenericToolMessage({
                         onClick={() =>
                             void onOpenSession(openSessionAction.sessionId)
                         }
-                        title={getOpenSessionActionTitle(activity)}
+                        title={getOpenSessionActionTitle(
+                            activity,
+                            openSessionTitle,
+                        )}
                         type="button"
                     >
-                        {getOpenSessionActionLabel(activity)}
+                        {getOpenSessionActionLabel(
+                            activity,
+                            openSessionTitle,
+                        )}
                     </button>
                 ) : null}
             </div>
@@ -1704,26 +1707,305 @@ function GenericToolMessage({
 
 /* ─── Public component ─── */
 
-export const ToolActivityItem = memo(function ToolActivityItem({
+export type ToolActivitySurface = "card" | "rail-row";
+
+function getCompactActivityStatus(
+    activity: AiToolActivity,
+    category: ReturnType<typeof getToolActivityDescriptor>["category"],
+): string | null {
+    if (activity.status === "pending") {
+        return "Queued";
+    }
+    if (activity.status === "in_progress") {
+        return "Running";
+    }
+    if (
+        category === "command" &&
+        activity.status === "completed" &&
+        activity.exitCode === 0
+    ) {
+        return "Done";
+    }
+    return null;
+}
+
+export function shouldShowCompactActivitySummary(
+    summary: string | null,
+    category: ReturnType<typeof getToolActivityDescriptor>["category"],
+    hasTerminalOutput: boolean,
+): boolean {
+    if (summary === null) {
+        return false;
+    }
+
+    return !(
+        category === "command" &&
+        hasTerminalOutput &&
+        summary.trim().toLocaleLowerCase() === "terminal output available."
+    );
+}
+
+function CompactToolActivityRow({
     activity,
-    canRenderFileReference: canRenderFileReferenceOverride,
-    expansionMode = "collapsed",
-    isLatestStreamingTool = false,
+    canRenderFileReference,
+    fileIndex,
     onOpenFile,
     onOpenFileReference,
     onOpenSession,
-    trackedFiles = [],
+    openSessionTitle,
     projectId,
     resolveFileReference,
-    worktreeId = null,
+    worktreeId,
 }: {
     readonly activity: AiToolActivity;
     readonly canRenderFileReference?: (
         rawReference: string,
         reference: ResolvedProjectFileReference,
     ) => boolean;
-    readonly expansionMode?: AiToolCardExpansionMode;
-    readonly isLatestStreamingTool?: boolean;
+    readonly fileIndex: ReadonlySet<string> | null;
+    readonly onOpenFile: ToolActivityItemProps["onOpenFile"];
+    readonly onOpenFileReference?: (
+        reference: ResolvedProjectFileReference,
+    ) => void;
+    readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
+    readonly openSessionTitle: string | null;
+    readonly projectId: string | null;
+    readonly resolveFileReference?: (
+        reference: string,
+    ) => ResolvedProjectFileReference | null;
+    readonly worktreeId: string | null;
+}) {
+    const descriptor = getToolActivityDescriptor(activity);
+    const rawTarget =
+        descriptor.category === "file" ? descriptor.target : null;
+    const canOpenReference =
+        rawTarget !== null &&
+        canOpenToolFileReference({
+            canRenderFileReference,
+            fileIndex,
+            projectId,
+            resolveFileReference,
+            target: rawTarget,
+        });
+    const displayTarget =
+        descriptor.target &&
+        !activity.title
+            .toLocaleLowerCase()
+            .includes(descriptor.target.toLocaleLowerCase())
+            ? descriptor.target
+            : null;
+    const hasRawInput = activity.rawInputJson !== null;
+    const hasRawOutput = activity.rawOutputJson !== null;
+    const hasTerminalOutput = activity.terminalOutput !== null;
+    const shouldShowSummary = shouldShowCompactActivitySummary(
+        activity.summary,
+        descriptor.category,
+        hasTerminalOutput,
+    );
+    const hasLocations = activity.locations.length > 0;
+    const hasDetail =
+        shouldShowSummary ||
+        hasLocations ||
+        hasRawInput ||
+        hasRawOutput ||
+        hasTerminalOutput;
+    const [expanded, setExpanded] = usePersistentToolExpansion(
+        `${activity.sessionId}:${activity.id}:rail-row`,
+        false,
+    );
+    const detailId = `${activity.sessionId}:${activity.id}:rail-row-details`;
+    const status = getCompactActivityStatus(activity, descriptor.category);
+    const openSessionAction =
+        activity.action?.kind === "open_session" ? activity.action : null;
+
+    return (
+        <div
+            className="min-w-0 max-w-full select-none text-text-secondary"
+            data-tool-activity-surface="rail-row"
+            style={{
+                fontSize: "0.82em",
+                opacity: activity.status === "completed" ? 0.74 : 0.92,
+            }}
+        >
+            <div className="flex min-h-7 w-full items-center gap-2">
+                <span className="shrink-0 opacity-75" aria-hidden="true">
+                    {getToolIcon(activity)}
+                </span>
+                {canOpenReference && rawTarget ? (
+                    <button
+                        className="flex min-w-0 flex-1 items-center gap-2 text-left text-text-primary hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:shadow-[0_0_0_1px_var(--color-accent)]"
+                        onClick={() =>
+                            openToolFileReference({
+                                canRenderFileReference,
+                                fileIndex,
+                                onOpenFile,
+                                onOpenFileReference,
+                                projectId,
+                                resolveFileReference,
+                                target: rawTarget,
+                                worktreeId,
+                            })
+                        }
+                        title={rawTarget ?? activity.title}
+                        type="button"
+                    >
+                        <span className="min-w-0 truncate">
+                            {activity.title}
+                        </span>
+                        {displayTarget ? (
+                            <span className="min-w-0 truncate font-mono text-[10px] text-text-secondary">
+                                {displayTarget}
+                            </span>
+                        ) : null}
+                    </button>
+                ) : (
+                    <span
+                        className="flex min-w-0 flex-1 items-center gap-2 text-text-primary"
+                        title={activity.title}
+                    >
+                        <span className="min-w-0 truncate">
+                            {activity.title}
+                        </span>
+                        {displayTarget ? (
+                            <span className="min-w-0 truncate font-mono text-[10px] text-text-secondary">
+                                {displayTarget}
+                            </span>
+                        ) : null}
+                    </span>
+                )}
+                {status ? (
+                    <span className="shrink-0 text-[10px] font-medium text-text-secondary">
+                        {status}
+                    </span>
+                ) : null}
+                {openSessionAction && onOpenSession ? (
+                    <button
+                        className="app-no-drag shrink-0 rounded border border-border/70 px-1.5 py-0.5 text-[10px] font-medium text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+                        onClick={() =>
+                            void onOpenSession(openSessionAction.sessionId)
+                        }
+                        title={getOpenSessionActionTitle(
+                            activity,
+                            openSessionTitle,
+                        )}
+                        type="button"
+                    >
+                        {getOpenSessionActionLabel(activity, openSessionTitle)}
+                    </button>
+                ) : null}
+                {hasDetail ? (
+                    <button
+                        aria-controls={detailId}
+                        aria-expanded={expanded}
+                        aria-label={
+                            expanded ? "Collapse details" : "Expand details"
+                        }
+                        className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-secondary hover:bg-bg-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:shadow-[0_0_0_1px_var(--color-accent)]"
+                        onClick={() => setExpanded((current) => !current)}
+                        type="button"
+                    >
+                        <Chevron expanded={expanded} />
+                    </button>
+                ) : null}
+            </div>
+
+            {expanded ? (
+                <div
+                    aria-label={`${activity.title} details`}
+                    className="mb-1 ml-5 space-y-1"
+                    id={detailId}
+                    role="region"
+                >
+                    {shouldShowSummary && activity.summary ? (
+                        <ToolDetailSummary
+                            backgroundColor="var(--color-bg-tertiary)"
+                            canRenderFileReference={canRenderFileReference}
+                            content={activity.summary}
+                            onOpenFileReference={onOpenFileReference}
+                            resolveFileReference={resolveFileReference}
+                        />
+                    ) : null}
+                    {hasLocations ? (
+                        <div className="flex flex-wrap gap-1">
+                            {activity.locations.map((location) => {
+                                const target =
+                                    formatToolLocationReference(location);
+                                const canOpen = canOpenToolFileReference({
+                                    canRenderFileReference,
+                                    fileIndex,
+                                    projectId,
+                                    resolveFileReference,
+                                    target,
+                                });
+
+                                return (
+                                    <button
+                                        className="app-no-drag rounded-md px-2 py-0.5 text-text-secondary hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-default disabled:opacity-60"
+                                        disabled={!canOpen}
+                                        key={target}
+                                        onClick={() => {
+                                            if (canOpen) {
+                                                openToolFileReference({
+                                                    canRenderFileReference,
+                                                    fileIndex,
+                                                    onOpenFile,
+                                                    onOpenFileReference,
+                                                    projectId,
+                                                    resolveFileReference,
+                                                    target,
+                                                    worktreeId,
+                                                });
+                                            }
+                                        }}
+                                        type="button"
+                                    >
+                                        {target}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    ) : null}
+                    {activity.terminalOutput ? (
+                        <ToolDetailCodeBlock
+                            backgroundColor="var(--color-bg-tertiary)"
+                            color="var(--color-text-secondary)"
+                            content={activity.terminalOutput}
+                            languageInfo={
+                                descriptor.category === "command"
+                                    ? "shell"
+                                    : null
+                            }
+                        />
+                    ) : null}
+                    {hasRawInput ? (
+                        <ToolDetailCodeBlock
+                            backgroundColor="var(--color-bg-tertiary)"
+                            color="var(--color-text-secondary)"
+                            content={formatRawJson(activity.rawInputJson ?? "")}
+                            languageInfo="json"
+                        />
+                    ) : null}
+                    {hasRawOutput && !hasTerminalOutput ? (
+                        <ToolDetailCodeBlock
+                            backgroundColor="var(--color-bg-tertiary)"
+                            color="var(--color-text-secondary)"
+                            content={formatRawJson(activity.rawOutputJson ?? "")}
+                            languageInfo="json"
+                        />
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    );
+}
+
+export interface ToolActivityItemProps {
+    readonly activity: AiToolActivity;
+    readonly canRenderFileReference?: (
+        rawReference: string,
+        reference: ResolvedProjectFileReference,
+    ) => boolean;
+    readonly compactTerminal?: boolean;
     readonly onOpenFile: (
         projectId: string,
         relativePath: string,
@@ -1740,8 +2022,23 @@ export const ToolActivityItem = memo(function ToolActivityItem({
     readonly resolveFileReference?: (
         reference: string,
     ) => ResolvedProjectFileReference | null;
+    readonly surface?: ToolActivitySurface;
     readonly worktreeId?: string | null;
-}) {
+}
+
+export const ToolActivityItem = memo(function ToolActivityItem({
+    activity,
+    canRenderFileReference: canRenderFileReferenceOverride,
+    compactTerminal = false,
+    onOpenFile,
+    onOpenFileReference,
+    onOpenSession,
+    trackedFiles = [],
+    projectId,
+    resolveFileReference,
+    surface = "card",
+    worktreeId = null,
+}: ToolActivityItemProps) {
     const pendingTrackedFiles = trackedFiles.filter(
         isAiTrackedFileUnresolved,
     );
@@ -1757,6 +2054,19 @@ export const ToolActivityItem = memo(function ToolActivityItem({
     const canRenderFileReference =
         canRenderFileReferenceOverride ?? projectCanRenderFileReference;
     const fileIndex = useProjectFileIndex(projectId, worktreeId ?? null);
+    const openSessionId =
+        activity.action?.kind === "open_session"
+            ? activity.action.sessionId
+            : null;
+    const openSessionTitle = useAiStore((state) => {
+        if (!openSessionId) return null;
+        const targetSession = state.sessions[openSessionId];
+        return (
+            targetSession?.snapshot?.title ??
+            targetSession?.meta?.title ??
+            null
+        );
+    });
 
     useRenderProbe("ToolActivityItem", {
         activityId: activity.id,
@@ -1767,28 +2077,35 @@ export const ToolActivityItem = memo(function ToolActivityItem({
     });
 
     if (isTurnStartedActivity(activity)) {
-        return <TurnStartedDivider activity={activity} />;
+        return null;
+    }
+
+    if (isStatusToolActivity(activity)) {
+        return <StatusActivityItem activity={activity} />;
+    }
+
+    if (surface === "rail-row") {
+        return (
+            <CompactToolActivityRow
+                activity={activity}
+                canRenderFileReference={canRenderFileReference}
+                fileIndex={fileIndex}
+                onOpenFile={onOpenFile}
+                onOpenFileReference={onOpenFileReference}
+                onOpenSession={onOpenSession}
+                openSessionTitle={openSessionTitle}
+                projectId={projectId}
+                resolveFileReference={resolveFileReference}
+                worktreeId={worktreeId}
+            />
+        );
     }
 
     if (isFileToolActivity(activity, trackedFiles)) {
-        const fileToolExpansionMode = isEditedFileToolActivity(
-            activity,
-            trackedFiles,
-        )
-            ? expansionMode
-            : "collapsed";
-
         if (hasInlineReview) {
-            const reviewExpansionState = getToolCardExpansionState({
-                defaultExpanded: false,
-                expansionMode: fileToolExpansionMode,
-                isLatestStreamingTool,
-            });
             const reviewPanel = (
                 <ChangeReviewPanel
                     activity={activity}
-                    defaultExpanded={reviewExpansionState.defaultExpanded}
-                    forceExpanded={reviewExpansionState.forceExpanded}
                     onOpenFile={onOpenFile}
                     projectId={projectId}
                     resolveFileReference={resolveFileReference}
@@ -1800,7 +2117,10 @@ export const ToolActivityItem = memo(function ToolActivityItem({
             if (isTerminalToolActivity(activity)) {
                 return (
                     <div className="min-w-0 space-y-2">
-                        <TerminalToolMessage activity={activity} />
+                        <TerminalToolMessage
+                            activity={activity}
+                            compactByDefault={compactTerminal}
+                        />
                         {reviewPanel}
                     </div>
                 );
@@ -1810,16 +2130,19 @@ export const ToolActivityItem = memo(function ToolActivityItem({
         }
 
         if (isTerminalToolActivity(activity)) {
-            return <TerminalToolMessage activity={activity} />;
+            return (
+                <TerminalToolMessage
+                    activity={activity}
+                    compactByDefault={compactTerminal}
+                />
+            );
         }
 
         return (
             <FileToolMessage
                 activity={activity}
                 canRenderFileReference={canRenderFileReference}
-                expansionMode={fileToolExpansionMode}
                 fileIndex={fileIndex}
-                isLatestStreamingTool={isLatestStreamingTool}
                 onOpenFile={onOpenFile}
                 onOpenFileReference={onOpenFileReference}
                 pendingTrackedFiles={pendingTrackedFiles}
@@ -1831,7 +2154,12 @@ export const ToolActivityItem = memo(function ToolActivityItem({
     }
 
     if (isTerminalToolActivity(activity)) {
-        return <TerminalToolMessage activity={activity} />;
+        return (
+            <TerminalToolMessage
+                activity={activity}
+                compactByDefault={compactTerminal}
+            />
+        );
     }
 
     return (
@@ -1840,6 +2168,7 @@ export const ToolActivityItem = memo(function ToolActivityItem({
             canRenderFileReference={canRenderFileReference}
             onOpenFileReference={onOpenFileReference}
             onOpenSession={onOpenSession}
+            openSessionTitle={openSessionTitle}
             resolveFileReference={resolveFileReference}
         />
     );
@@ -1848,66 +2177,19 @@ export const ToolActivityItem = memo(function ToolActivityItem({
 ToolActivityItem.displayName = "ToolActivityItem";
 
 function areToolActivityItemPropsEqual(
-    previous: Readonly<{
-        readonly activity: AiToolActivity;
-        readonly canRenderFileReference?: (
-            rawReference: string,
-            reference: ResolvedProjectFileReference,
-        ) => boolean;
-        readonly expansionMode?: AiToolCardExpansionMode;
-        readonly isLatestStreamingTool?: boolean;
-        readonly onOpenFile: (
-            projectId: string,
-            relativePath: string,
-            worktreeId?: string | null,
-            reviewContext?: RuntimeWorkspaceFileReviewContext | null,
-            openLocation?: RuntimeWorkspaceFileOpenLocation | null,
-        ) => Promise<void>;
-        readonly onOpenFileReference?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
-        readonly trackedFiles?: readonly AiTrackedFile[];
-        readonly projectId: string | null;
-        readonly resolveFileReference?: (
-            reference: string,
-        ) => ResolvedProjectFileReference | null;
-        readonly worktreeId?: string | null;
-    }>,
-    next: Readonly<{
-        readonly activity: AiToolActivity;
-        readonly canRenderFileReference?: (
-            rawReference: string,
-            reference: ResolvedProjectFileReference,
-        ) => boolean;
-        readonly expansionMode?: AiToolCardExpansionMode;
-        readonly isLatestStreamingTool?: boolean;
-        readonly onOpenFile: (
-            projectId: string,
-            relativePath: string,
-            worktreeId?: string | null,
-            reviewContext?: RuntimeWorkspaceFileReviewContext | null,
-            openLocation?: RuntimeWorkspaceFileOpenLocation | null,
-        ) => Promise<void>;
-        readonly onOpenFileReference?: (
-            reference: ResolvedProjectFileReference,
-        ) => void;
-        readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
-        readonly trackedFiles?: readonly AiTrackedFile[];
-        readonly projectId: string | null;
-        readonly resolveFileReference?: (
-            reference: string,
-        ) => ResolvedProjectFileReference | null;
-        readonly worktreeId?: string | null;
-    }>,
+    previous: Readonly<ToolActivityItemProps>,
+    next: Readonly<ToolActivityItemProps>,
 ) {
     return (
         previous.activity === next.activity &&
         previous.canRenderFileReference === next.canRenderFileReference &&
-        previous.expansionMode === next.expansionMode &&
-        previous.isLatestStreamingTool === next.isLatestStreamingTool &&
+        previous.compactTerminal === next.compactTerminal &&
+        previous.onOpenFile === next.onOpenFile &&
+        previous.onOpenFileReference === next.onOpenFileReference &&
         previous.onOpenSession === next.onOpenSession &&
         previous.projectId === next.projectId &&
+        previous.resolveFileReference === next.resolveFileReference &&
+        previous.surface === next.surface &&
         previous.trackedFiles === next.trackedFiles &&
         previous.worktreeId === next.worktreeId
     );

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
@@ -1,0 +1,573 @@
+/** @vitest-environment jsdom */
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AiToolActivity } from "@shared/ipc";
+import {
+    resetSettingsStoreForTests,
+    useSettingsStore,
+} from "@renderer/app/store/settings-store";
+
+import type {
+    ChatTimelineActivitySegmentRow,
+    ToolActivitySegmentEntry,
+} from "./chatTimelineModel";
+import type { ToolActivityReviewEntry } from "./toolActivityReviewModel";
+import { ToolActivitySegment } from "./ToolActivitySegment";
+import { ToolExpansionStoreProvider } from "./toolExpansionStore";
+
+vi.mock("./ToolActivityItem", () => ({
+    ToolActivityItem: ({
+        activity,
+        compactTerminal,
+        surface,
+    }: {
+        readonly activity: AiToolActivity;
+        readonly compactTerminal: boolean;
+        readonly surface: string;
+    }) => (
+        <div
+            data-child-activity={activity.id}
+            data-compact-terminal={String(compactTerminal)}
+            data-tool-surface={surface}
+        >
+            {activity.title}
+        </div>
+    ),
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Root[] = [];
+
+afterEach(() => {
+    while (mountedRoots.length > 0) {
+        const root = mountedRoots.pop();
+        if (root) {
+            act(() => root.unmount());
+        }
+    }
+    resetSettingsStoreForTests();
+});
+
+function createActivity(
+    id: string,
+    overrides: Partial<AiToolActivity> = {},
+): AiToolActivity {
+    const index = Number(id.match(/\d+$/)?.[0] ?? "1");
+    const createdAt = `2026-07-10T00:00:${String(index).padStart(2, "0")}.000Z`;
+    return {
+        action: null,
+        createdAt,
+        diffs: [],
+        exitCode: null,
+        id,
+        kind: "read",
+        locations: [],
+        rawInputJson: JSON.stringify({ file_path: `src/${id}.ts` }),
+        rawOutputJson: null,
+        sessionId: "session-1",
+        status: "completed",
+        summary: null,
+        terminalOutput: null,
+        title: `Read src/${id}.ts`,
+        updatedAt: createdAt,
+        ...overrides,
+    };
+}
+
+function createReviewEntry(activity: AiToolActivity): ToolActivityReviewEntry {
+    return {
+        activity,
+        hasPendingTrackedFiles: false,
+        pendingTrackedFiles: [],
+        trackedFiles: [],
+    };
+}
+
+function createSegment(
+    entries: readonly ToolActivitySegmentEntry[],
+    overrides: Partial<ChatTimelineActivitySegmentRow["summary"]> = {},
+): ChatTimelineActivitySegmentRow {
+    const first = entries[0]?.reviewEntry.activity;
+    const latest = entries.at(-1)?.reviewEntry.activity;
+    if (!first || !latest) {
+        throw new Error("A test segment requires activity.");
+    }
+
+    return {
+        entries,
+        id: `activity-segment:session-1:${first.id}`,
+        kind: "activity-segment",
+        summary: {
+            actionCount: entries.length,
+            changeCount: entries.filter(
+                (entry) => entry.policy === "standalone-change",
+            ).length,
+            changedFileCount: 0,
+            commandCount: 0,
+            failureCount: 0,
+            fileCount: entries.length,
+            hiddenActivityCount: entries.length,
+            isInProgress: false,
+            latestActivityId: latest.id,
+            latestTitle: latest.title,
+            searchCount: 0,
+            startedAt: first.createdAt,
+            updatedAt: latest.updatedAt,
+            ...overrides,
+        },
+    };
+}
+
+function createEntry(
+    id: string,
+    policy: ToolActivitySegmentEntry["policy"] = "groupable",
+    overrides: Partial<AiToolActivity> = {},
+): ToolActivitySegmentEntry {
+    return {
+        policy,
+        reviewEntry: createReviewEntry(createActivity(id, overrides)),
+    };
+}
+
+const DEFAULT_PROPS = {
+    onOpenFile: async () => {},
+    projectId: "project-1",
+    worktreeId: null,
+};
+
+function renderInteractive(segment: ChatTimelineActivitySegmentRow) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mountedRoots.push(root);
+    act(() => {
+        root.render(
+            createElement(ToolActivitySegment, {
+                ...DEFAULT_PROPS,
+                segment,
+            }),
+        );
+    });
+    return container;
+}
+
+describe("ToolActivitySegment", () => {
+    it("keeps a single action compact while naming it in the summary", () => {
+        const segment = createSegment(
+            [
+                createEntry("command-1", "groupable", {
+                    kind: "shell",
+                    rawInputJson: JSON.stringify({
+                        command: "git status --short",
+                    }),
+                    title: "Running command",
+                }),
+            ],
+            { commandCount: 1 },
+        );
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivitySegment, {
+                ...DEFAULT_PROPS,
+                segment,
+            }),
+        );
+
+        expect(markup).toContain("Worked · 1 action");
+        expect(markup).toContain("git status --short");
+        expect(markup).not.toContain("Latest:");
+    });
+
+    it("uses the turn tail rather than stale tool state for the headline", () => {
+        const segment = createSegment(
+            [
+                createEntry("command-1", "groupable", {
+                    kind: "shell",
+                    status: "in_progress",
+                    title: "Run checks",
+                }),
+                createEntry("command-2", "groupable", {
+                    kind: "shell",
+                    status: "completed",
+                    title: "Check results",
+                }),
+            ],
+            { commandCount: 2, isInProgress: true },
+        );
+
+        const historicalMarkup = renderToStaticMarkup(
+            createElement(ToolActivitySegment, {
+                ...DEFAULT_PROPS,
+                segment,
+            }),
+        );
+        const activeMarkup = renderToStaticMarkup(
+            createElement(ToolActivitySegment, {
+                ...DEFAULT_PROPS,
+                isCurrentTurnTail: true,
+                segment,
+            }),
+        );
+
+        expect(historicalMarkup).toContain("Worked · 2 actions");
+        expect(historicalMarkup).toContain("Latest: Check results");
+        expect(activeMarkup).toContain("Working · 2 actions");
+        expect(activeMarkup).toContain("Current: Check results");
+    });
+
+    it("renders a transparent tree rail when activity is expanded", () => {
+        const container = renderInteractive(
+            createSegment([
+                createEntry("read-1"),
+                createEntry("edit-2", "standalone-change"),
+            ]),
+        );
+        const segment = container.querySelector<HTMLElement>(
+            "[data-tool-activity-segment]",
+        );
+
+        expect(segment?.dataset.activityRail).toBe("true");
+        expect(segment?.style.backgroundColor).toBe("");
+        expect(segment?.style.border).toBe("");
+        expect(segment?.className).not.toContain("overflow-hidden");
+        expect(segment?.className).not.toContain("rounded-lg");
+
+        expect(
+            container.querySelectorAll<HTMLElement>(
+                "[data-activity-rail-decoration]",
+            ),
+        ).toHaveLength(0);
+        expect(container.querySelector('[role="region"]')).toBeNull();
+        const disclosure = container.querySelector<HTMLButtonElement>(
+            'button[aria-label^="Show full activity:"]',
+        );
+        expect(disclosure?.getAttribute("aria-expanded")).toBe("false");
+        expect(disclosure?.getAttribute("aria-controls")).toContain(
+            ":activity",
+        );
+        expect(disclosure?.textContent).not.toContain("Show full activity");
+
+        act(() => disclosure?.click());
+
+        expect(
+            container.querySelectorAll("[data-activity-rail-decoration]"),
+        ).toHaveLength(2);
+        expect(
+            Array.from(
+                container.querySelectorAll<HTMLElement>(
+                    "[data-activity-rail-decoration]",
+                ),
+            ).map((member) => member.dataset.activityRailDecoration),
+        ).toEqual(["branch", "branch"]);
+        expect(
+            container
+                .querySelector('[role="region"]')
+                ?.getAttribute("aria-label"),
+        ).toBe("Full tool activity");
+    });
+
+    it("keeps a large safe burst DOM-bounded while collapsed", () => {
+        const entries = Array.from({ length: 50 }, (_, index) =>
+            createEntry(`read-${index + 1}`),
+        );
+        const container = renderInteractive(createSegment(entries));
+
+        expect(
+            container
+                .querySelector("[data-tool-activity-segment]")
+                ?.getAttribute("data-activity-count"),
+        ).toBe("50");
+        expect(container.querySelectorAll("[data-child-activity]")).toHaveLength(
+            0,
+        );
+        expect(
+            container
+                .querySelector<HTMLButtonElement>("button")
+                ?.getAttribute("aria-label"),
+        ).toContain("Show full activity");
+        expect(container.querySelectorAll("*").length).toBeLessThan(30);
+
+        act(() =>
+            container.querySelector<HTMLButtonElement>("button")?.click(),
+        );
+        const expandedEntries = Array.from(
+            container.querySelectorAll<HTMLElement>("[data-child-activity]"),
+        );
+        expect(expandedEntries).toHaveLength(50);
+        expect(
+            expandedEntries.every(
+                (entry) => entry.dataset.toolSurface === "rail-row",
+            ),
+        ).toBe(true);
+        expect(
+            container
+                .querySelector('[role="region"]')
+                ?.getAttribute("aria-label"),
+        ).toBe("Full tool activity");
+    });
+
+    it("uses the AI setting as the initial state without overriding manual changes", () => {
+        act(() =>
+            useSettingsStore.setState((state) => ({
+                aiChat: {
+                    ...state.aiChat,
+                    toolActivityDefaultExpansion: "expanded",
+                },
+            })),
+        );
+        const container = renderInteractive(
+            createSegment([createEntry("read-91"), createEntry("read-92")]),
+        );
+        const disclosure = container.querySelector<HTMLButtonElement>(
+            'button[aria-label^="Hide full activity:"]',
+        );
+
+        expect(disclosure?.getAttribute("aria-expanded")).toBe("true");
+        expect(container.querySelectorAll("[data-child-activity]")).toHaveLength(
+            2,
+        );
+
+        act(() => disclosure?.click());
+        expect(disclosure?.getAttribute("aria-expanded")).toBe("false");
+        expect(container.querySelectorAll("[data-child-activity]")).toHaveLength(
+            0,
+        );
+
+        act(() =>
+            useSettingsStore.setState((state) => ({
+                aiChat: {
+                    ...state.aiChat,
+                    toolActivityDefaultExpansion: "collapsed",
+                },
+            })),
+        );
+        expect(disclosure?.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("applies an asynchronously hydrated expansion default to untouched segments", () => {
+        const container = renderInteractive(
+            createSegment([createEntry("read-93")]),
+        );
+        const disclosure = container.querySelector<HTMLButtonElement>(
+            'button[aria-label^="Show full activity:"]',
+        );
+
+        expect(disclosure?.getAttribute("aria-expanded")).toBe("false");
+        act(() =>
+            useSettingsStore.setState((state) => ({
+                aiChat: {
+                    ...state.aiChat,
+                    toolActivityDefaultExpansion: "expanded",
+                },
+            })),
+        );
+
+        expect(disclosure?.getAttribute("aria-expanded")).toBe("true");
+        expect(container.querySelectorAll("[data-child-activity]")).toHaveLength(
+            1,
+        );
+    });
+
+    it("hides safe and important entries behind the same summary", () => {
+        const segment = createSegment(
+            [
+                createEntry("read-1"),
+                createEntry("edit-2", "standalone-change", {
+                    diffs: [
+                        {
+                            hunks: [],
+                            isText: true,
+                            kind: "update",
+                            newText: "after\n",
+                            oldText: "before\n",
+                            path: "src/app.ts",
+                            previousPath: null,
+                            reversible: true,
+                        },
+                    ],
+                    kind: "edit",
+                    title: "Edit src/app.ts",
+                }),
+                createEntry("read-3"),
+                createEntry("failed-4", "standalone-attention", {
+                    kind: "shell",
+                    status: "failed",
+                    title: "Tests failed",
+                }),
+            ],
+            { changedFileCount: 1, failureCount: 1 },
+        );
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivitySegment, {
+                ...DEFAULT_PROPS,
+                segment,
+            }),
+        );
+
+        expect(markup).toContain(
+            "Worked · 4 actions · 1 file changed · 1 failure",
+        );
+        expect(markup).toContain(">+1<");
+        expect(markup).toContain(">-1<");
+        expect(markup).toContain("Changed");
+        expect(markup).not.toContain("Edit src/app.ts");
+        expect(markup).toContain("Latest: Tests failed");
+        expect(markup).not.toContain("Read src/read-1.ts");
+        expect(markup).not.toContain("Read src/read-3.ts");
+        expect(markup).not.toContain("data-child-activity");
+        expect(markup).not.toContain("data-compact-terminal");
+    });
+
+    it("reveals the complete chronological sequence without duplicates", () => {
+        const container = renderInteractive(
+            createSegment([
+                createEntry("read-1"),
+                createEntry("edit-2", "standalone-change"),
+                createEntry("read-3"),
+            ]),
+        );
+        const button = container.querySelector<HTMLButtonElement>("button");
+
+        expect(button?.type).toBe("button");
+        expect(button?.getAttribute("aria-expanded")).toBe("false");
+        expect(button?.className).toContain(
+            "focus-visible:shadow-[inset_0_0_0_1px_var(--color-accent)]",
+        );
+        expect(
+            Array.from(
+                container.querySelectorAll<HTMLElement>(
+                    "[data-child-activity]",
+                ),
+            ).map((member) => member.dataset.childActivity),
+        ).toEqual([]);
+
+        act(() => button?.click());
+
+        expect(button?.getAttribute("aria-expanded")).toBe("true");
+        expect(button?.getAttribute("aria-label")).toContain(
+            "Hide full activity",
+        );
+        expect(button?.textContent).not.toContain("Hide full activity");
+        expect(
+            Array.from(
+                container.querySelectorAll<HTMLElement>(
+                    "[data-child-activity]",
+                ),
+            ).map((member) => member.dataset.childActivity),
+        ).toEqual(["read-1", "edit-2", "read-3"]);
+        const surfaces = Array.from(
+            container.querySelectorAll<HTMLElement>("[data-tool-surface]"),
+        ).map((member) => member.dataset.toolSurface);
+        expect(surfaces).toEqual(["rail-row", "card", "rail-row"]);
+        const indents = Array.from(
+            container.querySelectorAll<HTMLElement>(
+                "[data-activity-rail-indent]",
+            ),
+        ).map((member) => member.dataset.activityRailIndent);
+        expect(indents).toEqual(["child", "child", "child"]);
+        expect(
+            container.querySelector<HTMLElement>(
+                '[data-activity-rail-indent="child"]',
+            )?.className,
+        ).toContain("pl-10");
+    });
+
+    it("uses rail rows for coordination and unknown activity", () => {
+        const container = renderInteractive(
+            createSegment([
+                createEntry("read-1"),
+                createEntry("agent-2", "standalone-attention", {
+                    action: {
+                        kind: "open_session",
+                        sessionId: "child-session",
+                    },
+                    kind: "other",
+                    title: "Started child agent",
+                }),
+                createEntry("unknown-3", "standalone-unknown", {
+                    kind: "other",
+                    title: "Unknown tool",
+                }),
+            ]),
+        );
+
+        expect(container.textContent).not.toContain("Started child agent");
+        expect(container.textContent).toContain("Latest: Unknown tool");
+        expect(container.querySelectorAll("[data-child-activity]")).toHaveLength(
+            0,
+        );
+        act(() =>
+            container.querySelector<HTMLButtonElement>("button")?.click(),
+        );
+
+        expect(container.textContent).toContain("Started child agent");
+        expect(container.textContent).toContain("Unknown tool");
+        expect(
+            container.querySelectorAll('[data-tool-surface="card"]'),
+        ).toHaveLength(0);
+        expect(
+            container.querySelectorAll('[data-tool-surface="rail-row"]'),
+        ).toHaveLength(3);
+    });
+
+    it("hides important-only segments behind the same disclosure", () => {
+        const container = renderInteractive(
+            createSegment([
+                createEntry("edit-1", "standalone-change"),
+                createEntry("failed-2", "standalone-attention"),
+            ]),
+        );
+
+        const disclosure = container.querySelector<HTMLButtonElement>(
+            'button[aria-label^="Show full activity:"]',
+        );
+        expect(disclosure).not.toBeNull();
+        expect(container.querySelectorAll("[data-child-activity]")).toHaveLength(
+            0,
+        );
+
+        act(() => disclosure?.click());
+        expect(container.querySelectorAll("[data-child-activity]")).toHaveLength(
+            2,
+        );
+    });
+
+    it("restores expansion by segment id after a virtualized unmount", () => {
+        const segment = createSegment([
+            createEntry("read-1"),
+            createEntry("read-2"),
+        ]);
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        mountedRoots.push(root);
+
+        function Harness({ show }: { readonly show: boolean }) {
+            return (
+                <ToolExpansionStoreProvider>
+                    {show ? (
+                        <ToolActivitySegment
+                            {...DEFAULT_PROPS}
+                            segment={segment}
+                        />
+                    ) : null}
+                </ToolExpansionStoreProvider>
+            );
+        }
+
+        act(() => root.render(<Harness show />));
+        act(() => container.querySelector<HTMLButtonElement>("button")?.click());
+        act(() => root.render(<Harness show={false} />));
+        act(() => root.render(<Harness show />));
+
+        expect(
+            container
+                .querySelector<HTMLButtonElement>("button")
+                ?.getAttribute("aria-expanded"),
+        ).toBe("true");
+    });
+});

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
@@ -1,0 +1,298 @@
+import { memo, useMemo } from "react";
+
+import { useSettingsStore } from "@renderer/app/store/settings-store";
+
+import type {
+    ChatTimelineActivitySegmentRow,
+} from "./chatTimelineModel";
+import { formatDiffStat } from "../review/reviewDiff";
+import { deriveActivitySegmentChangeStats } from "./activitySegmentChangeStats";
+import { getToolActivityDescriptor } from "./toolActivityDescriptor";
+import {
+    ToolActivityItem,
+    type ToolActivityItemProps,
+} from "./ToolActivityItem";
+import { usePersistentToolExpansion } from "./toolExpansionStore";
+
+type ToolActivitySegmentProps = Pick<
+    ToolActivityItemProps,
+    | "canRenderFileReference"
+    | "onOpenFile"
+    | "onOpenFileReference"
+    | "onOpenSession"
+    | "projectId"
+    | "resolveFileReference"
+    | "worktreeId"
+> & {
+    /** True only while this segment is the trailing activity of an active turn. */
+    readonly isCurrentTurnTail?: boolean;
+    readonly segment: ChatTimelineActivitySegmentRow;
+};
+
+function pluralize(count: number, singular: string, plural = `${singular}s`) {
+    return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function getSegmentHeadline(
+    segment: ChatTimelineActivitySegmentRow,
+    isCurrentTurnTail: boolean,
+): string {
+    const { summary } = segment;
+    const details = [
+        pluralize(summary.actionCount, "action"),
+        summary.changedFileCount > 0
+            ? pluralize(
+                  summary.changedFileCount,
+                  "file changed",
+                  "files changed",
+              )
+            : null,
+        summary.failureCount > 0
+            ? pluralize(summary.failureCount, "failure")
+            : null,
+    ].filter((detail): detail is string => detail !== null);
+
+    if (isCurrentTurnTail) {
+        return `Working · ${details.join(" · ")}`;
+    }
+
+    if (
+        summary.changeCount === 0 &&
+        summary.commandCount === 0 &&
+        summary.failureCount === 0 &&
+        (summary.fileCount > 0 || summary.searchCount > 0)
+    ) {
+        const explorationDetails = [
+            summary.fileCount > 0
+                ? pluralize(summary.fileCount, "file")
+                : null,
+            summary.searchCount > 0
+                ? pluralize(summary.searchCount, "search", "searches")
+                : null,
+        ].filter((detail): detail is string => detail !== null);
+        return `Explored ${explorationDetails.join(" · ")}`;
+    }
+
+    return `Worked · ${details.join(" · ")}`;
+}
+
+function getLatestActivityLabel(
+    segment: ChatTimelineActivitySegmentRow,
+): string {
+    const latestActivity = segment.entries.at(-1)?.reviewEntry.activity;
+    if (!latestActivity) {
+        return segment.summary.latestTitle;
+    }
+
+    const descriptor = getToolActivityDescriptor(latestActivity);
+    return (
+        descriptor.command ?? descriptor.target ?? segment.summary.latestTitle
+    );
+}
+
+function Chevron({ expanded }: { readonly expanded: boolean }) {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="11"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.8"
+            style={{
+                transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+                transition: "transform 150ms ease",
+            }}
+            viewBox="0 0 16 16"
+            width="11"
+        >
+            <path d="m4 6 4 4 4-4" />
+        </svg>
+    );
+}
+
+export const ToolActivitySegment = memo(function ToolActivitySegment({
+    canRenderFileReference,
+    onOpenFile,
+    onOpenFileReference,
+    onOpenSession,
+    projectId,
+    resolveFileReference,
+    isCurrentTurnTail = false,
+    segment,
+    worktreeId,
+}: ToolActivitySegmentProps) {
+    const defaultExpansion = useSettingsStore(
+        (state) => state.aiChat.toolActivityDefaultExpansion,
+    );
+    const defaultExpanded = defaultExpansion === "expanded";
+    const [expanded, setExpanded] = usePersistentToolExpansion(
+        `${segment.id}:full-activity:${defaultExpansion}`,
+        defaultExpanded,
+    );
+    const canExpand = segment.entries.length > 0;
+    const contentId = `${segment.id}:activity`;
+    const headline = getSegmentHeadline(segment, isCurrentTurnTail);
+    const latestActivityLabel = getLatestActivityLabel(segment);
+    const changeStats = useMemo(
+        () => deriveActivitySegmentChangeStats(segment.entries),
+        [segment.entries],
+    );
+    const hasChanges = segment.summary.changeCount > 0;
+    const visibleEntries = expanded ? segment.entries : [];
+    const activityState = isCurrentTurnTail
+        ? "In progress"
+        : "Completed";
+    const accessibleChangeSummary = hasChanges
+        ? ` ${pluralize(changeStats.additions, "addition")}, ${pluralize(changeStats.deletions, "deletion")}. Changed.`
+        : "";
+    const accessibleLabel = `${expanded ? "Hide" : "Show"} full activity: ${headline}.${accessibleChangeSummary} ${activityState}.`;
+    const headerContent = (
+        <>
+            <span className="min-w-0 flex-1">
+                <span
+                    className="block truncate text-[11px] font-medium leading-4"
+                    title={headline}
+                >
+                    {headline}
+                </span>
+                {segment.summary.actionCount > 1 ? (
+                    <span
+                        data-activity-rail-current="true"
+                        className="block truncate text-[10px] leading-3.5 text-text-secondary"
+                        title={segment.summary.latestTitle}
+                    >
+                        {isCurrentTurnTail ? "Current" : "Latest"}: {segment.summary.latestTitle}
+                    </span>
+                ) : (
+                    <span
+                        data-activity-rail-current="true"
+                        className="block truncate text-[10px] leading-3.5 text-text-secondary"
+                        title={latestActivityLabel}
+                    >
+                        {latestActivityLabel}
+                    </span>
+                )}
+            </span>
+            {hasChanges ? (
+                <span
+                    className="flex shrink-0 items-center gap-1.5 text-[10px] font-medium"
+                    data-activity-change-summary="true"
+                >
+                    {changeStats.additions > 0 ? (
+                        <span style={{ color: "var(--diff-add)" }}>
+                            +
+                            {formatDiffStat(
+                                changeStats.additions,
+                                changeStats.approximate,
+                            )}
+                        </span>
+                    ) : null}
+                    {changeStats.deletions > 0 ? (
+                        <span style={{ color: "var(--diff-remove)" }}>
+                            -
+                            {formatDiffStat(
+                                changeStats.deletions,
+                                changeStats.approximate,
+                            )}
+                        </span>
+                    ) : null}
+                    <span className="text-text-secondary">Changed</span>
+                </span>
+            ) : null}
+            {canExpand ? (
+                <span className="shrink-0 text-text-secondary">
+                    <Chevron expanded={expanded} />
+                </span>
+            ) : null}
+        </>
+    );
+
+    return (
+        <div
+            aria-busy={isCurrentTurnTail}
+            className="activity-rail min-w-0"
+            data-activity-count={segment.summary.actionCount}
+            data-activity-rail="true"
+            data-tool-activity-segment={segment.id}
+        >
+            {canExpand ? (
+                <button
+                    aria-controls={contentId}
+                    aria-expanded={expanded}
+                    aria-label={accessibleLabel}
+                    className="flex min-h-10 w-full items-center gap-2 rounded-md px-1 py-1 text-left transition-colors hover:bg-bg-elevated focus-visible:bg-bg-elevated focus-visible:outline-none focus-visible:shadow-[inset_0_0_0_1px_var(--color-accent)]"
+                    onClick={() => setExpanded((current) => !current)}
+                    style={{
+                        background: "none",
+                        border: "none",
+                        color: "var(--color-text-primary)",
+                    }}
+                    type="button"
+                >
+                    {headerContent}
+                </button>
+            ) : (
+                <div className="flex min-h-10 w-full items-center gap-2 px-1 py-1 text-left">
+                    {headerContent}
+                </div>
+            )}
+
+            {visibleEntries.length > 0 ? (
+                <div
+                    aria-label="Full tool activity"
+                    className="pt-1"
+                    id={contentId}
+                    role="region"
+                >
+                    <div
+                        className="activity-tree flex min-w-0 flex-col gap-1.5"
+                        role="list"
+                    >
+                        {visibleEntries.map(({ policy, reviewEntry }) => {
+                            const atomicRowId = `tool:${reviewEntry.activity.sessionId}:${reviewEntry.activity.id}`;
+                            return (
+                                <div
+                                    className="activity-tree-branch min-w-0 pl-10"
+                                    data-activity-rail-decoration="branch"
+                                    data-activity-rail-indent="child"
+                                    data-tool-activity-id={reviewEntry.activity.id}
+                                    data-tool-activity-visibility={
+                                        policy === "groupable"
+                                            ? "expanded-only"
+                                            : "always"
+                                    }
+                                    key={atomicRowId}
+                                    role="listitem"
+                                >
+                                    <div className="min-w-0 py-0.5">
+                                        <ToolActivityItem
+                                            activity={reviewEntry.activity}
+                                            canRenderFileReference={canRenderFileReference}
+                                            compactTerminal
+                                            onOpenFile={onOpenFile}
+                                            onOpenFileReference={onOpenFileReference}
+                                            onOpenSession={onOpenSession}
+                                            projectId={projectId}
+                                            resolveFileReference={resolveFileReference}
+                                            surface={
+                                                policy === "standalone-change"
+                                                    ? "card"
+                                                    : "rail-row"
+                                            }
+                                            trackedFiles={reviewEntry.trackedFiles}
+                                            worktreeId={worktreeId}
+                                        />
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            ) : null}
+        </div>
+    );
+});
+
+ToolActivitySegment.displayName = "ToolActivitySegment";

--- a/src/renderer/src/components/workspace/chat/chatCodeSizing.ts
+++ b/src/renderer/src/components/workspace/chat/chatCodeSizing.ts
@@ -1,6 +1,5 @@
 const DEFAULT_CHAT_FONT_SIZE = 14;
 const MIN_CODE_BLOCK_FONT_SIZE = 12;
-const MIN_CODE_LABEL_FONT_SIZE = 10;
 
 function getSafeChatFontSize(chatFontSize: number) {
     return Number.isFinite(chatFontSize)
@@ -12,12 +11,5 @@ export function getChatCodeBlockFontSize(chatFontSize: number) {
     return Math.max(
         MIN_CODE_BLOCK_FONT_SIZE,
         getSafeChatFontSize(chatFontSize) - 1,
-    );
-}
-
-export function getChatCodeLabelFontSize(chatFontSize: number) {
-    return Math.max(
-        MIN_CODE_LABEL_FONT_SIZE,
-        getSafeChatFontSize(chatFontSize) - 3,
     );
 }

--- a/src/renderer/src/components/workspace/chat/chatTimelineModel.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineModel.ts
@@ -524,7 +524,6 @@ function buildToolActivitySegmentSummary(
     let changeCount = 0;
     let commandCount = 0;
     let failureCount = 0;
-    let hiddenActivityCount = 0;
     let searchCount = 0;
     let updatedAt =
         entries[0]?.reviewEntry.activity.updatedAt ??
@@ -562,9 +561,6 @@ function buildToolActivitySegmentSummary(
         if (entry.policy === "standalone-change") {
             changeCount += 1;
         }
-        if (entry.policy === "groupable") {
-            hiddenActivityCount += 1;
-        }
         if (
             activity.status === "failed" ||
             (activity.exitCode !== null && activity.exitCode !== 0)
@@ -584,7 +580,7 @@ function buildToolActivitySegmentSummary(
         commandCount,
         failureCount,
         fileCount: fileTargets.length,
-        hiddenActivityCount,
+        hiddenActivityCount: entries.length,
         isInProgress: entries.some(
             (entry) =>
                 entry.reviewEntry.activity.status === "pending" ||

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -7,6 +7,8 @@ import {
     type ChatTimelineRow,
 } from "./chatTimelineModel";
 import {
+    CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX,
+    CHAT_ACTIVITY_RAIL_HEADER_HEIGHT_PX,
     CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
     CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
     CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
@@ -114,6 +116,27 @@ function createToolRow({
     };
 }
 
+function createActivitySegmentRow(): ChatTimelineRow {
+    const model = reconcileChatTimelineModel(null, {
+        messages: [],
+        status: "idle",
+        toolActivity: [
+            createActivity({
+                id: "read-1",
+                kind: "read",
+                rawInputJson: JSON.stringify({ file_path: "src/app.ts" }),
+                title: "Read src/app.ts",
+            }),
+        ],
+        trackedFiles: [],
+    });
+    const row = model.orderedRows[0];
+    if (!row || row.kind !== "activity-segment") {
+        throw new Error("Expected a tool activity segment row.");
+    }
+    return row;
+}
+
 function createElementRect(top: number): HTMLElement {
     return {
         getBoundingClientRect: () => ({ top }) as DOMRect,
@@ -150,6 +173,111 @@ describe("chatTimelineVirtualization", () => {
         expect(getChatTimelineRowKey(row)).toBe("message:message-42");
     });
 
+    it("uses the stable activity segment id as its virtual key", () => {
+        const row = createActivitySegmentRow();
+
+        expect(getChatTimelineRowKey(row)).toBe(
+            "activity-segment:session-1:read-1",
+        );
+    });
+
+    it("estimates compact segments at a fixed width-insensitive height", () => {
+        const row = createActivitySegmentRow();
+        const context = {
+            chatFontFamily: "Inter",
+            chatFontSize: 13,
+            gapPx: 8,
+            width: 640,
+        };
+
+        expect(estimateChatTimelineRowHeight(row, context)).toBe(
+            CHAT_ACTIVITY_RAIL_HEADER_HEIGHT_PX + 8,
+        );
+        expect(CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX).toBe(28);
+        expect(isWidthSensitiveChatTimelineRow(row)).toBe(false);
+        const wideKey = getChatTimelineRowMeasurementKey(row, context);
+        expect(
+            getChatTimelineRowMeasurementKey(row, {
+                ...context,
+                width: 920,
+            }),
+        ).toBe(wideKey);
+    });
+
+    it("estimates collapsed mixed activity as a summary-only rail", () => {
+        const createDiff = (id: string, path: string, second: number) =>
+            createActivity({
+                createdAt: `2026-04-14T00:00:0${second}.000Z`,
+                diffs: [
+                    {
+                        hunks: [],
+                        isText: true,
+                        kind: "update" as const,
+                        newText: "next",
+                        oldText: "prev",
+                        path,
+                        previousPath: null,
+                        reversible: true,
+                    },
+                ],
+                id,
+                kind: "edit",
+                title: `Edit ${path}`,
+                updatedAt: `2026-04-14T00:00:0${second}.000Z`,
+            });
+        const model = reconcileChatTimelineModel(null, {
+            messages: [],
+            status: "idle",
+            toolActivity: [
+                createActivity({
+                    id: "read-1",
+                    kind: "read",
+                    rawInputJson: JSON.stringify({ file_path: "src/app.ts" }),
+                    title: "Read src/app.ts",
+                }),
+                createDiff("edit-1", "src/app.ts", 1),
+                createDiff("edit-2", "src/parser.ts", 2),
+                createActivity({
+                    createdAt: "2026-04-14T00:00:03.000Z",
+                    exitCode: 1,
+                    id: "test-1",
+                    kind: "shell",
+                    status: "failed",
+                    terminalOutput: "Tests failed",
+                    title: "Run tests",
+                    updatedAt: "2026-04-14T00:00:03.000Z",
+                }),
+            ],
+            trackedFiles: [],
+        });
+        const row = model.orderedRows[0];
+
+        expect(model.orderedRows).toHaveLength(1);
+        expect(row?.kind).toBe("activity-segment");
+        if (!row || row.kind !== "activity-segment") {
+            throw new Error("Expected one mixed activity segment.");
+        }
+        expect(row.entries.map((entry) => entry.policy)).toEqual([
+            "groupable",
+            "standalone-change",
+            "standalone-change",
+            "standalone-attention",
+        ]);
+        expect(
+            estimateChatTimelineRowHeight(row, {
+                gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+                width: 640,
+            }),
+        ).toBe(48);
+        expect(
+            estimateChatTimelineRowHeight(row, {
+                gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+                toolActivityDefaultExpansion: "expanded",
+                width: 640,
+            }),
+        ).toBe(198);
+    });
+
     it("calculates measured row gaps without duplicating the parent gap", () => {
         expect(
             getChatTimelineVirtualRowGapPx({
@@ -171,7 +299,7 @@ describe("chatTimelineVirtualization", () => {
         ).toBe(0);
     });
 
-    it("returns positive estimates and accounts for content, gap, and expansion mode", () => {
+    it("returns positive estimates and accounts for content and gaps", () => {
         const shortMessage = createMessageRow({ content: "short" });
         const richMessage = createMessageRow({
             attachments: [
@@ -212,33 +340,21 @@ describe("chatTimelineVirtualization", () => {
 
         const messageHeight = estimateChatTimelineRowHeight(shortMessage, {
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            toolCardExpansionMode: "collapsed",
         });
         const richMessageHeight = estimateChatTimelineRowHeight(richMessage, {
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            toolCardExpansionMode: "collapsed",
         });
         const collapsedToolHeight = estimateChatTimelineRowHeight(
             collapsedTool,
             {
                 gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-                toolCardExpansionMode: "collapsed",
             },
         );
-        const expandedToolHeight = estimateChatTimelineRowHeight(
-            collapsedTool,
-            {
-                gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-                toolCardExpansionMode: "expanded",
-            },
-        );
-
         expect(messageHeight).toBeGreaterThan(CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX);
         expect(richMessageHeight).toBeGreaterThan(messageHeight);
         expect(collapsedToolHeight).toBeGreaterThan(
             CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
         );
-        expect(expandedToolHeight).toBeGreaterThan(collapsedToolHeight);
     });
 
     it("uses the available width when estimating message wrapping", () => {
@@ -251,13 +367,11 @@ describe("chatTimelineVirtualization", () => {
         const narrowHeight = estimateChatTimelineRowHeight(longMessage, {
             chatFontSize: 13,
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            toolCardExpansionMode: "collapsed",
             width: 320,
         });
         const wideHeight = estimateChatTimelineRowHeight(longMessage, {
             chatFontSize: 13,
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            toolCardExpansionMode: "collapsed",
             width: 960,
         });
 
@@ -275,13 +389,11 @@ describe("chatTimelineVirtualization", () => {
         const thinkingHeight = estimateChatTimelineRowHeight(thinkingRow, {
             chatFontSize: 13,
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            toolCardExpansionMode: "collapsed",
             width: 520,
         });
         const assistantHeight = estimateChatTimelineRowHeight(assistantRow, {
             chatFontSize: 13,
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            toolCardExpansionMode: "collapsed",
             width: 520,
         });
 
@@ -312,12 +424,10 @@ describe("chatTimelineVirtualization", () => {
             collapsedGenericTool,
             {
                 gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-                toolCardExpansionMode: "collapsed",
             },
         );
         const failedHeight = estimateChatTimelineRowHeight(failedGenericTool, {
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            toolCardExpansionMode: "collapsed",
         });
 
         expect(collapsedHeight).toBeLessThan(64);
@@ -338,7 +448,6 @@ describe("chatTimelineVirtualization", () => {
         expect(
             estimateChatTimelineRowHeight(statusRow, {
                 gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-                toolCardExpansionMode: "expanded",
             }),
         ).toBe(28 + CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX);
     });
@@ -378,8 +487,6 @@ describe("chatTimelineVirtualization", () => {
             chatFontFamily: "Inter",
             chatFontSize: 13,
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            isLatestStreamingTool: false,
-            toolCardExpansionMode: "collapsed",
             width: 640,
         });
 
@@ -388,8 +495,6 @@ describe("chatTimelineVirtualization", () => {
                 chatFontFamily: "Inter",
                 chatFontSize: 14,
                 gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-                isLatestStreamingTool: false,
-                toolCardExpansionMode: "collapsed",
                 width: 640,
             }),
         ).not.toBe(base);
@@ -398,18 +503,6 @@ describe("chatTimelineVirtualization", () => {
                 chatFontFamily: "Inter",
                 chatFontSize: 13,
                 gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-                isLatestStreamingTool: false,
-                toolCardExpansionMode: "expanded",
-                width: 640,
-            }),
-        ).not.toBe(base);
-        expect(
-            getChatTimelineRowMeasurementKey(row, {
-                chatFontFamily: "Inter",
-                chatFontSize: 13,
-                gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-                isLatestStreamingTool: false,
-                toolCardExpansionMode: "collapsed",
                 width: 672,
             }),
         ).not.toBe(base);
@@ -418,8 +511,6 @@ describe("chatTimelineVirtualization", () => {
                 chatFontFamily: "Inter",
                 chatFontSize: 13,
                 gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-                isLatestStreamingTool: false,
-                toolCardExpansionMode: "collapsed",
                 width: 641,
             }),
         ).toBe(base);
@@ -430,8 +521,6 @@ describe("chatTimelineVirtualization", () => {
                     chatFontFamily: "Inter",
                     chatFontSize: 13,
                     gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-                    isLatestStreamingTool: false,
-                    toolCardExpansionMode: "collapsed",
                     width: 640,
                 },
             ),
@@ -443,8 +532,6 @@ describe("chatTimelineVirtualization", () => {
             chatFontFamily: "Inter",
             chatFontSize: 13,
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            isLatestStreamingTool: false,
-            toolCardExpansionMode: "collapsed" as const,
         };
         const toolRow = createToolRow();
         const messageRow = createMessageRow({ content: "hello" });
@@ -486,8 +573,6 @@ describe("chatTimelineVirtualization", () => {
             chatFontFamily: "Inter",
             chatFontSize: 13,
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            isLatestStreamingTool: false,
-            toolCardExpansionMode: "collapsed" as const,
         };
         const messageRow = createMessageRow({ content: "hello" });
 
@@ -505,19 +590,6 @@ describe("chatTimelineVirtualization", () => {
             }),
         );
 
-        // ...but still react to a real layout change like the expansion mode.
-        expect(
-            getChatTimelineRowIdentityKey(messageRow, {
-                ...baseContext,
-                toolCardExpansionMode: "expanded",
-                width: 640,
-            }),
-        ).not.toBe(
-            getChatTimelineRowIdentityKey(messageRow, {
-                ...baseContext,
-                width: 640,
-            }),
-        );
     });
 
     it("buckets virtual measurement widths to reduce resize churn", () => {
@@ -547,8 +619,6 @@ describe("chatTimelineVirtualization", () => {
             chatFontFamily: "Inter",
             chatFontSize: 13,
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            isLatestStreamingTool: false,
-            toolCardExpansionMode: "collapsed" as const,
             width: 640,
         };
         const row = createMessageRow({ content: "original" });
@@ -579,8 +649,6 @@ describe("chatTimelineVirtualization", () => {
             chatFontFamily: "Inter",
             chatFontSize: 13,
             gapPx: CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
-            isLatestStreamingTool: false,
-            toolCardExpansionMode: "collapsed" as const,
             width: 640,
         };
         const reconcile = (summary: string, updatedAt: string) =>

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -1,4 +1,4 @@
-import type { AiToolCardExpansionMode } from "@shared/ipc";
+import type { AiToolActivityDefaultExpansion } from "@shared/ipc";
 
 import { CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
 import type { ChatTimelineRow } from "./chatTimelineModel";
@@ -16,6 +16,11 @@ export const CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT = 720;
 export const CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX = 8;
 export const CHAT_TIMELINE_VIRTUAL_WIDTH_BUCKET_PX = 24;
 export const CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX = CHAT_CONTENT_MAX_WIDTH_PX;
+export const CHAT_ACTIVITY_RAIL_HEADER_HEIGHT_PX = 40;
+export const CHAT_ACTIVITY_RAIL_CONTENT_TOP_PX = 4;
+export const CHAT_ACTIVITY_RAIL_ENTRY_GAP_PX = 6;
+export const CHAT_ACTIVITY_RAIL_ENTRY_PADDING_Y_PX = 4;
+export const CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX = 28;
 
 interface ShouldVirtualizeChatTimelineOptions {
     readonly enabled?: boolean;
@@ -25,8 +30,7 @@ interface ShouldVirtualizeChatTimelineOptions {
 export interface ChatTimelineRowEstimateContext {
     readonly chatFontSize?: number;
     readonly gapPx?: number;
-    readonly isLatestStreamingTool?: boolean;
-    readonly toolCardExpansionMode: AiToolCardExpansionMode;
+    readonly toolActivityDefaultExpansion?: AiToolActivityDefaultExpansion;
     readonly width?: number;
 }
 
@@ -65,8 +69,7 @@ function getChatTimelineRowLayoutBase(
         context.chatFontFamily ?? "default",
         context.chatFontSize ?? "default",
         context.gapPx ?? 0,
-        context.isLatestStreamingTool ? "latest" : "history",
-        context.toolCardExpansionMode,
+        context.toolActivityDefaultExpansion ?? "collapsed",
     ].join(":");
 }
 
@@ -213,10 +216,35 @@ export function estimateChatTimelineRowHeight(
     }
 
     if (row.kind === "activity-segment") {
-        return gapPx;
+        if (context.toolActivityDefaultExpansion !== "expanded") {
+            return Math.ceil(CHAT_ACTIVITY_RAIL_HEADER_HEIGHT_PX + gapPx);
+        }
+
+        const activityHeight = row.entries.reduce(
+            (height, entry, index) =>
+                height +
+                (entry.policy === "groupable"
+                    ? CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX
+                    : estimateToolActivityHeight(
+                          entry.reviewEntry,
+                          context,
+                          true,
+                      )) +
+                CHAT_ACTIVITY_RAIL_ENTRY_PADDING_Y_PX +
+                (index > 0 ? CHAT_ACTIVITY_RAIL_ENTRY_GAP_PX : 0),
+            0,
+        );
+        return Math.ceil(
+            CHAT_ACTIVITY_RAIL_HEADER_HEIGHT_PX +
+                CHAT_ACTIVITY_RAIL_CONTENT_TOP_PX +
+                activityHeight +
+                gapPx,
+        );
     }
 
-    return Math.ceil(estimateToolRowHeight(row, context) + gapPx);
+    return Math.ceil(
+        estimateToolActivityHeight(row.reviewEntry, context) + gapPx,
+    );
 }
 
 function estimateMessageRowHeight(
@@ -231,15 +259,21 @@ function estimateMessageRowHeight(
     }
 
     const content = message.content ?? "";
+    const availableCharacters = estimateCharactersPerLine(
+        context.width,
+        chatFontSize,
+    );
     const estimatedLines = estimateTextLines(
         content,
-        estimateCharactersPerLine(context.width, chatFontSize),
+        message.kind === "user" && (context.width ?? 0) > 420
+            ? Math.max(24, Math.floor(availableCharacters * 0.7))
+            : availableCharacters,
     );
     const contentHeight = Math.min(340, estimatedLines * 18 * fontScale);
     const codeBlockCount = countCodeBlocks(content);
     const attachmentHeight = message.attachments.length * 48;
     const imageHeight = message.generatedImage ? 190 : 0;
-    const baseHeight = message.kind === "user" ? 54 : 72;
+    const baseHeight = message.kind === "user" ? 74 : 72;
 
     return (
         baseHeight +
@@ -269,21 +303,20 @@ function estimateCharactersPerLine(
     );
 }
 
-function estimateToolRowHeight(
-    row: Extract<ChatTimelineRow, { readonly kind: "tool" }>,
-    context: ChatTimelineRowEstimateContext,
+function estimateToolActivityHeight(
+    reviewEntry: Extract<
+        ChatTimelineRow,
+        { readonly kind: "tool" }
+    >["reviewEntry"],
+    _context: ChatTimelineRowEstimateContext,
+    compactTerminal = false,
 ): number {
-    const activity = row.reviewEntry.activity;
-    const trackedFiles = row.reviewEntry.trackedFiles;
+    const activity = reviewEntry.activity;
+    const trackedFiles = reviewEntry.trackedFiles;
     const hasInlineReview = trackedFiles.length > 0 || activity.diffs.length > 0;
-    const hasLocations = activity.locations.length > 0;
     const hasTerminalOutput = !!activity.terminalOutput;
     const hasSummary = !!activity.summary;
     const hasRawJson = !!activity.rawInputJson || !!activity.rawOutputJson;
-    const isExpandedByMode =
-        context.toolCardExpansionMode === "expanded" ||
-        (context.toolCardExpansionMode === "latest" &&
-            context.isLatestStreamingTool === true);
 
     if (isTurnStartedActivity(activity)) {
         return 48;
@@ -294,11 +327,16 @@ function estimateToolRowHeight(
     }
 
     if (isTerminalToolActivity(activity)) {
+        if (compactTerminal) {
+            return CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX;
+        }
         const startsExpanded =
             hasTerminalOutput &&
             (activity.status === "failed" ||
                 (activity.exitCode !== null && activity.exitCode !== 0));
-        return startsExpanded ? 210 : 42;
+        return startsExpanded
+            ? 210
+            : CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX;
     }
 
     if (hasInlineReview) {
@@ -309,25 +347,15 @@ function estimateToolRowHeight(
         );
         const collapsedHeight = Math.min(
             220,
-            collapsedItemCount * 44 +
+            collapsedItemCount * CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX +
                 Math.max(0, collapsedItemCount - 1) *
-                    CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+                    CHAT_ACTIVITY_RAIL_ENTRY_PADDING_Y_PX,
         );
-        const detailHeight = Math.min(
-            360,
-            activity.diffs.length * 82 + trackedFiles.length * 58,
-        );
-        return isExpandedByMode ? 132 + detailHeight : collapsedHeight;
+        return collapsedHeight;
     }
 
     if (isFileToolActivity(activity, trackedFiles)) {
-        const hasDetail = hasSummary || hasLocations || activity.diffs.length > 0;
-        const detailHeight =
-            (hasSummary ? 76 : 0) +
-            (hasLocations ? Math.min(96, activity.locations.length * 28) : 0) +
-            Math.min(240, activity.diffs.length * 72);
-
-        return hasDetail && isExpandedByMode ? 64 + detailHeight : 42;
+        return 42;
     }
 
     if (activity.status === "failed") {

--- a/src/renderer/src/components/workspace/chat/composerParts.test.ts
+++ b/src/renderer/src/components/workspace/chat/composerParts.test.ts
@@ -39,6 +39,22 @@ describe("composerParts", () => {
         ]);
     });
 
+    it("keeps the full selection preview in composer mentions", () => {
+        const selectedText =
+            "const descriptiveVariableName = buildSomethingWithoutTruncation();";
+        const parts = appendSelectionMentionPart([], {
+            endLine: 12,
+            path: "src/app.ts",
+            selectedText,
+            startLine: 12,
+        });
+
+        expect(parts.find((part) => part.type === "selection_mention")).toMatchObject({
+            label: `(12) - ${selectedText}`,
+            type: "selection_mention",
+        });
+    });
+
     it("serializes selection mentions for the prompt as line references", () => {
         const parts: AIComposerPart[] = [
             { type: "text", text: "Inspect " },

--- a/src/renderer/src/components/workspace/chat/toolActivityPresentation.test.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityPresentation.test.ts
@@ -69,7 +69,7 @@ describe("getToolActivityPresentationPolicy", () => {
         expect(classify(createEntry({ kind }))).toBe("groupable");
     });
 
-    it("groups only terminal activity with proven success or active execution", () => {
+    it("groups terminal activity with proven success or active execution", () => {
         expect(
             classify(
                 createEntry({
@@ -93,7 +93,7 @@ describe("getToolActivityPresentationPolicy", () => {
         ).toBe("standalone-unknown");
         expect(
             classify(createEntry({ kind: "bash", status: "pending" })),
-        ).toBe("standalone-unknown");
+        ).toBe("groupable");
     });
 
     it("keeps failed and non-zero activity standalone", () => {

--- a/src/renderer/src/components/workspace/chat/toolActivityPresentation.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityPresentation.ts
@@ -59,6 +59,7 @@ function isKnownGroupableActivity(entry: ToolActivityReviewEntry): boolean {
     }
 
     return (
+        activity.status === "pending" ||
         activity.status === "in_progress" ||
         (activity.status === "completed" && activity.exitCode === 0)
     );

--- a/src/renderer/src/components/workspace/chat/toolActivityReviewModel.test.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityReviewModel.test.ts
@@ -93,6 +93,23 @@ describe("toolActivityReviewModel", () => {
         ).toEqual(["tracked-2", "tracked-1"]);
     });
 
+    it("scopes explicit tool-call matches to the activity session", () => {
+        const activity = createActivity();
+        const trackedFiles = [
+            createTrackedFile({ identityKey: "current-session" }),
+            createTrackedFile({
+                identityKey: "other-session",
+                sessionId: "session-2",
+            }),
+        ];
+
+        expect(
+            deriveTrackedFilesForToolActivity(activity, trackedFiles).map(
+                (trackedFile) => trackedFile.identityKey,
+            ),
+        ).toEqual(["current-session"]);
+    });
+
     it("uses path fallback only when match is unique", () => {
         const activity = createActivity({
             diffs: [
@@ -118,6 +135,47 @@ describe("toolActivityReviewModel", () => {
                 (candidate) => candidate.identityKey,
             ),
         ).toEqual(["tracked-1"]);
+    });
+
+    it("uses structured raw input when native locations are missing", () => {
+        const activity = createActivity({
+            id: "tool-without-link",
+            kind: "read",
+            locations: [],
+            rawInputJson: JSON.stringify({ file_path: "src/app.ts" }),
+        });
+        const trackedFile = createTrackedFile({ toolCallId: null });
+
+        expect(
+            deriveTrackedFilesForToolActivity(activity, [trackedFile]).map(
+                (candidate) => candidate.identityKey,
+            ),
+        ).toEqual(["tracked-1"]);
+    });
+
+    it("scopes raw-input path fallback to the activity session", () => {
+        const activity = createActivity({
+            id: "tool-without-link",
+            kind: "read",
+            rawInputJson: JSON.stringify({ file_path: "src/app.ts" }),
+        });
+        const trackedFiles = [
+            createTrackedFile({
+                identityKey: "current-session",
+                toolCallId: null,
+            }),
+            createTrackedFile({
+                identityKey: "other-session",
+                sessionId: "session-2",
+                toolCallId: null,
+            }),
+        ];
+
+        expect(
+            deriveTrackedFilesForToolActivity(activity, trackedFiles).map(
+                (trackedFile) => trackedFile.identityKey,
+            ),
+        ).toEqual(["current-session"]);
     });
 
     it("uses normalized path fallback for Windows separator aliases", () => {

--- a/src/renderer/src/components/workspace/projectFileReferences.test.ts
+++ b/src/renderer/src/components/workspace/projectFileReferences.test.ts
@@ -16,6 +16,33 @@ describe("projectFileReferences", () => {
         });
     });
 
+    it("parses natural-language line references", () => {
+        expect(
+            parseProjectFileReference("manage_profiles_modal.rs (line 790)"),
+        ).toEqual({
+            endLine: 790,
+            isAbsolute: false,
+            path: "manage_profiles_modal.rs",
+            startLine: 790,
+        });
+        expect(
+            parseProjectFileReference(
+                "src/profile_selector.rs (lines 177-184)",
+            ),
+        ).toEqual({
+            endLine: 184,
+            isAbsolute: false,
+            path: "src/profile_selector.rs",
+            startLine: 177,
+        });
+        expect(parseProjectFileReference("src/app.ts, line 12")).toEqual({
+            endLine: 12,
+            isAbsolute: false,
+            path: "src/app.ts",
+            startLine: 12,
+        });
+    });
+
     it("parses parenthesized relative file paths", () => {
         expect(parseProjectFileReference("src/components/Foo(test).tsx")).toEqual({
             endLine: null,

--- a/src/renderer/src/components/workspace/projectFileReferences.ts
+++ b/src/renderer/src/components/workspace/projectFileReferences.ts
@@ -30,6 +30,8 @@ interface ParsedLineRange {
 const FILE_PROTOCOL = "file://";
 const HASH_LINE_RE = /^#L?(\d+)(?:-L?(\d+))?$/;
 const TRAILING_LINE_RE = /^(.*?):(\d+)(?:-(\d+))?(?::\d+)?$/;
+const NATURAL_LINE_RE =
+    /^(.*?)\s*(?:\((?:line|lines)\s+(\d+)(?:\s*[-–]\s*(\d+))?\)|,\s*(?:line|lines)\s+(\d+)(?:\s*[-–]\s*(\d+))?)$/i;
 const WINDOWS_DRIVE_RE = /^[A-Za-z]:[\\/]/;
 
 export function isLikelyProjectFileReference(target: string): boolean {
@@ -195,7 +197,22 @@ function parsePlainTarget(target: string): ParsedProjectFileReference | null {
         return null;
     }
 
-    const parsedLine = parseTrailingLineRange(pathPart);
+    const naturalLineMatch = pathPart.match(NATURAL_LINE_RE);
+    const naturalStartLine = Number(
+        naturalLineMatch?.[2] ?? naturalLineMatch?.[4] ?? NaN,
+    );
+    const naturalEndLine = Number(
+        naturalLineMatch?.[3] ?? naturalLineMatch?.[5] ?? NaN,
+    );
+    const parsedLine = naturalLineMatch
+        ? {
+              endLine: Number.isFinite(naturalEndLine)
+                  ? naturalEndLine
+                  : naturalStartLine,
+              path: naturalLineMatch[1]?.trim() ?? "",
+              startLine: naturalStartLine,
+          }
+        : parseTrailingLineRange(pathPart);
     const candidatePath = parsedLine.path;
     const isAbsolute = looksAbsolutePath(candidatePath);
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -473,7 +473,7 @@ body {
 .markdown-file-preview ul,
 .markdown-file-preview ol,
 .markdown-file-preview blockquote,
-.markdown-file-preview .markdown-file-preview__code-frame,
+.markdown-file-preview .markdown-code-frame,
 .markdown-file-preview pre,
 .markdown-file-preview .markdown-file-preview__table-wrap {
     margin: 0 0 1em;
@@ -566,8 +566,9 @@ body {
     white-space: break-spaces;
 }
 
-.markdown-file-preview__code-block {
+.markdown-code-block {
     max-width: 100%;
+    margin: 0;
     overflow: auto;
     border: 1px solid color-mix(in srgb, var(--color-border) 82%, transparent);
     border-radius: 6px;
@@ -579,20 +580,28 @@ body {
     padding: 0.85em 1em;
 }
 
-.markdown-file-preview__code-block code {
+.markdown-code-block code {
     display: block;
-    min-width: max-content;
     font-family: inherit;
 }
 
-.markdown-file-preview__code-frame {
+.markdown-file-preview .markdown-code-block code {
+    min-width: max-content;
+}
+
+.chat-markdown-code-block code {
+    min-width: 0;
+}
+
+.markdown-code-frame {
+    position: relative;
     overflow: hidden;
     border: 1px solid color-mix(in srgb, var(--color-border) 82%, transparent);
     border-radius: 6px;
     background: color-mix(in srgb, var(--color-bg-tertiary) 68%, transparent);
 }
 
-.markdown-file-preview__code-header {
+.markdown-code-header {
     display: flex;
     min-height: 2.45em;
     align-items: center;
@@ -606,7 +615,14 @@ body {
     padding: 0.18em 0.55em 0 1em;
 }
 
-.markdown-file-preview__copy-button {
+.markdown-code-copy-overlay {
+    position: absolute;
+    z-index: 1;
+    top: 0.55em;
+    right: 0.55em;
+}
+
+.markdown-code-copy-button {
     display: inline-flex;
     width: 20px;
     height: 20px;
@@ -624,22 +640,31 @@ body {
         opacity 100ms ease;
 }
 
-.markdown-file-preview__copy-button:hover {
+.markdown-code-copy-button:hover {
     color: var(--color-text-primary);
     opacity: 1;
 }
 
-.markdown-file-preview__copy-button:focus-visible {
+.markdown-code-copy-button[data-copied="true"] {
+    color: var(--color-accent);
+}
+
+.markdown-code-copy-button:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--color-accent) 42%, transparent);
     outline-offset: 2px;
 }
 
-.markdown-file-preview__code-frame > .markdown-file-preview__code-block {
+.markdown-code-frame > .markdown-code-block {
     margin: 0;
     border: 0;
     border-radius: 0;
     background: transparent;
     padding-top: 0.3em;
+}
+
+.markdown-code-frame--unlabeled > .markdown-code-block {
+    padding-right: 2.75em;
+    padding-top: 0.85em;
 }
 
 .markdown-file-preview__table-wrap {
@@ -1206,35 +1231,55 @@ button {
 .sidebar-agents-row {
     display: flex;
     flex-direction: column;
-    gap: calc(2px * var(--sidebar-list-scale, 1));
+    gap: 0;
     align-items: flex-start;
-    padding: calc(6px * var(--sidebar-list-scale, 1))
+    min-height: calc(26px * var(--sidebar-list-scale, 1));
+    padding: calc(3px * var(--sidebar-list-scale, 1))
         calc(8px * var(--sidebar-list-scale, 1));
     border-radius: 6px;
-    border-left: 2px solid transparent;
     background: transparent;
     text-align: left;
     cursor: pointer;
-    transition:
-        background-color 120ms ease,
-        border-color 120ms ease;
+    transition: background-color 120ms ease;
     user-select: none;
     -webkit-user-select: none;
 }
 
+.sidebar-agents-title {
+    color: var(--color-text-secondary);
+    font-family: var(--font-mono, monospace);
+    font-size: calc(11px * var(--sidebar-list-scale, 1));
+    font-weight: 400;
+    letter-spacing: 0.035em;
+    line-height: 1.3;
+}
+
+.sidebar-agents-row[data-active="true"] .sidebar-agents-title,
+.sidebar-agents-row:hover .sidebar-agents-title {
+    color: var(--color-text-primary);
+}
+
+.sidebar-agents-compact-relative-time {
+    opacity: 0;
+    transition: opacity 120ms ease;
+}
+
+.sidebar-agents-row:hover .sidebar-agents-compact-relative-time,
+.sidebar-agents-row:focus-visible .sidebar-agents-compact-relative-time,
+.sidebar-agents-row:focus-within .sidebar-agents-compact-relative-time {
+    opacity: 1;
+}
+
 .sidebar-agents-row:hover {
     background: color-mix(in srgb, var(--color-bg-tertiary) 55%, transparent);
-    border-left-color: color-mix(in srgb, var(--color-accent) 35%, transparent);
 }
 
 .sidebar-agents-row[data-active="true"] {
     background: color-mix(in srgb, var(--color-accent) 12%, transparent);
-    border-left-color: var(--color-accent);
 }
 
 .sidebar-agents-row[data-active="true"]:hover {
     background: color-mix(in srgb, var(--color-accent) 16%, transparent);
-    border-left-color: var(--color-accent);
 }
 
 .sidebar-agents-row:focus-visible {
@@ -1364,7 +1409,6 @@ button {
     gap: calc(6px * var(--sidebar-list-scale, 1));
 }
 
-.sidebar-agents-title,
 .sidebar-agents-rename {
     font-size: calc(11.5px * var(--sidebar-list-scale, 1));
     line-height: 1.3;
@@ -1375,27 +1419,12 @@ button {
     -webkit-user-select: text;
 }
 
-.sidebar-agents-preview {
-    font-size: calc(10.5px * var(--sidebar-list-scale, 1));
-    line-height: 1.35;
-}
-
-.sidebar-agents-meta,
-.sidebar-agents-timestamp {
-    font-size: calc(10px * var(--sidebar-list-scale, 1));
-    line-height: 1.35;
-}
-
-.sidebar-agents-timestamp {
-    font-variant-numeric: tabular-nums;
-    letter-spacing: 0.01em;
-}
-
 .sidebar-agents-activity-dot {
     font-size: calc(9px * var(--sidebar-list-scale, 1));
 }
 
 .sidebar-agents-pin-button {
+    order: 1;
     width: calc(20px * var(--sidebar-list-scale, 1));
     height: calc(20px * var(--sidebar-list-scale, 1));
     opacity: 0;
@@ -2823,4 +2852,100 @@ body.resizing-composer {
 .review-ghost-btn:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--color-accent) 55%, transparent);
     outline-offset: 1px;
+}
+
+/* Inline Markdown code uses semantic theme colors so it stays quiet and
+   readable across light, dark, built-in, and custom palettes. */
+.chat-inline-code {
+    padding: 1px 4px;
+    border-radius: 3px;
+    background: color-mix(
+        in srgb,
+        var(--color-bg-tertiary) 82%,
+        transparent
+    );
+    box-decoration-break: clone;
+    box-shadow: inset 0 0 0 1px
+        color-mix(in srgb, var(--color-border) 42%, transparent);
+    color: color-mix(
+        in srgb,
+        var(--color-text-primary) 78%,
+        var(--color-text-secondary)
+    );
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-size: 0.82em;
+    overflow-wrap: anywhere;
+    -webkit-box-decoration-break: clone;
+}
+
+/* Activity segments use their own width so narrow chat panes can simplify
+   secondary labels without coupling the layout to the window breakpoint. */
+.activity-rail {
+    container-type: inline-size;
+}
+
+.activity-tree-branch {
+    --activity-tree-color: color-mix(
+        in srgb,
+        var(--color-text-secondary) 34%,
+        transparent
+    );
+    position: relative;
+}
+
+.activity-tree-branch::before,
+.activity-tree-branch::after {
+    content: "";
+    pointer-events: none;
+    position: absolute;
+}
+
+.activity-tree-branch::before {
+    background: repeating-linear-gradient(
+        to bottom,
+        var(--activity-tree-color) 0 2px,
+        transparent 2px 5px
+    );
+    bottom: -0.375rem;
+    left: 1rem;
+    top: -0.375rem;
+    width: 1px;
+}
+
+.activity-tree-branch::after {
+    background: repeating-linear-gradient(
+        to right,
+        var(--activity-tree-color) 0 2px,
+        transparent 2px 5px
+    );
+    height: 1px;
+    left: 1rem;
+    top: 1rem;
+    width: 0.875rem;
+}
+
+.activity-tree-branch:first-child::before {
+    top: -1.5rem;
+}
+
+.activity-tree-branch:last-child::before {
+    bottom: calc(100% - 1rem);
+}
+
+@container (max-width: 360px) {
+    [data-activity-rail-current="true"] {
+        display: none;
+    }
+}
+
+/* User messages stay compact in wide panes and recover the full row width in
+   narrow panes where a fixed percentage would make text unnecessarily tall. */
+.user-message-layout {
+    container-type: inline-size;
+}
+
+@container (max-width: 420px) {
+    .user-message-bubble {
+        width: 100%;
+    }
 }

--- a/src/shared/composer-display-markers.test.ts
+++ b/src/shared/composer-display-markers.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    formatComposerDisplaySelectionLabel,
+    parseComposerDisplayFileMention,
+    parseComposerDisplayFolderMention,
+    parseComposerDisplaySelectionMention,
+    serializeComposerDisplayFileMention,
+    serializeComposerDisplayFolderMention,
+    serializeComposerDisplaySelectionMention,
+    serializeComposerMessagePartsForDisplay,
+} from "./composer-display-markers";
+
+describe("composer display markers", () => {
+    it("round-trips file mention metadata safely", () => {
+        const serialized = serializeComposerDisplayFileMention({
+            label: "thread.rs",
+            relativePath: "vendor/codex-acp/src/thread.rs",
+        });
+        const payload = serialized.slice(2, -2);
+
+        expect(parseComposerDisplayFileMention(payload)).toEqual({
+            label: "thread.rs",
+            relativePath: "vendor/codex-acp/src/thread.rs",
+        });
+    });
+
+    it("ignores legacy and malformed markers", () => {
+        expect(parseComposerDisplayFileMention("@thread.rs")).toBeNull();
+        expect(parseComposerDisplayFileMention("file|%ZZ|thread.rs")).toBeNull();
+    });
+
+    it("round-trips folder mention metadata safely", () => {
+        const serialized = serializeComposerDisplayFolderMention({
+            folderPath: "src/components",
+            label: "components",
+        });
+
+        expect(parseComposerDisplayFolderMention(serialized.slice(2, -2))).toEqual({
+            folderPath: "src/components",
+            label: "components",
+        });
+    });
+
+    it("round-trips and formats selection mention metadata", () => {
+        const serialized = serializeComposerDisplaySelectionMention({
+            endLine: 14,
+            label: "(8:14) - selected code",
+            path: "src/elicitation.ts",
+            startLine: 8,
+        });
+        const parsed = parseComposerDisplaySelectionMention(
+            serialized.slice(2, -2),
+        );
+
+        expect(parsed).toEqual({
+            endLine: 14,
+            label: "(8:14) - selected code",
+            path: "src/elicitation.ts",
+            startLine: 8,
+        });
+        expect(parsed && formatComposerDisplaySelectionLabel(parsed)).toBe(
+            "elicitation.ts (lines 8–14)",
+        );
+    });
+
+    it("uses enriched selections for optimistic user messages", () => {
+        const serialized = serializeComposerMessagePartsForDisplay(
+            [
+                {
+                    endLine: 14,
+                    label: "(8:14) - full selected preview",
+                    path: "src/elicitation.ts",
+                    selectedText: "full selected preview",
+                    startLine: 8,
+                    type: "selection_mention",
+                },
+                { text: " what do you see?", type: "text" },
+            ],
+            "fallback",
+        );
+
+        expect(serialized).toContain("selection|src%2Felicitation.ts|8|14|");
+        expect(serialized).toContain(" what do you see?");
+    });
+});

--- a/src/shared/composer-display-markers.ts
+++ b/src/shared/composer-display-markers.ts
@@ -1,0 +1,195 @@
+import type { AiComposerMessagePart } from "./ipc";
+
+export const COMPOSER_DISPLAY_PILL_OPEN = "\u200B\u00AB";
+export const COMPOSER_DISPLAY_PILL_CLOSE = "\u00BB\u200B";
+
+const FILE_MENTION_PREFIX = "file|";
+const FOLDER_MENTION_PREFIX = "folder|";
+const SELECTION_MENTION_PREFIX = "selection|";
+
+export interface ComposerDisplayFileMention {
+    readonly label: string;
+    readonly relativePath: string;
+}
+
+export interface ComposerDisplayFolderMention {
+    readonly folderPath: string;
+    readonly label: string;
+}
+
+export function serializeComposerDisplayFolderMention(
+    mention: ComposerDisplayFolderMention,
+): string {
+    const payload = [
+        FOLDER_MENTION_PREFIX.slice(0, -1),
+        encodeURIComponent(mention.folderPath),
+        encodeURIComponent(mention.label),
+    ].join("|");
+
+    return `${COMPOSER_DISPLAY_PILL_OPEN}${payload}${COMPOSER_DISPLAY_PILL_CLOSE}`;
+}
+
+export function parseComposerDisplayFolderMention(
+    payload: string,
+): ComposerDisplayFolderMention | null {
+    if (!payload.startsWith(FOLDER_MENTION_PREFIX)) {
+        return null;
+    }
+
+    const parts = payload.split("|");
+    if (parts.length !== 3 || !parts[1] || !parts[2]) {
+        return null;
+    }
+
+    try {
+        const folderPath = decodeURIComponent(parts[1]);
+        const label = decodeURIComponent(parts[2]);
+        return folderPath && label ? { folderPath, label } : null;
+    } catch {
+        return null;
+    }
+}
+
+export interface ComposerDisplaySelectionMention {
+    readonly endLine: number;
+    readonly label: string;
+    readonly path: string;
+    readonly startLine: number;
+}
+
+export function serializeComposerDisplayFileMention(
+    mention: ComposerDisplayFileMention,
+): string {
+    const payload = [
+        FILE_MENTION_PREFIX.slice(0, -1),
+        encodeURIComponent(mention.relativePath),
+        encodeURIComponent(mention.label),
+    ].join("|");
+
+    return `${COMPOSER_DISPLAY_PILL_OPEN}${payload}${COMPOSER_DISPLAY_PILL_CLOSE}`;
+}
+
+export function parseComposerDisplayFileMention(
+    payload: string,
+): ComposerDisplayFileMention | null {
+    if (!payload.startsWith(FILE_MENTION_PREFIX)) {
+        return null;
+    }
+
+    const parts = payload.split("|");
+    if (parts.length !== 3 || !parts[1] || !parts[2]) {
+        return null;
+    }
+
+    try {
+        const relativePath = decodeURIComponent(parts[1]);
+        const label = decodeURIComponent(parts[2]);
+        return relativePath && label ? { label, relativePath } : null;
+    } catch {
+        return null;
+    }
+}
+
+export function serializeComposerDisplaySelectionMention(
+    mention: ComposerDisplaySelectionMention,
+): string {
+    const payload = [
+        SELECTION_MENTION_PREFIX.slice(0, -1),
+        encodeURIComponent(mention.path),
+        String(mention.startLine),
+        String(mention.endLine),
+        encodeURIComponent(mention.label),
+    ].join("|");
+
+    return `${COMPOSER_DISPLAY_PILL_OPEN}${payload}${COMPOSER_DISPLAY_PILL_CLOSE}`;
+}
+
+export function parseComposerDisplaySelectionMention(
+    payload: string,
+): ComposerDisplaySelectionMention | null {
+    if (!payload.startsWith(SELECTION_MENTION_PREFIX)) {
+        return null;
+    }
+
+    const parts = payload.split("|");
+    if (parts.length !== 5 || !parts[1] || !parts[4]) {
+        return null;
+    }
+
+    const startLine = Number(parts[2]);
+    const endLine = Number(parts[3]);
+    if (
+        !Number.isInteger(startLine) ||
+        !Number.isInteger(endLine) ||
+        startLine < 1 ||
+        endLine < startLine
+    ) {
+        return null;
+    }
+
+    try {
+        const path = decodeURIComponent(parts[1]);
+        const label = decodeURIComponent(parts[4]);
+        return path ? { endLine, label, path, startLine } : null;
+    } catch {
+        return null;
+    }
+}
+
+export function formatComposerDisplaySelectionLabel(
+    mention: ComposerDisplaySelectionMention,
+): string {
+    const fileName = mention.path.replaceAll("\\", "/").split("/").at(-1);
+    const range =
+        mention.startLine === mention.endLine
+            ? `(line ${mention.startLine})`
+            : `(lines ${mention.startLine}–${mention.endLine})`;
+    return `${fileName || mention.path} ${range}`;
+}
+
+export function serializeComposerMessagePartsForDisplay(
+    parts: readonly AiComposerMessagePart[] | undefined,
+    fallback: string,
+): string {
+    if (!parts || parts.length === 0) {
+        return fallback;
+    }
+
+    return parts
+        .map((part) => {
+            switch (part.type) {
+                case "text":
+                    return part.text;
+                case "file_mention":
+                    return serializeComposerDisplayFileMention({
+                        label: part.label,
+                        relativePath: part.relativePath,
+                    });
+                case "selection_mention":
+                    return serializeComposerDisplaySelectionMention({
+                        endLine: part.endLine,
+                        label: part.label,
+                        path: part.path,
+                        startLine: part.startLine,
+                    });
+                case "folder_mention":
+                    return serializeComposerDisplayFolderMention({
+                        folderPath: part.folderPath,
+                        label: part.label,
+                    });
+                case "fetch_mention":
+                    return `${COMPOSER_DISPLAY_PILL_OPEN}@fetch${COMPOSER_DISPLAY_PILL_CLOSE}`;
+                case "plan_mention":
+                    return `${COMPOSER_DISPLAY_PILL_OPEN}/plan${COMPOSER_DISPLAY_PILL_CLOSE}`;
+                case "file_attachment":
+                    return `${COMPOSER_DISPLAY_PILL_OPEN}📎${part.label}${COMPOSER_DISPLAY_PILL_CLOSE}`;
+                case "git_commit_mention":
+                    return `${COMPOSER_DISPLAY_PILL_OPEN}commit: ${part.label}${COMPOSER_DISPLAY_PILL_CLOSE}`;
+                case "github_issue_mention":
+                case "github_pull_request_mention":
+                    return `${COMPOSER_DISPLAY_PILL_OPEN}${part.label}${COMPOSER_DISPLAY_PILL_CLOSE}`;
+            }
+        })
+        .join("")
+        .trim();
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -223,7 +223,7 @@ export type ThemePreset =
     | "claude"
     | "codex";
 
-export type AiToolCardExpansionMode = "collapsed" | "latest" | "expanded";
+export type AiToolActivityDefaultExpansion = "collapsed" | "expanded";
 
 export interface AppAiChatSettings {
     readonly chatFontFamily: ChatFontFamily;
@@ -235,7 +235,7 @@ export interface AppAiChatSettings {
     readonly screenshotRetentionSeconds: number;
     readonly historyRetentionDays: number;
     readonly contextUsageBarEnabled: boolean;
-    readonly toolCardExpansionMode: AiToolCardExpansionMode;
+    readonly toolActivityDefaultExpansion: AiToolActivityDefaultExpansion;
 }
 
 export interface AppAppearanceSettings {


### PR DESCRIPTION
## Summary

- Render compact activity rails with stable scrolling, summaries, changed-file context, and lifecycle-aware completion states.
- Unify Markdown code frames and file, folder, and selection mentions across chat and previews.
- Simplify the agent sidebar into compact persistent rows and align its actions.

## Validation

- Typecheck.
- Renderer workspace, sidebar, shared utilities, AI service, and native gateway test suites.
- Diff whitespace validation.
- Combined branch tree matches the original integrated state.