### PR TITLE
perf(chat): preserve history state and virtual timeline geometry across navigation

### DIFF
--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -5,7 +5,8 @@ use std::thread;
 use comando_ai::AiEngine;
 use comando_ai::events::{
     AI_ERROR_EVENT, AI_RUNTIME_STATUS_EVENT, AI_SESSION_CLOSED_EVENT, AI_SESSION_CREATED_EVENT,
-    AI_SESSION_UPDATED_EVENT, AiRuntimeEvent, session_closed, session_created, session_updated,
+    AI_SESSION_UPDATED_EVENT, AiRuntimeEvent, session_closed, session_created,
+    session_status_updated, session_updated,
 };
 use comando_ai::history::{
     AiHistoryMigrationMode, AiHistoryMigrationOptions, AiHistoryMigrator, AiHistoryStore,
@@ -2261,7 +2262,7 @@ impl NativeBackend {
                             ),
                             event(
                                 AI_SESSION_UPDATED_EVENT,
-                                serde_json::to_value(session_updated(&summary))
+                                serde_json::to_value(session_status_updated(&summary))
                                     .expect("ai session updated event serializes"),
                             ),
                         ],

--- a/crates/comando-ai/src/events.rs
+++ b/crates/comando-ai/src/events.rs
@@ -82,6 +82,17 @@ pub fn session_updated(session: &NativeAiSessionSummary) -> NativeAiSessionUpdat
     }
 }
 
+pub fn session_status_updated(session: &NativeAiSessionSummary) -> NativeAiSessionUpdatedPayload {
+    NativeAiSessionUpdatedPayload {
+        session_id: session.session_id.clone(),
+        runtime_id: session.runtime_id.clone(),
+        runtime_session_id: session.runtime_session_id.clone(),
+        status: session.status.clone(),
+        title: None,
+        updated_at: session.updated_at.clone(),
+    }
+}
+
 pub fn session_closed(session: &NativeAiSessionSummary) -> NativeAiSessionClosedPayload {
     NativeAiSessionClosedPayload {
         session_id: session.session_id.clone(),

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -172,6 +172,7 @@ import { createIpcInFlightLimiter } from "@main/ipc/rate-limit";
 import { resolveSettingsSnapshotSaveEffects } from "@main/ipc/settings-save-effects";
 import { debugBenignError } from "@main/observability/logging";
 import { resolveCodexGeneratedImageFilePath } from "@main/file-preview-protocol";
+import { isNativeBackendOperationCancelled } from "@main/native-backend/client";
 
 import type { AiService } from "@main/ai/service";
 import {
@@ -1624,10 +1625,19 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     const searchProjectEntriesLimiter = createIpcInFlightLimiter(8);
     ipcMain.handle(
         IPC_CHANNELS.searchProjectEntries,
-        (_event, input: SearchProjectEntriesInput) =>
-            searchProjectEntriesLimiter(() =>
-                options.projectService.searchProjectEntries(input),
-            ),
+        async (_event, input: SearchProjectEntriesInput) => {
+            try {
+                return await searchProjectEntriesLimiter(() =>
+                    options.projectService.searchProjectEntries(input),
+                );
+            } catch (error) {
+                if (isNativeBackendOperationCancelled(error)) {
+                    debugBenignError("projects.search-entries.cancelled", error);
+                    return [];
+                }
+                throw error;
+            }
+        },
     );
     ipcMain.handle(IPC_CHANNELS.getWorkspaceSnapshot, (event) => {
         const context = requireWindowContext(event.sender, "main");

--- a/src/main/native-backend/client.test.ts
+++ b/src/main/native-backend/client.test.ts
@@ -4,7 +4,12 @@ import { PassThrough } from "node:stream";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { NativeBackendClient, NativeBackendError, type NativeBackendSpawn } from "./client";
+import {
+    isNativeBackendOperationCancelled,
+    NativeBackendClient,
+    NativeBackendError,
+    type NativeBackendSpawn,
+} from "./client";
 
 beforeEach(() => {
     vi.useRealTimers();
@@ -15,6 +20,22 @@ afterEach(() => {
 });
 
 describe("NativeBackendClient", () => {
+    it("identifies expected operation cancellations", () => {
+        expect(
+            isNativeBackendOperationCancelled(
+                new NativeBackendError({
+                    code: "operation_cancelled",
+                    details: null,
+                    message: "Native search operation was cancelled.",
+                    retryable: false,
+                }),
+            ),
+        ).toBe(true);
+        expect(isNativeBackendOperationCancelled(new Error("cancelled"))).toBe(
+            false,
+        );
+    });
+
     it("resolves requests from matching responses", async () => {
         const { child, client } = createClient();
         const linePromise = readStdinLine(child);

--- a/src/main/native-backend/client.ts
+++ b/src/main/native-backend/client.ts
@@ -38,6 +38,13 @@ export class NativeBackendError extends Error {
     }
 }
 
+export function isNativeBackendOperationCancelled(error: unknown): boolean {
+    return (
+        error instanceof NativeBackendError &&
+        error.code === "operation_cancelled"
+    );
+}
+
 function formatNativeBackendErrorMessage(
     payload: NativeBackendErrorPayload,
 ): string {

--- a/src/renderer/src/app/ai/transcriptModel.ts
+++ b/src/renderer/src/app/ai/transcriptModel.ts
@@ -70,6 +70,19 @@ const PLAN_ENTRY_ID = "plan:active";
 const STATUS_ENTRY_ID = "status:active-turn";
 const OPAQUE_ENCRYPTED_MESSAGE_PATTERN = /^gAAAAA[A-Za-z0-9_-]{40,}={0,2}$/;
 
+interface TranscriptPresentationCache {
+    readonly messages: readonly AiMessage[];
+    readonly toolActivity: readonly AiToolActivity[];
+}
+
+// Transcript models are immutable. Cache their projected arrays so remounting
+// a chat does not scan the complete ordered entry list twice before timeline
+// reconciliation even begins.
+const transcriptPresentationCache = new WeakMap<
+    AiSessionTranscriptModel,
+    TranscriptPresentationCache
+>();
+
 export function createEmptyAiSessionTranscriptModel(): AiSessionTranscriptModel {
     return buildAiSessionTranscriptModel({
         messages: [],
@@ -243,19 +256,37 @@ export function writeAiSessionTranscriptToSnapshot(
 export function getAiSessionTranscriptMessages(
     transcript: AiSessionTranscriptModel,
 ): readonly AiMessage[] {
-    return transcript.messageOrder.flatMap((entryId) => {
-        const entry = transcript.messagesById[entryId];
-        return entry?.kind === "message" ? [entry.message] : [];
-    });
+    return getTranscriptPresentationCache(transcript).messages;
 }
 
 export function getAiSessionTranscriptToolActivity(
     transcript: AiSessionTranscriptModel,
 ): readonly AiToolActivity[] {
-    return transcript.messageOrder.flatMap((entryId) => {
+    return getTranscriptPresentationCache(transcript).toolActivity;
+}
+
+function getTranscriptPresentationCache(
+    transcript: AiSessionTranscriptModel,
+): TranscriptPresentationCache {
+    const cached = transcriptPresentationCache.get(transcript);
+    if (cached) {
+        return cached;
+    }
+
+    const messages: AiMessage[] = [];
+    const toolActivity: AiToolActivity[] = [];
+    for (const entryId of transcript.messageOrder) {
         const entry = transcript.messagesById[entryId];
-        return entry?.kind === "tool" ? [entry.activity] : [];
-    });
+        if (entry?.kind === "message") {
+            messages.push(entry.message);
+        } else if (entry?.kind === "tool") {
+            toolActivity.push(entry.activity);
+        }
+    }
+
+    const presentation = { messages, toolActivity };
+    transcriptPresentationCache.set(transcript, presentation);
+    return presentation;
 }
 
 export function mergeAiSessionTranscriptSources(

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -596,6 +596,28 @@ describe("ai-store queue", () => {
         ).toBe("Revisa login");
     });
 
+    it("preserves the root chat title when cancellation only changes status", () => {
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                status: "streaming",
+                title: "Diagnose chat cancellation",
+            }),
+        );
+
+        useAiStore.getState().applySessionEvent(
+            createSessionEvent({
+                kind: "status",
+                status: "idle",
+                title: null,
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot?.title,
+        ).toBe("Diagnose chat cancellation");
+    });
+
     it("does not request resync for idle sessions", async () => {
         vi.useFakeTimers();
         const resyncAiSession = vi.fn().mockResolvedValue(null);

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -905,7 +905,7 @@ describe("ai-store queue", () => {
             writable: true,
         });
 
-        await useAiStore.getState().ensureSession(TAB);
+        await useAiStore.getState().ensureSession(TAB, { force: true });
 
         expect(prepareAiSession).toHaveBeenCalledWith({
             projectId: TAB.projectId,
@@ -956,7 +956,7 @@ describe("ai-store queue", () => {
         });
 
         await useAiStore.getState().ensureSession(TAB);
-        await useAiStore.getState().ensureSession(TAB);
+        await useAiStore.getState().ensureSession(TAB, { force: true });
 
         expect(prepareAiSession).toHaveBeenCalledTimes(2);
         expect(
@@ -1130,6 +1130,48 @@ describe("ai-store queue", () => {
         expect(session?.snapshot?.modelId).toBe("gpt-5");
     });
 
+    it("hydrates a registered history tab instead of mistaking its placeholder for history", async () => {
+        const historyTab: WorkspaceChatTab = {
+            ...TAB,
+            sessionOpenMode: "history",
+        };
+        const snapshot = createSnapshot({
+            messages: [createMessage({ content: "Restored history" })],
+        });
+        const getAiSessionSnapshot = vi.fn().mockResolvedValue(snapshot);
+
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    getAiRuntimeStatus: vi
+                        .fn()
+                        .mockResolvedValue(createRuntimeStatus()),
+                    getAiSessionSnapshot,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().registerSessionTab(historyTab);
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]
+                ?.historyHydrationState,
+        ).toBe("not_loaded");
+
+        await useAiStore.getState().ensureSession(historyTab);
+
+        expect(getAiSessionSnapshot).toHaveBeenCalledWith(TAB.sessionId);
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot?.messages[0]
+                ?.content,
+        ).toBe("Restored history");
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]
+                ?.historyHydrationState,
+        ).toBe("loaded");
+    });
+
     it("prepares a closed restored history chat before queuing a follow-up prompt", async () => {
         const historyTab: WorkspaceChatTab = {
             ...TAB,
@@ -1190,14 +1232,10 @@ describe("ai-store queue", () => {
         await useAiStore.getState().ensureSession(historyTab);
         await useAiStore.getState().sendPrompt(historyTab, "Continue.");
 
-        expect(prepareAiSession).toHaveBeenCalledWith({
-            projectId: TAB.projectId,
-            runtimeId: TAB.runtimeId,
-            sessionId: TAB.sessionId,
-            title: TAB.title,
-            worktreeId: TAB.worktreeId,
-        });
-        expect(enqueueAiPrompt).toHaveBeenCalledAfter(prepareAiSession);
+        // Dispatch preparation belongs to the main-owned prompt queue. The
+        // renderer keeps history navigation free of runtime work.
+        expect(prepareAiSession).not.toHaveBeenCalled();
+        expect(enqueueAiPrompt).toHaveBeenCalled();
         expect(
             useAiStore.getState().sessions[TAB.sessionId]?.activeQueuedPrompt
                 ?.queuedPrompt.status,

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -132,6 +132,8 @@ interface ActiveQueuedPromptState {
     readonly queuedPrompt: QueuedPrompt;
 }
 
+type AiHistoryHydrationState = "not_loaded" | "loading" | "loaded" | "failed";
+
 interface AiSessionClientState {
     readonly activeDispatchToken: string | null;
     readonly activePromptMessageAliases: Readonly<Record<string, string>>;
@@ -144,6 +146,7 @@ interface AiSessionClientState {
     readonly editingQueuedPromptState: QueuedPromptEditState | null;
     readonly editingQueuedPrompt: QueuedPrompt | null;
     readonly incomingSnapshotVersion: number;
+    readonly historyHydrationState: AiHistoryHydrationState;
     readonly isDispatching: boolean;
     readonly lastIncomingSnapshotUpdatedAt: string | null;
     readonly localError: string | null;
@@ -1195,8 +1198,25 @@ export const useAiStore = create<AiStore>((set, get) => ({
         const currentSession = get().sessions[tab.sessionId] ?? null;
         const shouldHydratePassively =
             !options?.force &&
-            getSessionRuntimeStateForTab(tab) === "history" &&
-            currentSession?.runtimeState !== "live";
+            getSessionRuntimeStateForTab(tab) === "history";
+
+        if (shouldHydratePassively) {
+            // A registered tab receives an empty snapshot placeholder. Only a
+            // completed history read may suppress a later hydration.
+            if (
+                currentSession?.runtimeState === "live" ||
+                currentSession?.historyHydrationState === "loaded"
+            ) {
+                return;
+            }
+        } else if (
+            !options?.force &&
+            currentSession?.runtimeState === "live" &&
+            currentSession.snapshot?.runtimeSessionId
+        ) {
+            return;
+        }
+
         const requestKey = `${tab.sessionId}:${shouldHydratePassively ? "history" : "live"}`;
         const existingRequest = ensureSessionInFlight.get(requestKey);
         if (existingRequest) {
@@ -1809,13 +1829,6 @@ export const useAiStore = create<AiStore>((set, get) => ({
             return;
         }
 
-        if (getSessionRuntimeStateForTab(tab) === "history") {
-            await get().ensureSession(
-                { ...tab, sessionOpenMode: "live" },
-                { force: true },
-            );
-        }
-
         get().registerSessionTab(tab);
         const session = get().sessions[tab.sessionId] ?? createSessionState();
         const editingQueuedPrompt = session.editingQueuedPrompt;
@@ -1866,6 +1879,8 @@ function createSessionState(
         editingQueuedPromptState: null,
         editingQueuedPrompt: null,
         incomingSnapshotVersion: 0,
+        historyHydrationState:
+            runtimeState === "history" ? "not_loaded" : "loaded",
         isDispatching: false,
         lastIncomingSnapshotUpdatedAt: null,
         localError: null,
@@ -2013,12 +2028,18 @@ async function executeSessionPrepare(
                             ? error.message
                             : `Could not hydrate the ${getRuntimeDisplayName(tab.runtimeId)} session.`,
                     meta: buildSessionMeta(tab),
-                    runtimeState: "live",
-                    snapshot: createEmptySessionSnapshot(
-                        tab,
-                        state.runtimeCatalogById[tab.runtimeId] ?? null,
-                    ),
-                    transcript: createEmptyAiSessionTranscriptModel(),
+                    runtimeState: "history",
+                    // Keep the readable history on screen when reconnecting the
+                    // runtime fails. The user can retry without losing context.
+                    snapshot:
+                        state.sessions[tab.sessionId]?.snapshot ??
+                        createEmptySessionSnapshot(
+                            tab,
+                            state.runtimeCatalogById[tab.runtimeId] ?? null,
+                        ),
+                    transcript:
+                        state.sessions[tab.sessionId]?.transcript ??
+                        createEmptyAiSessionTranscriptModel(),
                 },
             },
         }));
@@ -2031,6 +2052,24 @@ async function executePassiveSessionHydration(
     set: SetAiState,
 ): Promise<void> {
     get().registerSessionTab(tab);
+
+    set((state) => {
+        const session = state.sessions[tab.sessionId];
+        if (!session || session.runtimeState === "live") {
+            return state;
+        }
+
+        return {
+            sessions: {
+                ...state.sessions,
+                [tab.sessionId]: {
+                    ...session,
+                    historyHydrationState: "loading",
+                    localError: null,
+                },
+            },
+        };
+    });
 
     try {
         const runtimeStatusPromise = getComandoApi().getAiRuntimeStatus(
@@ -2106,6 +2145,7 @@ async function executePassiveSessionHydration(
                                       null,
                               }),
                         localError: null,
+                        historyHydrationState: "loaded",
                         meta: buildSessionMeta(tab),
                         runtimeState: "history",
                         snapshot: resolved.snapshot,
@@ -2136,6 +2176,7 @@ async function executePassiveSessionHydration(
                             error instanceof Error
                                 ? error.message
                                 : "Could not load this saved chat.",
+                        historyHydrationState: "failed",
                         meta: buildSessionMeta(tab),
                         runtimeState: "history",
                         snapshot: createEmptySessionSnapshot(

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -263,7 +263,7 @@ describe("workspace file opening", () => {
 
         await useWorkspaceStore.getState().hydrate();
 
-        expect(ensureSessionMock).toHaveBeenCalledTimes(4);
+        expect(ensureSessionMock).toHaveBeenCalledTimes(2);
         expect(ensureSessionMock).toHaveBeenCalledWith(
             expect.objectContaining({ sessionId: "session-left" }),
         );
@@ -272,20 +272,6 @@ describe("workspace file opening", () => {
         );
         expect(ensureSessionMock).not.toHaveBeenCalledWith(
             expect.objectContaining({ sessionId: "session-inactive" }),
-        );
-        expect(ensureSessionMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                sessionId: "session-left",
-                sessionOpenMode: "live",
-            }),
-            { force: true },
-        );
-        expect(ensureSessionMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                sessionId: "session-right",
-                sessionOpenMode: "live",
-            }),
-            { force: true },
         );
     });
 
@@ -345,12 +331,8 @@ describe("workspace file opening", () => {
 
         await useWorkspaceStore.getState().selectTab("pane-root", tab.id);
 
-        expect(ensureSessionMock).toHaveBeenCalledTimes(2);
+        expect(ensureSessionMock).toHaveBeenCalledTimes(1);
         expect(ensureSessionMock.mock.calls[0]).toEqual([tab]);
-        expect(ensureSessionMock.mock.calls[1]).toEqual([
-            { ...tab, sessionOpenMode: "live" },
-            { force: true },
-        ]);
     });
 
     it("creates OpenCode chat tabs with OpenCode titles", async () => {
@@ -2003,18 +1985,7 @@ describe("workspace file opening", () => {
             title: "Recovered session",
             worktreeId: "worktree-1",
         });
-        expect(ensureSessionMock).toHaveBeenCalledTimes(1);
-        expect(ensureSessionMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                id: "chat-existing",
-                kind: "chat",
-                projectId: "project-1",
-                runtimeId: "codex",
-                sessionId: "session-persisted",
-                title: "Recovered session",
-                worktreeId: "worktree-1",
-            }),
-        );
+        expect(ensureSessionMock).not.toHaveBeenCalled();
         await flushWorkspacePersistenceForTests();
         expect(saveWorkspaceSnapshotMock).toHaveBeenCalled();
     });
@@ -2210,17 +2181,7 @@ describe("workspace file opening", () => {
             title: "Recovered Grok session",
             worktreeId: "worktree-9",
         });
-        expect(ensureSessionMock).toHaveBeenCalledTimes(1);
-        expect(ensureSessionMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                kind: "chat",
-                projectId: "project-1",
-                runtimeId: "grok",
-                sessionId: "session-new-history",
-                title: "Recovered Grok session",
-                worktreeId: "worktree-9",
-            }),
-        );
+        expect(ensureSessionMock).not.toHaveBeenCalled();
         await flushWorkspacePersistenceForTests();
         expect(saveWorkspaceSnapshotMock).toHaveBeenCalled();
     });

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -1981,11 +1981,17 @@ describe("workspace file opening", () => {
             kind: "chat",
             projectId: "project-1",
             runtimeId: "codex",
+            sessionOpenMode: "history",
             sessionId: "session-persisted",
             title: "Recovered session",
             worktreeId: "worktree-1",
         });
-        expect(ensureSessionMock).not.toHaveBeenCalled();
+        expect(ensureSessionMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sessionOpenMode: "history",
+                sessionId: "session-persisted",
+            }),
+        );
         await flushWorkspacePersistenceForTests();
         expect(saveWorkspaceSnapshotMock).toHaveBeenCalled();
     });
@@ -2177,11 +2183,17 @@ describe("workspace file opening", () => {
             kind: "chat",
             projectId: "project-1",
             runtimeId: "grok",
+            sessionOpenMode: "history",
             sessionId: "session-new-history",
             title: "Recovered Grok session",
             worktreeId: "worktree-9",
         });
-        expect(ensureSessionMock).not.toHaveBeenCalled();
+        expect(ensureSessionMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sessionOpenMode: "history",
+                sessionId: "session-new-history",
+            }),
+        );
         await flushWorkspacePersistenceForTests();
         expect(saveWorkspaceSnapshotMock).toHaveBeenCalled();
     });

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -575,7 +575,9 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 projectId: input.projectId,
                 runtimeId: input.runtimeId,
                 sessionOpenMode:
-                    input.sessionOpenMode ?? existingTab.sessionOpenMode,
+                    input.sessionOpenMode ??
+                    existingTab.sessionOpenMode ??
+                    "history",
                 title: input.title,
                 worktreeId: input.worktreeId ?? null,
             };
@@ -650,7 +652,9 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             kind: "chat",
             projectId: input.projectId,
             runtimeId: input.runtimeId,
-            sessionOpenMode: input.sessionOpenMode,
+            // This API opens an existing session. Loading its durable
+            // transcript must not depend on every caller passing a mode.
+            sessionOpenMode: input.sessionOpenMode ?? "history",
             sessionId: input.sessionId,
             title: input.title,
             worktreeId: input.worktreeId ?? null,

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -1799,6 +1799,12 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     },
 
     setActivePane: async (paneId) => {
+        // A mouse-down inside a pane bubbles to the pane container. Avoid
+        // treating an interaction in the already focused pane as navigation.
+        if (get().activePaneId === paneId) {
+            return;
+        }
+
         set((state) => ({
             ...(() => {
                 const nextState = activatePane(state, paneId);
@@ -2773,21 +2779,13 @@ function ensureActiveHydratedSessions(state: WorkspaceTreeState): void {
 function prewarmFocusedAiSession(
     tab: RuntimeWorkspaceTab,
 ): void {
-    if (tab.kind !== "chat" && tab.kind !== "review") {
+    if (tab.kind !== "chat" || tab.sessionOpenMode !== "history") {
         return;
     }
 
-    void (async () => {
-        await useAiStore.getState().ensureSession(tab);
-        if (tab.kind !== "chat" || tab.sessionOpenMode !== "history") {
-            return;
-        }
-
-        await useAiStore.getState().ensureSession(
-            { ...tab, sessionOpenMode: "live" },
-            { force: true },
-        );
-    })();
+    // History is readable without a live ACP runtime. Runtime preparation is
+    // intentionally deferred to prompt dispatch or an explicit control action.
+    void useAiStore.getState().ensureSession(tab);
 }
 
 async function hydrateRuntimeTabs(

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -444,6 +444,7 @@ export function SidebarAgentsPanel({
             void openChatSessionTab({
                 projectId: session.projectId,
                 runtimeId: session.runtimeId as AiRuntimeId,
+                sessionOpenMode: "history",
                 sessionId: session.sessionId,
                 title: session.title,
                 worktreeId: session.worktreeId ?? null,

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -64,6 +64,7 @@ import {
 } from "@renderer/components/workspace/workspaceTabActivity";
 import { ProviderIcon } from "@renderer/components/workspace/ProviderIcon";
 import { releaseScopedToolUiStateStore } from "@renderer/components/workspace/chat/toolExpansionStore";
+import { releaseCachedChatTimeline } from "@renderer/components/workspace/chat/chatTimelineCache";
 
 import {
     applySessionUpdateToSidebarHistory,
@@ -647,6 +648,7 @@ export function SidebarAgentsPanel({
 
                 await api.deleteAiSession(historySession.sessionId);
                 releaseScopedToolUiStateStore(historySession.sessionId);
+                releaseCachedChatTimeline(historySession.sessionId);
 
                 for (const tabId of matchingTabIds) {
                     await closeTab(tabId);

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
@@ -11,7 +11,10 @@ import {
     type MockInstance,
 } from "vitest";
 
-import { MeasuredVirtualList } from "./MeasuredVirtualList";
+import {
+    MeasuredVirtualList,
+    resetMeasuredVirtualListMeasurementsForTests,
+} from "./MeasuredVirtualList";
 
 // Integration coverage for the virtualized measurement path under react-dom:
 // the scroll-anchor compensation (a row above the viewport re-measures → scroll
@@ -81,6 +84,7 @@ class FakeResizeObserver {
 // getBoundingClientRect off this map so a fired resize stays reflected if the row
 // is ever re-measured; fireRowResize updates it alongside firing the observer.
 const heightByElement = new WeakMap<Element, number>();
+const heightByListKey = new Map<string, number>();
 
 function fireRowResize(
     element: Element,
@@ -88,6 +92,10 @@ function fireRowResize(
     options?: { readonly contentHeight?: number },
 ) {
     heightByElement.set(element, height);
+    const listKey = (element as HTMLElement).dataset.listKey;
+    if (listKey) {
+        heightByListKey.set(listKey, height);
+    }
     const contentHeight = options?.contentHeight ?? height;
     for (const observer of observers) {
         observer.fire(element, height, contentHeight);
@@ -105,7 +113,9 @@ function createItems(count: number): Item[] {
 }
 
 interface MountConfig {
+    readonly estimateSize?: (item: Item, index: number) => number;
     readonly items: readonly Item[];
+    readonly measurementCacheKey?: string;
     readonly overscan: number;
     readonly preserveScrollAnchorOnItemsChange?: boolean;
     readonly preserveScrollAnchorOnMeasure: boolean;
@@ -146,11 +156,12 @@ function mountList(config: MountConfig): MountedList {
     const element = () => (
         <MeasuredVirtualList
             defaultViewportHeight={VIEWPORT_HEIGHT}
-            estimateSize={() => ITEM_HEIGHT}
+            estimateSize={config.estimateSize ?? (() => ITEM_HEIGHT)}
             getItemIdentityKey={config.getItemIdentityKey}
             getItemKey={(item) => item.id}
             getItemMeasurementKey={currentMeasurementKey}
             items={currentItems}
+            measurementCacheKey={config.measurementCacheKey}
             overscan={config.overscan}
             preserveScrollAnchorOnItemsChange={
                 config.preserveScrollAnchorOnItemsChange
@@ -235,6 +246,8 @@ beforeEach(() => {
     (
         globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
     ).IS_REACT_ACT_ENVIRONMENT = true;
+    resetMeasuredVirtualListMeasurementsForTests();
+    heightByListKey.clear();
     (
         globalThis as unknown as { ResizeObserver: typeof FakeResizeObserver }
     ).ResizeObserver = FakeResizeObserver;
@@ -246,9 +259,14 @@ beforeEach(() => {
     getBoundingClientRectSpy = vi
         .spyOn(Element.prototype, "getBoundingClientRect")
         .mockImplementation(function getBoundingClientRect(
-            this: Element,
-        ): DOMRect {
-            const height = heightByElement.get(this) ?? ITEM_HEIGHT;
+        this: Element,
+    ): DOMRect {
+            const height =
+                heightByElement.get(this) ??
+                heightByListKey.get(
+                    (this as HTMLElement).dataset.listKey ?? "",
+                ) ??
+                ITEM_HEIGHT;
             return {
                 height,
                 width: 0,
@@ -455,6 +473,70 @@ describe("MeasuredVirtualList scroll anchoring (integration)", () => {
 });
 
 describe("MeasuredVirtualList measurement wiring (integration)", () => {
+    it("recomputes long-chat geometry when returning to an already open tab", () => {
+        const items = createItems(5000);
+        const estimateSize = vi.fn(() => ITEM_HEIGHT);
+        const config = {
+            estimateSize,
+            items,
+            measurementCacheKey: "chat-timeline:session-a",
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+        };
+        const firstTab = mountList(config);
+
+        act(() => {
+            firstTab.root.unmount();
+        });
+        const otherTab = mountList({
+            items: createItems(20),
+            measurementCacheKey: "chat-timeline:session-b",
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+        });
+        act(() => {
+            otherTab.root.unmount();
+        });
+
+        estimateSize.mockClear();
+        const returnedTab = mountList(config);
+
+        // Virtualization saves DOM work, but the current geometry builder still
+        // estimates every off-screen row before it can calculate the range.
+        expect(estimateSize.mock.calls.length).toBeGreaterThanOrEqual(4900);
+
+        act(() => {
+            returnedTab.root.unmount();
+        });
+    });
+
+    it("reuses measured row heights after remounting the same list", () => {
+        const config = {
+            items: createItems(60),
+            measurementCacheKey: "chat-timeline:session-1",
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+        };
+        const firstMount = mountList(config);
+
+        act(() => {
+            fireRowResize(rowWrapper(firstMount.mountNode, 0), 60);
+        });
+        expect(totalHeightPx(firstMount)).toBe("1240px");
+        act(() => {
+            firstMount.root.unmount();
+        });
+
+        const secondMount = mountList(config);
+
+        // The cached measurement is applied before the newly mounted rows are
+        // observed, avoiding the estimate → measured layout correction.
+        expect(totalHeightPx(secondMount)).toBe("1240px");
+        act(() => {
+            secondMount.root.unmount();
+        });
+    });
+
     it("measures each row once on attach, not on every render", () => {
         const list = mountList({
             items: createItems(60),

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
@@ -114,6 +114,7 @@ function createItems(count: number): Item[] {
 
 interface MountConfig {
     readonly estimateSize?: (item: Item, index: number) => number;
+    readonly geometryCacheSignature?: string;
     readonly items: readonly Item[];
     readonly measurementCacheKey?: string;
     readonly overscan: number;
@@ -160,6 +161,7 @@ function mountList(config: MountConfig): MountedList {
             getItemIdentityKey={config.getItemIdentityKey}
             getItemKey={(item) => item.id}
             getItemMeasurementKey={currentMeasurementKey}
+            geometryCacheSignature={config.geometryCacheSignature}
             items={currentItems}
             measurementCacheKey={config.measurementCacheKey}
             overscan={config.overscan}
@@ -288,6 +290,22 @@ afterEach(() => {
 });
 
 describe("MeasuredVirtualList scroll anchoring (integration)", () => {
+    it("expands the rendered buffer after a large scroll jump", () => {
+        const list = mountList({
+            items: createItems(500),
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+        });
+
+        scrollTo(list, 3600);
+
+        // A fixed overscan of 10 would keep roughly 25 rows mounted. The
+        // velocity-aware buffer covers the next paint while momentum scrolling.
+        expect(renderedIndexes(list.mountNode).length).toBeGreaterThan(80);
+
+        list.root.unmount();
+    });
+
     it("preserves a keyed viewport anchor when rows split above it", () => {
         const initialItems = createItems(60);
         const list = mountList({
@@ -478,6 +496,7 @@ describe("MeasuredVirtualList measurement wiring (integration)", () => {
         const estimateSize = vi.fn(() => ITEM_HEIGHT);
         const config = {
             estimateSize,
+            geometryCacheSignature: "default",
             items,
             measurementCacheKey: "chat-timeline:session-a",
             overscan: 10,
@@ -501,9 +520,9 @@ describe("MeasuredVirtualList measurement wiring (integration)", () => {
         estimateSize.mockClear();
         const returnedTab = mountList(config);
 
-        // Virtualization saves DOM work, but the current geometry builder still
-        // estimates every off-screen row before it can calculate the range.
-        expect(estimateSize.mock.calls.length).toBeGreaterThanOrEqual(4900);
+        // Returning to an already open tab reuses the base layout instead of
+        // estimating every off-screen row before calculating the range.
+        expect(estimateSize.mock.calls.length).toBeLessThan(100);
 
         act(() => {
             returnedTab.root.unmount();

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -12,10 +12,24 @@ import {
 const DEFAULT_OVERSCAN = 4;
 const DEFAULT_VIEWPORT_HEIGHT = 720;
 const MAX_CACHED_MEASUREMENT_SETS = 12;
+const MAX_DYNAMIC_OVERSCAN_ROWS = 64;
+const SCROLL_OVERSCAN_ROW_HEIGHT_PX = 72;
 
 interface CachedMeasurements {
+    readonly geometry: CachedGeometry | null;
     readonly measuredByIdentity: ReadonlyMap<string, number>;
     readonly measuredSizes: ReadonlyMap<string, number>;
+}
+
+interface CachedGeometry {
+    readonly itemIdentityKeys: readonly string[];
+    readonly itemKeys: readonly string[];
+    readonly itemMeasurementKeys: readonly string[];
+    readonly items: readonly unknown[];
+    readonly offsets: readonly number[];
+    readonly signature: string;
+    readonly sizes: readonly number[];
+    readonly totalSize: number;
 }
 
 const cachedMeasurementsByKey = new Map<string, CachedMeasurements>();
@@ -49,6 +63,7 @@ function cacheMeasurements(
 
 function cacheCurrentMeasurements(
     cacheKey: string,
+    geometry: CachedGeometry | null,
     measuredSizesRef: Readonly<{
         readonly current: ReadonlyMap<string, number>;
     }>,
@@ -57,6 +72,7 @@ function cacheCurrentMeasurements(
     }>,
 ): void {
     cacheMeasurements(cacheKey, {
+        geometry,
         measuredByIdentity: new Map(measuredByIdentityRef.current),
         measuredSizes: new Map(measuredSizesRef.current),
     });
@@ -115,6 +131,8 @@ export interface MeasuredVirtualListProps<T> {
      * still validate each entry, so stale rows are ignored after a change.
      */
     readonly measurementCacheKey?: string;
+    /** Stable layout inputs. A changed value invalidates cached geometry. */
+    readonly geometryCacheSignature?: string | null;
     readonly onRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onReady?: (handle: MeasuredVirtualListHandle | null) => void;
     readonly preserveScrollAnchorOnItemsChange?: boolean;
@@ -139,7 +157,9 @@ interface MeasuredVirtualItem<T> {
 }
 
 interface LayoutSnapshot<T> {
+    readonly offsets: readonly number[];
     readonly range: MeasuredVirtualRange;
+    readonly sizes: readonly number[];
     readonly totalSize: number;
     readonly virtualItems: readonly MeasuredVirtualItem<T>[];
 }
@@ -465,6 +485,7 @@ export function MeasuredVirtualList<T>({
     getItemMeasurementKey,
     getItemIdentityKey,
     measurementCacheKey,
+    geometryCacheSignature = null,
     onRangeChange,
     onReady,
     preserveScrollAnchorOnItemsChange = false,
@@ -483,11 +504,15 @@ export function MeasuredVirtualList<T>({
             ? getCachedMeasurements(measurementCacheKey)
             : null;
     }
+    const initialMeasuredSizesRef = useRef(
+        new Map(initialMeasurementsRef.current?.measuredSizes),
+    );
     const [measuredSizes, setMeasuredSizes] = useState<Map<string, number>>(
-        () => new Map(initialMeasurementsRef.current?.measuredSizes),
+        initialMeasuredSizesRef.current,
     );
     const measuredSizesRef = useRef(measuredSizes);
     const [scrollState, setScrollState] = useState(() => ({
+        overscan,
         scrollTop: 0,
         viewportHeight: isBrowser
             ? defaultViewportHeight
@@ -510,6 +535,7 @@ export function MeasuredVirtualList<T>({
     const previousItemKeysRef = useRef<readonly string[] | null>(null);
     const resizeObserverRef = useRef<ResizeObserver | null>(null);
     const previousRangeRef = useRef<MeasuredVirtualRange | null>(null);
+    const previousScrollTopRef = useRef(0);
     const shouldPreserveScrollAnchorOnMeasureRef = useRef(
         shouldPreserveScrollAnchorOnMeasure,
     );
@@ -520,18 +546,36 @@ export function MeasuredVirtualList<T>({
         shouldPreserveScrollAnchorOnMeasure;
     shouldPreserveScrollAnchorOnItemsChangeRef.current =
         shouldPreserveScrollAnchorOnItemsChange;
+    const cachedGeometry = useMemo(() => {
+        const geometry = initialMeasurementsRef.current?.geometry ?? null;
+        if (!geometry || geometry.items !== items) {
+            return null;
+        }
+        if (
+            geometryCacheSignature !== null &&
+            geometry.signature !== geometryCacheSignature
+        ) {
+            return null;
+        }
+        return geometry;
+    }, [geometryCacheSignature, items]);
     const itemKeys = useMemo(
-        () => items.map((item, index) => getItemKey(item, index)),
-        [getItemKey, items],
+        () =>
+            cachedGeometry
+                ? cachedGeometry.itemKeys
+                : items.map((item, index) => getItemKey(item, index)),
+        [cachedGeometry, getItemKey, items],
     );
     const itemMeasurementKeys = useMemo(
         () =>
-            items.map((item, index) =>
-                getItemMeasurementKey
-                    ? getItemMeasurementKey(item, index)
-                    : itemKeys[index],
-            ),
-        [getItemMeasurementKey, itemKeys, items],
+            cachedGeometry
+                ? cachedGeometry.itemMeasurementKeys
+                : items.map((item, index) =>
+                      getItemMeasurementKey
+                          ? getItemMeasurementKey(item, index)
+                          : itemKeys[index],
+                  ),
+        [cachedGeometry, getItemMeasurementKey, itemKeys, items],
     );
     const itemIndexByMeasurementKey = useMemo(() => {
         const next = new Map<string, number>();
@@ -544,12 +588,14 @@ export function MeasuredVirtualList<T>({
     }, [itemMeasurementKeys]);
     const itemIdentityKeys = useMemo(
         () =>
-            items.map((item, index) =>
-                getItemIdentityKey
-                    ? getItemIdentityKey(item, index)
-                    : itemMeasurementKeys[index],
-            ),
-        [getItemIdentityKey, itemMeasurementKeys, items],
+            cachedGeometry
+                ? cachedGeometry.itemIdentityKeys
+                : items.map((item, index) =>
+                      getItemIdentityKey
+                          ? getItemIdentityKey(item, index)
+                          : itemMeasurementKeys[index],
+                  ),
+        [cachedGeometry, getItemIdentityKey, itemMeasurementKeys, items],
     );
     // Live list-key -> measurement-key map. The row ref is keyed by the stable
     // list key, so a measurement must resolve the row's CURRENT measurement key
@@ -570,6 +616,7 @@ export function MeasuredVirtualList<T>({
     const measuredByIdentityRef = useRef(
         new Map(initialMeasurementsRef.current?.measuredByIdentity),
     );
+    const geometryRef = useRef<CachedGeometry | null>(null);
     const virtualizationEnabled = enabled && isBrowser;
 
     // Keep the latest values in refs so updateMeasuredSize — and therefore the
@@ -605,6 +652,7 @@ export function MeasuredVirtualList<T>({
         return () => {
             cacheCurrentMeasurements(
                 measurementCacheKey,
+                geometryRef.current,
                 measuredSizesRef,
                 measuredByIdentityRef,
             );
@@ -803,9 +851,19 @@ export function MeasuredVirtualList<T>({
         const syncScrollState = () => {
             const nextScrollTop = container.scrollTop;
             const nextViewportHeight = container.clientHeight;
+            const scrollDelta = Math.abs(
+                nextScrollTop - previousScrollTopRef.current,
+            );
+            previousScrollTopRef.current = nextScrollTop;
+            const dynamicOverscan = Math.min(
+                MAX_DYNAMIC_OVERSCAN_ROWS,
+                overscan +
+                    Math.ceil(scrollDelta / SCROLL_OVERSCAN_ROW_HEIGHT_PX),
+            );
 
             setScrollState((current) => {
                 if (
+                    current.overscan === dynamicOverscan &&
                     current.scrollTop === nextScrollTop &&
                     current.viewportHeight === nextViewportHeight
                 ) {
@@ -813,6 +871,7 @@ export function MeasuredVirtualList<T>({
                 }
 
                 return {
+                    overscan: dynamicOverscan,
                     scrollTop: nextScrollTop,
                     viewportHeight: nextViewportHeight,
                 };
@@ -837,7 +896,7 @@ export function MeasuredVirtualList<T>({
             container.removeEventListener("scroll", syncScrollState);
             observer?.disconnect();
         };
-    }, [scrollContainerRef, virtualizationEnabled]);
+    }, [overscan, scrollContainerRef, virtualizationEnabled]);
 
     // Resolve a row's height: an exact measurement wins; otherwise the row's
     // last measurement under its width-invariant identity (so a resize doesn't
@@ -869,19 +928,30 @@ export function MeasuredVirtualList<T>({
     );
 
     const layout = useMemo((): LayoutSnapshot<T> => {
-        const sizes = items.map((_item, index) => resolveItemSize(index));
-        const offsets = new Array<number>(items.length);
-        let totalSize = 0;
+        const canReuseBaseGeometry =
+            cachedGeometry !== null &&
+            measuredSizes === initialMeasuredSizesRef.current;
+        const sizes = canReuseBaseGeometry
+            ? cachedGeometry.sizes
+            : items.map((_item, index) => resolveItemSize(index));
+        let offsets: readonly number[];
+        let totalSize = canReuseBaseGeometry ? cachedGeometry.totalSize : 0;
 
-        for (let index = 0; index < items.length; index += 1) {
-            offsets[index] = totalSize;
-            totalSize += sizes[index];
+        if (canReuseBaseGeometry) {
+            offsets = cachedGeometry.offsets;
+        } else {
+            const nextOffsets = new Array<number>(items.length);
+            for (let index = 0; index < items.length; index += 1) {
+                nextOffsets[index] = totalSize;
+                totalSize += sizes[index];
+            }
+            offsets = nextOffsets;
         }
 
         const range = calculateMeasuredVirtualRange({
             itemCount: items.length,
             offsets,
-            overscan,
+            overscan: scrollState.overscan,
             scrollMarginTop: normalizedScrollMarginTop,
             scrollTop: scrollState.scrollTop,
             sizes,
@@ -891,7 +961,9 @@ export function MeasuredVirtualList<T>({
 
         if (items.length === 0) {
             return {
+                offsets,
                 range,
+                sizes,
                 totalSize,
                 virtualItems: [],
             };
@@ -899,7 +971,9 @@ export function MeasuredVirtualList<T>({
 
         if (!virtualizationEnabled) {
             return {
+                offsets,
                 range,
+                sizes,
                 totalSize,
                 virtualItems: items.map((item, index) => ({
                     index,
@@ -934,21 +1008,39 @@ export function MeasuredVirtualList<T>({
         }
 
         return {
+            offsets,
             range,
+            sizes,
             totalSize,
             virtualItems,
         };
     }, [
+        cachedGeometry,
         itemMeasurementKeys,
         itemKeys,
         items,
+        measuredSizes,
         normalizedScrollMarginTop,
-        overscan,
         resolveItemSize,
         scrollState.scrollTop,
+        scrollState.overscan,
         scrollState.viewportHeight,
         virtualizationEnabled,
     ]);
+
+    geometryRef.current =
+        geometryCacheSignature === null
+            ? null
+            : {
+                  itemIdentityKeys,
+                  itemKeys,
+                  itemMeasurementKeys,
+                  items,
+                  offsets: layout.offsets,
+                  signature: geometryCacheSignature,
+                  sizes: layout.sizes,
+                  totalSize: layout.totalSize,
+              };
 
     layoutRangeRef.current = layout.range;
 

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -11,6 +11,60 @@ import {
 
 const DEFAULT_OVERSCAN = 4;
 const DEFAULT_VIEWPORT_HEIGHT = 720;
+const MAX_CACHED_MEASUREMENT_SETS = 12;
+
+interface CachedMeasurements {
+    readonly measuredByIdentity: ReadonlyMap<string, number>;
+    readonly measuredSizes: ReadonlyMap<string, number>;
+}
+
+const cachedMeasurementsByKey = new Map<string, CachedMeasurements>();
+
+function getCachedMeasurements(cacheKey: string): CachedMeasurements | null {
+    const cached = cachedMeasurementsByKey.get(cacheKey) ?? null;
+    if (!cached) {
+        return null;
+    }
+
+    cachedMeasurementsByKey.delete(cacheKey);
+    cachedMeasurementsByKey.set(cacheKey, cached);
+    return cached;
+}
+
+function cacheMeasurements(
+    cacheKey: string,
+    measurements: CachedMeasurements,
+): void {
+    cachedMeasurementsByKey.delete(cacheKey);
+    cachedMeasurementsByKey.set(cacheKey, measurements);
+
+    while (cachedMeasurementsByKey.size > MAX_CACHED_MEASUREMENT_SETS) {
+        const oldestKey = cachedMeasurementsByKey.keys().next().value;
+        if (!oldestKey) {
+            return;
+        }
+        cachedMeasurementsByKey.delete(oldestKey);
+    }
+}
+
+function cacheCurrentMeasurements(
+    cacheKey: string,
+    measuredSizesRef: Readonly<{
+        readonly current: ReadonlyMap<string, number>;
+    }>,
+    measuredByIdentityRef: Readonly<{
+        readonly current: ReadonlyMap<string, number>;
+    }>,
+): void {
+    cacheMeasurements(cacheKey, {
+        measuredByIdentity: new Map(measuredByIdentityRef.current),
+        measuredSizes: new Map(measuredSizesRef.current),
+    });
+}
+
+export function resetMeasuredVirtualListMeasurementsForTests(): void {
+    cachedMeasurementsByKey.clear();
+}
 
 export interface MeasuredVirtualRange {
     readonly startIndex: number;
@@ -56,6 +110,11 @@ export interface MeasuredVirtualListProps<T> {
      * to estimateSize. Defaults to the measurement key (no carry-over).
      */
     readonly getItemIdentityKey?: (item: T, index: number) => string;
+    /**
+     * Keeps measurements across an unmount/remount of the same list. Item keys
+     * still validate each entry, so stale rows are ignored after a change.
+     */
+    readonly measurementCacheKey?: string;
     readonly onRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onReady?: (handle: MeasuredVirtualListHandle | null) => void;
     readonly preserveScrollAnchorOnItemsChange?: boolean;
@@ -405,6 +464,7 @@ export function MeasuredVirtualList<T>({
     getItemKey,
     getItemMeasurementKey,
     getItemIdentityKey,
+    measurementCacheKey,
     onRangeChange,
     onReady,
     preserveScrollAnchorOnItemsChange = false,
@@ -415,8 +475,16 @@ export function MeasuredVirtualList<T>({
 }: MeasuredVirtualListProps<T>) {
     const isBrowser = typeof window !== "undefined";
     const normalizedScrollMarginTop = Math.max(0, scrollMarginTop);
+    const initialMeasurementsRef = useRef<
+        CachedMeasurements | null | undefined
+    >(undefined);
+    if (initialMeasurementsRef.current === undefined) {
+        initialMeasurementsRef.current = measurementCacheKey
+            ? getCachedMeasurements(measurementCacheKey)
+            : null;
+    }
     const [measuredSizes, setMeasuredSizes] = useState<Map<string, number>>(
-        () => new Map(),
+        () => new Map(initialMeasurementsRef.current?.measuredSizes),
     );
     const measuredSizesRef = useRef(measuredSizes);
     const [scrollState, setScrollState] = useState(() => ({
@@ -499,7 +567,9 @@ export function MeasuredVirtualList<T>({
     // the element maps below) and read during layout to bridge a row's height
     // across a measurement-key churn; pruned to the live identities alongside
     // measuredSizes so it stays bounded.
-    const measuredByIdentityRef = useRef(new Map<string, number>());
+    const measuredByIdentityRef = useRef(
+        new Map(initialMeasurementsRef.current?.measuredByIdentity),
+    );
     const virtualizationEnabled = enabled && isBrowser;
 
     // Keep the latest values in refs so updateMeasuredSize — and therefore the
@@ -526,6 +596,20 @@ export function MeasuredVirtualList<T>({
     itemIndexByMeasurementKeyRef.current = itemIndexByMeasurementKey;
     itemIdentityKeysRef.current = itemIdentityKeys;
     measurementKeyByListKeyRef.current = measurementKeyByListKey;
+
+    useEffect(() => {
+        if (!measurementCacheKey) {
+            return;
+        }
+
+        return () => {
+            cacheCurrentMeasurements(
+                measurementCacheKey,
+                measuredSizesRef,
+                measuredByIdentityRef,
+            );
+        };
+    }, [measurementCacheKey]);
 
     const shouldPreserveScrollAnchorOnMeasureNow = useCallback(() => {
         return (

--- a/src/renderer/src/components/workspace/AIChatAgentControls.test.tsx
+++ b/src/renderer/src/components/workspace/AIChatAgentControls.test.tsx
@@ -219,7 +219,7 @@ describe("AIChatAgentControls", () => {
         );
     });
 
-    it("expands GPT-5.6 variants and shows the selected variant label", () => {
+    it("lists GPT-5.6 variants with their short labels", () => {
         const onConfigOptionChange = vi.fn();
         const { container } = mountControls({
             configOptions: GPT_5_6_MODEL_CONFIG_OPTIONS,
@@ -229,16 +229,10 @@ describe("AIChatAgentControls", () => {
 
         const modelButton = getButtonByTitle(container, "Model");
         expect(modelButton.textContent).toContain("Terra");
-        expect(modelButton.textContent).not.toContain("GPT 5.6");
-
         click(modelButton);
-        const groupButton = getButtonByText(document.body, "GPT 5.6");
-        expect(groupButton.getAttribute("aria-expanded")).toBe("false");
-        expect(() => getButtonByText(document.body, "Sol")).toThrow();
-
-        click(groupButton);
-        expect(groupButton.getAttribute("aria-expanded")).toBe("true");
-
+        expect(document.body.textContent).not.toContain("GPT 5.6");
+        expect(document.body.textContent).not.toContain("Other models");
+        expect(getButtonByText(document.body, "Terra")).toBeTruthy();
         click(getButtonByText(document.body, "Sol"));
         expect(onConfigOptionChange).toHaveBeenCalledWith(
             "model",

--- a/src/renderer/src/components/workspace/AIChatAgentControls.tsx
+++ b/src/renderer/src/components/workspace/AIChatAgentControls.tsx
@@ -64,8 +64,6 @@ interface DropdownMenuPosition {
     readonly y: number;
 }
 
-const GPT_5_6_MODEL_GROUP = "GPT 5.6";
-
 function formatFallbackLabel(value: string): string {
     if (value.trim().includes(" ")) {
         return value;
@@ -622,10 +620,11 @@ function getModeConfigOption(
 
 function mapConfigOption(
     option: Extract<AiSessionConfigOption, { type: "select" }>,
+    includeGroupLabels = true,
 ) {
     return option.options.map((item) => ({
         description: item.description,
-        groupLabel: item.groupLabel,
+        groupLabel: includeGroupLabels ? item.groupLabel : null,
         label: formatFallbackLabel(item.label),
         value: item.value,
     }));
@@ -701,7 +700,7 @@ export function AIChatAgentControls({
               }));
     const visibleModels =
         modelConfig?.type === "select"
-            ? mapConfigOption(modelConfig)
+            ? mapConfigOption(modelConfig, false)
             : models.map((model) => ({
                   description: model.description,
                   label: formatFallbackLabel(model.name),
@@ -740,7 +739,6 @@ export function AIChatAgentControls({
 
             {visibleModels.length > 0 ? (
                 <DropdownField
-                    collapsibleGroupLabels={[GPT_5_6_MODEL_GROUP]}
                     disabled={disabled}
                     emptySearchMessage={`No ${runtimeId} models match that search.`}
                     label="Model"

--- a/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
@@ -50,6 +50,7 @@ import { PlanMessage } from "./chat/PlanMessage";
 import { ToolActivitySegment } from "./chat/ToolActivitySegment";
 import { ToolActivityItem } from "./chat/ToolActivityItem";
 import { releaseScopedToolUiStateStore } from "./chat/toolExpansionStore";
+import { releaseCachedChatTimeline } from "./chat/chatTimelineCache";
 import {
     reconcileChatTimelineModel,
     type ChatTimelineRow,
@@ -842,6 +843,7 @@ export function ChatHistoryTabView({ tab }: ChatHistoryTabViewProps) {
 
                 await getComandoApi().deleteAiSession(session.sessionId);
                 releaseScopedToolUiStateStore(session.sessionId);
+                releaseCachedChatTimeline(session.sessionId);
 
                 for (const tabId of matchingTabIds) {
                     await closeTab(tabId);

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -71,6 +71,10 @@ import {
     type ChatTimelineRow,
 } from "./chat/chatTimelineModel";
 import {
+    cacheChatTimeline,
+    getCachedChatTimeline,
+} from "./chat/chatTimelineCache";
+import {
     isActiveChatTurnStatus,
     isChatStreamingStatus,
 } from "./chat/chatTurnStatus";
@@ -413,7 +417,10 @@ export const ChatTabView = memo(function ChatTabView({
     );
     const ensureLiveAgentSession = useCallback(async () => {
         const currentSession = useAiStore.getState().sessions[tab.sessionId] ?? null;
-        if (currentSession?.snapshot?.runtimeSessionId) {
+        if (
+            currentSession?.runtimeState === "live" &&
+            currentSession.snapshot?.runtimeSessionId
+        ) {
             return;
         }
         await ensureSession(liveSessionTab, { force: true });
@@ -449,7 +456,9 @@ export const ChatTabView = memo(function ChatTabView({
     }, [sessionTab]);
 
     useEffect(() => {
-        void ensureSession(latestSessionTabRef.current);
+        if (latestSessionTabRef.current.sessionOpenMode === "history") {
+            void ensureSession(latestSessionTabRef.current);
+        }
     }, [ensureSession, sessionPreparationKey]);
 
     const snapshot =
@@ -806,6 +815,18 @@ export const ChatTabView = memo(function ChatTabView({
         return toolCallIds;
     }, [pendingPermission?.toolCallId, pendingUserInput?.toolCallId]);
     const timelineModel = useMemo(() => {
+        const cachedTimeline = getCachedChatTimeline({
+            activeTurnStartedAt,
+            attentionToolCallIds,
+            sessionId: tab.sessionId,
+            status: snapshot.status,
+            trackedFiles: canonicalTrackedFiles,
+            transcript,
+        });
+        if (cachedTimeline) {
+            return cachedTimeline;
+        }
+
         const previousTimelineState = stableTimelineRef.current;
         const previousTimelineModel =
             previousTimelineState.sessionId === tab.sessionId
@@ -834,7 +855,24 @@ export const ChatTabView = memo(function ChatTabView({
             model: timelineModel,
             sessionId: tab.sessionId,
         };
-    }, [timelineModel, tab.sessionId]);
+        cacheChatTimeline({
+            activeTurnStartedAt,
+            attentionToolCallIds,
+            model: timelineModel,
+            sessionId: tab.sessionId,
+            status: snapshot.status,
+            trackedFiles: canonicalTrackedFiles,
+            transcript,
+        });
+    }, [
+        activeTurnStartedAt,
+        attentionToolCallIds,
+        canonicalTrackedFiles,
+        snapshot.status,
+        tab.sessionId,
+        timelineModel,
+        transcript,
+    ]);
     const persistedViewState = useMemo(
         () =>
             readPersistedChatViewState(

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -2485,6 +2485,7 @@ const ChatTimeline = memo(function ChatTimeline({
                             projectId={projectId}
                             resolveFileReference={resolveFileReference}
                             scrollRef={scrollRef}
+                            sessionId={sessionId}
                             shouldPreserveVirtualMeasureAnchor={
                                 shouldPreserveVirtualMeasureAnchor
                             }
@@ -2609,6 +2610,7 @@ type ChatTimelineHistoryProps = {
         reference: string,
     ) => ResolvedProjectFileReference | null;
     readonly scrollRef: RefObject<HTMLDivElement | null>;
+    readonly sessionId: string;
     readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
     readonly worktreeId: string | null;
@@ -2632,6 +2634,7 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
     projectId,
     resolveFileReference,
     scrollRef,
+    sessionId,
     shouldPreserveVirtualMeasureAnchor,
     shouldPreserveVirtualResizeAnchor,
     worktreeId,
@@ -2684,6 +2687,7 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
             onVirtualResizeStart={onVirtualResizeStart}
             renderRow={renderRow}
             scrollRef={scrollRef}
+            sessionId={sessionId}
             shouldPreserveVirtualMeasureAnchor={
                 shouldPreserveVirtualMeasureAnchor
             }

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -415,9 +415,10 @@ export const ChatTabView = memo(function ChatTabView({
         }),
         [sessionTab],
     );
-    const ensureLiveAgentSession = useCallback(async () => {
+    const ensureLiveAgentSession = useCallback(async (force = false) => {
         const currentSession = useAiStore.getState().sessions[tab.sessionId] ?? null;
         if (
+            !force &&
             currentSession?.runtimeState === "live" &&
             currentSession.snapshot?.runtimeSessionId
         ) {
@@ -434,7 +435,10 @@ export const ChatTabView = memo(function ChatTabView({
                     await mutation();
                     return;
                 } catch (error) {
-                    await ensureLiveAgentSession();
+                    // The renderer can retain a live snapshot after the ACP
+                    // runtime has dropped its remote session. Force a real
+                    // prepare before retrying instead of repeating the stale RPC.
+                    await ensureLiveAgentSession(true);
                     await mutation();
                     console.warn(
                         "[comando] Recovered AI session control update after live session prepare.",

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -123,6 +123,7 @@ import {
 /* ─── Types ─── */
 
 interface ChatTabViewProps {
+    readonly active: boolean;
     readonly onDraftChange: (tabId: string, draft: string) => void;
     readonly onOpenFile: (
         projectId: string,
@@ -174,6 +175,7 @@ type AiRuntimeCatalog = Pick<
 /* ─── Main component ─── */
 
 export const ChatTabView = memo(function ChatTabView({
+    active,
     onDraftChange,
     onOpenFile,
     onOpenImage,
@@ -274,6 +276,7 @@ export const ChatTabView = memo(function ChatTabView({
     const scrollPersistTimerRef = useRef<number | null>(null);
     const pendingPersistedScrollTopRef = useRef<number | null>(null);
     const pendingPersistedNearBottomRef = useRef<boolean | null>(null);
+    const hasActivatedViewRef = useRef(false);
     const stableTimelineRef = useRef<{
         readonly model: ChatTimelineModel | null;
         readonly sessionId: string;
@@ -457,10 +460,13 @@ export const ChatTabView = memo(function ChatTabView({
     }, [sessionTab]);
 
     useEffect(() => {
-        if (latestSessionTabRef.current.sessionOpenMode === "history") {
+        if (
+            active &&
+            latestSessionTabRef.current.sessionOpenMode === "history"
+        ) {
             void ensureSession(latestSessionTabRef.current);
         }
-    }, [ensureSession, sessionPreparationKey]);
+    }, [active, ensureSession, sessionPreparationKey]);
 
     const snapshot =
         sessionState?.snapshot ?? createEmptySnapshot(tab, runtimeCatalog);
@@ -759,7 +765,7 @@ export const ChatTabView = memo(function ChatTabView({
         pendingReviewCount > 0;
 
     useEffect(() => {
-        if (activeTurnKey === null || activeTurnStartedAt === null) {
+        if (!active || activeTurnKey === null || activeTurnStartedAt === null) {
             streamStartTimeRef.current = null;
             let cancelled = false;
             queueMicrotask(() => {
@@ -802,7 +808,7 @@ export const ChatTabView = memo(function ChatTabView({
             cancelled = true;
             window.clearInterval(interval);
         };
-    }, [activeTurnKey, activeTurnStartedAt]);
+    }, [active, activeTurnKey, activeTurnStartedAt]);
 
     /* eslint-disable react-hooks/refs -- The timeline reconciler needs the last committed model to preserve row identity during render. */
     const attentionToolCallIds = useMemo(() => {
@@ -883,6 +889,14 @@ export const ChatTabView = memo(function ChatTabView({
             ),
         [tab.projectId, tab.sessionId, tab.worktreeId],
     );
+    const persistedViewStateRef = useRef<{
+        readonly isNearBottom: boolean;
+        readonly scrollTop: number;
+    } | null>(persistedViewState);
+
+    useEffect(() => {
+        persistedViewStateRef.current = persistedViewState;
+    }, [persistedViewState]);
 
     useRenderProbe("ChatTabView", {
         composerPartCount: composerParts.length,
@@ -1012,16 +1026,24 @@ export const ChatTabView = memo(function ChatTabView({
             readonly scrollTop?: number;
         }) => {
             const scrollEl = scrollRef.current;
+            const previousViewState = persistedViewStateRef.current;
             const scrollTop =
                 overrides?.scrollTop ??
                 scrollEl?.scrollTop ??
-                persistedViewState?.scrollTop ??
+                previousViewState?.scrollTop ??
                 0;
             const nextIsNearBottom =
                 overrides?.isNearBottom ??
                 (scrollEl
                     ? isNearBottom(scrollEl)
-                    : persistedViewState?.isNearBottom ?? true);
+                    : previousViewState?.isNearBottom ?? true);
+
+            // Retained chat views do not remount between tab switches, so keep
+            // the latest persisted position in memory for the next activation.
+            persistedViewStateRef.current = {
+                isNearBottom: nextIsNearBottom,
+                scrollTop,
+            };
 
             persistChatViewState(
                 tab.projectId,
@@ -1035,8 +1057,6 @@ export const ChatTabView = memo(function ChatTabView({
         },
         [
             isNearBottom,
-            persistedViewState?.isNearBottom,
-            persistedViewState?.scrollTop,
             tab.projectId,
             tab.sessionId,
             tab.worktreeId,
@@ -1202,6 +1222,10 @@ export const ChatTabView = memo(function ChatTabView({
     ]);
 
     useLayoutEffect(() => {
+        if (!active) {
+            return;
+        }
+
         let cancelled = false;
         const setJumpToBottomVisibility = (visible: boolean) => {
             queueMicrotask(() => {
@@ -1211,8 +1235,9 @@ export const ChatTabView = memo(function ChatTabView({
             });
         };
         const scrollEl = scrollRef.current;
-        const restoreScrollTop = persistedViewState?.scrollTop ?? 0;
-        const shouldRestoreBottom = persistedViewState?.isNearBottom ?? true;
+        const restoreScrollTop = persistedViewStateRef.current?.scrollTop ?? 0;
+        const shouldRestoreBottom =
+            persistedViewStateRef.current?.isNearBottom ?? true;
 
         if (!scrollEl) {
             shouldAutoFollowRef.current = shouldRestoreBottom;
@@ -1220,6 +1245,35 @@ export const ChatTabView = memo(function ChatTabView({
             return () => {
                 cancelled = true;
             };
+        }
+
+        const wasPreviouslyActivated = hasActivatedViewRef.current;
+        hasActivatedViewRef.current = true;
+
+        const persistViewStateOnDeactivate = () => {
+            cancelled = true;
+            cancelPendingScrollToBottom();
+            cancelBottomFollowSettle();
+            if (restoreScrollFrameRef.current !== null) {
+                window.cancelAnimationFrame(restoreScrollFrameRef.current);
+                restoreScrollFrameRef.current = null;
+            }
+            const flushedState = flushScheduledScrollPersist();
+            persistCurrentViewState(
+                resolveChatScrollPersistenceState({
+                    currentScrollTop: scrollEl.scrollTop,
+                    pendingIsNearBottom: flushedState?.isNearBottom ?? null,
+                    pendingScrollTop: flushedState?.scrollTop ?? null,
+                    restoreScrollTop,
+                    shouldAutoFollow: shouldAutoFollowRef.current,
+                }),
+            );
+        };
+
+        // A retained view already owns the correct DOM scroll position. Avoid
+        // forcing layout and scheduling follow-up frames on every tab switch.
+        if (wasPreviouslyActivated) {
+            return persistViewStateOnDeactivate;
         }
 
         if (shouldRestoreBottom) {
@@ -1252,48 +1306,34 @@ export const ChatTabView = memo(function ChatTabView({
             setJumpToBottomVisibility(!isNearBottom(nextScrollEl));
         });
 
-        return () => {
-            cancelled = true;
-            cancelPendingScrollToBottom();
-            cancelBottomFollowSettle();
-            if (restoreScrollFrameRef.current !== null) {
-                window.cancelAnimationFrame(restoreScrollFrameRef.current);
-                restoreScrollFrameRef.current = null;
-            }
-            const flushedState = flushScheduledScrollPersist();
-            persistCurrentViewState(
-                resolveChatScrollPersistenceState({
-                    currentScrollTop: scrollEl.scrollTop,
-                    pendingIsNearBottom: flushedState?.isNearBottom ?? null,
-                    pendingScrollTop: flushedState?.scrollTop ?? null,
-                    restoreScrollTop,
-                    shouldAutoFollow: shouldAutoFollowRef.current,
-                }),
-            );
-        };
+        return persistViewStateOnDeactivate;
     }, [
         cancelBottomFollowSettle,
         cancelPendingScrollToBottom,
         flushScheduledScrollPersist,
         isNearBottom,
         persistCurrentViewState,
-        persistedViewState?.isNearBottom,
-        persistedViewState?.scrollTop,
         scheduleScrollToBottom,
         scrollToBottom,
+        active,
         tab.sessionId,
     ]);
 
     useLayoutEffect(() => {
-        if (shouldAutoFollowRef.current) {
+        if (active && shouldAutoFollowRef.current) {
             scheduleScrollToBottom();
         }
-    }, [scheduleScrollToBottom, snapshot.updatedAt]);
+    }, [active, scheduleScrollToBottom, snapshot.updatedAt]);
 
     useEffect(() => {
         const scrollEl = scrollRef.current;
         const contentEl = timelineContentRef.current;
-        if (!scrollEl || !contentEl || typeof ResizeObserver === "undefined") {
+        if (
+            !active ||
+            !scrollEl ||
+            !contentEl ||
+            typeof ResizeObserver === "undefined"
+        ) {
             return;
         }
 
@@ -1309,7 +1349,7 @@ export const ChatTabView = memo(function ChatTabView({
         return () => {
             observer.disconnect();
         };
-    }, [scheduleScrollToBottom, tab.sessionId]);
+    }, [active, scheduleScrollToBottom, tab.sessionId]);
 
     const handleScroll = useCallback(() => {
         const el = scrollRef.current;
@@ -1763,8 +1803,10 @@ export const ChatTabView = memo(function ChatTabView({
     );
 
     const handleChatFocus = useCallback(() => {
-        markChatTabFocused(tab.id);
-    }, [markChatTabFocused, tab.id]);
+        if (active) {
+            markChatTabFocused(tab.id);
+        }
+    }, [active, markChatTabFocused, tab.id]);
 
     return (
         <div
@@ -1873,6 +1915,7 @@ export const ChatTabView = memo(function ChatTabView({
                 ) : null}
 
                 <ChatTimeline
+                    active={active}
                     canRenderFileReference={canRenderFileReference}
                     chatFontFamily={chatFontFamily}
                     chatFontSize={aiChatSettings.chatFontSize}
@@ -2349,6 +2392,7 @@ function ImageAttachmentChip(props: {
 }
 
 type ChatTimelineProps = {
+    readonly active: boolean;
     readonly canRenderFileReference?: (
         rawReference: string,
         reference: ResolvedProjectFileReference,
@@ -2398,7 +2442,24 @@ type ChatTimelineProps = {
     readonly worktreeId: string | null;
 };
 
+function areChatTimelinePropsEqual(
+    previous: Readonly<ChatTimelineProps>,
+    next: Readonly<ChatTimelineProps>,
+): boolean {
+    // Hidden warm views should retain their last committed DOM until they are
+    // activated again. The next active render receives the latest timeline.
+    if (!previous.active && !next.active) {
+        return true;
+    }
+
+    const previousEntries = Object.entries(previous) as Array<
+        [keyof ChatTimelineProps, ChatTimelineProps[keyof ChatTimelineProps]]
+    >;
+    return previousEntries.every(([key, value]) => Object.is(value, next[key]));
+}
+
 const ChatTimeline = memo(function ChatTimeline({
+    active,
     canRenderFileReference,
     chatFontFamily,
     chatFontSize,
@@ -2431,6 +2492,7 @@ const ChatTimeline = memo(function ChatTimeline({
     worktreeId,
 }: ChatTimelineProps) {
     useRenderProbe("ChatTimeline", {
+        active,
         historyRows: historyRows.length,
         isStreaming,
         rows: historyRows.length + (liveTailRow ? 1 : 0),
@@ -2528,7 +2590,7 @@ const ChatTimeline = memo(function ChatTimeline({
             </div>
         </ToolExpansionStoreProvider>
     );
-});
+}, areChatTimelinePropsEqual);
 
 ChatTimeline.displayName = "ChatTimeline";
 

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -429,15 +429,12 @@ export const ChatTabView = memo(function ChatTabView({
     const runAgentControlMutation = useCallback(
         (mutation: () => Promise<void>) => {
             void (async () => {
-                await ensureLiveAgentSession();
-
                 try {
                     await mutation();
                     return;
                 } catch (error) {
-                    // The renderer can retain a live snapshot after the ACP
-                    // runtime has dropped its remote session. Force a real
-                    // prepare before retrying instead of repeating the stale RPC.
+                    // A live snapshot can outlast its remote session. Recreate it
+                    // only after a mutation fails, then retry the stale RPC once.
                     await ensureLiveAgentSession(true);
                     await mutation();
                     console.warn(

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -245,6 +245,7 @@ const CLAUDE_CODE_TERMINAL_DESCRIPTION =
 const CLAUDE_CODE_NOT_FOUND_MESSAGE =
     "The claude command was not found in Comando's PATH. Your shell may still resolve it.";
 const GIT_GUTTER_LIVE_DIFF_DEBOUNCE_MS = 200;
+const MAX_RETAINED_CHAT_TAB_VIEWS = 4;
 
 type GitGutterLiveDiffState =
     | {
@@ -1732,6 +1733,28 @@ function WorkspacePaneView({
         ? (paneTabs.find((tab) => tab.id === paneActiveTabId) ?? null)
         : null;
     const activeChatTab = activeTab?.kind === "chat" ? activeTab : null;
+    const [retainedChatTabIds, setRetainedChatTabIds] = useState<
+        readonly string[]
+    >(() => (activeChatTab ? [activeChatTab.id] : []));
+    const retainChatTab = useCallback((tabId: string) => {
+        const tab = useWorkspaceStore.getState().tabsById[tabId];
+        if (tab?.kind !== "chat") {
+            return;
+        }
+
+        setRetainedChatTabIds((currentIds) => {
+            if (currentIds.at(-1) === tabId) {
+                return currentIds;
+            }
+
+            // Keep recently visited chats warm without retaining an unbounded
+            // number of full transcript trees in a pane.
+            return [
+                ...currentIds.filter((currentTabId) => currentTabId !== tabId),
+                tabId,
+            ].slice(-MAX_RETAINED_CHAT_TAB_VIEWS);
+        });
+    }, []);
     const activeFileTab = activeTab?.kind === "file" ? activeTab : null;
     const paneFileTabs = useMemo(
         () =>
@@ -1744,6 +1767,55 @@ function WorkspacePaneView({
         (state) => state.recentActiveTabIds,
     );
     const isActivePane = activePaneId === paneNodeId;
+
+    useEffect(() => {
+        const activeChatTabId = activeChatTab?.id;
+        if (!activeChatTabId) {
+            return;
+        }
+
+        let cancelled = false;
+        queueMicrotask(() => {
+            if (!cancelled) {
+                retainChatTab(activeChatTabId);
+            }
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [activeChatTab?.id, retainChatTab]);
+
+    const retainedChatTabs = useMemo(
+        () =>
+            paneTabs.filter(
+                (tab): tab is RuntimeWorkspaceChatTab =>
+                    tab.kind === "chat" &&
+                    (retainedChatTabIds.includes(tab.id) ||
+                        tab.id === activeChatTab?.id),
+            ),
+        [activeChatTab?.id, paneTabs, retainedChatTabIds],
+    );
+    const handleSelectTab = useCallback(
+        (tabId: string) => {
+            retainChatTab(tabId);
+            void selectTab(paneNodeId, tabId);
+        },
+        [paneNodeId, retainChatTab, selectTab],
+    );
+    const handleSelectAdjacentTab = useCallback(
+        async (direction: "next" | "previous") => {
+            await selectAdjacentTab(paneNodeId, direction);
+            const nextPane = findWorkspaceNodeById(
+                useWorkspaceStore.getState().rootNode,
+                paneNodeId,
+            );
+            if (nextPane?.type === "pane" && nextPane.activeTabId) {
+                retainChatTab(nextPane.activeTabId);
+            }
+        },
+        [paneNodeId, retainChatTab, selectAdjacentTab],
+    );
     const activeTabWorktreeId = activeTab?.worktreeId ?? null;
     const activeChatSessionId = activeChatTab?.sessionId ?? null;
     const activeChatFallbackTitle = activeChatTab?.title ?? "Chat";
@@ -1916,7 +1988,7 @@ function WorkspacePaneView({
         event.preventDefault();
         event.stopPropagation();
         void setActivePane(paneNodeId);
-        void selectTab(paneNodeId, tabId);
+        handleSelectTab(tabId);
         setTabContextMenu({
             x: event.clientX,
             y: event.clientY,
@@ -2047,6 +2119,9 @@ function WorkspacePaneView({
                 const paneId = findPaneIdByTabId(candidateTabId) ?? paneNodeId;
 
                 await setActivePane(paneId);
+                if (paneId === paneNodeId) {
+                    retainChatTab(candidateTabId);
+                }
                 await selectTab(paneId, candidateTabId);
 
                 const targetTab =
@@ -2109,6 +2184,7 @@ function WorkspacePaneView({
             attachSelectionMention,
             createChatTab,
             paneNodeId,
+            retainChatTab,
             selectTab,
             setActivePane,
         ],
@@ -2297,7 +2373,7 @@ function WorkspacePaneView({
         openChatHistoryTab,
         openGitTab,
         paneNodeId,
-        selectAdjacentTab,
+        selectAdjacentTab: handleSelectAdjacentTab,
     });
     useEffect(() => {
         paneShortcutHandlersRef.current = {
@@ -2309,7 +2385,7 @@ function WorkspacePaneView({
             openChatHistoryTab,
             openGitTab,
             paneNodeId,
-            selectAdjacentTab,
+            selectAdjacentTab: handleSelectAdjacentTab,
         };
     }, [
         createTerminalTab,
@@ -2320,7 +2396,7 @@ function WorkspacePaneView({
         openChatHistoryTab,
         openGitTab,
         paneNodeId,
-        selectAdjacentTab,
+        handleSelectAdjacentTab,
     ]);
 
     useEffect(() => {
@@ -2376,7 +2452,6 @@ function WorkspacePaneView({
                 event.preventDefault();
                 event.stopPropagation();
                 void handlers.selectAdjacentTab(
-                    handlers.paneNodeId,
                     event.shiftKey ? "previous" : "next",
                 );
                 return;
@@ -2516,7 +2591,7 @@ function WorkspacePaneView({
                                                 return;
                                             }
 
-                                            void selectTab(paneNodeId, tab.id);
+                                            handleSelectTab(tab.id);
                                         }}
                                         onContextMenu={(event) =>
                                             handleTabContextMenu(event, tab.id)
@@ -2653,6 +2728,33 @@ function WorkspacePaneView({
                         onSave={saveFileTab}
                         recentActiveTabIds={recentActiveTabIds}
                     />
+                    {retainedChatTabs.map((tab) => {
+                        const isActiveChat = tab.id === activeTab?.id;
+
+                        return (
+                            <div
+                                aria-hidden={!isActiveChat}
+                                className={
+                                    isActiveChat
+                                        ? "relative z-1 h-full"
+                                        : "pointer-events-none invisible absolute inset-0"
+                                }
+                                inert={!isActiveChat}
+                                key={tab.id}
+                            >
+                                <ChatTabView
+                                    active={isActiveChat}
+                                    onDraftChange={handleChatDraftChange}
+                                    onOpenFile={handleOpenWorkspaceFile}
+                                    onOpenImage={handleOpenChatImage}
+                                    onOpenReview={() =>
+                                        handleOpenChatReview(tab)
+                                    }
+                                    tab={tab}
+                                />
+                            </div>
+                        );
+                    })}
                     {activeTab ? (
                         activeTab.kind === "file" ? (
                             null
@@ -2677,18 +2779,7 @@ function WorkspacePaneView({
                             <GitHubPullRequestsTabView tab={activeTab} />
                         ) : activeTab.kind === "github_pull_request" ? (
                             <GitHubPullRequestTabView tab={activeTab} />
-                        ) : activeTab.kind === "terminal" ? null : (
-                            <ChatTabView
-                                key={activeTab.id}
-                                onDraftChange={handleChatDraftChange}
-                                onOpenFile={handleOpenWorkspaceFile}
-                                onOpenImage={handleOpenChatImage}
-                                onOpenReview={() =>
-                                    handleOpenChatReview(activeTab)
-                                }
-                                tab={activeTab}
-                            />
-                        )
+                        ) : null
                     ) : (
                         <WorkspacePaneEmptyState />
                     )}

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -448,6 +448,16 @@ export const ChatTimelineHistoryRows = memo(
                     getItemKey={getChatTimelineRowKey}
                     getItemIdentityKey={getItemIdentityKey}
                     getItemMeasurementKey={getItemMeasurementKey}
+                    geometryCacheSignature={
+                        contentMeasurementWidth > 0
+                            ? [
+                                  chatFontFamily ?? "default",
+                                  chatFontSize ?? "default",
+                                  toolActivityDefaultExpansion,
+                                  contentMeasurementWidth,
+                              ].join(":")
+                            : null
+                    }
                     items={historyRows}
                     measurementCacheKey={
                         sessionId ? `chat-timeline:${sessionId}` : undefined

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -42,6 +42,7 @@ interface ChatTimelineHistoryRowsProps {
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
     readonly historyRows: readonly ChatTimelineRow[];
+    readonly sessionId?: string;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onVirtualResizeEnd?: () => void;
     readonly onVirtualResizeAutoFollow?: () => void;
@@ -76,6 +77,7 @@ export const ChatTimelineHistoryRows = memo(
         chatFontFamily,
         chatFontSize,
         historyRows,
+        sessionId,
         onVirtualRangeChange,
         onVirtualResizeEnd,
         onVirtualResizeAutoFollow,
@@ -447,6 +449,9 @@ export const ChatTimelineHistoryRows = memo(
                     getItemIdentityKey={getItemIdentityKey}
                     getItemMeasurementKey={getItemMeasurementKey}
                     items={historyRows}
+                    measurementCacheKey={
+                        sessionId ? `chat-timeline:${sessionId}` : undefined
+                    }
                     onRangeChange={onVirtualRangeChange}
                     onReady={handleVirtualListReady}
                     overscan={CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN}

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
@@ -184,6 +184,23 @@ describe("ToolActivitySegment", () => {
         expect(markup).toContain("Worked · 1 action");
         expect(markup).toContain("git status --short");
         expect(markup).not.toContain("Latest:");
+        expect(markup).toContain('data-activity-rail-prefix="true"');
+    });
+
+    it("uses the same activity prefix for explored work", () => {
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivitySegment, {
+                ...DEFAULT_PROPS,
+                segment: createSegment([createEntry("read-1")], {
+                    commandCount: 0,
+                    fileCount: 1,
+                    searchCount: 0,
+                }),
+            }),
+        );
+
+        expect(markup).toContain("Explored 1 file");
+        expect(markup).toContain('data-activity-rail-prefix="true"');
     });
 
     it("uses the turn tail rather than stale tool state for the headline", () => {
@@ -466,7 +483,7 @@ describe("ToolActivitySegment", () => {
         const surfaces = Array.from(
             container.querySelectorAll<HTMLElement>("[data-tool-surface]"),
         ).map((member) => member.dataset.toolSurface);
-        expect(surfaces).toEqual(["rail-row", "rail-row", "rail-row"]);
+        expect(surfaces).toEqual(["rail-row", "card", "rail-row"]);
         const indents = Array.from(
             container.querySelectorAll<HTMLElement>(
                 "[data-activity-rail-indent]",
@@ -516,6 +533,33 @@ describe("ToolActivitySegment", () => {
         expect(
             container.querySelectorAll('[data-tool-surface="rail-row"]'),
         ).toHaveLength(3);
+    });
+
+    it("keeps changed files as individual review cards below Worked", () => {
+        const container = renderInteractive(
+            createSegment([
+                createEntry("read-1"),
+                createEntry("edit-2", "standalone-change", {
+                    kind: "edit",
+                    title: "Updated ChatTabView.tsx",
+                }),
+            ]),
+        );
+
+        act(() =>
+            container.querySelector<HTMLButtonElement>("button")?.click(),
+        );
+
+        expect(
+            container
+                .querySelector<HTMLElement>('[data-child-activity="edit-2"]')
+                ?.dataset.toolSurface,
+        ).toBe("card");
+        expect(
+            container
+                .querySelector<HTMLElement>('[data-child-activity="read-1"]')
+                ?.dataset.toolSurface,
+        ).toBe("rail-row");
     });
 
     it("hides important-only segments behind the same disclosure", () => {

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
@@ -151,14 +151,13 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
     const accessibleLabel = `${expanded ? "Hide" : "Show"} full activity: ${headline}.${accessibleChangeSummary} ${activityState}.`;
     const headerContent = (
         <>
-            {isWorkedSegment ? (
-                <span
-                    aria-hidden="true"
-                    className="shrink-0 self-start leading-4 text-text-secondary"
-                >
-                    {">"}
-                </span>
-            ) : null}
+            <span
+                aria-hidden="true"
+                className="shrink-0 self-start leading-4 text-text-secondary"
+                data-activity-rail-prefix="true"
+            >
+                {">"}
+            </span>
             <span className="min-w-0 flex-1">
                 <span
                     className={`block truncate text-[11px] leading-4 ${
@@ -287,7 +286,11 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                                             onOpenSession={onOpenSession}
                                             projectId={projectId}
                                             resolveFileReference={resolveFileReference}
-                                            surface="rail-row"
+                                            surface={
+                                                policy === "standalone-change"
+                                                    ? "card"
+                                                    : "rail-row"
+                                            }
                                             trackedFiles={reviewEntry.trackedFiles}
                                             worktreeId={worktreeId}
                                         />

--- a/src/renderer/src/components/workspace/chat/chatTimelineCache.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineCache.test.ts
@@ -39,6 +39,12 @@ describe("chatTimelineCache", () => {
                 ...input,
                 attentionToolCallIds: new Set<string>(),
             }),
+        ).toBe(model);
+        expect(
+            getCachedChatTimeline({
+                ...input,
+                attentionToolCallIds: new Set(["tool-call-1"]),
+            }),
         ).toBeNull();
     });
 });

--- a/src/renderer/src/components/workspace/chat/chatTimelineCache.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineCache.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { AiSessionSnapshot } from "@shared/ipc";
+import { createEmptyAiSessionTranscriptModel } from "@renderer/app/ai/transcriptModel";
+
+import type { ChatTimelineModel } from "./chatTimelineModel";
+import {
+    cacheChatTimeline,
+    getCachedChatTimeline,
+    resetCachedChatTimelinesForTests,
+} from "./chatTimelineCache";
+
+const transcript = createEmptyAiSessionTranscriptModel();
+const trackedFiles: AiSessionSnapshot["trackedFiles"] = [];
+const attentionToolCallIds = new Set<string>();
+const model = {} as ChatTimelineModel;
+
+afterEach(() => {
+    resetCachedChatTimelinesForTests();
+});
+
+describe("chatTimelineCache", () => {
+    it("reuses a timeline only while its render inputs are unchanged", () => {
+        const input = {
+            activeTurnStartedAt: null,
+            attentionToolCallIds,
+            model,
+            sessionId: "session-1",
+            status: "idle" as const,
+            trackedFiles,
+            transcript,
+        };
+
+        cacheChatTimeline(input);
+
+        expect(getCachedChatTimeline(input)).toBe(model);
+        expect(
+            getCachedChatTimeline({
+                ...input,
+                attentionToolCallIds: new Set<string>(),
+            }),
+        ).toBeNull();
+    });
+});

--- a/src/renderer/src/components/workspace/chat/chatTimelineCache.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineCache.ts
@@ -1,0 +1,72 @@
+import type { AiSessionSnapshot } from "@shared/ipc";
+import type { AiSessionTranscriptModel } from "@renderer/app/ai/transcriptModel";
+
+import type { ChatTimelineModel } from "./chatTimelineModel";
+
+const MAX_CACHED_TIMELINES = 12;
+
+interface CachedTimeline {
+    readonly activeTurnStartedAt: string | null;
+    readonly attentionToolCallIds: ReadonlySet<string>;
+    readonly model: ChatTimelineModel;
+    readonly status: AiSessionSnapshot["status"];
+    readonly trackedFiles: AiSessionSnapshot["trackedFiles"];
+    readonly transcript: AiSessionTranscriptModel;
+}
+
+const cachedTimelines = new Map<string, CachedTimeline>();
+
+export function getCachedChatTimeline(input: {
+    readonly activeTurnStartedAt: string | null;
+    readonly attentionToolCallIds: ReadonlySet<string>;
+    readonly sessionId: string;
+    readonly status: AiSessionSnapshot["status"];
+    readonly trackedFiles: AiSessionSnapshot["trackedFiles"];
+    readonly transcript: AiSessionTranscriptModel;
+}): ChatTimelineModel | null {
+    const cached = cachedTimelines.get(input.sessionId);
+    if (
+        !cached ||
+        cached.activeTurnStartedAt !== input.activeTurnStartedAt ||
+        cached.attentionToolCallIds !== input.attentionToolCallIds ||
+        cached.status !== input.status ||
+        cached.trackedFiles !== input.trackedFiles ||
+        cached.transcript !== input.transcript
+    ) {
+        return null;
+    }
+
+    // Touch the entry so recently visited chats retain their derived model.
+    cachedTimelines.delete(input.sessionId);
+    cachedTimelines.set(input.sessionId, cached);
+    return cached.model;
+}
+
+export function cacheChatTimeline(input: {
+    readonly activeTurnStartedAt: string | null;
+    readonly attentionToolCallIds: ReadonlySet<string>;
+    readonly model: ChatTimelineModel;
+    readonly sessionId: string;
+    readonly status: AiSessionSnapshot["status"];
+    readonly trackedFiles: AiSessionSnapshot["trackedFiles"];
+    readonly transcript: AiSessionTranscriptModel;
+}): void {
+    cachedTimelines.delete(input.sessionId);
+    cachedTimelines.set(input.sessionId, input);
+
+    while (cachedTimelines.size > MAX_CACHED_TIMELINES) {
+        const oldestSessionId = cachedTimelines.keys().next().value;
+        if (!oldestSessionId) {
+            return;
+        }
+        cachedTimelines.delete(oldestSessionId);
+    }
+}
+
+export function releaseCachedChatTimeline(sessionId: string): void {
+    cachedTimelines.delete(sessionId);
+}
+
+export function resetCachedChatTimelinesForTests(): void {
+    cachedTimelines.clear();
+}

--- a/src/renderer/src/components/workspace/chat/chatTimelineCache.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineCache.ts
@@ -7,7 +7,7 @@ const MAX_CACHED_TIMELINES = 12;
 
 interface CachedTimeline {
     readonly activeTurnStartedAt: string | null;
-    readonly attentionToolCallIds: ReadonlySet<string>;
+    readonly attentionToolCallIdsKey: string;
     readonly model: ChatTimelineModel;
     readonly status: AiSessionSnapshot["status"];
     readonly trackedFiles: AiSessionSnapshot["trackedFiles"];
@@ -15,6 +15,10 @@ interface CachedTimeline {
 }
 
 const cachedTimelines = new Map<string, CachedTimeline>();
+
+function getAttentionToolCallIdsKey(ids: ReadonlySet<string>): string {
+    return [...ids].sort().join("\u0000");
+}
 
 export function getCachedChatTimeline(input: {
     readonly activeTurnStartedAt: string | null;
@@ -28,7 +32,8 @@ export function getCachedChatTimeline(input: {
     if (
         !cached ||
         cached.activeTurnStartedAt !== input.activeTurnStartedAt ||
-        cached.attentionToolCallIds !== input.attentionToolCallIds ||
+        cached.attentionToolCallIdsKey !==
+            getAttentionToolCallIdsKey(input.attentionToolCallIds) ||
         cached.status !== input.status ||
         cached.trackedFiles !== input.trackedFiles ||
         cached.transcript !== input.transcript
@@ -52,7 +57,12 @@ export function cacheChatTimeline(input: {
     readonly transcript: AiSessionTranscriptModel;
 }): void {
     cachedTimelines.delete(input.sessionId);
-    cachedTimelines.set(input.sessionId, input);
+    cachedTimelines.set(input.sessionId, {
+        ...input,
+        attentionToolCallIdsKey: getAttentionToolCallIdsKey(
+            input.attentionToolCallIds,
+        ),
+    });
 
     while (cachedTimelines.size > MAX_CACHED_TIMELINES) {
         const oldestSessionId = cachedTimelines.keys().next().value;

--- a/src/renderer/src/components/workspace/chat/chatTimelineModel.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineModel.test.ts
@@ -817,7 +817,7 @@ describe("chatTimelineModel activity segments", () => {
                 "groupable",
                 "standalone-attention",
                 "groupable",
-                "standalone-unknown",
+                "groupable",
             ]);
         }
     });

--- a/src/renderer/src/components/workspace/chat/toolActivityKinds.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityKinds.ts
@@ -17,7 +17,12 @@ import type { AiToolActivity, AiTrackedFile } from "@shared/ipc";
  */
 
 // Tool kinds that render as a terminal card (command + captured output).
-export const TERMINAL_TOOL_KINDS = new Set(["bash", "shell", "execute"]);
+export const TERMINAL_TOOL_KINDS = new Set([
+    "bash",
+    "exec",
+    "shell",
+    "execute",
+]);
 
 // Tool kinds that touch files and render as a file card.
 export const FILE_TOOL_KINDS = new Set([

--- a/src/renderer/src/components/workspace/chat/toolActivityPresentation.test.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityPresentation.test.ts
@@ -90,7 +90,7 @@ describe("getToolActivityPresentationPolicy", () => {
                     status: "completed",
                 }),
             ),
-        ).toBe("standalone-unknown");
+        ).toBe("groupable");
         expect(
             classify(createEntry({ kind: "bash", status: "pending" })),
         ).toBe("groupable");
@@ -171,13 +171,18 @@ describe("getToolActivityPresentationPolicy", () => {
         ).toBe("structural");
     });
 
-    it("keeps unknown and MCP activity standalone", () => {
-        expect(classify(createEntry({ kind: "other" }))).toBe(
-            "standalone-unknown",
-        );
-        expect(classify(createEntry({ kind: "mcp" }))).toBe(
-            "standalone-unknown",
-        );
+    it("groups successful unknown and unified exec activity", () => {
+        expect(classify(createEntry({ kind: "other" }))).toBe("groupable");
+        expect(classify(createEntry({ kind: "mcp" }))).toBe("groupable");
+        expect(
+            classify(
+                createEntry({
+                    exitCode: 0,
+                    kind: "exec",
+                    status: "completed",
+                }),
+            ),
+        ).toBe("groupable");
     });
 
     it("prioritizes structural and change evidence over attention", () => {

--- a/src/renderer/src/components/workspace/chat/toolActivityPresentation.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityPresentation.ts
@@ -1,21 +1,9 @@
 import {
     isEditedFileToolActivity,
     isStatusToolActivity,
-    isTerminalToolActivity,
     isTurnStartedActivity,
 } from "./toolActivityKinds";
 import type { ToolActivityReviewEntry } from "./toolActivityReviewModel";
-
-const GROUPABLE_OBSERVATION_TOOL_KINDS = new Set([
-    "fetch",
-    "find",
-    "glob",
-    "grep",
-    "list",
-    "read",
-    "read_file",
-    "search",
-]);
 
 export type ToolActivityPresentationPolicy =
     | "groupable"
@@ -46,25 +34,6 @@ function requiresAttention(
     );
 }
 
-function isKnownGroupableActivity(entry: ToolActivityReviewEntry): boolean {
-    const { activity } = entry;
-    const kind = activity.kind.toLowerCase();
-
-    if (GROUPABLE_OBSERVATION_TOOL_KINDS.has(kind)) {
-        return true;
-    }
-
-    if (!isTerminalToolActivity(activity)) {
-        return false;
-    }
-
-    return (
-        activity.status === "pending" ||
-        activity.status === "in_progress" ||
-        (activity.status === "completed" && activity.exitCode === 0)
-    );
-}
-
 export function getToolActivityPresentationPolicy(
     entry: ToolActivityReviewEntry,
     context: ToolActivityPresentationContext,
@@ -84,9 +53,8 @@ export function getToolActivityPresentationPolicy(
         return "standalone-attention";
     }
 
-    if (isKnownGroupableActivity(entry)) {
-        return "groupable";
-    }
-
-    return "standalone-unknown";
+    // ACP runtimes can introduce successful tool kinds without a renderer
+    // release. Unknown routine work belongs in the collapsed activity rail;
+    // only changes, failures, and user-facing actions need their own card.
+    return "groupable";
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2936,6 +2936,12 @@ body.resizing-composer {
     [data-activity-rail-current="true"] {
         display: none;
     }
+
+    /* The header becomes single-line here, so keep the rail prefix centered
+       with the title instead of pinned to the button's top edge. */
+    [data-activity-rail-prefix="true"] {
+        align-self: center;
+    }
 }
 
 /* User messages stay compact in wide panes and recover the full row width in

--- a/vendor/codex-acp/src/codex_agent.rs
+++ b/vendor/codex-acp/src/codex_agent.rs
@@ -1163,9 +1163,7 @@ impl CodexAgent {
 
         let thread = self.get_thread(&args.session_id)?;
 
-        thread.set_config_option(args.config_id, args.value).await?;
-
-        let config_options = thread.config_options().await?;
+        let config_options = thread.set_config_option(args.config_id, args.value).await?;
 
         Ok(SetSessionConfigOptionResponse::new(config_options))
     }

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -16,7 +16,7 @@ use agent_client_protocol::{
         PermissionOptionKind, Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus, PromptRequest,
         RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
         ResourceLink, SelectedPermissionOutcome, SessionConfigId, SessionConfigOption,
-        SessionConfigOptionCategory, SessionConfigOptionValue, SessionConfigSelectGroup,
+        SessionConfigOptionCategory, SessionConfigOptionValue,
         SessionConfigSelectOption, SessionConfigValueId, SessionId, SessionInfoUpdate, SessionMode,
         SessionModeId, SessionModeState, SessionNotification, SessionUpdate, StopReason, Terminal,
         TextContent, TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation,
@@ -147,10 +147,6 @@ const CODEX_ACP_STATUS_EVENT_ID_PREFIX: &str = "codex-acp:status:";
 const CODEX_ACP_IMAGE_GENERATION_EVENT_ID_PREFIX: &str = "codex-acp:image:";
 const FILE_DELETED_PLACEHOLDER: &str = "[file deleted]";
 const GPT_5_6_MODEL_PREFIX: &str = "gpt-5.6-";
-const GPT_5_6_MODEL_GROUP_ID: &str = "gpt-5.6";
-const GPT_5_6_MODEL_GROUP_NAME: &str = "GPT 5.6";
-const OTHER_MODELS_GROUP_ID: &str = "other-models";
-const OTHER_MODELS_GROUP_NAME: &str = "Other models";
 
 fn debug_ai_worker_enabled() -> bool {
     matches!(std::env::var("COMANDO_DEBUG_AI_WORKER").as_deref(), Ok("1"))
@@ -159,31 +155,6 @@ fn debug_ai_worker_enabled() -> bool {
 fn gpt_5_6_variant_name(preset: &ModelPreset) -> Option<String> {
     let variant = preset.model.strip_prefix(GPT_5_6_MODEL_PREFIX)?;
     (!variant.is_empty()).then(|| variant.to_title_case())
-}
-
-fn model_picker_groups(
-    gpt_5_6_options: Vec<SessionConfigSelectOption>,
-    other_options: Vec<SessionConfigSelectOption>,
-) -> Vec<SessionConfigSelectGroup> {
-    let mut groups = Vec::with_capacity(2);
-
-    if !gpt_5_6_options.is_empty() {
-        groups.push(SessionConfigSelectGroup::new(
-            GPT_5_6_MODEL_GROUP_ID,
-            GPT_5_6_MODEL_GROUP_NAME,
-            gpt_5_6_options,
-        ));
-    }
-
-    if !other_options.is_empty() {
-        groups.push(SessionConfigSelectGroup::new(
-            OTHER_MODELS_GROUP_ID,
-            OTHER_MODELS_GROUP_NAME,
-            other_options,
-        ));
-    }
-
-    groups
 }
 
 fn session_mode_id_for_active_profile(profile_id: &str) -> Option<&'static str> {
@@ -4255,12 +4226,11 @@ impl<A: Auth> ThreadActor<A> {
         let current_model = self.get_current_model().await;
         let current_preset = presets.iter().find(|p| p.model == current_model).cloned();
 
-        let mut gpt_5_6_model_select_options = Vec::new();
-        let mut other_model_select_options = Vec::new();
+        let mut model_select_options = Vec::new();
 
         if current_preset.is_none() {
             // If no preset found, return the current model string as-is
-            other_model_select_options.push(SessionConfigSelectOption::new(
+            model_select_options.push(SessionConfigSelectOption::new(
                 current_model.clone(),
                 current_model.clone(),
             ));
@@ -4271,11 +4241,11 @@ impl<A: Auth> ThreadActor<A> {
             .filter(|model| model.show_in_picker || model.model == current_model)
         {
             match gpt_5_6_variant_name(&preset) {
-                Some(variant_name) => gpt_5_6_model_select_options.push(
+                Some(variant_name) => model_select_options.push(
                     SessionConfigSelectOption::new(preset.id, variant_name)
                         .description(preset.description),
                 ),
-                None => other_model_select_options.push(
+                None => model_select_options.push(
                     SessionConfigSelectOption::new(preset.id, preset.display_name)
                         .description(preset.description),
                 ),
@@ -4283,14 +4253,9 @@ impl<A: Auth> ThreadActor<A> {
         }
 
         options.push(
-            SessionConfigOption::select(
-                "model",
-                "Model",
-                current_model,
-                model_picker_groups(gpt_5_6_model_select_options, other_model_select_options),
-            )
-            .category(SessionConfigOptionCategory::Model)
-            .description("Choose which model Codex should use"),
+            SessionConfigOption::select("model", "Model", current_model, model_select_options)
+                .category(SessionConfigOptionCategory::Model)
+                .description("Choose which model Codex should use"),
         );
 
         let current_service_tier = self.current_service_tier();
@@ -6957,7 +6922,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn groups_gpt_5_6_model_variants_in_config_options() -> anyhow::Result<()> {
+    async fn lists_gpt_5_6_model_variants_with_other_config_options() -> anyhow::Result<()> {
         let (_session_id, _client, _thread, message_tx, handle) = setup().await?;
         let (response_tx, response_rx) = oneshot::channel();
 
@@ -6971,18 +6936,17 @@ mod tests {
         let SessionConfigKind::Select(model_select) = &model_option.kind else {
             panic!("model option should be a select");
         };
-        let SessionConfigSelectOptions::Grouped(groups) = &model_select.options else {
-            panic!("model options should be grouped");
+        let SessionConfigSelectOptions::Ungrouped(model_options) = &model_select.options else {
+            panic!("model options should be ungrouped");
         };
-        let gpt_5_6_group = groups
+        let mut variants = model_options
             .iter()
-            .find(|group| group.group.0.as_ref() == GPT_5_6_MODEL_GROUP_ID)
-            .expect("GPT-5.6 group should be present");
-
-        assert_eq!(gpt_5_6_group.name, GPT_5_6_MODEL_GROUP_NAME);
-        let mut variants = gpt_5_6_group
-            .options
-            .iter()
+            .filter(|option| {
+                matches!(
+                    option.value.0.as_ref(),
+                    "gpt-5.6-luna" | "gpt-5.6-sol" | "gpt-5.6-terra"
+                )
+            })
             .map(|option| option.name.as_str())
             .collect::<Vec<_>>();
         variants.sort_unstable();

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -16,10 +16,10 @@ use agent_client_protocol::{
         PermissionOptionKind, Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus, PromptRequest,
         RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
         ResourceLink, SelectedPermissionOutcome, SessionConfigId, SessionConfigOption,
-        SessionConfigOptionCategory, SessionConfigOptionValue,
-        SessionConfigSelectOption, SessionConfigValueId, SessionId, SessionInfoUpdate, SessionMode,
-        SessionModeId, SessionModeState, SessionNotification, SessionUpdate, StopReason, Terminal,
-        TextContent, TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation,
+        SessionConfigOptionCategory, SessionConfigOptionValue, SessionConfigSelectOption,
+        SessionConfigValueId, SessionId, SessionInfoUpdate, SessionMode, SessionModeId,
+        SessionModeState, SessionNotification, SessionUpdate, StopReason, Terminal, TextContent,
+        TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation,
         ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
         UsageUpdate,
     },
@@ -609,6 +609,7 @@ enum ThreadMessage {
     Load {
         response_tx: oneshot::Sender<Result<LoadSessionResponse, Error>>,
     },
+    #[cfg(test)]
     GetConfigOptions {
         response_tx: oneshot::Sender<Result<Vec<SessionConfigOption>, Error>>,
     },
@@ -623,7 +624,7 @@ enum ThreadMessage {
     SetConfigOption {
         config_id: SessionConfigId,
         value: SessionConfigOptionValue,
-        response_tx: oneshot::Sender<Result<(), Error>>,
+        response_tx: oneshot::Sender<Result<Vec<SessionConfigOption>, Error>>,
     },
     Cancel {
         response_tx: oneshot::Sender<Result<(), Error>>,
@@ -695,17 +696,6 @@ impl Thread {
             .map_err(|e| Error::internal_error().data(e.to_string()))?
     }
 
-    pub async fn config_options(&self) -> Result<Vec<SessionConfigOption>, Error> {
-        let (response_tx, response_rx) = oneshot::channel();
-
-        let message = ThreadMessage::GetConfigOptions { response_tx };
-        drop(self.message_tx.send(message));
-
-        response_rx
-            .await
-            .map_err(|e| Error::internal_error().data(e.to_string()))?
-    }
-
     pub async fn prompt(&self, request: PromptRequest) -> Result<StopReason, Error> {
         let (response_tx, response_rx) = oneshot::channel();
 
@@ -737,7 +727,7 @@ impl Thread {
         &self,
         config_id: SessionConfigId,
         value: SessionConfigOptionValue,
-    ) -> Result<(), Error> {
+    ) -> Result<Vec<SessionConfigOption>, Error> {
         let (response_tx, response_rx) = oneshot::channel();
 
         let message = ThreadMessage::SetConfigOption {
@@ -4045,6 +4035,7 @@ impl<A: Auth> ThreadActor<A> {
                     ));
                 });
             }
+            #[cfg(test)]
             ThreadMessage::GetConfigOptions { response_tx } => {
                 let result = self.config_options().await;
                 drop(response_tx.send(result));
@@ -4066,12 +4057,17 @@ impl<A: Auth> ThreadActor<A> {
                 value,
                 response_tx,
             } => {
-                let result = self.handle_set_config_option(config_id, value).await;
-                let config_changed = result.is_ok();
+                let result = match self.handle_set_config_option(config_id, value).await {
+                    Ok(()) => match self.config_options().await {
+                        Ok(config_options) => {
+                            self.emit_config_options_update(config_options.clone());
+                            Ok(config_options)
+                        }
+                        Err(error) => Err(error),
+                    },
+                    Err(error) => Err(error),
+                };
                 drop(response_tx.send(result));
-                if config_changed {
-                    self.maybe_emit_config_options_update().await;
-                }
             }
             ThreadMessage::Cancel { response_tx } => {
                 let result = self.handle_cancel().await;
@@ -4337,6 +4333,10 @@ impl<A: Auth> ThreadActor<A> {
     async fn maybe_emit_config_options_update(&mut self) {
         let config_options = self.config_options().await.unwrap_or_default();
 
+        self.emit_config_options_update(config_options);
+    }
+
+    fn emit_config_options_update(&mut self, config_options: Vec<SessionConfigOption>) {
         if self
             .last_sent_config_options
             .as_ref()
@@ -6982,7 +6982,7 @@ mod tests {
             value: SessionConfigOptionValue::value_id(selected_preset.id.clone()),
             response_tx,
         })?;
-        response_rx.await??;
+        let response_config_options = response_rx.await??;
 
         tokio::time::timeout(Duration::from_millis(100), async {
             loop {
@@ -7010,6 +7010,7 @@ mod tests {
                 _ => None,
             })
             .expect("config option update should be emitted");
+        assert_eq!(response_config_options, update.config_options);
         let model_option = update
             .config_options
             .iter()


### PR DESCRIPTION
## Summary

- hydrate restored chat sessions as readable history without eagerly starting their runtime
- preserve loaded history and retry safely when runtime preparation fails
- cache transcript projections, reconciled timeline models, and virtual-list measurements across chat tab switches
- keep routine tool activity compact while surfacing changes, failures, and actions clearly
- fix the activity rail headline layout in narrow panes

## Validation

- `pnpm exec vitest run src/renderer/src/app/store/ai-store.test.ts src/renderer/src/app/store/workspace-store.test.ts src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx src/renderer/src/components/workspace/chat/chatTimelineCache.test.ts src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx src/renderer/src/components/workspace/chat/toolActivityPresentation.test.ts`

6 test files passed (150 tests).