### PR TITLE
fix(chat): unify activity rows and preserve timeline state

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -63,6 +63,7 @@ import {
     type WorkspaceChatTabActivityIndicator,
 } from "@renderer/components/workspace/workspaceTabActivity";
 import { ProviderIcon } from "@renderer/components/workspace/ProviderIcon";
+import { releaseScopedToolUiStateStore } from "@renderer/components/workspace/chat/toolExpansionStore";
 
 import {
     applySessionUpdateToSidebarHistory,
@@ -645,6 +646,7 @@ export function SidebarAgentsPanel({
                     .map((candidate) => candidate.id);
 
                 await api.deleteAiSession(historySession.sessionId);
+                releaseScopedToolUiStateStore(historySession.sessionId);
 
                 for (const tabId of matchingTabIds) {
                     await closeTab(tabId);

--- a/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
@@ -49,6 +49,7 @@ import { ChatMessageRow } from "./chat/ChatMessageRow";
 import { PlanMessage } from "./chat/PlanMessage";
 import { ToolActivitySegment } from "./chat/ToolActivitySegment";
 import { ToolActivityItem } from "./chat/ToolActivityItem";
+import { releaseScopedToolUiStateStore } from "./chat/toolExpansionStore";
 import {
     reconcileChatTimelineModel,
     type ChatTimelineRow,
@@ -840,6 +841,7 @@ export function ChatHistoryTabView({ tab }: ChatHistoryTabViewProps) {
                     .map((candidate) => candidate.id);
 
                 await getComandoApi().deleteAiSession(session.sessionId);
+                releaseScopedToolUiStateStore(session.sessionId);
 
                 for (const tabId of matchingTabIds) {
                     await closeTab(tabId);

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -1860,6 +1860,7 @@ export const ChatTabView = memo(function ChatTabView({
                     projectId={tab.projectId}
                     resolveFileReference={resolveChatFileReference}
                     scrollRef={scrollRef}
+                    sessionId={tab.sessionId}
                     showJumpToBottom={showJumpToBottom}
                     shouldPreserveVirtualMeasureAnchor={
                         shouldPreserveTimelineVirtualMeasureAnchor
@@ -2348,6 +2349,7 @@ type ChatTimelineProps = {
         reference: string,
     ) => ResolvedProjectFileReference | null;
     readonly scrollRef: RefObject<HTMLDivElement | null>;
+    readonly sessionId: string;
     readonly showJumpToBottom: boolean;
     readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
@@ -2380,6 +2382,7 @@ const ChatTimeline = memo(function ChatTimeline({
     projectId,
     resolveFileReference,
     scrollRef,
+    sessionId,
     showJumpToBottom,
     shouldPreserveVirtualMeasureAnchor,
     shouldPreserveVirtualResizeAnchor,
@@ -2397,7 +2400,7 @@ const ChatTimeline = memo(function ChatTimeline({
         : "relative min-h-0 min-w-0 flex-1";
 
     return (
-        <ToolExpansionStoreProvider>
+        <ToolExpansionStoreProvider scopeKey={sessionId}>
             <div
                 aria-hidden={covered}
                 className={timelineContainerClassName}

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -148,53 +148,56 @@ function createRows(count: number): ChatTimelineRow[] {
     });
 }
 
-function createSegmentRow(): ChatTimelineRow {
-    const activity: AiToolActivity = {
-        action: null,
-        createdAt: "2026-04-14T00:00:00.000Z",
-        diffs: [],
-        exitCode: null,
-        id: "read-1",
-        kind: "read",
-        locations: [],
-        rawInputJson: JSON.stringify({ file_path: "src/app.ts" }),
-        rawOutputJson: null,
-        sessionId: "session-1",
-        status: "completed",
-        summary: null,
-        terminalOutput: null,
-        title: "Read src/app.ts",
-        updatedAt: "2026-04-14T00:00:00.000Z",
-    };
+function createSegmentRow(entryCount = 1): ChatTimelineRow {
+    const activities: AiToolActivity[] = Array.from(
+        { length: entryCount },
+        (_, index) => ({
+            action: null,
+            createdAt: "2026-04-14T00:00:00.000Z",
+            diffs: [],
+            exitCode: null,
+            id: `read-${index + 1}`,
+            kind: "read",
+            locations: [],
+            rawInputJson: JSON.stringify({ file_path: "src/app.ts" }),
+            rawOutputJson: null,
+            sessionId: "session-1",
+            status: "completed",
+            summary: null,
+            terminalOutput: null,
+            title: "Read src/app.ts",
+            updatedAt: "2026-04-14T00:00:00.000Z",
+        }),
+    );
+    const firstActivity = activities[0];
+    const latestActivity = activities.at(-1)!;
 
     return {
-        entries: [
-            {
-                policy: "groupable",
-                reviewEntry: {
-                    activity,
-                    hasPendingTrackedFiles: false,
-                    pendingTrackedFiles: [],
-                    trackedFiles: [],
-                },
+        entries: activities.map((activity) => ({
+            policy: "groupable",
+            reviewEntry: {
+                activity,
+                hasPendingTrackedFiles: false,
+                pendingTrackedFiles: [],
+                trackedFiles: [],
             },
-        ],
+        })),
         id: "activity-segment:session-1:read-1",
         kind: "activity-segment",
         summary: {
-            actionCount: 1,
+            actionCount: entryCount,
             changeCount: 0,
             changedFileCount: 0,
             commandCount: 0,
             failureCount: 0,
             fileCount: 1,
-            hiddenActivityCount: 1,
+            hiddenActivityCount: entryCount,
             isInProgress: false,
-            latestActivityId: "read-1",
+            latestActivityId: latestActivity.id,
             latestTitle: "Read src/app.ts",
             searchCount: 0,
-            startedAt: activity.createdAt,
-            updatedAt: activity.updatedAt,
+            startedAt: firstActivity.createdAt,
+            updatedAt: latestActivity.updatedAt,
         },
     };
 }
@@ -385,6 +388,21 @@ describe("ChatTimelineHistoryRows", () => {
             "activity-segment:session-1:read-1",
         );
         expect(markup).toContain("activity-segment:session-1:read-1");
+    });
+
+    it("virtualizes an activity-heavy chat even with one presentation row", () => {
+        const rows = [
+            createSegmentRow(CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD),
+        ];
+        const markup = renderHistoryRows(rows);
+
+        expect(measuredVirtualListMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                firstKey: "activity-segment:session-1:read-1",
+                itemCount: 1,
+            }),
+        );
+        expect(markup).toContain("mock-measured-virtual-list");
     });
 
     it("freezes content width during panel resize and re-syncs on release", () => {

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -390,19 +390,17 @@ describe("ChatTimelineHistoryRows", () => {
         expect(markup).toContain("activity-segment:session-1:read-1");
     });
 
-    it("virtualizes an activity-heavy chat even with one presentation row", () => {
+    it("keeps an activity-heavy single presentation row non-virtualized", () => {
         const rows = [
             createSegmentRow(CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD),
         ];
         const markup = renderHistoryRows(rows);
 
-        expect(measuredVirtualListMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                firstKey: "activity-segment:session-1:read-1",
-                itemCount: 1,
-            }),
-        );
-        expect(markup).toContain("mock-measured-virtual-list");
+        // Virtualization only mounts and unmounts top-level timeline rows.
+        // A single segment would still render all of its entries either way.
+        expect(measuredVirtualListMock).not.toHaveBeenCalled();
+        expect(markup).toContain("activity-segment:session-1:read-1");
+        expect(markup).not.toContain("mock-measured-virtual-list");
     });
 
     it("freezes content width during panel resize and re-syncs on release", () => {

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -23,6 +23,7 @@ import type { ChatTimelineRow } from "./chatTimelineModel";
 import {
     CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT,
     CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN,
+    calculateChatTimelineVirtualizationCost,
     calculateChatTimelineVirtualScrollMarginTop,
     estimateChatTimelineRowHeight,
     getChatTimelineEffectiveContentWidth,
@@ -111,9 +112,11 @@ export const ChatTimelineHistoryRows = memo(
         >(null);
         const isFreezeActiveRef = useRef(false);
         isFreezeActiveRef.current = frozenContentWidth !== null;
-        const shouldVirtualize = shouldVirtualizeChatTimeline(
-            historyRows.length,
+        const virtualizationCost = calculateChatTimelineVirtualizationCost(
+            historyRows,
         );
+        const shouldVirtualize =
+            shouldVirtualizeChatTimeline(virtualizationCost);
 
         const restorePendingResizeAnchor = useCallback(() => {
             const anchor = pendingResizeAnchorRef.current;

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
@@ -441,6 +441,64 @@ describe("ToolActivityItem", () => {
         expect(markup).not.toContain("Reject");
     });
 
+    it("keeps change review behind the compact rail disclosure", () => {
+        const container = renderInteractiveToolActivityItem({
+            activity: createActivity({
+                diffs: [
+                    {
+                        hunks: [
+                            {
+                                id: "hunk-1",
+                                lines: [
+                                    {
+                                        id: "line-1",
+                                        text: "const before = true;",
+                                        type: "remove",
+                                    },
+                                    {
+                                        id: "line-2",
+                                        text: "const after = true;",
+                                        type: "add",
+                                    },
+                                ],
+                                newCount: 1,
+                                newStart: 8,
+                                oldCount: 1,
+                                oldStart: 8,
+                            },
+                        ],
+                        isText: true,
+                        kind: "update",
+                        newText: "const after = true;\n",
+                        oldText: "const before = true;\n",
+                        path: "src/app.ts",
+                        previousPath: null,
+                        reversible: true,
+                    },
+                ],
+                kind: "edit",
+                title: "Edit src/app.ts",
+            }),
+            onOpenFile: async () => {},
+            projectId: "project-1",
+            surface: "rail-row",
+            trackedFiles: [],
+            worktreeId: null,
+        });
+
+        expect(container.querySelector("[data-change-review-surface]")).toBeNull();
+        act(() =>
+            container
+                .querySelector<HTMLButtonElement>(
+                    'button[aria-label="Expand details"]',
+                )
+                ?.click(),
+        );
+        expect(
+            container.querySelector('[data-change-review-surface="rail-row"]'),
+        ).not.toBeNull();
+    });
+
     it("renders activity-only diffs with the rich preview instead of a summary card", () => {
         const markup = renderToStaticMarkup(
             createElement(ToolActivityItem, {

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
@@ -1755,6 +1755,7 @@ function CompactToolActivityRow({
     openSessionTitle,
     projectId,
     resolveFileReference,
+    trackedFiles,
     worktreeId,
 }: {
     readonly activity: AiToolActivity;
@@ -1773,6 +1774,7 @@ function CompactToolActivityRow({
     readonly resolveFileReference?: (
         reference: string,
     ) => ResolvedProjectFileReference | null;
+    readonly trackedFiles: readonly AiTrackedFile[];
     readonly worktreeId: string | null;
 }) {
     const descriptor = getToolActivityDescriptor(activity);
@@ -1803,12 +1805,15 @@ function CompactToolActivityRow({
         hasTerminalOutput,
     );
     const hasLocations = activity.locations.length > 0;
+    const hasInlineReview =
+        trackedFiles.length > 0 || activity.diffs.length > 0;
     const hasDetail =
         shouldShowSummary ||
         hasLocations ||
         hasRawInput ||
         hasRawOutput ||
-        hasTerminalOutput;
+        hasTerminalOutput ||
+        hasInlineReview;
     const [expanded, setExpanded] = usePersistentToolExpansion(
         `${activity.sessionId}:${activity.id}:rail-row`,
         false,
@@ -1993,6 +1998,16 @@ function CompactToolActivityRow({
                             languageInfo="json"
                         />
                     ) : null}
+                    {hasInlineReview ? (
+                        <ChangeReviewPanel
+                            activity={activity}
+                            onOpenFile={onOpenFile}
+                            projectId={projectId}
+                            resolveFileReference={resolveFileReference}
+                            trackedFiles={trackedFiles}
+                            worktreeId={worktreeId}
+                        />
+                    ) : null}
                 </div>
             ) : null}
         </div>
@@ -2096,6 +2111,7 @@ export const ToolActivityItem = memo(function ToolActivityItem({
                 openSessionTitle={openSessionTitle}
                 projectId={projectId}
                 resolveFileReference={resolveFileReference}
+                trackedFiles={trackedFiles}
                 worktreeId={worktreeId}
             />
         );

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
@@ -16,7 +16,10 @@ import type {
 } from "./chatTimelineModel";
 import type { ToolActivityReviewEntry } from "./toolActivityReviewModel";
 import { ToolActivitySegment } from "./ToolActivitySegment";
-import { ToolExpansionStoreProvider } from "./toolExpansionStore";
+import {
+    resetScopedToolUiStateStoresForTests,
+    ToolExpansionStoreProvider,
+} from "./toolExpansionStore";
 
 vi.mock("./ToolActivityItem", () => ({
     ToolActivityItem: ({
@@ -51,6 +54,7 @@ afterEach(() => {
         }
     }
     resetSettingsStoreForTests();
+    resetScopedToolUiStateStoresForTests();
 });
 
 function createActivity(
@@ -569,5 +573,55 @@ describe("ToolActivitySegment", () => {
                 .querySelector<HTMLButtonElement>("button")
                 ?.getAttribute("aria-expanded"),
         ).toBe("true");
+    });
+
+    it("restores expansion after the scoped provider remounts", () => {
+        const segment = createSegment([
+            createEntry("read-11"),
+            createEntry("read-12"),
+        ]);
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        mountedRoots.push(root);
+
+        const renderChat = () =>
+            root.render(
+                <ToolExpansionStoreProvider scopeKey="session-1">
+                    <ToolActivitySegment
+                        {...DEFAULT_PROPS}
+                        segment={segment}
+                    />
+                </ToolExpansionStoreProvider>,
+            );
+
+        act(renderChat);
+        act(() => container.querySelector<HTMLButtonElement>("button")?.click());
+        act(() => root.render(null));
+        act(renderChat);
+
+        expect(
+            container
+                .querySelector<HTMLButtonElement>("button")
+                ?.getAttribute("aria-expanded"),
+        ).toBe("true");
+
+        act(() => root.render(null));
+        act(() =>
+            root.render(
+                <ToolExpansionStoreProvider scopeKey="session-2">
+                    <ToolActivitySegment
+                        {...DEFAULT_PROPS}
+                        segment={segment}
+                    />
+                </ToolExpansionStoreProvider>,
+            ),
+        );
+
+        expect(
+            container
+                .querySelector<HTMLButtonElement>("button")
+                ?.getAttribute("aria-expanded"),
+        ).toBe("false");
     });
 });

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
@@ -466,7 +466,7 @@ describe("ToolActivitySegment", () => {
         const surfaces = Array.from(
             container.querySelectorAll<HTMLElement>("[data-tool-surface]"),
         ).map((member) => member.dataset.toolSurface);
-        expect(surfaces).toEqual(["rail-row", "card", "rail-row"]);
+        expect(surfaces).toEqual(["rail-row", "rail-row", "rail-row"]);
         const indents = Array.from(
             container.querySelectorAll<HTMLElement>(
                 "[data-activity-rail-indent]",

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
@@ -134,6 +134,7 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
     const canExpand = segment.entries.length > 0;
     const contentId = `${segment.id}:activity`;
     const headline = getSegmentHeadline(segment, isCurrentTurnTail);
+    const isWorkedSegment = headline.startsWith("Worked ·");
     const latestActivityLabel = getLatestActivityLabel(segment);
     const changeStats = useMemo(
         () => deriveActivitySegmentChangeStats(segment.entries),
@@ -150,9 +151,19 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
     const accessibleLabel = `${expanded ? "Hide" : "Show"} full activity: ${headline}.${accessibleChangeSummary} ${activityState}.`;
     const headerContent = (
         <>
+            {isWorkedSegment ? (
+                <span
+                    aria-hidden="true"
+                    className="shrink-0 self-start leading-4 text-text-secondary"
+                >
+                    {">"}
+                </span>
+            ) : null}
             <span className="min-w-0 flex-1">
                 <span
-                    className="block truncate text-[11px] font-medium leading-4"
+                    className={`block truncate text-[11px] leading-4 ${
+                        isWorkedSegment ? "font-bold" : "font-medium"
+                    }`}
                     title={headline}
                 >
                     {headline}

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
@@ -276,11 +276,7 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                                             onOpenSession={onOpenSession}
                                             projectId={projectId}
                                             resolveFileReference={resolveFileReference}
-                                            surface={
-                                                policy === "standalone-change"
-                                                    ? "card"
-                                                    : "rail-row"
-                                            }
+                                            surface="rail-row"
                                             trackedFiles={reviewEntry.trackedFiles}
                                             worktreeId={worktreeId}
                                         />

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -12,6 +12,7 @@ import {
     CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
     CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
     CHAT_TIMELINE_VIRTUAL_ROW_GAP_PX,
+    calculateChatTimelineVirtualizationCost,
     calculateChatTimelineVirtualScrollMarginTop,
     estimateChatTimelineRowHeight,
     getChatTimelineEffectiveContentWidth,
@@ -165,6 +166,24 @@ describe("chatTimelineVirtualization", () => {
                 threshold: 20,
             }),
         ).toBe(true);
+    });
+
+    it("counts the activities represented by a presentation segment", () => {
+        const segment = createActivitySegmentRow();
+        if (segment.kind !== "activity-segment") {
+            throw new Error("Expected an activity segment.");
+        }
+
+        const repeatedEntries = Array.from(
+            { length: CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD },
+            () => segment.entries[0],
+        );
+
+        expect(
+            calculateChatTimelineVirtualizationCost([
+                { ...segment, entries: repeatedEntries },
+            ]),
+        ).toBe(CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD);
     });
 
     it("preserves row ids as virtual keys", () => {

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -168,7 +168,7 @@ describe("chatTimelineVirtualization", () => {
         ).toBe(true);
     });
 
-    it("counts the activities represented by a presentation segment", () => {
+    it("counts virtualizable presentation rows rather than segment entries", () => {
         const segment = createActivitySegmentRow();
         if (segment.kind !== "activity-segment") {
             throw new Error("Expected an activity segment.");
@@ -183,7 +183,7 @@ describe("chatTimelineVirtualization", () => {
             calculateChatTimelineVirtualizationCost([
                 { ...segment, entries: repeatedEntries },
             ]),
-        ).toBe(CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD);
+        ).toBe(1);
     });
 
     it("preserves row ids as virtual keys", () => {

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -239,15 +239,11 @@ export function estimateChatTimelineRowHeight(
         }
 
         const activityHeight = row.entries.reduce(
-            (height, entry, index) =>
+            (height, _entry, index) =>
                 height +
-                (entry.policy === "groupable"
-                    ? CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX
-                    : estimateToolActivityHeight(
-                          entry.reviewEntry,
-                          context,
-                          true,
-                      )) +
+                // Every entry is now a collapsed rail row. Change previews are
+                // mounted only after the row's own disclosure is opened.
+                CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX +
                 CHAT_ACTIVITY_RAIL_ENTRY_PADDING_Y_PX +
                 (index > 0 ? CHAT_ACTIVITY_RAIL_ENTRY_GAP_PX : 0),
             0,
@@ -331,7 +327,6 @@ function estimateToolActivityHeight(
 ): number {
     const activity = reviewEntry.activity;
     const trackedFiles = reviewEntry.trackedFiles;
-    const hasInlineReview = trackedFiles.length > 0 || activity.diffs.length > 0;
     const hasTerminalOutput = !!activity.terminalOutput;
     const hasSummary = !!activity.summary;
     const hasRawJson = !!activity.rawInputJson || !!activity.rawOutputJson;
@@ -355,21 +350,6 @@ function estimateToolActivityHeight(
         return startsExpanded
             ? 210
             : CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX;
-    }
-
-    if (hasInlineReview) {
-        const collapsedItemCount = Math.max(
-            1,
-            trackedFiles.length,
-            activity.diffs.length,
-        );
-        const collapsedHeight = Math.min(
-            220,
-            collapsedItemCount * CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX +
-                Math.max(0, collapsedItemCount - 1) *
-                    CHAT_ACTIVITY_RAIL_ENTRY_PADDING_Y_PX,
-        );
-        return collapsedHeight;
     }
 
     if (isFileToolActivity(activity, trackedFiles)) {

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -46,14 +46,32 @@ export interface ChatTimelineVirtualScrollMarginOptions {
 }
 
 export function shouldVirtualizeChatTimeline(
-    rowCount: number,
+    virtualizationCost: number,
     options: ShouldVirtualizeChatTimelineOptions = {},
 ): boolean {
     const enabled = options.enabled ?? CHAT_TIMELINE_VIRTUALIZATION_ENABLED;
     const threshold =
         options.threshold ?? CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD;
 
-    return enabled && rowCount >= threshold;
+    return enabled && virtualizationCost >= threshold;
+}
+
+/**
+ * Presentation rows deliberately collapse consecutive tool activity into a
+ * single rail. Count the activities represented by that rail so grouping the
+ * UI cannot accidentally disable virtualization for an otherwise large chat.
+ */
+export function calculateChatTimelineVirtualizationCost(
+    rows: readonly ChatTimelineRow[],
+): number {
+    return rows.reduce(
+        (cost, row) =>
+            cost +
+            (row.kind === "activity-segment"
+                ? Math.max(1, row.entries.length)
+                : 1),
+        0,
+    );
 }
 
 export function getChatTimelineRowKey(row: ChatTimelineRow): string {

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -57,21 +57,14 @@ export function shouldVirtualizeChatTimeline(
 }
 
 /**
- * Presentation rows deliberately collapse consecutive tool activity into a
- * single rail. Count the activities represented by that rail so grouping the
- * UI cannot accidentally disable virtualization for an otherwise large chat.
+ * The virtual list can only mount and unmount top-level timeline rows. Tool
+ * activity inside a segment is rendered together by that one row, so counting
+ * its entries here would enable virtualization without reducing that work.
  */
 export function calculateChatTimelineVirtualizationCost(
     rows: readonly ChatTimelineRow[],
 ): number {
-    return rows.reduce(
-        (cost, row) =>
-            cost +
-            (row.kind === "activity-segment"
-                ? Math.max(1, row.entries.length)
-                : 1),
-        0,
-    );
+    return rows.length;
 }
 
 export function getChatTimelineRowKey(row: ChatTimelineRow): string {

--- a/src/renderer/src/components/workspace/chat/toolExpansionStore.test.ts
+++ b/src/renderer/src/components/workspace/chat/toolExpansionStore.test.ts
@@ -2,9 +2,27 @@ import { describe, expect, it } from "vitest";
 
 import {
     applyPersistentToolStateUpdate,
+    getScopedToolUiStateStore,
     readStoredToolState,
+    resetScopedToolUiStateStoresForTests,
     resolvePersistentToolState,
 } from "./toolExpansionStore";
+
+describe("getScopedToolUiStateStore", () => {
+    it("reuses state for the same chat scope and isolates other chats", () => {
+        resetScopedToolUiStateStoresForTests();
+        const firstMount = getScopedToolUiStateStore("session-1");
+        firstMount.set("activity", true);
+
+        expect(getScopedToolUiStateStore("session-1")).toBe(firstMount);
+        expect(
+            getScopedToolUiStateStore("session-1").get("activity"),
+        ).toBe(true);
+        expect(
+            getScopedToolUiStateStore("session-2").has("activity"),
+        ).toBe(false);
+    });
+});
 
 describe("readStoredToolState", () => {
     it("returns the default when the key is absent", () => {

--- a/src/renderer/src/components/workspace/chat/toolExpansionStore.test.ts
+++ b/src/renderer/src/components/workspace/chat/toolExpansionStore.test.ts
@@ -4,6 +4,7 @@ import {
     applyPersistentToolStateUpdate,
     getScopedToolUiStateStore,
     readStoredToolState,
+    releaseScopedToolUiStateStore,
     resetScopedToolUiStateStoresForTests,
     resolvePersistentToolState,
 } from "./toolExpansionStore";
@@ -21,6 +22,17 @@ describe("getScopedToolUiStateStore", () => {
         expect(
             getScopedToolUiStateStore("session-2").has("activity"),
         ).toBe(false);
+    });
+
+    it("releases state for a permanently deleted chat scope", () => {
+        resetScopedToolUiStateStoresForTests();
+        getScopedToolUiStateStore("session-1").set("activity", true);
+
+        releaseScopedToolUiStateStore("session-1");
+
+        expect(getScopedToolUiStateStore("session-1").has("activity")).toBe(
+            false,
+        );
     });
 });
 

--- a/src/renderer/src/components/workspace/chat/toolExpansionStore.tsx
+++ b/src/renderer/src/components/workspace/chat/toolExpansionStore.tsx
@@ -37,6 +37,15 @@ export function getScopedToolUiStateStore(
     return store;
 }
 
+/**
+ * Discards state after its chat session has been permanently deleted. This is
+ * intentionally separate from provider unmounting: virtual rows and inactive
+ * tabs unmount temporarily and must retain their UI state.
+ */
+export function releaseScopedToolUiStateStore(scopeKey: string): void {
+    toolUiStateStoreByScope.delete(scopeKey);
+}
+
 export function resetScopedToolUiStateStoresForTests(): void {
     toolUiStateStoreByScope.clear();
 }

--- a/src/renderer/src/components/workspace/chat/toolExpansionStore.tsx
+++ b/src/renderer/src/components/workspace/chat/toolExpansionStore.tsx
@@ -2,6 +2,7 @@ import {
     createContext,
     useCallback,
     useContext,
+    useMemo,
     useState,
     type Dispatch,
     type ReactNode,
@@ -9,32 +10,54 @@ import {
 } from "react";
 
 /**
- * Per-tab store of transient tool-card UI state, keyed by a caller-provided
- * string. The timeline virtualizes its history, so a row's `ToolActivityItem`
- * (and the `ChangeReviewPanel` it can render) unmounts when it scrolls out of
- * range and would lose any locally-held state — which card is expanded, how
- * tall the user dragged a diff preview. The store lives in the scroller (which
- * does not unmount on scroll), so that state survives the row remounting.
+ * Store of transient tool-card UI state, keyed by a caller-provided string.
+ * A scoped provider reuses the same store after its chat tab remounts; an
+ * unscoped provider keeps the previous local-only behavior. This lets virtual
+ * rows and inactive chat tabs unmount without losing expansion or diff sizing.
  *
- * The store is a plain Map held in a stable state slot: its identity never
- * changes, so providing it through context does not trigger re-renders. When
+ * The store is a plain Map whose identity remains stable for its scope, so
+ * providing it through context does not trigger unrelated re-renders. When
  * absent (no provider), the hooks degrade to ordinary local state.
  */
 type ToolUiStateStore = Map<string, unknown>;
 
 const ToolUiStateStoreContext = createContext<ToolUiStateStore | null>(null);
+const toolUiStateStoreByScope = new Map<string, ToolUiStateStore>();
+
+export function getScopedToolUiStateStore(
+    scopeKey: string,
+): ToolUiStateStore {
+    const existing = toolUiStateStoreByScope.get(scopeKey);
+    if (existing) {
+        return existing;
+    }
+
+    const store = new Map<string, unknown>();
+    toolUiStateStoreByScope.set(scopeKey, store);
+    return store;
+}
+
+export function resetScopedToolUiStateStoresForTests(): void {
+    toolUiStateStoreByScope.clear();
+}
 
 export function ToolExpansionStoreProvider({
     children,
+    scopeKey,
 }: {
     readonly children: ReactNode;
+    readonly scopeKey?: string;
 }) {
-    // Lazy-initialized once; the Map identity is stable across renders, so the
-    // context value never changes and consumers don't re-render from it.
-    const [store] = useState<ToolUiStateStore>(() => new Map());
+    const store = useMemo(
+        () =>
+            scopeKey
+                ? getScopedToolUiStateStore(scopeKey)
+                : new Map<string, unknown>(),
+        [scopeKey],
+    );
 
     return (
-        <ToolUiStateStoreContext.Provider value={store}>
+        <ToolUiStateStoreContext.Provider key={scopeKey} value={store}>
             {children}
         </ToolUiStateStoreContext.Provider>
     );


### PR DESCRIPTION
## Summary

Unifies tool activity and change previews into a consistent expandable timeline row, while preserving the UI state of activity panels across tab switches and virtualized remounts.

## Changes

- Render file and diff reviews inside compact activity rows rather than as separate cards.
- Persist activity expansion state and diff preview sizing per chat session.
- Clean up persisted activity state when a chat session is deleted.
- Refine “Worked” activity headers for clearer visual hierarchy.
- Adjust timeline virtualization to account for top-level presentation rows only.
- Update row-height estimates for the unified compact activity layout.
- Add regression coverage for activity rendering, persisted state, and virtualization behavior.

## Why

The timeline could display change activity inconsistently and lose expanded state or resized diff previews when switching tabs or when rows were unmounted by virtualization. This makes activity presentation more cohesive and keeps transient UI state stable for the lifetime of the session.