### PR TITLE
Fix selector changes in newly created chats

### DIFF
--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -1352,6 +1352,94 @@ describe("AiService prepareSession", () => {
         expect(loadRuntimeSelectionPreferences).toHaveBeenCalledTimes(1);
     });
 
+    it("stops applying captured defaults after a manual selection", async () => {
+        const prepareSession = vi.fn<NativeAiGateway["prepareSession"]>(
+            ({ launch }) => Promise.resolve(launch.persistedSnapshot),
+        );
+        let resolveModelMutation!: () => void;
+        const modelMutationPending = new Promise<void>((resolve) => {
+            resolveModelMutation = resolve;
+        });
+        const setSessionConfigOption = vi.fn<
+            NativeAiGateway["setSessionConfigOption"]
+        >((input) =>
+            input.optionId === "model"
+                ? modelMutationPending
+                : Promise.resolve(),
+        );
+        const service = createPrepareService({
+            nativeAi: createNativeAi({
+                prepareSession,
+                setSessionConfigOption,
+            }),
+            persistence: {
+                loadLatestRuntimeCatalog: vi.fn(() => null),
+                loadRuntimeSelectionPreferences: vi.fn(() => ({
+                    configOptions: {
+                        model: "gpt-5.5",
+                        reasoning_effort: "low",
+                    },
+                    modeId: null,
+                    modelId: "gpt-5.5",
+                })),
+                loadSessionSnapshot: vi.fn(() => null),
+                saveRuntimeSelectionPreferenceOption: vi.fn(),
+                saveRuntimeModePreference: vi.fn(),
+                saveRuntimeModelPreference: vi.fn(),
+                saveSessionSnapshot: vi.fn(),
+            } as never,
+        });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-1",
+                title: "Codex 1",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+
+        service.handleNativeSessionCatalogPatch(
+            "window-1",
+            "session-1",
+            {
+                configOptions: [
+                    createModelConfig("gpt-5.4-mini"),
+                    createReasoningConfig("medium"),
+                ],
+            },
+            "2026-04-15T22:24:13.719838Z",
+        );
+        await vi.waitFor(() => {
+            expect(setSessionConfigOption).toHaveBeenCalledWith({
+                optionId: "model",
+                sessionId: "session-1",
+                value: "gpt-5.5",
+            });
+        });
+
+        await service.setSessionConfigOption({
+            optionId: "reasoning_effort",
+            sessionId: "session-1",
+            value: "high",
+        });
+        resolveModelMutation();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(setSessionConfigOption).not.toHaveBeenCalledWith({
+            optionId: "reasoning_effort",
+            sessionId: "session-1",
+            value: "low",
+        });
+        expect(setSessionConfigOption).toHaveBeenCalledWith({
+            optionId: "reasoning_effort",
+            sessionId: "session-1",
+            value: "high",
+        });
+    });
+
     it("does not apply runtime preferences to restored sessions without their own selections", async () => {
         const runtimeCatalog = createSnapshot({
             configOptions: [createReasoningConfig("medium")],

--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -1420,13 +1420,13 @@ describe("AiService prepareSession", () => {
             });
         });
 
-        await service.setSessionConfigOption({
-            optionId: "reasoning_effort",
+        const manualModelMutation = service.setSessionConfigOption({
+            optionId: "model",
             sessionId: "session-1",
-            value: "high",
+            value: "gpt-5.4-mini",
         });
         resolveModelMutation();
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        await manualModelMutation;
 
         expect(setSessionConfigOption).not.toHaveBeenCalledWith({
             optionId: "reasoning_effort",
@@ -1434,10 +1434,15 @@ describe("AiService prepareSession", () => {
             value: "low",
         });
         expect(setSessionConfigOption).toHaveBeenCalledWith({
-            optionId: "reasoning_effort",
+            optionId: "model",
             sessionId: "session-1",
-            value: "high",
+            value: "gpt-5.4-mini",
         });
+        const updatedSnapshot = await service.getSessionSnapshot("session-1");
+        expect(
+            updatedSnapshot?.configOptions.find((option) => option.id === "model")
+                ?.value,
+        ).toBe("gpt-5.4-mini");
     });
 
     it("does not apply runtime preferences to restored sessions without their own selections", async () => {

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -1530,6 +1530,7 @@ export class AiService {
     }
 
     async setSessionMode(input: AiSessionModeMutationInput): Promise<void> {
+        this.#cancelCapturedRuntimeDefaults(input.sessionId);
         await this.#setSessionMode(input, { rememberRuntimePreference: true });
     }
 
@@ -1561,6 +1562,7 @@ export class AiService {
     }
 
     async setSessionModel(input: AiSessionModelMutationInput): Promise<void> {
+        this.#cancelCapturedRuntimeDefaults(input.sessionId);
         await this.#setSessionModel(input, { rememberRuntimePreference: true });
     }
 
@@ -1594,9 +1596,14 @@ export class AiService {
     async setSessionConfigOption(
         input: AiSessionConfigOptionMutationInput,
     ): Promise<void> {
+        this.#cancelCapturedRuntimeDefaults(input.sessionId);
         await this.#setSessionConfigOption(input, {
             rememberRuntimePreference: true,
         });
+    }
+
+    #cancelCapturedRuntimeDefaults(sessionId: string): void {
+        this.#capturedRuntimeDefaultsBySessionId.delete(sessionId);
     }
 
     async #setSessionConfigOption(
@@ -2702,7 +2709,7 @@ export class AiService {
         const modelConfig = getModelConfigOption(snapshot.configOptions);
         if (
             !modelConfig &&
-            canApplyCapturedDefaults &&
+            this.#hasCapturedRuntimeDefaults(sessionId, capturedDefaults) &&
             capturedDefaults.modelId &&
             capturedDefaults.modelId !== snapshot.modelId &&
             snapshot.models.some((model) => model.id === capturedDefaults.modelId)
@@ -2720,7 +2727,7 @@ export class AiService {
         const modeConfig = getModeConfigOption(snapshot.configOptions);
         if (
             !modeConfig &&
-            canApplyCapturedDefaults &&
+            this.#hasCapturedRuntimeDefaults(sessionId, capturedDefaults) &&
             capturedDefaults.modeId &&
             capturedDefaults.modeId !== snapshot.modeId &&
             snapshot.modes.some((mode) => mode.id === capturedDefaults.modeId)
@@ -2743,6 +2750,9 @@ export class AiService {
             },
         );
         for (const mutation of mutations) {
+            if (!this.#hasCapturedRuntimeDefaults(sessionId, capturedDefaults)) {
+                break;
+            }
             await this.#setSessionConfigOption(
                 {
                     optionId: mutation.optionId,
@@ -2755,13 +2765,23 @@ export class AiService {
         }
 
         if (
-            canApplyCapturedDefaults &&
+            this.#hasCapturedRuntimeDefaults(sessionId, capturedDefaults) &&
             snapshotHasEffectiveSelections(snapshot)
         ) {
             this.#capturedRuntimeDefaultsBySessionId.delete(sessionId);
         }
 
         return snapshot;
+    }
+
+    #hasCapturedRuntimeDefaults(
+        sessionId: string,
+        capturedDefaults: CapturedRuntimeDefaults,
+    ): boolean {
+        return (
+            this.#capturedRuntimeDefaultsBySessionId.get(sessionId) ===
+            capturedDefaults
+        );
     }
 
     #scheduleCapturedRuntimeDefaultsApplication(

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -452,6 +452,7 @@ export class AiService {
         string,
         CapturedRuntimeDefaults
     >();
+    readonly #selectionMutationChains = new Map<string, Promise<void>>();
     #nativeAi: NativeAiGateway | null;
     readonly #nativeAuthMigratedRuntimeIds = new Set<AiRuntimeId>();
     readonly #nativeChildParentSessionIds = new Map<string, string>();
@@ -1531,7 +1532,9 @@ export class AiService {
 
     async setSessionMode(input: AiSessionModeMutationInput): Promise<void> {
         this.#cancelCapturedRuntimeDefaults(input.sessionId);
-        await this.#setSessionMode(input, { rememberRuntimePreference: true });
+        await this.#enqueueSelectionMutation(input.sessionId, () =>
+            this.#setSessionMode(input, { rememberRuntimePreference: true }),
+        );
     }
 
     async #setSessionMode(
@@ -1563,7 +1566,9 @@ export class AiService {
 
     async setSessionModel(input: AiSessionModelMutationInput): Promise<void> {
         this.#cancelCapturedRuntimeDefaults(input.sessionId);
-        await this.#setSessionModel(input, { rememberRuntimePreference: true });
+        await this.#enqueueSelectionMutation(input.sessionId, () =>
+            this.#setSessionModel(input, { rememberRuntimePreference: true }),
+        );
     }
 
     async #setSessionModel(
@@ -1597,13 +1602,37 @@ export class AiService {
         input: AiSessionConfigOptionMutationInput,
     ): Promise<void> {
         this.#cancelCapturedRuntimeDefaults(input.sessionId);
-        await this.#setSessionConfigOption(input, {
-            rememberRuntimePreference: true,
-        });
+        await this.#enqueueSelectionMutation(input.sessionId, () =>
+            this.#setSessionConfigOption(input, {
+                rememberRuntimePreference: true,
+            }),
+        );
     }
 
     #cancelCapturedRuntimeDefaults(sessionId: string): void {
         this.#capturedRuntimeDefaultsBySessionId.delete(sessionId);
+    }
+
+    async #enqueueSelectionMutation<T>(
+        sessionId: string,
+        mutation: () => Promise<T>,
+    ): Promise<T> {
+        const previous =
+            this.#selectionMutationChains.get(sessionId) ?? Promise.resolve();
+        const current = previous.catch(() => undefined).then(mutation);
+        const tail = current.then(
+            () => undefined,
+            () => undefined,
+        );
+        this.#selectionMutationChains.set(sessionId, tail);
+
+        try {
+            return await current;
+        } finally {
+            if (this.#selectionMutationChains.get(sessionId) === tail) {
+                this.#selectionMutationChains.delete(sessionId);
+            }
+        }
     }
 
     async #setSessionConfigOption(
@@ -2707,38 +2736,50 @@ export class AiService {
         const canApplyCapturedDefaults =
             this.#capturedRuntimeDefaultsBySessionId.has(sessionId);
         const modelConfig = getModelConfigOption(snapshot.configOptions);
+        const capturedModelId = capturedDefaults.modelId;
         if (
             !modelConfig &&
             this.#hasCapturedRuntimeDefaults(sessionId, capturedDefaults) &&
-            capturedDefaults.modelId &&
-            capturedDefaults.modelId !== snapshot.modelId &&
-            snapshot.models.some((model) => model.id === capturedDefaults.modelId)
+            capturedModelId &&
+            capturedModelId !== snapshot.modelId &&
+            snapshot.models.some((model) => model.id === capturedModelId)
         ) {
-            await this.#setSessionModel(
-                {
-                    modelId: capturedDefaults.modelId,
-                    sessionId,
-                },
-                { rememberRuntimePreference: false },
-            );
+            await this.#enqueueSelectionMutation(sessionId, async () => {
+                if (!this.#hasCapturedRuntimeDefaults(sessionId, capturedDefaults)) {
+                    return;
+                }
+                await this.#setSessionModel(
+                    {
+                        modelId: capturedModelId,
+                        sessionId,
+                    },
+                    { rememberRuntimePreference: false },
+                );
+            });
             snapshot = this.#liveSnapshots.get(sessionId) ?? snapshot;
         }
 
         const modeConfig = getModeConfigOption(snapshot.configOptions);
+        const capturedModeId = capturedDefaults.modeId;
         if (
             !modeConfig &&
             this.#hasCapturedRuntimeDefaults(sessionId, capturedDefaults) &&
-            capturedDefaults.modeId &&
-            capturedDefaults.modeId !== snapshot.modeId &&
-            snapshot.modes.some((mode) => mode.id === capturedDefaults.modeId)
+            capturedModeId &&
+            capturedModeId !== snapshot.modeId &&
+            snapshot.modes.some((mode) => mode.id === capturedModeId)
         ) {
-            await this.#setSessionMode(
-                {
-                    modeId: capturedDefaults.modeId,
-                    sessionId,
-                },
-                { rememberRuntimePreference: false },
-            );
+            await this.#enqueueSelectionMutation(sessionId, async () => {
+                if (!this.#hasCapturedRuntimeDefaults(sessionId, capturedDefaults)) {
+                    return;
+                }
+                await this.#setSessionMode(
+                    {
+                        modeId: capturedModeId,
+                        sessionId,
+                    },
+                    { rememberRuntimePreference: false },
+                );
+            });
             snapshot = this.#liveSnapshots.get(sessionId) ?? snapshot;
         }
 
@@ -2753,14 +2794,19 @@ export class AiService {
             if (!this.#hasCapturedRuntimeDefaults(sessionId, capturedDefaults)) {
                 break;
             }
-            await this.#setSessionConfigOption(
-                {
-                    optionId: mutation.optionId,
-                    sessionId,
-                    value: mutation.value,
-                },
-                { rememberRuntimePreference: false },
-            );
+            await this.#enqueueSelectionMutation(sessionId, async () => {
+                if (!this.#hasCapturedRuntimeDefaults(sessionId, capturedDefaults)) {
+                    return;
+                }
+                await this.#setSessionConfigOption(
+                    {
+                        optionId: mutation.optionId,
+                        sessionId,
+                        value: mutation.value,
+                    },
+                    { rememberRuntimePreference: false },
+                );
+            });
             snapshot = this.#liveSnapshots.get(sessionId) ?? snapshot;
         }
 

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -412,14 +412,16 @@ export const ChatTabView = memo(function ChatTabView({
         [sessionTab],
     );
     const ensureLiveAgentSession = useCallback(async () => {
+        const currentSession = useAiStore.getState().sessions[tab.sessionId] ?? null;
+        if (currentSession?.snapshot?.runtimeSessionId) {
+            return;
+        }
         await ensureSession(liveSessionTab, { force: true });
-    }, [ensureSession, liveSessionTab]);
+    }, [ensureSession, liveSessionTab, tab.sessionId]);
     const runAgentControlMutation = useCallback(
         (mutation: () => Promise<void>) => {
             void (async () => {
-                if (tab.sessionOpenMode === "history") {
-                    await ensureLiveAgentSession();
-                }
+                await ensureLiveAgentSession();
 
                 try {
                     await mutation();
@@ -439,7 +441,7 @@ export const ChatTabView = memo(function ChatTabView({
                 );
             });
         },
-        [ensureLiveAgentSession, tab.sessionOpenMode],
+        [ensureLiveAgentSession],
     );
 
     useEffect(() => {


### PR DESCRIPTION
## Summary

- wait for new chat sessions to finish preparing before applying selector changes
- cancel and serialize captured default mutations so manual selections remain authoritative
- add regression coverage for selector mutation races

## Validation

- `pnpm run typecheck`
- `pnpm exec eslint src/renderer/src/components/workspace/ChatTabView.tsx`
- `pnpm exec vitest run src/main/ai/service.prepare.test.ts src/renderer/src/app/store/ai-store.test.ts`