### PR TITLE
[WIP] feat(workspace): add persistent project and worktree context tabs

### DIFF
--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "@shared/ipc";
 
 import type { NativeAiGateway } from "./contracts";
+import { NativeBackendError } from "../native-backend/client";
 
 const readyStatus: AiRuntimeStatus = {
     authMethod: "chatgpt",
@@ -982,6 +983,108 @@ describe("AiService prepareSession", () => {
                 ?.value,
         ).toBe("gpt-5.5");
         expect(onSessionSnapshot.mock.lastCall?.[0]).toBe("window-1");
+    });
+
+    it("reprepares a live session once when a control mutation loses its runtime session", async () => {
+        const snapshot = createSnapshot({
+            configOptions: [createReasoningConfig("low")],
+            runtimeSessionId: "runtime-session-1",
+        });
+        const prepareSession = vi
+            .fn<NativeAiGateway["prepareSession"]>()
+            .mockResolvedValueOnce(snapshot)
+            .mockResolvedValueOnce({
+                ...snapshot,
+                runtimeSessionId: "runtime-session-2",
+            });
+        const setSessionConfigOption = vi
+            .fn<NativeAiGateway["setSessionConfigOption"]>()
+            .mockRejectedValueOnce(
+                new NativeBackendError({
+                    code: "ai_session_not_found",
+                    details: null,
+                    message: "The AI session was not found.",
+                    retryable: false,
+                }),
+            )
+            .mockResolvedValueOnce(undefined);
+        const service = createPrepareService({
+            nativeAi: createNativeAi({
+                prepareSession,
+                setSessionConfigOption,
+            }),
+        });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-1",
+                title: "Codex 1",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+
+        await service.setSessionConfigOption({
+            optionId: "reasoning_effort",
+            sessionId: "session-1",
+            value: "high",
+        });
+
+        expect(prepareSession).toHaveBeenCalledTimes(2);
+        expect(setSessionConfigOption).toHaveBeenCalledTimes(2);
+        expect(await service.getSessionSnapshot("session-1")).toMatchObject({
+            runtimeSessionId: "runtime-session-2",
+        });
+    });
+
+    it("does not reprepare a live session for another control mutation failure", async () => {
+        const snapshot = createSnapshot({
+            configOptions: [createReasoningConfig("low")],
+            runtimeSessionId: "runtime-session-1",
+        });
+        const prepareSession = vi
+            .fn<NativeAiGateway["prepareSession"]>()
+            .mockResolvedValue(snapshot);
+        const setSessionConfigOption = vi
+            .fn<NativeAiGateway["setSessionConfigOption"]>()
+            .mockRejectedValue(
+                new NativeBackendError({
+                    code: "ai_runtime_exited",
+                    details: null,
+                    message: "The runtime exited.",
+                    retryable: false,
+                }),
+            );
+        const service = createPrepareService({
+            nativeAi: createNativeAi({
+                prepareSession,
+                setSessionConfigOption,
+            }),
+        });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-1",
+                title: "Codex 1",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+
+        await expect(
+            service.setSessionConfigOption({
+                optionId: "reasoning_effort",
+                sessionId: "session-1",
+                value: "high",
+            }),
+        ).rejects.toThrow("The runtime exited.");
+
+        expect(prepareSession).toHaveBeenCalledTimes(1);
+        expect(setSessionConfigOption).toHaveBeenCalledTimes(1);
     });
 
     it("keeps live reasoning config option changes in the main snapshot", async () => {

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -78,6 +78,7 @@ import type {
     SecretStoreGateway,
 } from "@main/ai/secret-store";
 import { debugBenignError } from "@main/observability/logging";
+import { NativeBackendError } from "@main/native-backend/client";
 
 import {
     createEmptyAiSessionSnapshot,
@@ -1553,7 +1554,9 @@ export class AiService {
             return;
         }
 
-        await this.#requireNativeAiGateway().setSessionMode(input);
+        await this.#runLiveSessionControlMutation(input.sessionId, () =>
+            this.#requireNativeAiGateway().setSessionMode(input),
+        );
         const snapshot = await this.#updateSessionSnapshot(
             input.sessionId,
             (currentSnapshot) =>
@@ -1587,7 +1590,9 @@ export class AiService {
             return;
         }
 
-        await this.#requireNativeAiGateway().setSessionModel(input);
+        await this.#runLiveSessionControlMutation(input.sessionId, () =>
+            this.#requireNativeAiGateway().setSessionModel(input),
+        );
         const snapshot = await this.#updateSessionSnapshot(
             input.sessionId,
             (currentSnapshot) =>
@@ -1659,7 +1664,9 @@ export class AiService {
             return;
         }
 
-        await this.#requireNativeAiGateway().setSessionConfigOption(input);
+        await this.#runLiveSessionControlMutation(input.sessionId, () =>
+            this.#requireNativeAiGateway().setSessionConfigOption(input),
+        );
         const snapshot = await this.#updateSessionSnapshot(
             input.sessionId,
             (currentSnapshot) =>
@@ -1676,6 +1683,48 @@ export class AiService {
                 input.value,
             );
         }
+    }
+
+    async #runLiveSessionControlMutation(
+        sessionId: string,
+        mutation: () => Promise<void>,
+    ): Promise<void> {
+        try {
+            await mutation();
+            return;
+        } catch (error) {
+            if (!isNativeAiSessionNotFoundError(error)) {
+                throw error;
+            }
+
+            // The runtime can evict a session after the main process cached it.
+            // Recreate it once here so every renderer uses the same recovery path.
+            debugBenignError("ai.service.recoverSessionControl", error);
+            await this.#recoverMissingLiveSession(sessionId);
+        }
+
+        await mutation();
+    }
+
+    async #recoverMissingLiveSession(sessionId: string): Promise<void> {
+        const context = this.#liveSessionContexts.get(sessionId);
+        const snapshot = this.#liveSnapshots.get(sessionId);
+        if (!context || !snapshot) {
+            throw new Error("The AI session was not found.");
+        }
+
+        this.#cancelCapturedRuntimeDefaults(sessionId);
+        this.#nativeSessionIds.delete(sessionId);
+        await this.prepareSession(
+            {
+                projectId: snapshot.projectId,
+                runtimeId: snapshot.runtimeId,
+                sessionId,
+                title: snapshot.title,
+                worktreeId: snapshot.worktreeId ?? null,
+            },
+            context.ownerWindowId,
+        );
     }
 
     #rememberRuntimeModePreference(
@@ -5861,6 +5910,13 @@ function isNativeTrackedFilesPatch(update: AiSessionUpdate): boolean {
             update.patch.changes,
             "trackedFiles",
         )
+    );
+}
+
+function isNativeAiSessionNotFoundError(error: unknown): boolean {
+    return (
+        error instanceof NativeBackendError &&
+        error.code === "ai_session_not_found"
     );
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,6 +24,7 @@ import {
     type TerminalDataEvent,
     type TerminalExitEvent,
     type WindowContextSnapshot,
+    type WorkspaceNavigationSnapshot,
 } from "@shared/ipc";
 import {
     nativeProjectTreeInvalidationToIpc,
@@ -297,9 +298,7 @@ if (!hasSingleInstanceLock) {
                 persistenceService,
                 gitService,
                 githubService,
-                openProjectWindow: (input) => {
-                    openOrFocusProjectWindow(input);
-                },
+                openProjectWindow: openOrFocusProjectWindow,
                 projectService,
                 settingsService,
                 terminalService,
@@ -662,18 +661,21 @@ async function openNewMainWindow(projectId: string | null): Promise<void> {
     });
 }
 
-function openOrFocusProjectWindow(input: OpenProjectWindowInput): void {
+async function openOrFocusProjectWindow(
+    input: OpenProjectWindowInput,
+): Promise<void> {
     if (!persistenceService) {
-        return;
+        throw new Error("The persistence service is unavailable.");
     }
 
     const existingWindow = input.forceNewWindow
         ? null
         : windowRegistry.getMainWindowByProjectId(input.projectId);
     if (!existingWindow) {
-        void openNewMainWindowWithOptions({
+        await openNewMainWindowWithOptions({
             forceNewWindow: input.forceNewWindow,
             projectId: input.projectId,
+            workspaceSnapshot: input.workspaceSnapshot,
             worktreeId: input.worktreeId,
         });
         return;
@@ -711,10 +713,11 @@ function openOrFocusProjectWindow(input: OpenProjectWindowInput): void {
 async function openNewMainWindowWithOptions(input: {
     readonly forceNewWindow?: boolean;
     readonly projectId: string | null;
+    readonly workspaceSnapshot?: WorkspaceNavigationSnapshot;
     readonly worktreeId?: string | null;
 }): Promise<void> {
     if (!persistenceService) {
-        return;
+        throw new Error("The persistence service is unavailable.");
     }
 
     if (input.projectId && !input.forceNewWindow) {
@@ -759,6 +762,15 @@ async function openNewMainWindowWithOptions(input: {
                   worktreeId: input.worktreeId,
               },
     );
+
+    const workspaceId = snapshot.windowContext?.workspaceId;
+    if (input.workspaceSnapshot) {
+        if (!workspaceService || !workspaceId) {
+            throw new Error("The workspace service is unavailable.");
+        }
+        // Persist before the renderer hydrates so it restores the transferred layout.
+        await workspaceService.saveSnapshot(workspaceId, input.workspaceSnapshot);
+    }
 
     createTrackedMainWindow(snapshot);
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,7 @@
 import {
     app,
     BrowserWindow,
+    ipcMain,
     MessageChannelMain,
     type MessagePortMain,
 } from "electron";
@@ -118,9 +119,31 @@ let terminalService: TerminalGateway | null = null;
 let nativeBackendClient: NativeBackendClient | null = null;
 let workspaceService: WorkspaceGateway | null = null;
 let isQuitting = false;
+let isWorkspaceQuitReady = false;
+let pendingWorkspaceQuit: Promise<void> | null = null;
 let isFinalizingQuit = false;
 let hasRequestedNativeBackendTestEvent = false;
 let pendingShutdown: Promise<void> | null = null;
+let nextWorkspaceFlushRequestId = 0;
+const pendingWorkspaceFlushes = new Map<
+    string,
+    { readonly senderId: number; readonly resolve: () => void }
+>();
+
+ipcMain.on(
+    IPC_EVENTS.workspaceFlushAcknowledged,
+    (event, requestId: unknown) => {
+        if (typeof requestId !== "string") {
+            return;
+        }
+        const pending = pendingWorkspaceFlushes.get(requestId);
+        if (!pending || pending.senderId !== event.sender.id) {
+            return;
+        }
+        pendingWorkspaceFlushes.delete(requestId);
+        pending.resolve();
+    },
+);
 
 const AI_SESSION_STREAM_ACK_STALE_MS = 10_000;
 const AI_SESSION_STREAM_HEARTBEAT_MS = 1_000;
@@ -386,8 +409,19 @@ app.on("window-all-closed", () => {
     }
 });
 
-app.on("before-quit", () => {
+app.on("before-quit", (event) => {
     isQuitting = true;
+    if (isWorkspaceQuitReady) {
+        return;
+    }
+    event.preventDefault();
+    if (!pendingWorkspaceQuit) {
+        pendingWorkspaceQuit = flushAllWorkspaceWindowsForQuit().finally(() => {
+            pendingWorkspaceQuit = null;
+            isWorkspaceQuitReady = true;
+            app.quit();
+        });
+    }
 });
 
 app.on("will-quit", (event) => {
@@ -640,19 +674,8 @@ function restoreMainWindows(): void {
 function filterRestorableMainWindowSnapshots(
     snapshots: readonly PersistenceSnapshot[],
 ): readonly PersistenceSnapshot[] {
-    if (
-        !snapshots.some((snapshot) => getSnapshotProjectId(snapshot) !== null)
-    ) {
-        return snapshots;
-    }
-
-    return snapshots.filter(
-        (snapshot) => getSnapshotProjectId(snapshot) !== null,
-    );
-}
-
-function getSnapshotProjectId(snapshot: PersistenceSnapshot): string | null {
-    return snapshot.windowContext?.projectId ?? null;
+    // A projectless window is still a user-owned workspace and must survive restart.
+    return snapshots;
 }
 
 async function openNewMainWindow(projectId: string | null): Promise<void> {
@@ -864,6 +887,8 @@ function attachMainWindowLifecycle(
     context: WindowContextSnapshot,
 ): void {
     let timeout: NodeJS.Timeout | null = null;
+    let closeFlushComplete = false;
+    let closeFlushInFlight = false;
 
     const persistWindowState = () => {
         if (!persistenceService) {
@@ -905,8 +930,27 @@ function attachMainWindowLifecycle(
     window.on("unmaximize", schedulePersist);
     window.on("enter-full-screen", schedulePersist);
     window.on("leave-full-screen", schedulePersist);
-    window.on("close", () => {
+    window.on("close", (event) => {
         persistWindowState();
+
+        if (
+            !isWorkspaceQuitReady &&
+            !closeFlushComplete &&
+            !window.webContents.isDestroyed()
+        ) {
+            event.preventDefault();
+            if (!closeFlushInFlight) {
+                closeFlushInFlight = true;
+                void requestWorkspaceFlush(window).finally(() => {
+                    closeFlushComplete = true;
+                    closeFlushInFlight = false;
+                    if (!window.isDestroyed()) {
+                        window.close();
+                    }
+                });
+            }
+            return;
+        }
 
         if (isClosingLastAppWindow()) {
             isQuitting = true;
@@ -942,6 +986,39 @@ function attachMainWindowLifecycle(
     });
 
     persistWindowState();
+}
+
+async function requestWorkspaceFlush(window: BrowserWindow): Promise<void> {
+    const requestId = `${window.id}:${++nextWorkspaceFlushRequestId}`;
+    await new Promise<void>((resolve) => {
+        let settled = false;
+        const finish = () => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            pendingWorkspaceFlushes.delete(requestId);
+            resolve();
+        };
+        const timer = setTimeout(finish, 1_500);
+        pendingWorkspaceFlushes.set(requestId, {
+            resolve: finish,
+            senderId: window.webContents.id,
+        });
+        window.webContents.send(
+            IPC_EVENTS.workspaceFlushRequested,
+            requestId,
+        );
+    });
+}
+
+async function flushAllWorkspaceWindowsForQuit(): Promise<void> {
+    const windows = BrowserWindow.getAllWindows().filter((window) => {
+        if (window.isDestroyed() || window.webContents.isDestroyed()) {
+            return false;
+        }
+        return windowRegistry.getContextByBrowserWindow(window)?.windowKind === "main";
+    });
+    await Promise.all(windows.map(requestWorkspaceFlush));
 }
 
 function isClosingLastAppWindow(): boolean {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -156,6 +156,7 @@ import {
     type WorkspaceNavigationSnapshot,
 } from "@shared/ipc";
 import { normalizePathKey as normalizeSharedPathKey } from "@shared/path-identity";
+import { normalizeWorkspaceNavigationSnapshot } from "@shared/workspace-restore";
 
 import {
     BrowserWindow,
@@ -1640,16 +1641,39 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     );
     ipcMain.handle(IPC_CHANNELS.getWorkspaceSnapshot, (event) => {
         const context = requireWindowContext(event.sender, "main");
-        return options.workspaceService.loadSnapshot(context.workspaceId!);
+        return Promise.resolve(
+            options.workspaceService.loadSnapshot(context.workspaceId!),
+        )
+            .then((record) => record.snapshot);
     });
     ipcMain.handle(
         IPC_CHANNELS.saveWorkspaceSnapshot,
-        (event, snapshot: WorkspaceNavigationSnapshot) => {
+        async (event, snapshot: WorkspaceNavigationSnapshot) => {
             const context = requireWindowContext(event.sender, "main");
-            return options.workspaceService.saveSnapshot(
-                context.workspaceId!,
+            const normalizedSnapshot = normalizeWorkspaceNavigationSnapshot(
                 snapshot,
+            ).snapshot;
+            await options.workspaceService.saveSnapshot(
+                context.workspaceId!,
+                normalizedSnapshot,
             );
+            const activeContext = normalizedSnapshot.contexts.find(
+                (candidate) =>
+                    candidate.key === normalizedSnapshot.activeContextKey,
+            );
+            const projectId = activeContext?.projectId ?? null;
+            const worktreeId = activeContext?.worktreeId ?? null;
+            windowRegistry.updateMainWindowProjectId(
+                context.windowId,
+                projectId,
+                worktreeId,
+            );
+            const ownerWindow = BrowserWindow.fromWebContents(event.sender);
+            if (ownerWindow) {
+                ownerWindow.setTitle(
+                    buildMainWindowTitle(options.projectService, projectId),
+                );
+            }
         },
     );
     ipcMain.handle(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -27,6 +27,7 @@ import {
     type ClearProjectAppDataInput,
     type CloneRepositoryInput,
     type CloneRepositoryResult,
+    type ConfirmWorkspaceCloseInput,
     type CodexRuntimeSettingsInput,
     type CopyExternalProjectEntriesInput,
     type CopyProjectEntriesInput,
@@ -165,6 +166,7 @@ import {
     ipcMain,
     nativeTheme,
     shell,
+    type MessageBoxOptions,
     type OpenDialogOptions,
 } from "electron";
 
@@ -242,6 +244,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.openGeneratedImage);
     ipcMain.removeHandler(IPC_CHANNELS.revealGeneratedImage);
     ipcMain.removeHandler(IPC_CHANNELS.openProjectWindow);
+    ipcMain.removeHandler(IPC_CHANNELS.confirmWorkspaceClose);
     ipcMain.removeHandler(IPC_CHANNELS.checkCommandAvailability);
     ipcMain.removeHandler(IPC_CHANNELS.readClaudeCodeTranscript);
     ipcMain.removeHandler(IPC_CHANNELS.getSettingsSnapshot);
@@ -466,6 +469,53 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         IPC_CHANNELS.openProjectWindow,
         (_event, input: OpenProjectWindowInput) =>
             options.openProjectWindow(input),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.confirmWorkspaceClose,
+        async (event, input: ConfirmWorkspaceCloseInput): Promise<boolean> => {
+            if (
+                !input ||
+                typeof input.workspaceName !== "string" ||
+                !Number.isInteger(input.activeAgentCount) ||
+                !Number.isInteger(input.dirtyFileCount) ||
+                input.activeAgentCount < 0 ||
+                input.dirtyFileCount < 0
+            ) {
+                throw new TypeError("Expected a valid workspace close confirmation input.");
+            }
+
+            const ownerWindow =
+                BrowserWindow.fromWebContents(event.sender) ??
+                BrowserWindow.getFocusedWindow();
+            const details = [
+                input.activeAgentCount > 0
+                    ? `${input.activeAgentCount} ${input.activeAgentCount === 1 ? "agent is" : "agents are"} still working. ${input.activeAgentCount === 1 ? "It" : "They"} will continue running in the background if you close this workspace.`
+                    : null,
+                input.dirtyFileCount > 0
+                    ? `${input.dirtyFileCount} unsaved ${input.dirtyFileCount === 1 ? "file will" : "files will"} be discarded.`
+                    : null,
+            ]
+                .filter((detail): detail is string => Boolean(detail))
+                .join("\n\n");
+            const dialogOptions: MessageBoxOptions = {
+                buttons: ["Keep Workspace Open", "Close Workspace"],
+                cancelId: 0,
+                defaultId: 0,
+                detail: details,
+                message: `Close “${input.workspaceName}”?`,
+                noLink: true,
+                title:
+                    input.activeAgentCount > 0
+                        ? "Agents are still working"
+                        : "Unsaved changes",
+                type: "warning",
+            };
+            const result = ownerWindow
+                ? await dialog.showMessageBox(ownerWindow, dialogOptions)
+                : await dialog.showMessageBox(dialogOptions);
+
+            return result.response === 1;
+        },
     );
     ipcMain.handle(
         IPC_CHANNELS.checkCommandAvailability,

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -168,7 +168,11 @@ import {
     type OpenDialogOptions,
 } from "electron";
 
-import { forEachLiveWindow, refreshWindowsTitleBarOverlays } from "@main/window";
+import {
+    forEachLiveWindow,
+    MAC_MAIN_TRAFFIC_LIGHT_POSITION,
+    refreshWindowsTitleBarOverlays,
+} from "@main/window";
 import { createIpcInFlightLimiter } from "@main/ipc/rate-limit";
 import { resolveSettingsSnapshotSaveEffects } from "@main/ipc/settings-save-effects";
 import { debugBenignError } from "@main/observability/logging";
@@ -591,7 +595,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             const win = BrowserWindow.fromWebContents(event.sender);
             if (win && process.platform === "darwin") {
                 win.setWindowButtonPosition(
-                    visible ? { x: 18, y: 18 } : { x: -80, y: -80 },
+                    visible ? MAC_MAIN_TRAFFIC_LIGHT_POSITION : { x: -80, y: -80 },
                 );
             }
         },

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -214,7 +214,7 @@ interface RegisterIpcHandlersOptions {
     readonly gitService: GitGateway;
     readonly githubService: GitHubGateway;
     readonly getSnapshot: () => AppBootstrapSnapshot;
-    readonly openProjectWindow: (input: OpenProjectWindowInput) => void;
+    readonly openProjectWindow: (input: OpenProjectWindowInput) => Promise<void>;
     readonly persistenceService: PersistenceGateway;
     readonly projectService: ProjectService;
     readonly settingsService: SettingsGateway;
@@ -459,9 +459,8 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     );
     ipcMain.handle(
         IPC_CHANNELS.openProjectWindow,
-        (_event, input: OpenProjectWindowInput) => {
-            options.openProjectWindow(input);
-        },
+        (_event, input: OpenProjectWindowInput) =>
+            options.openProjectWindow(input),
     );
     ipcMain.handle(
         IPC_CHANNELS.checkCommandAvailability,

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -153,7 +153,7 @@ import {
     type TsconfigResolutionSnapshot,
     type WindowContextSnapshot,
     type WriteTerminalInput,
-    type WorkspaceSnapshot,
+    type WorkspaceNavigationSnapshot,
 } from "@shared/ipc";
 import { normalizePathKey as normalizeSharedPathKey } from "@shared/path-identity";
 
@@ -1645,7 +1645,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     });
     ipcMain.handle(
         IPC_CHANNELS.saveWorkspaceSnapshot,
-        (event, snapshot: WorkspaceSnapshot) => {
+        (event, snapshot: WorkspaceNavigationSnapshot) => {
             const context = requireWindowContext(event.sender, "main");
             return options.workspaceService.saveSnapshot(
                 context.workspaceId!,

--- a/src/main/native-backend/app-data.test.ts
+++ b/src/main/native-backend/app-data.test.ts
@@ -86,6 +86,10 @@ describe("createNativeAppDataClient", () => {
         expect(windows[0]?.windowContext?.workspaceId).toBe("workspace-1");
 
         const workspace = await client.workspace.loadSnapshot("workspace-1");
+        expect("version" in workspace).toBe(false);
+        if ("version" in workspace) {
+            throw new Error("Expected the migrated legacy workspace layout.");
+        }
         expect(workspace.activePaneId).toBe("pane-1");
         expect(workspace.tabs).toHaveLength(1);
         expect(workspace.tabs[0]?.title).toBe("README.md");

--- a/src/main/native-backend/app-data.test.ts
+++ b/src/main/native-backend/app-data.test.ts
@@ -5,7 +5,10 @@ import { DatabaseSync } from "node:sqlite";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { AiSessionSnapshot } from "@shared/ipc";
+import type {
+    AiSessionSnapshot,
+    WorkspaceNavigationSnapshot,
+} from "@shared/ipc";
 
 import type { NativeBackendRequester } from "./persistence";
 
@@ -24,6 +27,76 @@ afterEach(() => {
 });
 
 describe("createNativeAppDataClient", () => {
+    it("atomically restores isolated workspace snapshots for multiple windows", async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "comando-app-data-"));
+        tempDirs.push(tempDir);
+        const databaseFile = path.join(tempDir, "comando.sqlite");
+        new DatabaseSync(databaseFile).close();
+        const native = createFakeNativeRequester();
+        const { createNativeAppDataClient } = await import("./app-data");
+        const firstClient = await createNativeAppDataClient({
+            client: native.requester,
+            databaseFile,
+        });
+        const firstWindow = await firstClient.persistence.createMainWindowSession({
+            projectId: "project-1",
+        });
+        const secondWindow = await firstClient.persistence.createMainWindowSession({
+            projectId: "project-2",
+            worktreeId: "worktree-2",
+        });
+        const firstWorkspaceId = firstWindow.windowContext?.workspaceId;
+        const secondWorkspaceId = secondWindow.windowContext?.workspaceId;
+        if (!firstWorkspaceId || !secondWorkspaceId) {
+            throw new Error("Expected workspace ids for both windows.");
+        }
+        await firstClient.workspace.saveSnapshot(
+            firstWorkspaceId,
+            workspaceNavigation("project-1", null, "pane-a"),
+        );
+        await firstClient.workspace.saveSnapshot(
+            secondWorkspaceId,
+            workspaceNavigation("project-2", "worktree-2", "pane-b"),
+        );
+        await firstClient.close();
+
+        const secondClient = await createNativeAppDataClient({
+            client: native.requester,
+            databaseFile,
+        });
+        const firstRestore = await secondClient.workspace.loadSnapshot(firstWorkspaceId);
+        const secondRestore = await secondClient.workspace.loadSnapshot(secondWorkspaceId);
+
+        expect(firstRestore.revision).toBe(1);
+        expect(firstRestore.snapshot.contexts[0]?.workspace.activePaneId).toBe("pane-a");
+        expect(secondRestore.snapshot.contexts[0]).toMatchObject({
+            projectId: "project-2",
+            worktreeId: "worktree-2",
+            workspace: { activePaneId: "pane-b" },
+        });
+        expect(
+            secondClient.persistence.listRestorableMainWindowSnapshots(),
+        ).toHaveLength(2);
+        await secondClient.workspace.saveSnapshot(firstWorkspaceId, {
+            activeContextKey: null,
+            contexts: [],
+            openContextKeys: [],
+            version: 2,
+        });
+        const firstWindowId = firstWindow.windowContext?.windowId;
+        if (!firstWindowId) {
+            throw new Error("Expected the first window id.");
+        }
+        expect(
+            secondClient.persistence.loadSnapshot(firstWindowId),
+        ).toMatchObject({
+            activeProjectId: null,
+            activeWorktreeId: null,
+            windowContext: { projectId: null, worktreeId: null },
+        });
+        await secondClient.close();
+    });
+
     it("migrates legacy SQLite app data into native app-data and keyring", async () => {
         const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "comando-app-data-"));
         tempDirs.push(tempDir);
@@ -86,14 +159,13 @@ describe("createNativeAppDataClient", () => {
         expect(windows[0]?.windowContext?.workspaceId).toBe("workspace-1");
 
         const workspace = await client.workspace.loadSnapshot("workspace-1");
-        expect("version" in workspace).toBe(false);
-        if ("version" in workspace) {
-            throw new Error("Expected the migrated legacy workspace layout.");
-        }
-        expect(workspace.activePaneId).toBe("pane-1");
-        expect(workspace.tabs).toHaveLength(1);
-        expect(workspace.tabs[0]?.title).toBe("README.md");
-        expect(workspace.tabs[0]?.worktreeId).toBe("worktree-1");
+        expect(workspace.schemaVersion).toBe(1);
+        expect(workspace.snapshot.version).toBe(2);
+        const restoredLayout = workspace.snapshot.contexts[0]?.workspace;
+        expect(restoredLayout?.activePaneId).toBe("pane-1");
+        expect(restoredLayout?.tabs).toHaveLength(1);
+        expect(restoredLayout?.tabs[0]?.title).toBe("README.md");
+        expect(restoredLayout?.tabs[0]?.worktreeId).toBe("worktree-1");
 
         const projectSettings =
             client.settings.loadProjectSettings("project-1");
@@ -308,6 +380,37 @@ describe("createNativeAppDataClient", () => {
         await client.close();
     });
 });
+
+function workspaceNavigation(
+    projectId: string,
+    worktreeId: string | null,
+    paneId: string,
+): WorkspaceNavigationSnapshot {
+    const key = `${projectId}::${worktreeId ?? "__primary__"}`;
+    return {
+        activeContextKey: key,
+        contexts: [
+            {
+                key,
+                lastActivatedAt: "2026-01-01T00:00:00.000Z",
+                projectId,
+                workspace: {
+                    activePaneId: paneId,
+                    rootNode: {
+                        activeTabId: null,
+                        id: paneId,
+                        tabIds: [],
+                        type: "pane",
+                    },
+                    tabs: [],
+                },
+                worktreeId,
+            },
+        ],
+        openContextKeys: [key],
+        version: 2,
+    };
+}
 
 function createFakeNativeRequester(): {
     readonly appData: Map<string, unknown>;

--- a/src/main/native-backend/app-data.ts
+++ b/src/main/native-backend/app-data.ts
@@ -48,8 +48,13 @@ import type {
     ThemePreset,
     WorkspaceNode,
     WorkspaceNavigationSnapshot,
+    WindowWorkspaceRestoreRecord,
     WorkspaceSnapshot,
 } from "@shared/ipc";
+import {
+    createWindowWorkspaceRestoreRecord,
+    normalizeWindowWorkspaceRestoreRecord,
+} from "@shared/workspace-restore";
 
 import type {
     AiPersistenceGateway,
@@ -156,6 +161,7 @@ interface PersistedWindowRecord {
     readonly isOpen: boolean;
     readonly lastOpenedAt: string;
     readonly snapshot: PersistenceSnapshot;
+    readonly workspaceRestore?: WindowWorkspaceRestoreRecord;
 }
 
 interface LegacySettingRow {
@@ -205,6 +211,7 @@ interface LegacyProjectSettingRow {
 class NativeJsonStore {
     readonly #client: NativeBackendRequester;
     readonly #pendingWrites = new Set<Promise<void>>();
+    readonly #writeChains = new Map<string, Promise<void>>();
 
     constructor(client: NativeBackendRequester) {
         this.#client = client;
@@ -238,7 +245,20 @@ class NativeJsonStore {
     }
 
     async saveNow(key: string, value: unknown): Promise<void> {
-        await this.#client.request("app_data_set_json", { key, value });
+        const previous = this.#writeChains.get(key) ?? Promise.resolve();
+        const write = previous
+            .catch(() => undefined)
+            .then(async () => {
+                await this.#client.request("app_data_set_json", { key, value });
+            });
+        this.#writeChains.set(key, write);
+        try {
+            await write;
+        } finally {
+            if (this.#writeChains.get(key) === write) {
+                this.#writeChains.delete(key);
+            }
+        }
     }
 
     async flush(): Promise<void> {
@@ -251,6 +271,7 @@ class NativePersistenceClient implements PersistenceGateway {
     readonly #store: NativeJsonStore;
     readonly #recordsByWindowId = new Map<string, PersistedWindowRecord>();
     readonly #windowOrder: string[] = [];
+    #workspaceCommitChain: Promise<void> = Promise.resolve();
 
     constructor(
         store: NativeJsonStore,
@@ -376,6 +397,82 @@ class NativePersistenceClient implements PersistenceGateway {
 
     markWindowOpen(windowId: string): void {
         this.#setOpen(windowId, true);
+    }
+
+    findWorkspaceRestore(
+        workspaceId: string,
+    ): WindowWorkspaceRestoreRecord | null {
+        for (const record of this.#recordsByWindowId.values()) {
+            if (record.snapshot.windowContext?.workspaceId === workspaceId) {
+                return record.workspaceRestore ?? null;
+            }
+        }
+        return null;
+    }
+
+    findWorkspaceScope(workspaceId: string): {
+        readonly projectId: string | null;
+        readonly worktreeId: string | null;
+    } {
+        for (const record of this.#recordsByWindowId.values()) {
+            if (record.snapshot.windowContext?.workspaceId === workspaceId) {
+                return {
+                    projectId: record.snapshot.activeProjectId,
+                    worktreeId: record.snapshot.activeWorktreeId ?? null,
+                };
+            }
+        }
+        return { projectId: null, worktreeId: null };
+    }
+
+    async commitWorkspaceRestore(
+        workspaceId: string,
+        snapshot: WorkspaceNavigationSnapshot,
+    ): Promise<void> {
+        const commit = this.#workspaceCommitChain.then(() =>
+            this.#commitWorkspaceRestoreNow(workspaceId, snapshot),
+        );
+        this.#workspaceCommitChain = commit.catch(() => undefined);
+        await commit;
+    }
+
+    async #commitWorkspaceRestoreNow(
+        workspaceId: string,
+        snapshot: WorkspaceNavigationSnapshot,
+    ): Promise<void> {
+        const entry = [...this.#recordsByWindowId.entries()].find(
+            ([, record]) =>
+                record.snapshot.windowContext?.workspaceId === workspaceId,
+        );
+        if (!entry) {
+            throw new Error("The workspace window was not found.");
+        }
+        const [windowId, current] = entry;
+        const currentRevision = current.workspaceRestore?.revision ?? 0;
+        const activeContext = snapshot.contexts.find(
+            (context) => context.key === snapshot.activeContextKey,
+        );
+        const restore = createWindowWorkspaceRestoreRecord(
+            snapshot,
+            currentRevision + 1,
+        );
+        this.#recordsByWindowId.set(windowId, {
+            ...current,
+            snapshot: {
+                ...current.snapshot,
+                activeProjectId: activeContext?.projectId ?? null,
+                activeWorktreeId: activeContext?.worktreeId ?? null,
+                windowContext: current.snapshot.windowContext
+                    ? {
+                          ...current.snapshot.windowContext,
+                          projectId: activeContext?.projectId ?? null,
+                          worktreeId: activeContext?.worktreeId ?? null,
+                      }
+                    : null,
+            },
+            workspaceRestore: restore,
+        });
+        await this.#persist();
     }
 
     #rehydrate(records: readonly PersistedWindowRecord[]): void {
@@ -717,26 +814,62 @@ class NativeSecretStore implements SecretStoreGateway {
 }
 
 class NativeWorkspaceClient implements WorkspaceGateway {
+    readonly #persistence: NativePersistenceClient;
     readonly #store: NativeJsonStore;
 
-    constructor(store: NativeJsonStore) {
+    constructor(
+        store: NativeJsonStore,
+        persistence: NativePersistenceClient,
+    ) {
         this.#store = store;
+        this.#persistence = persistence;
     }
 
     async loadSnapshot(
         workspaceId: string,
-    ): Promise<PersistedWorkspaceSnapshot> {
-        return await this.#store.load(
+    ): Promise<WindowWorkspaceRestoreRecord> {
+        const embedded = this.#persistence.findWorkspaceRestore(workspaceId);
+        if (embedded) {
+            const normalized = normalizeWindowWorkspaceRestoreRecord(
+                embedded,
+                this.#persistence.findWorkspaceScope(workspaceId),
+            );
+            if (JSON.stringify(normalized) !== JSON.stringify(embedded)) {
+                await this.#persistence.commitWorkspaceRestore(
+                    workspaceId,
+                    normalized.snapshot,
+                );
+                return this.#persistence.findWorkspaceRestore(workspaceId) ?? normalized;
+            }
+            return normalized;
+        }
+        const legacy = await this.#store.load<PersistedWorkspaceSnapshot>(
             workspaceKey(workspaceId),
             createDefaultWorkspaceSnapshot(),
         );
+        const normalized = normalizeWindowWorkspaceRestoreRecord(
+            legacy,
+            this.#persistence.findWorkspaceScope(workspaceId),
+        );
+        await this.#persistence.commitWorkspaceRestore(
+            workspaceId,
+            normalized.snapshot,
+        );
+        return this.#persistence.findWorkspaceRestore(workspaceId) ?? normalized;
     }
 
     async saveSnapshot(
         workspaceId: string,
         snapshot: WorkspaceNavigationSnapshot,
     ): Promise<void> {
-        await this.#store.saveNow(workspaceKey(workspaceId), snapshot);
+        const normalizedSnapshot = normalizeWindowWorkspaceRestoreRecord(
+            snapshot,
+            this.#persistence.findWorkspaceScope(workspaceId),
+        ).snapshot;
+        return await this.#persistence.commitWorkspaceRestore(
+            workspaceId,
+            normalizedSnapshot,
+        );
     }
 
     loadChatSessionState(
@@ -1703,7 +1836,7 @@ export async function createNativeAppDataClient(
             appliedMigrations: ["native-schema"],
             databaseFile: options.databaseFile,
         },
-        workspace: new NativeWorkspaceClient(store),
+        workspace: new NativeWorkspaceClient(store, persistence),
         close: () => store.flush(),
     };
 }

--- a/src/main/native-backend/app-data.ts
+++ b/src/main/native-backend/app-data.ts
@@ -41,11 +41,13 @@ import type {
     PersistedShellState,
     PersistedWindowState,
     PersistenceSnapshot,
+    PersistedWorkspaceSnapshot,
     ProjectSettingsSnapshot,
     SettingsSnapshot,
     ThemeMode,
     ThemePreset,
     WorkspaceNode,
+    WorkspaceNavigationSnapshot,
     WorkspaceSnapshot,
 } from "@shared/ipc";
 
@@ -721,7 +723,9 @@ class NativeWorkspaceClient implements WorkspaceGateway {
         this.#store = store;
     }
 
-    async loadSnapshot(workspaceId: string): Promise<WorkspaceSnapshot> {
+    async loadSnapshot(
+        workspaceId: string,
+    ): Promise<PersistedWorkspaceSnapshot> {
         return await this.#store.load(
             workspaceKey(workspaceId),
             createDefaultWorkspaceSnapshot(),
@@ -730,7 +734,7 @@ class NativeWorkspaceClient implements WorkspaceGateway {
 
     async saveSnapshot(
         workspaceId: string,
-        snapshot: WorkspaceSnapshot,
+        snapshot: WorkspaceNavigationSnapshot,
     ): Promise<void> {
         await this.#store.saveNow(workspaceKey(workspaceId), snapshot);
     }

--- a/src/main/native-backend/app-data.ts
+++ b/src/main/native-backend/app-data.ts
@@ -1784,6 +1784,7 @@ function createDefaultSettingsSnapshot(): CompleteSettingsSnapshot {
         appearance: {
             agentsSidebarScale: AGENTS_SIDEBAR_SCALE_DEFAULT,
             boostCodeContrast: true,
+            chromeTransparency: 45,
             fileTreeScale: FILE_TREE_SCALE_DEFAULT,
             stickyFoldersEnabled: true,
             themeMode: "system",

--- a/src/main/settings/window-zoom.test.ts
+++ b/src/main/settings/window-zoom.test.ts
@@ -31,6 +31,7 @@ describe("broadcastSettingsUpdated", () => {
             {
                 agentsSidebarScale: 1,
                 boostCodeContrast: true,
+                chromeTransparency: 45,
                 fileTreeScale: 1,
                 stickyFoldersEnabled: true,
                 themeMode: "dark",
@@ -79,6 +80,7 @@ describe("broadcastSettingsUpdated", () => {
             appearance: {
                 agentsSidebarScale: 1,
                 boostCodeContrast: true,
+                chromeTransparency: 45,
                 fileTreeScale: 1,
                 stickyFoldersEnabled: true,
                 themeMode: "dark",

--- a/src/main/window.test.ts
+++ b/src/main/window.test.ts
@@ -5,8 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 interface MockedBrowserWindow {
     readonly options: Record<string, unknown>;
     readonly setBackgroundMaterial: ReturnType<typeof vi.fn>;
+    readonly setWindowButtonPosition: ReturnType<typeof vi.fn>;
     readonly setTitleBarOverlay: ReturnType<typeof vi.fn>;
     readonly setVibrancy: ReturnType<typeof vi.fn>;
+    triggerDidFinishLoad(): void;
 }
 
 const electronMocks = vi.hoisted(() => {
@@ -23,8 +25,14 @@ const electronMocks = vi.hoisted(() => {
         readonly setTitle = vi.fn();
         readonly setTitleBarOverlay = vi.fn();
         readonly setVibrancy = vi.fn();
+        readonly setWindowButtonPosition = vi.fn();
+        private readonly didFinishLoadHandlers: Array<() => void> = [];
         readonly webContents = {
-            on: vi.fn(),
+            on: vi.fn((eventName: string, listener: () => void) => {
+                if (eventName === "did-finish-load") {
+                    this.didFinishLoadHandlers.push(listener);
+                }
+            }),
             setWindowOpenHandler: vi.fn(),
         };
 
@@ -38,6 +46,12 @@ const electronMocks = vi.hoisted(() => {
 
         isDestroyed() {
             return this.destroyed;
+        }
+
+        triggerDidFinishLoad() {
+            for (const handler of this.didFinishLoadHandlers) {
+                handler();
+            }
         }
     }
 
@@ -80,7 +94,11 @@ vi.mock("electron", () => ({
     shell: electronMocks.shell,
 }));
 
-import { createMainWindow, refreshWindowsTitleBarOverlays } from "./window";
+import {
+    createMainWindow,
+    createSettingsWindow,
+    refreshWindowsTitleBarOverlays,
+} from "./window";
 
 describe("window titlebar overlays", () => {
     beforeEach(() => {
@@ -135,10 +153,20 @@ describe("window titlebar overlays", () => {
         vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
 
         createMainWindow();
+        createSettingsWindow();
 
         expect(electronMocks.windows[0]?.options).toMatchObject({
             titleBarStyle: "hidden",
+            trafficLightPosition: { x: 14, y: 8 },
+        });
+        expect(electronMocks.windows[1]?.options).toMatchObject({
+            titleBarStyle: "hidden",
             trafficLightPosition: { x: 14, y: 14 },
         });
+
+        electronMocks.windows[0]?.triggerDidFinishLoad();
+        expect(
+            electronMocks.windows[0]?.setWindowButtonPosition,
+        ).toHaveBeenCalledWith({ x: 14, y: 8 });
     });
 });

--- a/src/main/window.test.ts
+++ b/src/main/window.test.ts
@@ -157,7 +157,7 @@ describe("window titlebar overlays", () => {
 
         expect(electronMocks.windows[0]?.options).toMatchObject({
             titleBarStyle: "hidden",
-            trafficLightPosition: { x: 14, y: 8 },
+            trafficLightPosition: { x: 14, y: 12 },
         });
         expect(electronMocks.windows[1]?.options).toMatchObject({
             titleBarStyle: "hidden",
@@ -167,6 +167,6 @@ describe("window titlebar overlays", () => {
         electronMocks.windows[0]?.triggerDidFinishLoad();
         expect(
             electronMocks.windows[0]?.setWindowButtonPosition,
-        ).toHaveBeenCalledWith({ x: 14, y: 8 });
+        ).toHaveBeenCalledWith({ x: 14, y: 12 });
     });
 });

--- a/src/main/window.test.ts
+++ b/src/main/window.test.ts
@@ -138,7 +138,7 @@ describe("window titlebar overlays", () => {
 
         expect(electronMocks.windows[0]?.options).toMatchObject({
             titleBarStyle: "hidden",
-            trafficLightPosition: { x: 14, y: 11 },
+            trafficLightPosition: { x: 14, y: 14 },
         });
     });
 });

--- a/src/main/window.test.ts
+++ b/src/main/window.test.ts
@@ -130,4 +130,15 @@ describe("window titlebar overlays", () => {
             titleBarStyle: "hidden",
         });
     });
+
+    it("positions macOS main window traffic lights against the titlebar edge", () => {
+        vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+
+        createMainWindow();
+
+        expect(electronMocks.windows[0]?.options).toMatchObject({
+            titleBarStyle: "hidden",
+            trafficLightPosition: { x: 14, y: 11 },
+        });
+    });
 });

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -148,7 +148,7 @@ function createBaseWindow(options: {
         // hiddenInset adds a platform-dependent offset to explicit positions.
         trafficLightPosition: isMac
             ? (options.trafficLightPosition ??
-              (isMainWindow ? { x: 14, y: 8 } : undefined))
+              (isMainWindow ? { x: 14, y: 14 } : undefined))
             : undefined,
         vibrancy: isMacVibrant ? "sidebar" : undefined,
         visualEffectState: isMacVibrant ? "active" : undefined,

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -118,6 +118,7 @@ function createBaseWindow(options: {
     const usesNativeTransparency = options.transparencyEnabled !== false;
     const isAcrylic = isWindows && usesNativeTransparency;
     const isMacVibrant = isMac && usesNativeTransparency;
+    const isMainWindow = options.kind === "main";
 
     const titleBarOverlay = hasNativeTitleBarOverlay
         ? resolveDesktopTitleBarOverlay()
@@ -138,12 +139,16 @@ function createBaseWindow(options: {
         backgroundMaterial: isAcrylic ? "acrylic" : undefined,
         titleBarOverlay,
         titleBarStyle: isMac
-            ? "hiddenInset"
+            ? isMainWindow
+                ? "hidden"
+                : "hiddenInset"
             : hasNativeTitleBarOverlay
               ? "hidden"
               : "default",
+        // hiddenInset adds a platform-dependent offset to explicit positions.
         trafficLightPosition: isMac
-            ? (options.trafficLightPosition ?? { x: 18, y: 18 })
+            ? (options.trafficLightPosition ??
+              (isMainWindow ? { x: 14, y: 8 } : undefined))
             : undefined,
         vibrancy: isMacVibrant ? "sidebar" : undefined,
         visualEffectState: isMacVibrant ? "active" : undefined,

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -13,7 +13,7 @@ const rootDir = fileURLToPath(new URL("../../", import.meta.url));
 const MIN_VISIBLE_RESTORE_OVERLAP = 80;
 
 export const DESKTOP_TITLE_BAR_HEIGHT = 40;
-export const MAC_MAIN_TRAFFIC_LIGHT_POSITION = { x: 14, y: 8 };
+export const MAC_MAIN_TRAFFIC_LIGHT_POSITION = { x: 14, y: 12 };
 
 type WindowKind = "main" | "settings";
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -13,6 +13,7 @@ const rootDir = fileURLToPath(new URL("../../", import.meta.url));
 const MIN_VISIBLE_RESTORE_OVERLAP = 80;
 
 export const DESKTOP_TITLE_BAR_HEIGHT = 40;
+export const MAC_MAIN_TRAFFIC_LIGHT_POSITION = { x: 14, y: 8 };
 
 type WindowKind = "main" | "settings";
 
@@ -119,6 +120,10 @@ function createBaseWindow(options: {
     const isAcrylic = isWindows && usesNativeTransparency;
     const isMacVibrant = isMac && usesNativeTransparency;
     const isMainWindow = options.kind === "main";
+    const trafficLightPosition = isMac
+        ? (options.trafficLightPosition ??
+          (isMainWindow ? MAC_MAIN_TRAFFIC_LIGHT_POSITION : { x: 14, y: 14 }))
+        : undefined;
 
     const titleBarOverlay = hasNativeTitleBarOverlay
         ? resolveDesktopTitleBarOverlay()
@@ -139,17 +144,11 @@ function createBaseWindow(options: {
         backgroundMaterial: isAcrylic ? "acrylic" : undefined,
         titleBarOverlay,
         titleBarStyle: isMac
-            ? isMainWindow
-                ? "hidden"
-                : "hiddenInset"
+            ? "hidden"
             : hasNativeTitleBarOverlay
               ? "hidden"
               : "default",
-        // hiddenInset adds a platform-dependent offset to explicit positions.
-        trafficLightPosition: isMac
-            ? (options.trafficLightPosition ??
-              (isMainWindow ? { x: 14, y: 14 } : undefined))
-            : undefined,
+        trafficLightPosition,
         vibrancy: isMacVibrant ? "sidebar" : undefined,
         visualEffectState: isMacVibrant ? "active" : undefined,
         webPreferences: {
@@ -170,6 +169,14 @@ function createBaseWindow(options: {
 
         return { action: "deny" };
     });
+
+    if (trafficLightPosition) {
+        window.webContents.on("did-finish-load", () => {
+            if (!window.isDestroyed()) {
+                window.setWindowButtonPosition(trafficLightPosition);
+            }
+        });
+    }
 
     if (process.env.ELECTRON_RENDERER_URL) {
         const url = new URL(process.env.ELECTRON_RENDERER_URL);

--- a/src/main/workspace/service.ts
+++ b/src/main/workspace/service.ts
@@ -1,13 +1,13 @@
 import type {
     PersistedChatSessionState,
-    PersistedWorkspaceSnapshot,
     WorkspaceNavigationSnapshot,
+    WindowWorkspaceRestoreRecord,
 } from "@shared/ipc";
 
 type Awaitable<T> = T | Promise<T>;
 
 export interface WorkspaceGateway {
-    loadSnapshot(workspaceId: string): Awaitable<PersistedWorkspaceSnapshot>;
+    loadSnapshot(workspaceId: string): Awaitable<WindowWorkspaceRestoreRecord>;
     saveSnapshot(
         workspaceId: string,
         snapshot: WorkspaceNavigationSnapshot,

--- a/src/main/workspace/service.ts
+++ b/src/main/workspace/service.ts
@@ -1,12 +1,16 @@
-import type { PersistedChatSessionState, WorkspaceSnapshot } from "@shared/ipc";
+import type {
+    PersistedChatSessionState,
+    PersistedWorkspaceSnapshot,
+    WorkspaceNavigationSnapshot,
+} from "@shared/ipc";
 
 type Awaitable<T> = T | Promise<T>;
 
 export interface WorkspaceGateway {
-    loadSnapshot(workspaceId: string): Awaitable<WorkspaceSnapshot>;
+    loadSnapshot(workspaceId: string): Awaitable<PersistedWorkspaceSnapshot>;
     saveSnapshot(
         workspaceId: string,
-        snapshot: WorkspaceSnapshot,
+        snapshot: WorkspaceNavigationSnapshot,
     ): Awaitable<void>;
     loadChatSessionState(
         sessionId: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -171,7 +171,8 @@ import {
     type TrashProjectEntryInput,
     type TsconfigResolutionSnapshot,
     type WriteTerminalInput,
-    type WorkspaceSnapshot,
+    type PersistedWorkspaceSnapshot,
+    type WorkspaceNavigationSnapshot,
 } from "@shared/ipc";
 
 window.addEventListener("DOMContentLoaded", () => {
@@ -542,7 +543,7 @@ const comandoApi: ComandoApi = {
             await ipcRenderer.invoke(IPC_CHANNELS.getSystemTheme),
         ),
     getWorkspaceSnapshot: async () =>
-        assertIpcObject<WorkspaceSnapshot>(
+        assertIpcObject<PersistedWorkspaceSnapshot>(
             IPC_CHANNELS.getWorkspaceSnapshot,
             await ipcRenderer.invoke(IPC_CHANNELS.getWorkspaceSnapshot),
         ),
@@ -1265,7 +1266,7 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.removeProject, projectId),
     resizeTerminalSession: (input: ResizeTerminalSessionInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.resizeTerminalSession, input),
-    saveWorkspaceSnapshot: (snapshot: WorkspaceSnapshot) =>
+    saveWorkspaceSnapshot: (snapshot: WorkspaceNavigationSnapshot) =>
         ipcRenderer.invoke(IPC_CHANNELS.saveWorkspaceSnapshot, snapshot),
     notifyFileBuffer: (input: FileBufferNotificationInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.notifyFileBuffer, input),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -828,6 +828,30 @@ const comandoApi: ComandoApi = {
             );
         };
     },
+    onWorkspaceFlushRequested: (listener) => {
+        const handleEvent = (
+            _event: Electron.IpcRendererEvent,
+            requestId: string,
+        ) => {
+            void Promise.resolve()
+                .then(listener)
+                .then(() => {
+                    ipcRenderer.send(
+                        IPC_EVENTS.workspaceFlushAcknowledged,
+                        requestId,
+                    );
+                })
+                .catch(() => undefined);
+        };
+
+        ipcRenderer.on(IPC_EVENTS.workspaceFlushRequested, handleEvent);
+        return () => {
+            ipcRenderer.removeListener(
+                IPC_EVENTS.workspaceFlushRequested,
+                handleEvent,
+            );
+        };
+    },
     onTerminalData: (listener) => {
         const handleEvent = (
             _event: Electron.IpcRendererEvent,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -38,6 +38,7 @@ import {
     type CloneRepositoryInput,
     type CloneRepositoryResult,
     type ComandoApi,
+    type ConfirmWorkspaceCloseInput,
     type CheckCommandAvailabilityInput,
     type CheckCommandAvailabilityResult,
     type CodexRuntimeSettingsInput,
@@ -511,6 +512,8 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.revealGeneratedImage, path),
     openProjectWindow: (input: OpenProjectWindowInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.openProjectWindow, input),
+    confirmWorkspaceClose: (input: ConfirmWorkspaceCloseInput) =>
+        ipcRenderer.invoke(IPC_CHANNELS.confirmWorkspaceClose, input),
     checkCommandAvailability: async (input: CheckCommandAvailabilityInput) =>
         assertCommandAvailabilityResult(
             IPC_CHANNELS.checkCommandAvailability,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4399,6 +4399,11 @@ export function App() {
                                 .getState()
                                 .openContext(projectId, worktreeId);
                         }}
+                        onReorderContext={(contextKey, targetIndex) => {
+                            void useWorkspaceStore
+                                .getState()
+                                .reorderContext(contextKey, targetIndex);
+                        }}
                         onToggleLeftSidebar={() => {
                             toggleLeftCollapsed();
                             hideSidebarOverlayImmediately();

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,7 +8,6 @@ import {
     type KeyboardEvent as ReactKeyboardEvent,
     type MouseEvent as ReactMouseEvent,
     type PointerEvent as ReactPointerEvent,
-    type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
 
@@ -19,7 +18,6 @@ import type {
     GitWorktreeSummary,
     PersistenceSnapshot,
     ProjectTreeNode,
-    ProjectSummary,
     SettingsWindowCategory,
     SettingsSnapshot,
 } from "@shared/ipc";
@@ -304,9 +302,6 @@ export function App() {
     );
     const renameEntry = useProjectsStore((state) => state.renameEntry);
     const revealEntry = useProjectsStore((state) => state.revealEntry);
-    const setActiveProject = useProjectsStore(
-        (state) => state.setActiveProject,
-    );
     const toggleDirectory = useProjectsStore((state) => state.toggleDirectory);
     const treeNodes = useProjectsStore((state) => state.treeNodes);
     const expandedDirectories = useProjectsStore(
@@ -1012,9 +1007,6 @@ export function App() {
         const { projectId, worktreeId } = activeWorkspaceContext;
         void (async () => {
             await setActiveWorktree(projectId, worktreeId);
-            if (useProjectsStore.getState().activeProjectId !== projectId) {
-                await setActiveProject(projectId);
-            }
             if (cancelled) {
                 return;
             }
@@ -1034,7 +1026,6 @@ export function App() {
         refreshGitHistory,
         refreshGitProject,
         refreshProjectTree,
-        setActiveProject,
         setActiveWorktree,
     ]);
 
@@ -3331,15 +3322,10 @@ export function App() {
             [targetProjectContextKey]: true,
         }));
 
-        if (activeProjectId !== targetProjectId) {
-            await setActiveProject(targetProjectId);
-        }
-
-        const currentTargetWorktreeId =
-            useGitStore.getState().activeWorktreeIds[targetProjectId] ?? null;
-
-        if (currentTargetWorktreeId !== targetWorktreeId) {
-            await setActiveWorktree(targetProjectId, targetWorktreeId);
+        if (workspaceActiveContextKey !== targetProjectContextKey) {
+            await useWorkspaceStore
+                .getState()
+                .openContext(targetProjectId, targetWorktreeId);
         }
 
         await revealPathInTree(targetProjectId, targetPath, targetWorktreeId);
@@ -3347,14 +3333,12 @@ export function App() {
             currentSignal === null ? 0 : currentSignal + 1,
         );
     }, [
-        activeProjectId,
         activeWorkspaceTab,
         hideSidebarOverlayImmediately,
         revealPathInTree,
-        setActiveProject,
-        setActiveWorktree,
         setLeftCollapsed,
         setSidebarView,
+        workspaceActiveContextKey,
     ]);
 
     const handleSidebarViewChange = useCallback(
@@ -4339,42 +4323,6 @@ export function App() {
                 )}
             </div>
 
-            <div className="border-t border-border/50 px-2 py-2">
-                <ProjectSwitcher
-                    activeProject={activeProject}
-                    appUpdateState={appUpdateState}
-                    onCloneRepository={async (repositoryUrl) => {
-                        const projectIds = await cloneRepository(repositoryUrl);
-                        for (const projectId of projectIds) {
-                            await useWorkspaceStore
-                                .getState()
-                                .openContext(projectId);
-                        }
-                        return projectIds.length > 0;
-                    }}
-                    onOpenProjects={() => {
-                        void (async () => {
-                            const projectIds = await addProjects();
-                            for (const projectId of projectIds) {
-                                await useWorkspaceStore
-                                    .getState()
-                                    .openContext(projectId);
-                            }
-                        })();
-                    }}
-                    onOpenSettings={openSettingsWindow}
-                    onSelectProject={(projectId) => {
-                        if (projectId === activeProjectId) {
-                            return;
-                        }
-
-                        void useWorkspaceStore
-                            .getState()
-                            .openContext(projectId);
-                    }}
-                    projects={projects}
-                />
-            </div>
         </>
     );
 
@@ -4428,7 +4376,9 @@ export function App() {
                                 }
                             })();
                         }}
-                        onOpenSettings={() => openSettingsWindow()}
+                        onOpenSettings={(initialCategory) =>
+                            openSettingsWindow(initialCategory)
+                        }
                         onOpenWorktree={(projectId, worktreeId) => {
                             void useWorkspaceStore
                                 .getState()
@@ -4444,6 +4394,9 @@ export function App() {
                             hideSidebarOverlayImmediately();
                         }}
                         platform={bootstrap?.platform ?? null}
+                        settingsLabel={getSettingsUpdateMenuLabel(
+                            appUpdateState,
+                        )}
                     />
                     <div
                         className="grid min-h-0 flex-1"
@@ -4904,9 +4857,7 @@ function createInitialAppUpdateState(): AppUpdateState {
     };
 }
 
-function getProjectSwitcherUpdateMenuLabel(
-    state: AppUpdateState,
-): string | null {
+function getSettingsUpdateMenuLabel(state: AppUpdateState): string | null {
     if (state.canInstallUpdate || state.status === "downloaded") {
         return "Settings · Update ready";
     }
@@ -4920,377 +4871,6 @@ function getProjectSwitcherUpdateMenuLabel(
     }
 
     return null;
-}
-
-function ProjectSwitcher({
-    activeProject,
-    appUpdateState,
-    onCloneRepository,
-    onOpenProjects,
-    onOpenSettings,
-    onSelectProject,
-    projects,
-}: {
-    readonly activeProject: ProjectSummary | null;
-    readonly appUpdateState: AppUpdateState;
-    readonly onCloneRepository: (repositoryUrl: string) => Promise<boolean>;
-    readonly onOpenProjects: () => void;
-    readonly onOpenSettings: (initialCategory?: SettingsWindowCategory) => void;
-    readonly onSelectProject: (projectId: string) => void;
-    readonly projects: readonly ProjectSummary[];
-}) {
-    const [open, setOpen] = useState(false);
-    const [search, setSearch] = useState("");
-    const [cloneMode, setCloneMode] = useState(false);
-    const [cloneUrl, setCloneUrl] = useState("");
-    const [cloneError, setCloneError] = useState<string | null>(null);
-    const [cloneSubmitting, setCloneSubmitting] = useState(false);
-    const ref = useRef<HTMLDivElement | null>(null);
-    const searchRef = useRef<HTMLInputElement | null>(null);
-    const cloneInputRef = useRef<HTMLInputElement | null>(null);
-    const normalizedSearch = search.trim().toLowerCase();
-    const filteredProjects = projects.filter((project) => {
-        if (!normalizedSearch) return true;
-        return (
-            project.name.toLowerCase().includes(normalizedSearch) ||
-            project.rootPath.toLowerCase().includes(normalizedSearch)
-        );
-    });
-    const updateMenuLabel = getProjectSwitcherUpdateMenuLabel(appUpdateState);
-    const hasUpdateNotice = updateMenuLabel !== null;
-
-    const resetMenuState = () => {
-        setOpen(false);
-        setSearch("");
-        setCloneMode(false);
-        setCloneUrl("");
-        setCloneError(null);
-        setCloneSubmitting(false);
-    };
-
-    useEffect(() => {
-        if (!open) return;
-        if (cloneMode) {
-            cloneInputRef.current?.focus();
-        } else {
-            searchRef.current?.focus();
-        }
-        const handleDown = (e: MouseEvent) => {
-            if (ref.current && !ref.current.contains(e.target as Node)) {
-                resetMenuState();
-            }
-        };
-        const handleKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") {
-                if (cloneMode) {
-                    setCloneMode(false);
-                    setCloneUrl("");
-                    setCloneError(null);
-                    return;
-                }
-                resetMenuState();
-            }
-        };
-        document.addEventListener("mousedown", handleDown);
-        document.addEventListener("keydown", handleKey);
-        return () => {
-            document.removeEventListener("mousedown", handleDown);
-            document.removeEventListener("keydown", handleKey);
-        };
-    }, [open, cloneMode]);
-
-    const handleAction = (action: () => void) => {
-        resetMenuState();
-        queueMicrotask(action);
-    };
-
-    const handleCloneSubmit = async () => {
-        const trimmedUrl = cloneUrl.trim();
-        if (!trimmedUrl) {
-            setCloneError("Paste a repository URL before cloning.");
-            return;
-        }
-
-        setCloneSubmitting(true);
-        setCloneError(null);
-        try {
-            const completed = await onCloneRepository(trimmedUrl);
-            if (completed) {
-                resetMenuState();
-            } else {
-                setCloneSubmitting(false);
-            }
-        } catch (error) {
-            setCloneSubmitting(false);
-            setCloneError(
-                error instanceof Error
-                    ? error.message
-                    : "Could not clone the repository.",
-            );
-        }
-    };
-
-    const menuItem = (
-        label: string,
-        action: () => void,
-        checked = false,
-        muted = false,
-        trailing?: ReactNode,
-    ) => (
-        <button
-            className="project-switcher-menu-item"
-            key={label}
-            onClick={() => handleAction(action)}
-            type="button"
-        >
-            <span className="project-switcher-check">{checked ? "✓" : ""}</span>
-            <span
-                className="truncate"
-                style={{
-                    color: muted
-                        ? "var(--color-text-secondary)"
-                        : "var(--color-text-primary)",
-                }}
-            >
-                {label}
-            </span>
-            {trailing}
-        </button>
-    );
-
-    return (
-        <div ref={ref} style={{ position: "relative" }}>
-            {open && (
-                <div className="project-switcher-menu">
-                    {cloneMode ? (
-                        <div className="project-switcher-clone">
-                            <div className="project-switcher-clone-label">
-                                Clone repository
-                            </div>
-                            <input
-                                autoCapitalize="off"
-                                autoCorrect="off"
-                                className="project-switcher-clone-input"
-                                disabled={cloneSubmitting}
-                                onChange={(e) => {
-                                    setCloneUrl(e.target.value);
-                                    if (cloneError) setCloneError(null);
-                                }}
-                                onKeyDown={(e) => {
-                                    e.stopPropagation();
-                                    if (e.key === "Enter") {
-                                        e.preventDefault();
-                                        void handleCloneSubmit();
-                                    }
-                                }}
-                                placeholder="https://github.com/user/repo.git"
-                                ref={cloneInputRef}
-                                spellCheck={false}
-                                value={cloneUrl}
-                            />
-                            {cloneError && (
-                                <div className="project-switcher-clone-error">
-                                    {cloneError}
-                                </div>
-                            )}
-                            <div className="project-switcher-clone-actions">
-                                <button
-                                    className="project-switcher-clone-btn"
-                                    disabled={cloneSubmitting}
-                                    onClick={() => {
-                                        setCloneMode(false);
-                                        setCloneUrl("");
-                                        setCloneError(null);
-                                    }}
-                                    type="button"
-                                >
-                                    Back
-                                </button>
-                                <button
-                                    className="project-switcher-clone-btn project-switcher-clone-btn-primary"
-                                    disabled={
-                                        cloneSubmitting || !cloneUrl.trim()
-                                    }
-                                    onClick={() => {
-                                        void handleCloneSubmit();
-                                    }}
-                                    type="button"
-                                >
-                                    {cloneSubmitting
-                                        ? "Cloning…"
-                                        : "Choose folder & clone"}
-                                </button>
-                            </div>
-                        </div>
-                    ) : (
-                        <>
-                            {projects.length > 0 && (
-                                <div className="project-switcher-search">
-                                    <svg
-                                        fill="none"
-                                        height="12"
-                                        style={{
-                                            opacity: 0.4,
-                                            flexShrink: 0,
-                                        }}
-                                        viewBox="0 0 16 16"
-                                        width="12"
-                                    >
-                                        <circle
-                                            cx="7"
-                                            cy="7"
-                                            r="5"
-                                            stroke="currentColor"
-                                            strokeWidth="1.5"
-                                        />
-                                        <path
-                                            d="m13 13-2.5-2.5"
-                                            stroke="currentColor"
-                                            strokeLinecap="round"
-                                            strokeWidth="1.5"
-                                        />
-                                    </svg>
-                                    <input
-                                        autoCapitalize="off"
-                                        autoCorrect="off"
-                                        className="project-switcher-search-input"
-                                        onChange={(e) =>
-                                            setSearch(e.target.value)
-                                        }
-                                        onKeyDown={(e) => e.stopPropagation()}
-                                        placeholder="Search projects…"
-                                        ref={searchRef}
-                                        spellCheck={false}
-                                        value={search}
-                                    />
-                                    <span className="project-switcher-search-count">
-                                        {filteredProjects.length}/
-                                        {projects.length}
-                                    </span>
-                                </div>
-                            )}
-                            <div className="project-switcher-list">
-                                {projects.length > 0 &&
-                                filteredProjects.length === 0 ? (
-                                    <div className="project-switcher-empty">
-                                        No projects match your search.
-                                    </div>
-                                ) : (
-                                    filteredProjects.map((project) =>
-                                        menuItem(
-                                            project.name,
-                                            () => onSelectProject(project.id),
-                                            project.id === activeProject?.id,
-                                        ),
-                                    )
-                                )}
-                            </div>
-                            {projects.length > 0 && (
-                                <div className="project-switcher-sep" />
-                            )}
-                            {menuItem(
-                                "Open folder…",
-                                onOpenProjects,
-                                false,
-                                true,
-                            )}
-                            <button
-                                className="project-switcher-menu-item"
-                                onClick={() => {
-                                    setCloneMode(true);
-                                    setCloneError(null);
-                                    setCloneUrl("");
-                                }}
-                                type="button"
-                            >
-                                <span className="project-switcher-check" />
-                                <span
-                                    className="truncate"
-                                    style={{
-                                        color: "var(--color-text-secondary)",
-                                    }}
-                                >
-                                    Clone repository…
-                                </span>
-                            </button>
-                            {menuItem(
-                                updateMenuLabel ?? "Settings",
-                                () =>
-                                    onOpenSettings(
-                                        hasUpdateNotice
-                                            ? "updates"
-                                            : undefined,
-                                    ),
-                                false,
-                                true,
-                                hasUpdateNotice ? (
-                                    <span
-                                        aria-hidden="true"
-                                        className="project-switcher-update-dot"
-                                    />
-                                ) : undefined,
-                            )}
-                        </>
-                    )}
-                </div>
-            )}
-
-            <button
-                className="sidebar-action-row sidebar-action-row--switcher app-no-drag w-full"
-                onClick={() => setOpen((v) => !v)}
-                type="button"
-            >
-                <svg
-                    aria-hidden="true"
-                    fill="none"
-                    height="13"
-                    style={{ flexShrink: 0 }}
-                    viewBox="0 0 16 16"
-                    width="13"
-                >
-                    <path
-                        d="M6.73 1.2H9.27L9.58 2.77C10.01 2.9 10.42 3.07 10.8 3.3L12.18 2.49L13.97 4.28L13.16 5.66C13.39 6.04 13.56 6.45 13.69 6.88L15.26 7.19V9.73L13.69 10.04C13.56 10.47 13.39 10.88 13.16 11.26L13.97 12.64L12.18 14.43L10.8 13.62C10.42 13.85 10.01 14.02 9.58 14.15L9.27 15.72H6.73L6.42 14.15C5.99 14.02 5.58 13.85 5.2 13.62L3.82 14.43L2.03 12.64L2.84 11.26C2.61 10.88 2.44 10.47 2.31 10.04L0.74 9.73V7.19L2.31 6.88C2.44 6.45 2.61 6.04 2.84 5.66L2.03 4.28L3.82 2.49L5.2 3.3C5.58 3.07 5.99 2.9 6.42 2.77L6.73 1.2Z"
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="1"
-                    />
-                    <circle
-                        cx="8"
-                        cy="8"
-                        r="2.1"
-                        stroke="currentColor"
-                        strokeWidth="1.4"
-                    />
-                </svg>
-                <span
-                    className="flex-1 truncate text-left"
-                    style={{
-                        color: "var(--color-text-primary)",
-                        fontWeight: 500,
-                    }}
-                >
-                    {activeProject?.name ?? "Open project"}
-                </span>
-                <svg
-                    aria-hidden="true"
-                    fill="none"
-                    height="10"
-                    style={{ flexShrink: 0 }}
-                    viewBox="0 0 16 16"
-                    width="10"
-                >
-                    <path
-                        d="M5 6l3-3 3 3M5 10l3 3 3-3"
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="1.5"
-                    />
-                </svg>
-            </button>
-        </div>
-    );
 }
 
 function getGitContextKey(

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -136,7 +136,10 @@ import {
 } from "./components/workspace/quick-create";
 import { QuickOpenFilePalette } from "./components/workspace/QuickOpenFilePalette";
 import type { WorkspacePaneRecentProject } from "./components/workspace/WorkspacePaneEmptyState";
-import { closeWorkspaceTabsWithConfirmation } from "./components/workspace/workspaceCloseGuard";
+import {
+    closeWorkspaceContextWithConfirmation,
+    closeWorkspaceTabsWithConfirmation,
+} from "./components/workspace/workspaceCloseGuard";
 import {
     DesktopTopBar,
     type ProjectContextMenuProject,
@@ -351,10 +354,33 @@ export function App() {
             workspaceState.activeContextKey === contextKey
                 ? workspaceState.tabsById
                 : context.workspace.tabsById;
-        return closeWorkspaceTabsWithConfirmation(
-            Object.keys(tabsById),
+        const workspaceName =
+            useProjectsStore
+                .getState()
+                .projects.find((project) => project.id === context.projectId)
+                ?.name ?? "this workspace";
+        return closeWorkspaceContextWithConfirmation(
+            {
+                projectId: context.projectId,
+                sessions: useAiStore.getState().sessions,
+                tabsById,
+                worktreeId: context.worktreeId,
+            },
             () => useWorkspaceStore.getState().closeContext(contextKey),
-            { tabsById },
+            {
+                confirm: async (summary) => {
+                    const comandoApi = getComandoApi();
+                    if (!comandoApi) {
+                        return false;
+                    }
+
+                    return comandoApi.confirmWorkspaceClose({
+                        activeAgentCount: summary.activeAgentCount,
+                        dirtyFileCount: summary.dirtyFileCount,
+                        workspaceName,
+                    });
+                },
+            },
         );
     }, []);
     const requestMoveWorkspaceContextToNewWindow = useCallback(

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,6 +15,8 @@ import { createPortal } from "react-dom";
 import type {
     AppUpdateState,
     ComandoApi,
+    GitRepositorySnapshot,
+    GitWorktreeSummary,
     PersistenceSnapshot,
     ProjectTreeNode,
     ProjectSummary,
@@ -32,6 +34,10 @@ import {
     findProjectTreeNodeByPath,
 } from "./app/projects/git-tree";
 import { createGitProjectRefreshScheduler } from "./app/git/refresh-scheduler";
+import {
+    areGitWorktreeIdsEquivalent,
+    resolveProjectContextWorktreeId,
+} from "./app/git/context-key";
 import {
     reconcileFileTreeSelection,
     resolveActiveFileTreePath,
@@ -131,7 +137,11 @@ import {
 } from "./components/workspace/quick-create";
 import { QuickOpenFilePalette } from "./components/workspace/QuickOpenFilePalette";
 import { closeWorkspaceTabsWithConfirmation } from "./components/workspace/workspaceCloseGuard";
-import { DesktopTopBar } from "./components/DesktopTopBar";
+import {
+    DesktopTopBar,
+    type ProjectContextMenuProject,
+    type ProjectContextTabItem,
+} from "./components/DesktopTopBar";
 import { WorkspaceView } from "./components/workspace/WorkspaceView";
 import { WorkspaceTerminalHost } from "./features/terminal/WorkspaceTerminalHost";
 
@@ -145,6 +155,31 @@ type SidebarView = "files" | "git" | "agents" | "issues" | "pull_requests";
 
 const ROOT_NODE_KEY = "__root__";
 const PROJECT_SEARCH_FOLLOWUP_DEBOUNCE_MS = 50;
+
+function collectProjectWorktrees(
+    snapshots: Readonly<Record<string, GitRepositorySnapshot | null>>,
+    projectId: string,
+): readonly GitWorktreeSummary[] {
+    const worktreesById = new Map<string, GitWorktreeSummary>();
+    for (const snapshot of Object.values(snapshots)) {
+        if (snapshot?.projectId !== projectId) {
+            continue;
+        }
+        for (const worktree of snapshot.worktrees) {
+            worktreesById.set(worktree.id, worktree);
+        }
+    }
+    return [...worktreesById.values()];
+}
+
+function getWorktreeDisplayLabel(worktree: GitWorktreeSummary): string {
+    if (worktree.branchName) {
+        return worktree.branchName;
+    }
+
+    const pathParts = worktree.rootPath.split(/[\\/]/).filter(Boolean);
+    return pathParts.at(-1) ?? "Detached worktree";
+}
 
 type FileTreeContextMenuPayload =
     | {
@@ -221,7 +256,29 @@ export function App() {
     const bootstrapError = useAppStore((state) => state.error);
     const hydrateBootstrap = useAppStore((state) => state.hydrate);
 
-    const activeProjectId = useProjectsStore((state) => state.activeProjectId);
+    const persistedActiveProjectId = useProjectsStore(
+        (state) => state.activeProjectId,
+    );
+    const workspaceActiveContextKey = useWorkspaceStore(
+        (state) => state.activeContextKey,
+    );
+    const workspaceNavigationHydrated = useWorkspaceStore(
+        (state) => state.hydrated,
+    );
+    const workspaceContextsByKey = useWorkspaceStore(
+        (state) => state.contextsByKey,
+    );
+    const openWorkspaceContextKeys = useWorkspaceStore(
+        (state) => state.openContextKeys,
+    );
+    const activeWorkspaceContext = useWorkspaceStore((state) =>
+        state.activeContextKey
+            ? (state.contextsByKey[state.activeContextKey] ?? null)
+            : null,
+    );
+    const activeProjectId =
+        activeWorkspaceContext?.projectId ??
+        (workspaceNavigationHydrated ? null : persistedActiveProjectId);
     const addProjects = useProjectsStore((state) => state.addProjects);
     const cloneRepository = useProjectsStore((state) => state.cloneRepository);
     const hydrateProjects = useProjectsStore((state) => state.hydrate);
@@ -260,6 +317,7 @@ export function App() {
     const refreshGitHistory = useGitStore((state) => state.refreshHistory);
     const refreshGitProject = useGitStore((state) => state.refreshProject);
     const ingestGitSnapshot = useGitStore((state) => state.ingestSnapshot);
+    const gitSnapshots = useGitStore((state) => state.snapshots);
     const setActiveWorktree = useGitStore((state) => state.setActiveWorktree);
     const selectGitBranch = useGitStore((state) => state.selectBranch);
 
@@ -534,7 +592,10 @@ export function App() {
                         resolvedWorktreeId,
                     );
                 }
-                await workspaceHydrate();
+                await workspaceHydrate({
+                    activeProjectId: persistedProjectId,
+                    activeWorktreeId: persistedWorktreeId,
+                });
             } finally {
                 if (!isDisposed) {
                     setPersistenceReady(true);
@@ -654,10 +715,6 @@ export function App() {
 
         const unsubscribe = comandoApi.onProjectWindowRequested((payload) => {
             void (async () => {
-                if (activeProjectId !== payload.projectId) {
-                    await setActiveProject(payload.projectId);
-                }
-
                 const requestedWorktreeId =
                     payload.worktreeId !== undefined
                         ? (payload.worktreeId ?? null)
@@ -665,12 +722,9 @@ export function App() {
                               payload.projectId
                           ] ?? null);
 
-                if (payload.worktreeId !== undefined) {
-                    await setActiveWorktree(
-                        payload.projectId,
-                        requestedWorktreeId,
-                    );
-                }
+                await useWorkspaceStore
+                    .getState()
+                    .openContext(payload.projectId, requestedWorktreeId);
 
                 if (payload.branchName !== undefined) {
                     selectGitBranch(
@@ -680,22 +734,12 @@ export function App() {
                     );
                 }
 
-                await refreshGitProject(payload.projectId, requestedWorktreeId);
-                await refreshProjectTree(
-                    payload.projectId,
-                    requestedWorktreeId,
-                );
             })();
         });
 
         return unsubscribe;
     }, [
-        activeProjectId,
-        refreshGitProject,
-        refreshProjectTree,
         selectGitBranch,
-        setActiveProject,
-        setActiveWorktree,
     ]);
 
     useEffect(() => {
@@ -880,11 +924,22 @@ export function App() {
         void window.comando.saveActiveProjectId(activeProjectId);
     }, [activeProjectId, persistenceReady]);
 
-    const activeWorktreeId = useGitStore((state) =>
+    const gitActiveWorktreeId = useGitStore((state) =>
         activeProjectId
             ? (state.activeWorktreeIds[activeProjectId] ?? null)
             : null,
     );
+    const activeWorktreeId = activeWorkspaceContext
+        ? // Macro contexts use null for the logical primary checkout, while
+          // scoped services persist and query its canonical worktree id.
+          resolveProjectContextWorktreeId(
+              activeWorkspaceContext.projectId,
+              activeWorkspaceContext.worktreeId,
+              gitActiveWorktreeId,
+          )
+        : workspaceNavigationHydrated
+          ? null
+          : gitActiveWorktreeId;
     const activeProjectContextKey = getProjectContextKey(
         activeProjectId,
         activeWorktreeId,
@@ -893,6 +948,41 @@ export function App() {
         activeProjectId,
         activeWorktreeId,
     );
+
+    useEffect(() => {
+        if (!activeWorkspaceContext) {
+            return;
+        }
+
+        let cancelled = false;
+        const { projectId, worktreeId } = activeWorkspaceContext;
+        void (async () => {
+            await setActiveWorktree(projectId, worktreeId);
+            if (useProjectsStore.getState().activeProjectId !== projectId) {
+                await setActiveProject(projectId);
+            }
+            if (cancelled) {
+                return;
+            }
+
+            await Promise.all([
+                refreshProjectTree(projectId, worktreeId),
+                refreshGitProject(projectId, worktreeId),
+                refreshGitHistory(projectId, worktreeId),
+            ]);
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [
+        activeWorkspaceContext,
+        refreshGitHistory,
+        refreshGitProject,
+        refreshProjectTree,
+        setActiveProject,
+        setActiveWorktree,
+    ]);
 
     useEffect(() => {
         return scheduleEffectStateUpdate(() => {
@@ -1288,6 +1378,125 @@ export function App() {
 
     const activeProject =
         projects.find((project) => project.id === activeProjectId) ?? null;
+    useEffect(() => {
+        document.title = activeProject
+            ? `${activeProject.name} — Comando`
+            : (bootstrap?.app.windowTitle ?? "Comando");
+    }, [activeProject, bootstrap?.app.windowTitle]);
+    const projectContextTabs = useMemo<readonly ProjectContextTabItem[]>(
+        () =>
+            openWorkspaceContextKeys.flatMap((contextKey) => {
+                const context = workspaceContextsByKey[contextKey];
+                const project = context
+                    ? projects.find((entry) => entry.id === context.projectId)
+                    : null;
+                if (!context || !project) {
+                    return [];
+                }
+
+                const worktrees = collectProjectWorktrees(
+                    gitSnapshots,
+                    context.projectId,
+                );
+                const worktree = worktrees.find((entry) =>
+                    areGitWorktreeIdsEquivalent(
+                        context.projectId,
+                        context.worktreeId,
+                        entry.isPrimary ? null : entry.id,
+                    ),
+                );
+                return [
+                    {
+                        key: context.key,
+                        projectId: context.projectId,
+                        projectName: project.name,
+                        worktreeId: context.worktreeId,
+                        worktreeLabel: worktree
+                            ? getWorktreeDisplayLabel(worktree)
+                            : context.worktreeId
+                              ? "Worktree"
+                              : "Main checkout",
+                    },
+                ];
+            }),
+        [
+            gitSnapshots,
+            openWorkspaceContextKeys,
+            projects,
+            workspaceContextsByKey,
+        ],
+    );
+    const projectContextMenuProjects = useMemo<
+        readonly ProjectContextMenuProject[]
+    >(() => {
+        const openContextIdentities = openWorkspaceContextKeys.flatMap(
+            (contextKey) => {
+                const context = workspaceContextsByKey[contextKey];
+                return context
+                    ? [
+                          {
+                              projectId: context.projectId,
+                              worktreeId: context.worktreeId,
+                          },
+                      ]
+                    : [];
+            },
+        );
+
+        return projects.map((project) => {
+            const primaryIsOpen = openContextIdentities.some(
+                (context) =>
+                    context.projectId === project.id &&
+                    areGitWorktreeIdsEquivalent(
+                        project.id,
+                        context.worktreeId,
+                        null,
+                    ),
+            );
+            const worktrees = collectProjectWorktrees(gitSnapshots, project.id)
+                .filter((worktree) => !worktree.isPrimary)
+                .map((worktree) => ({
+                    id: worktree.id,
+                    isActive:
+                        activeWorkspaceContext?.projectId === project.id &&
+                        areGitWorktreeIdsEquivalent(
+                            project.id,
+                            activeWorkspaceContext.worktreeId,
+                            worktree.id,
+                        ),
+                    isOpen: openContextIdentities.some(
+                        (context) =>
+                            context.projectId === project.id &&
+                            areGitWorktreeIdsEquivalent(
+                                project.id,
+                                context.worktreeId,
+                                worktree.id,
+                            ),
+                    ),
+                    label: getWorktreeDisplayLabel(worktree),
+                }));
+
+            return {
+                id: project.id,
+                mainIsActive:
+                    activeWorkspaceContext?.projectId === project.id &&
+                    areGitWorktreeIdsEquivalent(
+                        project.id,
+                        activeWorkspaceContext.worktreeId,
+                        null,
+                    ),
+                mainIsOpen: primaryIsOpen,
+                name: project.name,
+                worktrees,
+            };
+        });
+    }, [
+        activeWorkspaceContext,
+        gitSnapshots,
+        openWorkspaceContextKeys,
+        projects,
+        workspaceContextsByKey,
+    ]);
     const activeTreeNodesByParent = useMemo(
         () => treeNodes[activeProjectContextKey] ?? {},
         [activeProjectContextKey, treeNodes],
@@ -1449,10 +1658,6 @@ export function App() {
     const activeGitError = gitErrors[activeGitContextKey] ?? null;
     const isMac = bootstrap?.platform === "darwin";
     const isWindows = bootstrap?.platform === "win32";
-    const isLinux = bootstrap?.platform === "linux";
-    const hasDesktopTitleBar = isWindows || isLinux;
-    const desktopTitleBarTitle =
-        activeProject?.name ?? bootstrap?.app.windowTitle ?? "Comando";
     const topStatus = [
         bootstrapError,
         projectsError,
@@ -3343,6 +3548,31 @@ export function App() {
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
+            if (
+                event.defaultPrevented ||
+                !(event.metaKey || event.ctrlKey) ||
+                event.altKey ||
+                !event.shiftKey ||
+                event.key.toLowerCase() !== "w" ||
+                !workspaceActiveContextKey
+            ) {
+                return;
+            }
+
+            event.preventDefault();
+            void useWorkspaceStore
+                .getState()
+                .closeContext(workspaceActiveContextKey);
+        };
+
+        window.addEventListener("keydown", handleKeyDown, true);
+        return () => {
+            window.removeEventListener("keydown", handleKeyDown, true);
+        };
+    }, [workspaceActiveContextKey]);
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === "b" && (event.metaKey || event.ctrlKey)) {
                 event.preventDefault();
                 toggleLeftCollapsed();
@@ -3411,9 +3641,8 @@ export function App() {
 
     useEffect(() => {
         if (!isMac) return;
-        const visible = !leftCollapsed || sidebarOverlayVisible;
-        void window.comando?.setTrafficLightVisibility(visible);
-    }, [isMac, leftCollapsed, sidebarOverlayVisible]);
+        void window.comando?.setTrafficLightVisibility(true);
+    }, [isMac]);
 
     useEffect(() => {
         const platform = bootstrap?.platform;
@@ -3460,6 +3689,7 @@ export function App() {
             <div
                 className="app-drag relative px-2"
                 style={{
+                    // Keep sidebar controls clear of the macOS traffic lights.
                     paddingTop: isMac ? 42 : isWindows ? 0 : 8,
                 }}
             >
@@ -4167,11 +4397,24 @@ export function App() {
                 <ProjectSwitcher
                     activeProject={activeProject}
                     appUpdateState={appUpdateState}
-                    onCloneRepository={(repositoryUrl) =>
-                        cloneRepository(repositoryUrl)
-                    }
+                    onCloneRepository={async (repositoryUrl) => {
+                        const projectIds = await cloneRepository(repositoryUrl);
+                        for (const projectId of projectIds) {
+                            await useWorkspaceStore
+                                .getState()
+                                .openContext(projectId);
+                        }
+                        return projectIds.length > 0;
+                    }}
                     onOpenProjects={() => {
-                        void addProjects();
+                        void (async () => {
+                            const projectIds = await addProjects();
+                            for (const projectId of projectIds) {
+                                await useWorkspaceStore
+                                    .getState()
+                                    .openContext(projectId);
+                            }
+                        })();
                     }}
                     onOpenSettings={openSettingsWindow}
                     onSelectProject={(projectId) => {
@@ -4179,9 +4422,9 @@ export function App() {
                             return;
                         }
 
-                        void getComandoApi()?.openProjectWindow({
-                            projectId,
-                        });
+                        void useWorkspaceStore
+                            .getState()
+                            .openContext(projectId);
                     }}
                     projects={projects}
                 />
@@ -4196,9 +4439,53 @@ export function App() {
         >
             <div className="relative h-screen">
                 <div className="flex h-full flex-col overflow-hidden">
-                    {hasDesktopTitleBar && (
-                        <DesktopTopBar title={desktopTitleBarTitle} />
-                    )}
+                    <DesktopTopBar
+                        activeContextKey={workspaceActiveContextKey}
+                        contexts={projectContextTabs}
+                        menuProjects={projectContextMenuProjects}
+                        onActivateContext={(contextKey) => {
+                            void useWorkspaceStore
+                                .getState()
+                                .activateContext(contextKey);
+                        }}
+                        onCloneRepository={async (repositoryUrl) => {
+                            const projectIds =
+                                await cloneRepository(repositoryUrl);
+                            for (const projectId of projectIds) {
+                                await useWorkspaceStore
+                                    .getState()
+                                    .openContext(projectId);
+                            }
+                            return projectIds.length > 0;
+                        }}
+                        onCloseContext={(contextKey) => {
+                            void useWorkspaceStore
+                                .getState()
+                                .closeContext(contextKey);
+                        }}
+                        onOpenProject={(projectId) => {
+                            void useWorkspaceStore
+                                .getState()
+                                .openContext(projectId);
+                        }}
+                        onOpenProjects={() => {
+                            void (async () => {
+                                const projectIds = await addProjects();
+                                for (const projectId of projectIds) {
+                                    await useWorkspaceStore
+                                        .getState()
+                                        .openContext(projectId);
+                                }
+                            })();
+                        }}
+                        onOpenSettings={() => openSettingsWindow()}
+                        onOpenWorktree={(projectId, worktreeId) => {
+                            void useWorkspaceStore
+                                .getState()
+                                .openContext(projectId, worktreeId);
+                        }}
+                        platform={bootstrap?.platform ?? null}
+                    />
                     <div
                         className="grid min-h-0 flex-1"
                         style={{
@@ -4282,7 +4569,7 @@ export function App() {
                         style={{
                             position: "absolute",
                             left: 0,
-                            top: 0,
+                            top: "var(--desktop-titlebar-height, 40px)",
                             bottom: 0,
                             width: sidebarOverlayVisible
                                 ? 0
@@ -4304,7 +4591,7 @@ export function App() {
                         style={{
                             position: "absolute",
                             left: 0,
-                            top: 0,
+                            top: "var(--desktop-titlebar-height, 40px)",
                             bottom: 0,
                             width: leftWidth,
                             zIndex: 10,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -17,6 +17,7 @@ import type {
     GitRepositorySnapshot,
     GitWorktreeSummary,
     PersistenceSnapshot,
+    ProjectSummary,
     ProjectTreeNode,
     SettingsWindowCategory,
     SettingsSnapshot,
@@ -134,6 +135,7 @@ import {
     createWorkspaceQuickFile,
 } from "./components/workspace/quick-create";
 import { QuickOpenFilePalette } from "./components/workspace/QuickOpenFilePalette";
+import type { WorkspacePaneRecentProject } from "./components/workspace/WorkspacePaneEmptyState";
 import { closeWorkspaceTabsWithConfirmation } from "./components/workspace/workspaceCloseGuard";
 import {
     DesktopTopBar,
@@ -153,6 +155,7 @@ type SidebarView = "files" | "git" | "agents" | "issues" | "pull_requests";
 
 const ROOT_NODE_KEY = "__root__";
 const PROJECT_SEARCH_FOLLOWUP_DEBOUNCE_MS = 50;
+const WORKSPACE_RECENT_PROJECTS_LIMIT = 6;
 
 function collectProjectWorktrees(
     snapshots: Readonly<Record<string, GitRepositorySnapshot | null>>,
@@ -1463,6 +1466,17 @@ export function App() {
             workspaceContextsByKey,
         ],
     );
+    const workspaceRecentProjects = useMemo<
+        readonly WorkspacePaneRecentProject[]
+    >(() => {
+        const lastOpenedTime = (project: ProjectSummary) =>
+            project.lastOpenedAt ? Date.parse(project.lastOpenedAt) : 0;
+        return projects
+            .filter((project) => project.id !== activeProjectId)
+            .toSorted((a, b) => lastOpenedTime(b) - lastOpenedTime(a))
+            .slice(0, WORKSPACE_RECENT_PROJECTS_LIMIT)
+            .map((project) => ({ id: project.id, name: project.name }));
+    }, [activeProjectId, projects]);
     const projectContextMenuProjects = useMemo<
         readonly ProjectContextMenuProject[]
     >(() => {
@@ -4326,6 +4340,19 @@ export function App() {
         </>
     );
 
+    const handleOpenProject = (projectId: string) => {
+        void useWorkspaceStore.getState().openContext(projectId);
+    };
+
+    const handleOpenProjects = () => {
+        void (async () => {
+            const projectIds = await addProjects();
+            for (const projectId of projectIds) {
+                await useWorkspaceStore.getState().openContext(projectId);
+            }
+        })();
+    };
+
     return (
         <div
             className="min-h-screen text-text-primary"
@@ -4361,21 +4388,8 @@ export function App() {
                                 contextKey,
                             );
                         }}
-                        onOpenProject={(projectId) => {
-                            void useWorkspaceStore
-                                .getState()
-                                .openContext(projectId);
-                        }}
-                        onOpenProjects={() => {
-                            void (async () => {
-                                const projectIds = await addProjects();
-                                for (const projectId of projectIds) {
-                                    await useWorkspaceStore
-                                        .getState()
-                                        .openContext(projectId);
-                                }
-                            })();
-                        }}
+                        onOpenProject={handleOpenProject}
+                        onOpenProjects={handleOpenProjects}
                         onOpenSettings={(initialCategory) =>
                             openSettingsWindow(initialCategory)
                         }
@@ -4468,9 +4482,12 @@ export function App() {
                             <WorkspaceView
                                 defaultProjectId={activeProjectId}
                                 defaultWorktreeId={activeWorktreeId}
+                                onOpenProject={handleOpenProject}
+                                onOpenProjects={handleOpenProjects}
                                 onRequestCreateFile={() => {
                                     void handleCreateTreeEntry("file", null);
                                 }}
+                                recentProjects={workspaceRecentProjects}
                             />
                         </main>
                     </div>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -341,6 +341,23 @@ export function App() {
             ),
         [closeWorkspaceTab],
     );
+    const requestCloseWorkspaceContext = useCallback((contextKey: string) => {
+        const workspaceState = useWorkspaceStore.getState();
+        const context = workspaceState.contextsByKey[contextKey];
+        if (!context) {
+            return Promise.resolve();
+        }
+
+        const tabsById =
+            workspaceState.activeContextKey === contextKey
+                ? workspaceState.tabsById
+                : context.workspace.tabsById;
+        return closeWorkspaceTabsWithConfirmation(
+            Object.keys(tabsById),
+            () => useWorkspaceStore.getState().closeContext(contextKey),
+            { tabsById },
+        );
+    }, []);
     const requestCloseActiveWorkspaceTab = useEffectEvent(() => {
         const workspaceState = useWorkspaceStore.getState();
         const activePane = findPaneById(
@@ -3558,16 +3575,14 @@ export function App() {
             }
 
             event.preventDefault();
-            void useWorkspaceStore
-                .getState()
-                .closeContext(workspaceActiveContextKey);
+            void requestCloseWorkspaceContext(workspaceActiveContextKey);
         };
 
         window.addEventListener("keydown", handleKeyDown, true);
         return () => {
             window.removeEventListener("keydown", handleKeyDown, true);
         };
-    }, [workspaceActiveContextKey]);
+    }, [requestCloseWorkspaceContext, workspaceActiveContextKey]);
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
@@ -4361,9 +4376,7 @@ export function App() {
                             return projectIds.length > 0;
                         }}
                         onCloseContext={(contextKey) => {
-                            void useWorkspaceStore
-                                .getState()
-                                .closeContext(contextKey);
+                            void requestCloseWorkspaceContext(contextKey);
                         }}
                         onOpenProject={(projectId) => {
                             void useWorkspaceStore

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3639,6 +3639,68 @@ export function App() {
     }, [requestCloseWorkspaceContext, workspaceActiveContextKey]);
 
     useEffect(() => {
+        const isSupportedPlatform =
+            bootstrap?.platform === "darwin" ||
+            bootstrap?.platform === "linux" ||
+            bootstrap?.platform === "win32";
+        if (!isSupportedPlatform) {
+            return;
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (
+                event.defaultPrevented ||
+                event.shiftKey ||
+                !event.altKey ||
+                (isMac ? !event.metaKey || event.ctrlKey : !event.ctrlKey || event.metaKey)
+            ) {
+                return;
+            }
+
+            const direction =
+                event.code === "BracketRight"
+                    ? "next"
+                    : event.code === "BracketLeft"
+                      ? "previous"
+                      : null;
+            if (!direction || openWorkspaceContextKeys.length < 2) {
+                return;
+            }
+
+            const activeIndex = openWorkspaceContextKeys.indexOf(
+                workspaceActiveContextKey ?? "",
+            );
+            if (activeIndex < 0) {
+                return;
+            }
+
+            const targetIndex =
+                direction === "next"
+                    ? (activeIndex + 1) % openWorkspaceContextKeys.length
+                    : (activeIndex - 1 + openWorkspaceContextKeys.length) %
+                      openWorkspaceContextKeys.length;
+            const targetContextKey = openWorkspaceContextKeys[targetIndex];
+            if (!targetContextKey) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            void useWorkspaceStore.getState().activateContext(targetContextKey);
+        };
+
+        window.addEventListener("keydown", handleKeyDown, true);
+        return () => {
+            window.removeEventListener("keydown", handleKeyDown, true);
+        };
+    }, [
+        bootstrap?.platform,
+        isMac,
+        openWorkspaceContextKeys,
+        workspaceActiveContextKey,
+    ]);
+
+    useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === "b" && (event.metaKey || event.ctrlKey)) {
                 event.preventDefault();

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -110,7 +110,6 @@ import {
     SidebarAgentsPanel,
     SidebarGitHubPanel,
     SidebarGitPanel,
-    SidebarGitScopePicker,
     type SidebarGitHubAddToChatRequest,
 } from "./components/sidebar";
 import {
@@ -3693,7 +3692,7 @@ export function App() {
                     paddingTop: isMac ? 42 : isWindows ? 0 : 8,
                 }}
             >
-                {isMac && (
+                {(isMac || isWindows) && (
                     <button
                         className="sidebar-collapse-toggle app-no-drag"
                         onClick={() => {
@@ -3734,57 +3733,10 @@ export function App() {
                         </svg>
                     </button>
                 )}
-                <div className="mt-1 flex items-center gap-1">
-                    <div className="min-w-0 flex-1">
-                        <SidebarGitScopePicker
-                            projectId={activeProjectId}
-                            worktreeId={activeWorktreeId}
-                        />
-                    </div>
-                    {isWindows && (
-                        <button
-                            className="sidebar-collapse-toggle sidebar-collapse-toggle--inline app-no-drag"
-                            onClick={() => {
-                                toggleLeftCollapsed();
-                                hideSidebarOverlayImmediately();
-                            }}
-                            title={
-                                leftCollapsed
-                                    ? "Expand sidebar"
-                                    : "Collapse sidebar"
-                            }
-                            type="button"
-                        >
-                            <svg
-                                aria-hidden="true"
-                                fill="none"
-                                height="16"
-                                viewBox="0 0 16 16"
-                                width="16"
-                            >
-                                <rect
-                                    x="1.5"
-                                    y="2.5"
-                                    width="13"
-                                    height="11"
-                                    rx="1.5"
-                                    stroke="currentColor"
-                                    strokeWidth="1.2"
-                                />
-                                <line
-                                    x1="5.5"
-                                    y1="2.5"
-                                    x2="5.5"
-                                    y2="13.5"
-                                    stroke="currentColor"
-                                    strokeWidth="1.2"
-                                />
-                            </svg>
-                        </button>
-                    )}
-                </div>
-
-                <div className="mt-1 flex items-center gap-1">
+                <div
+                    className="mt-1 flex items-center gap-1"
+                    style={isWindows ? { paddingRight: 36 } : undefined}
+                >
                     <button
                         className={[
                             "sidebar-action-row sidebar-action-row--compact app-no-drag min-w-0 flex-1",
@@ -4442,6 +4394,7 @@ export function App() {
                     <DesktopTopBar
                         activeContextKey={workspaceActiveContextKey}
                         contexts={projectContextTabs}
+                        leftSidebarCollapsed={leftCollapsed}
                         menuProjects={projectContextMenuProjects}
                         onActivateContext={(contextKey) => {
                             void useWorkspaceStore
@@ -4483,6 +4436,10 @@ export function App() {
                             void useWorkspaceStore
                                 .getState()
                                 .openContext(projectId, worktreeId);
+                        }}
+                        onToggleLeftSidebar={() => {
+                            toggleLeftCollapsed();
+                            hideSidebarOverlayImmediately();
                         }}
                         platform={bootstrap?.platform ?? null}
                     />

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -81,6 +81,7 @@ import { useProjectsStore } from "./app/store/projects-store";
 import { useSettingsStore } from "./app/store/settings-store";
 import { useShellStore } from "./app/store/shell-store";
 import {
+    flushWorkspacePersistenceNow,
     getBestMatchingChatTabId,
     useWorkspaceStore,
 } from "./app/store/workspace-store";
@@ -929,6 +930,16 @@ export function App() {
     }, [reopenLastClosedTab]);
 
     useEffect(() => {
+        const comandoApi = getComandoApi();
+        if (!comandoApi) {
+            return;
+        }
+        return comandoApi.onWorkspaceFlushRequested(
+            flushWorkspacePersistenceNow,
+        );
+    }, []);
+
+    useEffect(() => {
         syncViewport(window.innerWidth);
 
         const handleResize = () => {
@@ -966,14 +977,6 @@ export function App() {
         persistenceReady,
         sidebarView,
     ]);
-
-    useEffect(() => {
-        if (!persistenceReady || !window.comando) {
-            return;
-        }
-
-        void window.comando.saveActiveProjectId(activeProjectId);
-    }, [activeProjectId, persistenceReady]);
 
     const gitActiveWorktreeId = useGitStore((state) =>
         activeProjectId
@@ -1050,14 +1053,6 @@ export function App() {
             setQuickOpenSelectedIndex(0);
         });
     }, [activeProjectId, activeWorktreeId]);
-
-    useEffect(() => {
-        if (!persistenceReady || !window.comando) {
-            return;
-        }
-
-        void window.comando.saveActiveWorktreeId(activeWorktreeId);
-    }, [activeWorktreeId, persistenceReady]);
 
     useEffect(() => {
         if (!isFileTreeSearchOpen) {
@@ -1441,7 +1436,7 @@ export function App() {
                 const project = context
                     ? projects.find((entry) => entry.id === context.projectId)
                     : null;
-                if (!context || !project) {
+                if (!context) {
                     return [];
                 }
 
@@ -1460,12 +1455,12 @@ export function App() {
                     {
                         key: context.key,
                         projectId: context.projectId,
-                        projectName: project.name,
+                        projectName: project?.name ?? "Missing project",
                         worktreeId: context.worktreeId,
                         worktreeLabel: worktree
                             ? getWorktreeDisplayLabel(worktree)
                             : context.worktreeId
-                              ? "Worktree"
+                              ? "Missing worktree"
                               : "Main checkout",
                     },
                 ];

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1656,7 +1656,6 @@ export function App() {
     );
     const activeGitError = gitErrors[activeGitContextKey] ?? null;
     const isMac = bootstrap?.platform === "darwin";
-    const isWindows = bootstrap?.platform === "win32";
     const topStatus = [
         bootstrapError,
         projectsError,
@@ -3685,58 +3684,8 @@ export function App() {
 
     const sidebarContent = (
         <>
-            <div
-                className="app-drag relative px-2"
-                style={{
-                    // Keep sidebar controls clear of the macOS traffic lights.
-                    paddingTop: isMac ? 42 : isWindows ? 0 : 8,
-                }}
-            >
-                {(isMac || isWindows) && (
-                    <button
-                        className="sidebar-collapse-toggle app-no-drag"
-                        onClick={() => {
-                            toggleLeftCollapsed();
-                            hideSidebarOverlayImmediately();
-                        }}
-                        title={
-                            leftCollapsed
-                                ? "Expand sidebar"
-                                : "Collapse sidebar"
-                        }
-                        type="button"
-                    >
-                        <svg
-                            aria-hidden="true"
-                            fill="none"
-                            height="16"
-                            viewBox="0 0 16 16"
-                            width="16"
-                        >
-                            <rect
-                                x="1.5"
-                                y="2.5"
-                                width="13"
-                                height="11"
-                                rx="1.5"
-                                stroke="currentColor"
-                                strokeWidth="1.2"
-                            />
-                            <line
-                                x1="5.5"
-                                y1="2.5"
-                                x2="5.5"
-                                y2="13.5"
-                                stroke="currentColor"
-                                strokeWidth="1.2"
-                            />
-                        </svg>
-                    </button>
-                )}
-                <div
-                    className="mt-1 flex items-center gap-1"
-                    style={isWindows ? { paddingRight: 36 } : undefined}
-                >
+            <div className="app-drag px-2">
+                <div className="mt-1 flex items-center gap-1">
                     <button
                         className={[
                             "sidebar-action-row sidebar-action-row--compact app-no-drag min-w-0 flex-1",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -358,6 +358,41 @@ export function App() {
             { tabsById },
         );
     }, []);
+    const requestMoveWorkspaceContextToNewWindow = useCallback(
+        (contextKey: string) => {
+            const workspaceState = useWorkspaceStore.getState();
+            const context = workspaceState.contextsByKey[contextKey];
+            const workspaceSnapshot =
+                workspaceState.getContextNavigationSnapshot(contextKey);
+            if (!context || !workspaceSnapshot) {
+                return Promise.resolve();
+            }
+
+            const tabsById =
+                workspaceState.activeContextKey === contextKey
+                    ? workspaceState.tabsById
+                    : context.workspace.tabsById;
+            return closeWorkspaceTabsWithConfirmation(
+                Object.keys(tabsById),
+                async () => {
+                    const comandoApi = getComandoApi();
+                    if (!comandoApi) {
+                        throw new Error("The desktop bridge is unavailable.");
+                    }
+
+                    await comandoApi.openProjectWindow({
+                        forceNewWindow: true,
+                        projectId: context.projectId,
+                        workspaceSnapshot,
+                        worktreeId: context.worktreeId,
+                    });
+                    await useWorkspaceStore.getState().closeContext(contextKey);
+                },
+                { tabsById },
+            );
+        },
+        [],
+    );
     const requestCloseActiveWorkspaceTab = useEffectEvent(() => {
         const workspaceState = useWorkspaceStore.getState();
         const activePane = findPaneById(
@@ -4377,6 +4412,11 @@ export function App() {
                         }}
                         onCloseContext={(contextKey) => {
                             void requestCloseWorkspaceContext(contextKey);
+                        }}
+                        onMoveContextToNewWindow={(contextKey) => {
+                            void requestMoveWorkspaceContextToNewWindow(
+                                contextKey,
+                            );
                         }}
                         onOpenProject={(projectId) => {
                             void useWorkspaceStore

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -489,6 +489,18 @@ export function SettingsApp() {
         void saveAppAppearanceSettings(nextAppearance);
     };
 
+    const handleAppChromeTransparencyChange = (
+        chromeTransparency: number,
+    ) => {
+        const nextAppearance = {
+            ...appAppearance,
+            chromeTransparency,
+        };
+
+        setAppAppearance(nextAppearance);
+        void saveAppAppearanceSettings(nextAppearance);
+    };
+
     const handleAppTransparencyEnabledChange = (
         transparencyEnabled: boolean,
     ) => {
@@ -862,11 +874,13 @@ export function SettingsApp() {
             appAppearance={{
                 agentsSidebarScale: appAppearance.agentsSidebarScale,
                 boostCodeContrast: appAppearance.boostCodeContrast,
+                chromeTransparency: appAppearance.chromeTransparency,
                 fileTreeScale: appAppearance.fileTreeScale,
                 mode: appAppearance.themeMode,
                 onAgentsSidebarScaleChange:
                     handleAppAgentsSidebarScaleChange,
                 onBoostCodeContrastChange: handleAppBoostCodeContrastChange,
+                onChromeTransparencyChange: handleAppChromeTransparencyChange,
                 onFileTreeScaleChange: handleAppFileTreeScaleChange,
                 onModeChange: handleAppThemeModeChange,
                 onPresetChange: handleAppThemePresetChange,

--- a/src/renderer/src/app/git/context-key.test.ts
+++ b/src/renderer/src/app/git/context-key.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveProjectContextWorktreeId } from "./context-key";
+
+describe("resolveProjectContextWorktreeId", () => {
+    it("resolves the logical primary context to its canonical worktree id", () => {
+        expect(
+            resolveProjectContextWorktreeId(
+                "project-1",
+                null,
+                "project-1:primary",
+            ),
+        ).toBe("project-1:primary");
+        expect(
+            resolveProjectContextWorktreeId("project-1", null, null),
+        ).toBe("project-1:primary");
+    });
+
+    it("keeps an explicit macro worktree authoritative", () => {
+        expect(
+            resolveProjectContextWorktreeId(
+                "project-1",
+                "worktree-feature",
+                "project-1:primary",
+            ),
+        ).toBe("worktree-feature");
+    });
+});

--- a/src/renderer/src/app/git/context-key.ts
+++ b/src/renderer/src/app/git/context-key.ts
@@ -7,6 +7,18 @@ export function getPrimaryWorktreeId(projectId: string): string {
     return `${projectId}:primary`;
 }
 
+export function resolveProjectContextWorktreeId(
+    projectId: string,
+    contextWorktreeId: string | null,
+    activeGitWorktreeId: string | null,
+): string {
+    return (
+        contextWorktreeId ??
+        activeGitWorktreeId ??
+        getPrimaryWorktreeId(projectId)
+    );
+}
+
 export function normalizeGitWorktreeIdForContext(
     projectId: string,
     worktreeId: string | null,

--- a/src/renderer/src/app/projects/context-key.ts
+++ b/src/renderer/src/app/projects/context-key.ts
@@ -10,7 +10,11 @@ export function getProjectContextKey(
     projectId: string | null,
     worktreeId: string | null,
 ): string {
+    const normalizedWorktreeId =
+        projectId && worktreeId === `${projectId}:primary`
+            ? PROJECT_TREE_PRIMARY_CONTEXT
+            : (worktreeId ?? PROJECT_TREE_PRIMARY_CONTEXT);
     return `${projectId ?? NO_PROJECT_CONTEXT}::${
-        worktreeId ?? PROJECT_TREE_PRIMARY_CONTEXT
+        normalizedWorktreeId
     }`;
 }

--- a/src/renderer/src/app/settings/client.test.ts
+++ b/src/renderer/src/app/settings/client.test.ts
@@ -37,6 +37,7 @@ function createAppearanceSettings(
     return {
         agentsSidebarScale: 1,
         boostCodeContrast: true,
+        chromeTransparency: 45,
         fileTreeScale: 1,
         stickyFoldersEnabled: true,
         themeMode: "system",

--- a/src/renderer/src/app/settings/theme.ts
+++ b/src/renderer/src/app/settings/theme.ts
@@ -2,6 +2,10 @@ import {
     AGENTS_SIDEBAR_SCALE_DEFAULT,
     clampAgentsSidebarScale,
 } from "@shared/agents-sidebar-scale";
+import {
+    CHROME_TRANSPARENCY_DEFAULT,
+    clampChromeTransparency,
+} from "@shared/chrome-transparency";
 import { APP_ZOOM_FACTOR_DEFAULT, clampAppZoomFactor } from "@shared/app-zoom";
 import {
     EDITOR_AUTOSAVE_DELAY_MS_DEFAULT,
@@ -1753,6 +1757,7 @@ export function getDefaultAppAppearance(): AppAppearanceSettings {
     return {
         agentsSidebarScale: AGENTS_SIDEBAR_SCALE_DEFAULT,
         boostCodeContrast: true,
+        chromeTransparency: CHROME_TRANSPARENCY_DEFAULT,
         fileTreeScale: FILE_TREE_SCALE_DEFAULT,
         stickyFoldersEnabled: true,
         themeMode: "system",
@@ -1818,6 +1823,9 @@ export function resolveAppearance(
         ),
         boostCodeContrast:
             appAppearance?.boostCodeContrast ?? defaults.boostCodeContrast,
+        chromeTransparency: clampChromeTransparency(
+            appAppearance?.chromeTransparency ?? defaults.chromeTransparency,
+        ),
         fileTreeScale: clampFileTreeScale(
             appAppearance?.fileTreeScale ?? defaults.fileTreeScale,
         ),
@@ -1946,6 +1954,10 @@ export function applyAppearance(
     root.setAttribute(
         "data-transparency-enabled",
         appearance.transparencyEnabled ? "true" : "false",
+    );
+    root.style.setProperty(
+        "--chrome-transparency",
+        `${appearance.chromeTransparency}%`,
     );
     root.style.setProperty("--color-app", palette.app);
     root.style.setProperty("--color-bg-primary", palette.bgPrimary);

--- a/src/renderer/src/app/shortcuts/registry.test.ts
+++ b/src/renderer/src/app/shortcuts/registry.test.ts
@@ -31,4 +31,32 @@ describe("shortcutDefinitions", () => {
             section: "Git",
         });
     });
+
+    it("includes workspace navigation shortcuts", () => {
+        const nextWorkspaceShortcut = shortcutDefinitions.find(
+            (shortcut) => shortcut.id === "next_workspace",
+        );
+        const previousWorkspaceShortcut = shortcutDefinitions.find(
+            (shortcut) => shortcut.id === "previous_workspace",
+        );
+
+        expect(nextWorkspaceShortcut).toMatchObject({
+            description: "Switch to the next open workspace.",
+            keys: {
+                mac: "Cmd+Alt+]",
+                windows: "Ctrl+Alt+]",
+            },
+            label: "Next workspace",
+            section: "General",
+        });
+        expect(previousWorkspaceShortcut).toMatchObject({
+            description: "Switch to the previous open workspace.",
+            keys: {
+                mac: "Cmd+Alt+[",
+                windows: "Ctrl+Alt+[",
+            },
+            label: "Previous workspace",
+            section: "General",
+        });
+    });
 });

--- a/src/renderer/src/app/shortcuts/registry.ts
+++ b/src/renderer/src/app/shortcuts/registry.ts
@@ -15,10 +15,12 @@ export interface ShortcutDefinition {
         | "open_git_history"
         | "new_window"
         | "next_pane_tab"
+        | "next_workspace"
         | "open_current_project_in_new_window"
         | "open_file_picker"
         | "open_settings"
         | "previous_pane_tab"
+        | "previous_workspace"
         | "reload_window"
         | "reset_editor_font_size"
         | "reveal_active_file_in_tree"
@@ -162,6 +164,16 @@ export const shortcutDefinitions: readonly ShortcutDefinition[] = [
         section: "General",
     },
     {
+        id: "next_workspace",
+        label: "Next workspace",
+        description: "Switch to the next open workspace.",
+        keys: {
+            mac: "Cmd+Alt+]",
+            windows: "Ctrl+Alt+]",
+        },
+        section: "General",
+    },
+    {
         id: "open_settings",
         label: "Open settings",
         description:
@@ -179,6 +191,16 @@ export const shortcutDefinitions: readonly ShortcutDefinition[] = [
         keys: {
             mac: "Ctrl+Shift+Tab",
             windows: "Ctrl+Shift+Tab",
+        },
+        section: "General",
+    },
+    {
+        id: "previous_workspace",
+        label: "Previous workspace",
+        description: "Switch to the previous open workspace.",
+        keys: {
+            mac: "Cmd+Alt+[",
+            windows: "Ctrl+Alt+[",
         },
         section: "General",
     },

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -577,6 +577,94 @@ describe("ai-store queue", () => {
         expect(reasoningConfig).toMatchObject({ value: "low" });
     });
 
+    it("does not roll back a newer optimistic config selection when an older request fails", async () => {
+        let rejectFirstMutation!: (reason: unknown) => void;
+        const firstMutation = new Promise<void>((_resolve, reject) => {
+            rejectFirstMutation = reject;
+        });
+        const thirdMutation = createDeferred<void>();
+        const setAiSessionConfigOption = vi
+            .fn()
+            .mockReturnValueOnce(firstMutation)
+            .mockResolvedValueOnce(undefined)
+            .mockReturnValueOnce(thirdMutation.promise);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    setAiSessionConfigOption,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                configOptions: [
+                    {
+                        category: "reasoning",
+                        description: null,
+                        id: "reasoning_effort",
+                        label: "Reasoning",
+                        options: [
+                            {
+                                description: null,
+                                groupLabel: null,
+                                label: "Low",
+                                value: "low",
+                            },
+                            {
+                                description: null,
+                                groupLabel: null,
+                                label: "Medium",
+                                value: "medium",
+                            },
+                            {
+                                description: null,
+                                groupLabel: null,
+                                label: "High",
+                                value: "high",
+                            },
+                        ],
+                        type: "select",
+                        value: "low",
+                    },
+                ],
+                reasoningEffort: "low",
+            }),
+        );
+
+        const first = useAiStore.getState().setSessionConfigOption({
+            optionId: "reasoning_effort",
+            sessionId: TAB.sessionId,
+            value: "medium",
+        });
+        const second = useAiStore.getState().setSessionConfigOption({
+            optionId: "reasoning_effort",
+            sessionId: TAB.sessionId,
+            value: "high",
+        });
+
+        await second;
+
+        const third = useAiStore.getState().setSessionConfigOption({
+            optionId: "reasoning_effort",
+            sessionId: TAB.sessionId,
+            value: "low",
+        });
+
+        rejectFirstMutation(new Error("The first mutation failed."));
+        await expect(first).rejects.toThrow("The first mutation failed.");
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot
+                ?.reasoningEffort,
+        ).toBe("low");
+
+        thirdMutation.resolve();
+        await third;
+    });
+
     it("applies inferred titles from status events", () => {
         useAiStore.getState().applySessionSnapshot(
             createSnapshot({ title: "Codex 1" }),

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -93,6 +93,14 @@ type RuntimeAiSessionTab = RuntimeWorkspaceChatTab | RuntimeWorkspaceReviewTab;
 type AiSessionRuntimeState = "history" | "live";
 
 const ensureSessionInFlight = new Map<string, Promise<void>>();
+const optimisticSnapshotMutationStates = new Map<
+    string,
+    {
+        latestVersion: number;
+        nextVersion: number;
+        pendingVersions: Set<number>;
+    }
+>();
 
 interface RegisteredSessionMeta {
     readonly projectId: string | null;
@@ -588,6 +596,7 @@ async function requestAiSessionResyncAfterSilence(
 export function resetAiStoreRuntimeBuffersForTests(): void {
     resetBufferedSessionDeltas();
     resetAiSessionResyncWatchdogs();
+    optimisticSnapshotMutationStates.clear();
 }
 
 export const useAiStore = create<AiStore>((set, get) => ({
@@ -3740,6 +3749,16 @@ async function runOptimisticSnapshotMutation(
     set: SetAiState,
     get: GetAiState,
 ): Promise<void> {
+    const mutationState = optimisticSnapshotMutationStates.get(sessionId) ?? {
+        latestVersion: 0,
+        nextVersion: 0,
+        pendingVersions: new Set<number>(),
+    };
+    const mutationVersion = mutationState.nextVersion + 1;
+    mutationState.latestVersion = mutationVersion;
+    mutationState.nextVersion = mutationVersion;
+    mutationState.pendingVersions.add(mutationVersion);
+    optimisticSnapshotMutationStates.set(sessionId, mutationState);
     const previousSession = get().sessions[sessionId] ?? null;
     const previousSnapshot = previousSession?.snapshot ?? null;
 
@@ -3758,7 +3777,11 @@ async function runOptimisticSnapshotMutation(
     try {
         await runRemote();
     } catch (error) {
-        if (previousSession) {
+        if (
+            previousSession &&
+            optimisticSnapshotMutationStates.get(sessionId)?.latestVersion ===
+                mutationVersion
+        ) {
             set((state) => ({
                 sessions: {
                     ...state.sessions,
@@ -3767,6 +3790,11 @@ async function runOptimisticSnapshotMutation(
             }));
         }
         throw error;
+    } finally {
+        mutationState.pendingVersions.delete(mutationVersion);
+        if (mutationState.pendingVersions.size === 0) {
+            optimisticSnapshotMutationStates.delete(sessionId);
+        }
     }
 }
 

--- a/src/renderer/src/app/store/projects-store.ts
+++ b/src/renderer/src/app/store/projects-store.ts
@@ -26,9 +26,9 @@ interface ProjectsState {
         Record<ParentKey, readonly ProjectTreeNode[]>
     >;
     addProjectPath: (projectPath: string) => Promise<void>;
-    addProjects: () => Promise<void>;
+    addProjects: () => Promise<readonly string[]>;
     clearProjectAppData: (projectId: string) => Promise<void>;
-    cloneRepository: (repositoryUrl: string) => Promise<boolean>;
+    cloneRepository: (repositoryUrl: string) => Promise<readonly string[]>;
     createEntry: (
         projectId: string,
         parentRelativePath: string | null,
@@ -164,7 +164,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
                 await loadDirectory(nextActiveProjectId, null, set, get);
             }
 
-            await openProjectsInWindows(projectIdsToOpen);
+            void projectIdsToOpen;
         } catch (error) {
             set({
                 error:
@@ -195,7 +195,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
                 await loadDirectory(nextActiveProjectId, null, set, get);
             }
 
-            await openProjectsInWindows(projectIdsToOpen);
+            return projectIdsToOpen;
         } catch (error) {
             set({
                 error:
@@ -203,6 +203,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
                         ? error.message
                         : "Could not add the selected project.",
             });
+            return [];
         }
     },
 
@@ -240,7 +241,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
         const normalizedUrl = repositoryUrl.trim();
         if (!normalizedUrl) {
             set({ error: "Paste a repository URL before cloning." });
-            return false;
+            return [];
         }
 
         try {
@@ -250,7 +251,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
 
             if (response.kind === "canceled") {
                 set({ error: null });
-                return false;
+                return [];
             }
 
             const { projectIdsToOpen, projects } = response.result;
@@ -270,8 +271,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
                 await loadDirectory(nextActiveProjectId, null, set, get);
             }
 
-            await openProjectsInWindows(projectIdsToOpen);
-            return true;
+            return projectIdsToOpen;
         } catch (error) {
             set({
                 error:
@@ -279,7 +279,7 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
                         ? error.message
                         : "Could not clone the repository.",
             });
-            return false;
+            return [];
         }
     },
 
@@ -862,19 +862,6 @@ export function resolveNextActiveProjectId({
     }
 
     return null;
-}
-
-async function openProjectsInWindows(
-    projectIdsToOpen: readonly string[],
-): Promise<void> {
-    const comandoApi = getComandoApi();
-    if (!comandoApi || projectIdsToOpen.length === 0) {
-        return;
-    }
-
-    for (const projectId of projectIdsToOpen) {
-        await comandoApi.openProjectWindow({ projectId });
-    }
 }
 
 function getParentKey(parentRelativePath: string | null): ParentKey {

--- a/src/renderer/src/app/store/projects-store.ts
+++ b/src/renderer/src/app/store/projects-store.ts
@@ -9,6 +9,7 @@ import type {
     ProjectSummary,
     ProjectTreeNode,
 } from "@shared/ipc";
+import { getProjectContextKey } from "../projects/context-key";
 
 const ROOT_NODE_KEY = "__root__";
 
@@ -971,7 +972,7 @@ function getTreeContextKey(
     projectId: string,
     worktreeId: string | null | undefined,
 ): string {
-    return `${projectId}::${worktreeId ?? "__primary__"}`;
+    return getProjectContextKey(projectId, worktreeId ?? null);
 }
 
 export function resolveProjectTreeRefresh(input: {

--- a/src/renderer/src/app/store/settings-store.test.ts
+++ b/src/renderer/src/app/store/settings-store.test.ts
@@ -37,6 +37,7 @@ function createAppearanceSettings(
     return {
         agentsSidebarScale: 1,
         boostCodeContrast: true,
+        chromeTransparency: 45,
         fileTreeScale: 1,
         stickyFoldersEnabled: true,
         themeMode: "system",

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -115,6 +115,21 @@ function getActivePersistedLayout(snapshot: WorkspaceNavigationSnapshot) {
     )?.workspace;
 }
 
+function createDeferred<T>() {
+    let resolve: (value: T) => void = (_value: T): void => {
+        void _value;
+        throw new Error("Deferred promise was not initialized.");
+    };
+    const promise = new Promise<T>((nextResolve) => {
+        resolve = nextResolve;
+    });
+
+    return {
+        promise,
+        resolve: (value: T) => resolve(value),
+    };
+}
+
 describe("workspace file opening", () => {
     beforeEach(() => {
         resetWorkspacePersistenceForTests();
@@ -367,6 +382,313 @@ describe("workspace file opening", () => {
         expect(ensureSessionMock).not.toHaveBeenCalledWith(
             expect.objectContaining({ sessionId: "session-inactive" }),
         );
+    });
+
+    it("hydrates only active file tabs and loads inactive files on focus", async () => {
+        const activeFile = createWorkspaceFileTab(
+            "active-file",
+            "src/active.ts",
+        );
+        const inactiveFile = createWorkspaceFileTab(
+            "inactive-file",
+            "src/inactive.ts",
+        );
+        const targetContextKey = "project-2::__primary__";
+        const targetWorkspace: WorkspaceTreeState = {
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: activeFile.id,
+                id: "pane-root",
+                tabIds: [activeFile.id, inactiveFile.id],
+                type: "pane",
+            },
+            tabsById: {
+                [activeFile.id]: {
+                    ...activeFile,
+                    projectId: "project-2",
+                },
+                [inactiveFile.id]: {
+                    ...inactiveFile,
+                    projectId: "project-2",
+                },
+            },
+        };
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [targetContextKey]: {
+                    key: targetContextKey,
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: targetWorkspace,
+                    worktreeId: null,
+                },
+            },
+            openContextKeys: [...state.openContextKeys, targetContextKey],
+        }));
+
+        await useWorkspaceStore.getState().activateContext(targetContextKey);
+
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        });
+        expect(openProjectFileMock).toHaveBeenCalledWith({
+            projectId: "project-2",
+            relativePath: activeFile.relativePath,
+            worktreeId: null,
+        });
+
+        await useWorkspaceStore
+            .getState()
+            .selectTab("pane-root", inactiveFile.id);
+
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(2);
+        });
+        expect(openProjectFileMock).toHaveBeenLastCalledWith({
+            projectId: "project-2",
+            relativePath: inactiveFile.relativePath,
+            worktreeId: null,
+        });
+    });
+
+    it("retries a file load after a rapid context switch", async () => {
+        const sourceContextKey = "project-1::__primary__";
+        const targetContextKey = "project-2::__primary__";
+        const fileTab = createWorkspaceFileTab("file-source", "src/app.ts");
+        const sourceWorkspace: WorkspaceTreeState = {
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: fileTab.id,
+                id: "pane-root",
+                tabIds: [fileTab.id],
+                type: "pane",
+            },
+            tabsById: { [fileTab.id]: fileTab },
+        };
+        const initialLoad = createDeferred<ProjectFileDocument>();
+        openProjectFileMock.mockImplementationOnce(
+            () => initialLoad.promise,
+        );
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            ...sourceWorkspace,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [sourceContextKey]: {
+                    ...state.contextsByKey[sourceContextKey],
+                    workspace: sourceWorkspace,
+                },
+                [targetContextKey]: {
+                    key: targetContextKey,
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: createDefaultWorkspaceState(),
+                    worktreeId: null,
+                },
+            },
+            openContextKeys: [sourceContextKey, targetContextKey],
+        }));
+
+        await useWorkspaceStore.getState().selectTab("pane-root", fileTab.id);
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        });
+
+        await useWorkspaceStore.getState().activateContext(targetContextKey);
+        initialLoad.resolve({
+            absolutePath: "/tmp/src/app.ts",
+            content: "export const value = 1;\n",
+            imageDataBase64: null,
+            isBinary: false,
+            isTooLarge: false,
+            kind: "text",
+            languageId: "typescript",
+            languageLabel: "TypeScript",
+            mimeType: "text/typescript",
+            modifiedAtMs: 1,
+            name: "app.ts",
+            projectId: "project-1",
+            relativePath: fileTab.relativePath,
+            sizeBytes: 24,
+        });
+
+        await vi.waitFor(() => {
+            const storedTab =
+                useWorkspaceStore.getState().contextsByKey[sourceContextKey]
+                    ?.workspace.tabsById[fileTab.id];
+            expect(storedTab).toMatchObject({ isLoading: false });
+        });
+
+        await useWorkspaceStore.getState().activateContext(sourceContextKey);
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    it("reuses the pending load when returning to a context before it resolves", async () => {
+        const sourceContextKey = "project-1::__primary__";
+        const targetContextKey = "project-2::__primary__";
+        const fileTab = createWorkspaceFileTab("file-source", "src/app.ts");
+        const sourceWorkspace: WorkspaceTreeState = {
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: fileTab.id,
+                id: "pane-root",
+                tabIds: [fileTab.id],
+                type: "pane",
+            },
+            tabsById: { [fileTab.id]: fileTab },
+        };
+        const initialLoad = createDeferred<ProjectFileDocument>();
+        openProjectFileMock.mockImplementationOnce(() => initialLoad.promise);
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            ...sourceWorkspace,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [sourceContextKey]: {
+                    ...state.contextsByKey[sourceContextKey],
+                    workspace: sourceWorkspace,
+                },
+                [targetContextKey]: {
+                    key: targetContextKey,
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: createDefaultWorkspaceState(),
+                    worktreeId: null,
+                },
+            },
+            openContextKeys: [sourceContextKey, targetContextKey],
+        }));
+
+        await useWorkspaceStore.getState().selectTab("pane-root", fileTab.id);
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        });
+
+        await useWorkspaceStore.getState().activateContext(targetContextKey);
+        await useWorkspaceStore.getState().activateContext(sourceContextKey);
+        initialLoad.resolve({
+            absolutePath: "/tmp/src/app.ts",
+            content: "export const value = 1;\n",
+            imageDataBase64: null,
+            isBinary: false,
+            isTooLarge: false,
+            kind: "text",
+            languageId: "typescript",
+            languageLabel: "TypeScript",
+            mimeType: "text/typescript",
+            modifiedAtMs: 1,
+            name: "app.ts",
+            projectId: "project-1",
+            relativePath: fileTab.relativePath,
+            sizeBytes: 24,
+        });
+
+        await vi.waitFor(() => {
+            const currentTab = useWorkspaceStore.getState().tabsById[fileTab.id];
+            expect(
+                currentTab?.kind === "file"
+                    ? currentTab.document?.content
+                    : null,
+            ).toBe("export const value = 1;\n");
+        });
+        expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("shares a pending file load between active duplicate tabs", async () => {
+        const firstFile = createWorkspaceFileTab("file-left", "src/app.ts");
+        const secondFile = createWorkspaceFileTab("file-right", "src/app.ts");
+        const targetContextKey = "project-2::__primary__";
+        const targetWorkspace: WorkspaceTreeState = {
+            activePaneId: "pane-left",
+            rootNode: {
+                axis: "horizontal",
+                children: [
+                    {
+                        activeTabId: firstFile.id,
+                        id: "pane-left",
+                        tabIds: [firstFile.id],
+                        type: "pane",
+                    },
+                    {
+                        activeTabId: secondFile.id,
+                        id: "pane-right",
+                        tabIds: [secondFile.id],
+                        type: "pane",
+                    },
+                ],
+                id: "split-root",
+                sizes: [0.5, 0.5],
+                type: "split",
+            },
+            tabsById: {
+                [firstFile.id]: { ...firstFile, projectId: "project-2" },
+                [secondFile.id]: { ...secondFile, projectId: "project-2" },
+            },
+        };
+        const sharedLoad = createDeferred<ProjectFileDocument>();
+        openProjectFileMock.mockImplementationOnce(
+            () => sharedLoad.promise,
+        );
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [targetContextKey]: {
+                    key: targetContextKey,
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: targetWorkspace,
+                    worktreeId: null,
+                },
+            },
+            openContextKeys: [...state.openContextKeys, targetContextKey],
+        }));
+
+        await useWorkspaceStore.getState().activateContext(targetContextKey);
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        });
+
+        sharedLoad.resolve({
+            absolutePath: "/tmp/src/app.ts",
+            content: "export const value = 1;\n",
+            imageDataBase64: null,
+            isBinary: false,
+            isTooLarge: false,
+            kind: "text",
+            languageId: "typescript",
+            languageLabel: "TypeScript",
+            mimeType: "text/typescript",
+            modifiedAtMs: 1,
+            name: "app.ts",
+            projectId: "project-2",
+            relativePath: firstFile.relativePath,
+            sizeBytes: 24,
+        });
+
+        await vi.waitFor(() => {
+            const tabs = useWorkspaceStore.getState().tabsById;
+            const firstTab = tabs[firstFile.id];
+            const secondTab = tabs[secondFile.id];
+            expect(
+                firstTab?.kind === "file"
+                    ? firstTab.document?.content
+                    : null,
+            ).toBe("export const value = 1;\n");
+            expect(
+                secondTab?.kind === "file"
+                    ? secondTab.document?.content
+                    : null,
+            ).toBe("export const value = 1;\n");
+        });
     });
 
     it("hydrates legacy restored chat tabs in history mode", async () => {

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -333,6 +333,40 @@ describe("workspace file opening", () => {
         ]);
     });
 
+    it("reorders workspace contexts without changing the active context", async () => {
+        await useWorkspaceStore
+            .getState()
+            .openContext("project-2", null, { emptyLayout: true });
+        await useWorkspaceStore
+            .getState()
+            .openContext("project-3", null, { emptyLayout: true });
+        await useWorkspaceStore
+            .getState()
+            .activateContext("project-1::__primary__");
+
+        await useWorkspaceStore
+            .getState()
+            .reorderContext("project-3::__primary__", 0);
+
+        expect(useWorkspaceStore.getState().activeContextKey).toBe(
+            "project-1::__primary__",
+        );
+        expect(useWorkspaceStore.getState().openContextKeys).toEqual([
+            "project-3::__primary__",
+            "project-1::__primary__",
+            "project-2::__primary__",
+        ]);
+
+        await flushWorkspacePersistenceForTests();
+        expect(saveWorkspaceSnapshotMock.mock.calls.at(-1)?.[0]).toMatchObject({
+            openContextKeys: [
+                "project-3::__primary__",
+                "project-1::__primary__",
+                "project-2::__primary__",
+            ],
+        });
+    });
+
     it("hydrates and prewarms each active restored chat session", async () => {
         const snapshot: WorkspaceSnapshot = {
             activePaneId: "pane-left",

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -15,6 +15,7 @@ import {
 import { useAiStore } from "./ai-store";
 import {
     flushWorkspacePersistenceForTests,
+    flushWorkspacePersistenceNow,
     getBestMatchingChatTabId,
     getPaneChatTabId,
     getPaneRuntimeId,
@@ -1958,6 +1959,22 @@ describe("workspace file opening", () => {
         await flushWorkspacePersistenceForTests();
 
         expect(saveWorkspaceSnapshotMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not report a successful close flush when persistence keeps failing", async () => {
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+        saveWorkspaceSnapshotMock.mockRejectedValue(
+            new Error("persistence unavailable"),
+        );
+        await useWorkspaceStore.getState().openContext("project-failure");
+
+        await expect(flushWorkspacePersistenceNow()).rejects.toThrow(
+            "Could not persist the workspace before closing.",
+        );
+        expect(saveWorkspaceSnapshotMock).toHaveBeenCalledTimes(3);
+
+        saveWorkspaceSnapshotMock.mockResolvedValue(undefined);
+        errorSpy.mockRestore();
     });
 
     it("flushes split resize immediately when the drag is committed", async () => {

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -3,6 +3,7 @@ import type { editor as MonacoEditor } from "monaco-editor";
 
 import type {
     ProjectFileDocument,
+    WorkspaceNavigationSnapshot,
     WorkspacePaneNode,
     WorkspaceSnapshot,
 } from "@shared/ipc";
@@ -24,7 +25,7 @@ import {
 } from "./workspace-store";
 
 const saveWorkspaceSnapshotMock = vi.fn<
-    (snapshot: WorkspaceSnapshot) => Promise<void>
+    (snapshot: WorkspaceNavigationSnapshot) => Promise<void>
 >(async () => {});
 const closeAiSessionMock = vi.fn(async () => {});
 const closeTerminalSessionMock = vi.fn(async () => {});
@@ -106,6 +107,12 @@ function findWorkspacePane(
     }
 
     return null;
+}
+
+function getActivePersistedLayout(snapshot: WorkspaceNavigationSnapshot) {
+    return snapshot.contexts.find(
+        (context) => context.key === snapshot.activeContextKey,
+    )?.workspace;
 }
 
 describe("workspace file opening", () => {
@@ -195,17 +202,31 @@ describe("workspace file opening", () => {
             ensureSession: ensureSessionMock,
         });
 
+        const defaultWorkspace = createDefaultWorkspaceState();
+        const contextKey = "project-1::__primary__";
         useWorkspaceStore.setState((state) => ({
             ...state,
-            ...createDefaultWorkspaceState(),
+            ...defaultWorkspace,
+            activeContextKey: contextKey,
+            contextsByKey: {
+                [contextKey]: {
+                    key: contextKey,
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-1",
+                    workspace: defaultWorkspace,
+                    worktreeId: null,
+                },
+            },
             error: null,
             hydrated: true,
             lastFocusedChatTabId: null,
             lastFocusedRuntimeId: "codex",
             lastQuickCreateAction: "codex",
+            openContextKeys: [contextKey],
             recentActiveTabIds: [],
             recentClosedTabs: [],
             recentFocusedChatTabIds: [],
+            scopeEpoch: 0,
         }), true);
     });
 
@@ -222,6 +243,79 @@ describe("workspace file opening", () => {
             true,
         );
         vi.unstubAllGlobals();
+    });
+
+    it("keeps independent layouts for open project contexts", async () => {
+        const firstTab = createWorkspaceFileTab("file-project-1", "README.md");
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: firstTab.id,
+                id: "pane-root",
+                tabIds: [firstTab.id],
+                type: "pane",
+            },
+            tabsById: { [firstTab.id]: firstTab },
+        }));
+
+        await useWorkspaceStore.getState().openContext("project-2", null, {
+            emptyLayout: true,
+        });
+        expect(useWorkspaceStore.getState().tabsById).toEqual({});
+
+        const secondTab = createWorkspaceFileTab(
+            "file-project-2",
+            "src/index.ts",
+        );
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            rootNode: {
+                activeTabId: secondTab.id,
+                id: "pane-root",
+                tabIds: [secondTab.id],
+                type: "pane",
+            },
+            tabsById: {
+                [secondTab.id]: { ...secondTab, projectId: "project-2" },
+            },
+        }));
+
+        await useWorkspaceStore
+            .getState()
+            .activateContext("project-1::__primary__");
+        expect(useWorkspaceStore.getState().tabsById[firstTab.id]).toBeTruthy();
+        expect(
+            useWorkspaceStore.getState().tabsById[secondTab.id],
+        ).toBeUndefined();
+
+        await useWorkspaceStore.getState().openContext("project-2");
+        await useWorkspaceStore.getState().openContext("project-2");
+        expect(useWorkspaceStore.getState().openContextKeys).toEqual([
+            "project-1::__primary__",
+            "project-2::__primary__",
+        ]);
+        expect(useWorkspaceStore.getState().tabsById[secondTab.id]).toBeTruthy();
+
+        await useWorkspaceStore
+            .getState()
+            .closeContext("project-2::__primary__");
+        expect(useWorkspaceStore.getState().activeContextKey).toBe(
+            "project-1::__primary__",
+        );
+
+        await flushWorkspacePersistenceForTests();
+        const persistedSnapshot =
+            saveWorkspaceSnapshotMock.mock.calls.at(-1)?.[0];
+        expect(persistedSnapshot).toMatchObject({
+            activeContextKey: "project-1::__primary__",
+            openContextKeys: ["project-1::__primary__"],
+            version: 2,
+        });
+        expect(persistedSnapshot?.contexts).toHaveLength(1);
+        expect(persistedSnapshot?.contexts[0]?.workspace.tabs).toEqual([
+            expect.objectContaining({ id: firstTab.id }),
+        ]);
     });
 
     it("hydrates and prewarms each active restored chat session", async () => {
@@ -480,7 +574,9 @@ describe("workspace file opening", () => {
         if (!persistedSnapshot) {
             throw new Error("Expected workspace snapshot to be persisted.");
         }
-        const persistedFileTab = persistedSnapshot.tabs.find(
+        const persistedFileTab = getActivePersistedLayout(
+            persistedSnapshot,
+        )?.tabs.find(
             (tab) => tab.kind === "file" && tab.relativePath === "src/app.ts",
         );
         expect(persistedFileTab).toBeTruthy();
@@ -626,7 +722,7 @@ describe("workspace file opening", () => {
         await flushWorkspacePersistenceForTests();
         expect(saveWorkspaceSnapshotMock).toHaveBeenCalled();
         const snapshot = saveWorkspaceSnapshotMock.mock.calls.at(-1)?.[0];
-        expect(snapshot?.tabs).toEqual(
+        expect(snapshot ? getActivePersistedLayout(snapshot)?.tabs : null).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
                     kind: "file",
@@ -963,7 +1059,7 @@ describe("workspace file opening", () => {
         if (!persistedSnapshot) {
             throw new Error("Expected workspace snapshot to be persisted.");
         }
-        expect(persistedSnapshot.tabs).toEqual(
+        expect(getActivePersistedLayout(persistedSnapshot)?.tabs).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
                     issueNumber: 123,
@@ -1368,7 +1464,14 @@ describe("workspace file opening", () => {
 
         await flushWorkspacePersistenceForTests();
 
-        expect(saveWorkspaceSnapshotMock).toHaveBeenCalledWith({
+        const persistedSnapshot =
+            saveWorkspaceSnapshotMock.mock.calls.at(-1)?.[0];
+        expect(persistedSnapshot).toBeTruthy();
+        expect(
+            persistedSnapshot
+                ? getActivePersistedLayout(persistedSnapshot)
+                : null,
+        ).toEqual({
             activePaneId: "pane-root",
             rootNode: {
                 activeTabId: null,
@@ -1493,7 +1596,14 @@ describe("workspace file opening", () => {
             .resizeSplit("split-root", [0.68, 0.32]);
 
         expect(saveWorkspaceSnapshotMock).toHaveBeenCalledTimes(1);
-        expect(saveWorkspaceSnapshotMock).toHaveBeenCalledWith({
+        const persistedSnapshot =
+            saveWorkspaceSnapshotMock.mock.calls.at(-1)?.[0];
+        expect(persistedSnapshot).toBeTruthy();
+        expect(
+            persistedSnapshot
+                ? getActivePersistedLayout(persistedSnapshot)
+                : null,
+        ).toEqual({
             activePaneId: "pane-left",
             rootNode: {
                 axis: "horizontal",

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -333,6 +333,46 @@ describe("workspace file opening", () => {
         ]);
     });
 
+    it("exports one context as a self-contained navigation snapshot", () => {
+        const tab = createWorkspaceFileTab("file-project-1", "README.md");
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: tab.id,
+                id: "pane-root",
+                tabIds: [tab.id],
+                type: "pane",
+            },
+            tabsById: { [tab.id]: tab },
+        }));
+
+        const snapshot = useWorkspaceStore
+            .getState()
+            .getContextNavigationSnapshot("project-1::__primary__");
+
+        expect(snapshot).toMatchObject({
+            activeContextKey: "project-1::__primary__",
+            openContextKeys: ["project-1::__primary__"],
+            version: 2,
+        });
+        expect(snapshot?.contexts).toHaveLength(1);
+        expect(snapshot?.contexts[0]).toMatchObject({
+            key: "project-1::__primary__",
+            projectId: "project-1",
+            worktreeId: null,
+        });
+        expect(snapshot?.contexts[0]?.workspace).toMatchObject({
+            activePaneId: "pane-root",
+                tabs: [
+                expect.objectContaining({
+                    id: tab.id,
+                    relativePath: "README.md",
+                }),
+            ],
+        });
+    });
+
     it("reorders workspace contexts without changing the active context", async () => {
         await useWorkspaceStore
             .getState()

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -2199,6 +2199,96 @@ describe("workspace file opening", () => {
         });
     });
 
+    it("invalidates clean files in inactive contexts and reloads them on activation", async () => {
+        const activeWorkspace = createDefaultWorkspaceState();
+        const inactiveTab = {
+            ...createWorkspaceFileTab("file-inactive", "src/inactive.ts"),
+            document: {
+                absolutePath: "/tmp/src/inactive.ts",
+                content: "export const stale = true;\n",
+                imageDataBase64: null,
+                isBinary: false,
+                isTooLarge: false,
+                kind: "text" as const,
+                languageId: "typescript",
+                languageLabel: "TypeScript",
+                mimeType: "text/typescript",
+                modifiedAtMs: 1,
+                name: "inactive.ts",
+                projectId: "project-2",
+                relativePath: "src/inactive.ts",
+                sizeBytes: 27,
+            },
+            draftContent: "export const stale = true;\n",
+            projectId: "project-2",
+            savedContent: "export const stale = true;\n",
+        };
+        const inactiveWorkspace: WorkspaceTreeState = {
+            activePaneId: "pane-inactive",
+            rootNode: {
+                activeTabId: inactiveTab.id,
+                id: "pane-inactive",
+                tabIds: [inactiveTab.id],
+                type: "pane",
+            },
+            tabsById: { [inactiveTab.id]: inactiveTab },
+        };
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            ...activeWorkspace,
+            activeContextKey: "project-1::__primary__",
+            contextsByKey: {
+                "project-1::__primary__": {
+                    key: "project-1::__primary__",
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-1",
+                    workspace: activeWorkspace,
+                    worktreeId: null,
+                },
+                "project-2::__primary__": {
+                    key: "project-2::__primary__",
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: inactiveWorkspace,
+                    worktreeId: null,
+                },
+            },
+            openContextKeys: [
+                "project-1::__primary__",
+                "project-2::__primary__",
+            ],
+        }));
+
+        await useWorkspaceStore
+            .getState()
+            .refreshProjectTabs("project-2", null, ["src/inactive.ts"]);
+
+        expect(openProjectFileMock).not.toHaveBeenCalled();
+        expect(
+            useWorkspaceStore.getState().contextsByKey[
+                "project-2::__primary__"
+            ]?.workspace.tabsById[inactiveTab.id],
+        ).toMatchObject({ document: null, isDirty: false });
+
+        await useWorkspaceStore
+            .getState()
+            .activateContext("project-2::__primary__");
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledWith({
+                projectId: "project-2",
+                relativePath: "src/inactive.ts",
+                worktreeId: null,
+            });
+            expect(
+                useWorkspaceStore.getState().tabsById[inactiveTab.id],
+            ).toMatchObject({
+                document: { content: "export const value = 1;\n" },
+                isLoading: false,
+            });
+        });
+    });
+
     it("preserves edits made while a file save is in flight", async () => {
         const originalDocument: ProjectFileDocument = {
             absolutePath: "/tmp/notes.md",

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -5,6 +5,7 @@ import type {
     AiImageAttachment,
     AiRuntimeId,
     GitHubRepositoryRef,
+    PersistedWorkspaceSnapshot,
     ProjectFileDocument,
     WorkspaceChatHistoryTab,
     WorkspaceChatTab,
@@ -15,8 +16,9 @@ import type {
     WorkspaceGitHubPullRequestTab,
     WorkspaceGitHubPullRequestsTab,
     WorkspaceGitTab,
+    WorkspaceLayoutSnapshot,
+    WorkspaceNavigationSnapshot,
     WorkspaceReviewTab,
-    WorkspaceSnapshot,
 } from "@shared/ipc";
 import {
     getAiRuntimeDisplayName,
@@ -88,6 +90,7 @@ import { areGitWorktreeIdsEquivalent } from "../git/context-key";
 import { useTerminalRuntimeStore } from "@renderer/features/terminal/terminalRuntimeStore";
 import { useAiStore } from "./ai-store";
 import { useProjectsStore } from "./projects-store";
+import { getProjectContextKey } from "../projects/context-key";
 
 export type WorkspaceQuickCreateAction =
     | ActiveAiRuntimeId
@@ -109,7 +112,21 @@ export type WorkspaceOpenTarget =
           readonly type: "split";
       };
 
+export interface RuntimeWorkspaceContext {
+    readonly key: string;
+    readonly lastActivatedAt: string;
+    readonly projectId: string;
+    readonly workspace: WorkspaceTreeState;
+    readonly worktreeId: string | null;
+}
+
 interface WorkspaceStore extends WorkspaceTreeState {
+    readonly activeContextKey: string | null;
+    readonly contextsByKey: Record<string, RuntimeWorkspaceContext>;
+    readonly openContextKeys: readonly string[];
+    readonly scopeEpoch: number;
+    activateContext: (contextKey: string) => Promise<void>;
+    closeContext: (contextKey: string) => Promise<void>;
     closeOtherTabs: (tabId: string) => Promise<void>;
     readonly error: string | null;
     readonly hydrated: boolean;
@@ -221,7 +238,10 @@ interface WorkspaceStore extends WorkspaceTreeState {
         readonly target: WorkspaceOpenTarget;
         readonly worktreeId?: string | null;
     }) => Promise<string | null>;
-    hydrate: () => Promise<void>;
+    hydrate: (input?: {
+        readonly activeProjectId?: string | null;
+        readonly activeWorktreeId?: string | null;
+    }) => Promise<void>;
     moveActiveTab: (paneId: string, direction: MoveDirection) => Promise<void>;
     moveTab: (tabId: string, direction: MoveDirection) => Promise<void>;
     moveTabToPane: (
@@ -259,6 +279,11 @@ interface WorkspaceStore extends WorkspaceTreeState {
         readonly title: string;
         readonly worktreeId?: string | null;
     }) => Promise<void>;
+    openContext: (
+        projectId: string,
+        worktreeId?: string | null,
+        options?: { readonly emptyLayout?: boolean },
+    ) => Promise<void>;
     reloadFileTab: (tabId: string) => Promise<void>;
     refreshProjectTabs: (
         projectId: string,
@@ -357,6 +382,8 @@ interface ClosedWorkspaceTabEntry {
 
 export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     ...createDefaultWorkspaceState(),
+    activeContextKey: null,
+    contextsByKey: {},
     error: null,
     hydrated: false,
     lastFocusedChatTabId: null,
@@ -365,6 +392,150 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     recentActiveTabIds: [],
     recentClosedTabs: [],
     recentFocusedChatTabIds: [],
+    openContextKeys: [],
+    scopeEpoch: 0,
+
+    activateContext: async (contextKey) => {
+        const currentState = get();
+        if (currentState.activeContextKey === contextKey) {
+            return;
+        }
+
+        const contextsByKey = captureVisibleWorkspaceContext(currentState);
+        const targetContext = contextsByKey[contextKey];
+        if (!targetContext) {
+            return;
+        }
+
+        const scopeEpoch = currentState.scopeEpoch + 1;
+        const targetWorkspace = targetContext.workspace;
+        set({
+            ...targetWorkspace,
+            activeContextKey: contextKey,
+            contextsByKey: {
+                ...contextsByKey,
+                [contextKey]: {
+                    ...targetContext,
+                    lastActivatedAt: new Date().toISOString(),
+                },
+            },
+            error: null,
+            lastFocusedChatTabId: getPaneChatTabId(
+                targetWorkspace,
+                targetWorkspace.activePaneId,
+            ),
+            lastFocusedRuntimeId:
+                getPaneRuntimeId(
+                    targetWorkspace,
+                    targetWorkspace.activePaneId,
+                ) ?? "codex",
+            recentActiveTabIds: recordRecentTabActivation(
+                [],
+                getPaneActiveTabId(
+                    targetWorkspace,
+                    targetWorkspace.activePaneId,
+                ),
+            ),
+            recentClosedTabs: [],
+            recentFocusedChatTabIds: recordRecentChatFocus(
+                [],
+                getPaneChatTabId(
+                    targetWorkspace,
+                    targetWorkspace.activePaneId,
+                ),
+            ),
+            scopeEpoch,
+        });
+
+        ensureActiveHydratedSessions(targetWorkspace);
+        void hydrateRuntimeTabs(
+            workspaceStateToSnapshot(targetWorkspace),
+            get,
+            set,
+            { contextKey, scopeEpoch },
+        );
+        await persistWorkspaceState(get);
+    },
+
+    closeContext: async (contextKey) => {
+        const state = get();
+        const contextsByKey = captureVisibleWorkspaceContext(state);
+        const targetContext = contextsByKey[contextKey];
+        if (!targetContext) {
+            return;
+        }
+
+        await Promise.all(
+            Object.values(targetContext.workspace.tabsById).map(
+                closeTabSideEffects,
+            ),
+        );
+
+        const nextContextsByKey = { ...contextsByKey };
+        delete nextContextsByKey[contextKey];
+        const closedIndex = state.openContextKeys.indexOf(contextKey);
+        const openContextKeys = state.openContextKeys.filter(
+            (key) => key !== contextKey,
+        );
+
+        if (state.activeContextKey !== contextKey) {
+            set({ contextsByKey: nextContextsByKey, openContextKeys });
+            await persistWorkspaceState(get);
+            return;
+        }
+
+        const nextContextKey =
+            openContextKeys[Math.min(closedIndex, openContextKeys.length - 1)] ??
+            null;
+        const nextContext = nextContextKey
+            ? nextContextsByKey[nextContextKey]
+            : null;
+        const nextWorkspace =
+            nextContext?.workspace ?? createDefaultWorkspaceState();
+        set({
+            ...nextWorkspace,
+            activeContextKey: nextContextKey,
+            contextsByKey: nextContextsByKey,
+            error: null,
+            lastFocusedChatTabId: getPaneChatTabId(
+                nextWorkspace,
+                nextWorkspace.activePaneId,
+            ),
+            lastFocusedRuntimeId:
+                getPaneRuntimeId(
+                    nextWorkspace,
+                    nextWorkspace.activePaneId,
+                ) ?? "codex",
+            openContextKeys,
+            recentActiveTabIds: recordRecentTabActivation(
+                [],
+                getPaneActiveTabId(
+                    nextWorkspace,
+                    nextWorkspace.activePaneId,
+                ),
+            ),
+            recentClosedTabs: [],
+            recentFocusedChatTabIds: recordRecentChatFocus(
+                [],
+                getPaneChatTabId(
+                    nextWorkspace,
+                    nextWorkspace.activePaneId,
+                ),
+            ),
+            scopeEpoch: state.scopeEpoch + 1,
+        });
+
+        if (nextContextKey) {
+            ensureActiveHydratedSessions(nextWorkspace);
+            void hydrateRuntimeTabs(
+                workspaceStateToSnapshot(nextWorkspace),
+                get,
+                set,
+                { contextKey: nextContextKey, scopeEpoch: get().scopeEpoch },
+            );
+        }
+        await persistWorkspaceState(get);
+    },
 
     closeOtherTabs: async (tabId) => {
         const paneId = findPaneIdByTabId(get(), tabId);
@@ -996,44 +1167,126 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             input.target,
         ),
 
-    hydrate: async () => {
+    openContext: async (projectId, worktreeId = null) => {
+        const normalizedWorktreeId =
+            worktreeId === `${projectId}:primary` ? null : worktreeId;
+        const contextKey = getProjectContextKey(
+            projectId,
+            normalizedWorktreeId,
+        );
+        if (get().contextsByKey[contextKey]) {
+            await get().activateContext(contextKey);
+            return;
+        }
+
+        const context: RuntimeWorkspaceContext = {
+            key: contextKey,
+            lastActivatedAt: new Date().toISOString(),
+            projectId,
+            workspace: createDefaultWorkspaceState(),
+            worktreeId: normalizedWorktreeId,
+        };
+        set((state) => ({
+            contextsByKey: {
+                ...captureVisibleWorkspaceContext(state),
+                [contextKey]: context,
+            },
+            openContextKeys: [...state.openContextKeys, contextKey],
+        }));
+        await get().activateContext(contextKey);
+    },
+
+    hydrate: async (input = {}) => {
         try {
-            const snapshot = await getComandoApi().getWorkspaceSnapshot();
-            const runtimeTabs = createHydratedRuntimeTabs(snapshot);
-            const hydratedState = workspaceStateFromSnapshot(
-                snapshot,
-                runtimeTabs,
+            const persistedSnapshot =
+                await getComandoApi().getWorkspaceSnapshot();
+            const navigation = resolveWorkspaceNavigationSnapshot(
+                persistedSnapshot,
+                input.activeProjectId ?? null,
+                input.activeWorktreeId ?? null,
             );
+            const contextsByKey = Object.fromEntries(
+                navigation.contexts.map((context) => [
+                    context.key,
+                    {
+                        ...context,
+                        workspace: workspaceStateFromSnapshot(
+                            context.workspace,
+                            createHydratedRuntimeTabs(context.workspace),
+                        ),
+                    } satisfies RuntimeWorkspaceContext,
+                ]),
+            );
+            const openContextKeys = navigation.openContextKeys.filter(
+                (key) => Boolean(contextsByKey[key]),
+            );
+            const activeContextKey =
+                navigation.activeContextKey &&
+                openContextKeys.includes(navigation.activeContextKey)
+                    ? navigation.activeContextKey
+                    : (openContextKeys[0] ?? null);
+            const activeContext = activeContextKey
+                ? contextsByKey[activeContextKey]
+                : null;
+            const hydratedState =
+                activeContext?.workspace ?? createDefaultWorkspaceState();
+            const scopeEpoch = get().scopeEpoch + 1;
             set({
                 ...hydratedState,
+                activeContextKey,
+                contextsByKey,
                 error: null,
                 hydrated: true,
+                openContextKeys,
                 lastFocusedChatTabId: getPaneChatTabId(
                     hydratedState,
-                    snapshot.activePaneId,
+                    hydratedState.activePaneId,
                 ),
                 lastFocusedRuntimeId:
-                    getPaneRuntimeId(hydratedState, snapshot.activePaneId) ??
-                    "codex",
+                    getPaneRuntimeId(
+                        hydratedState,
+                        hydratedState.activePaneId,
+                    ) ?? "codex",
                 recentActiveTabIds: recordRecentTabActivation(
                     [],
-                    getPaneActiveTabId(hydratedState, snapshot.activePaneId),
+                    getPaneActiveTabId(
+                        hydratedState,
+                        hydratedState.activePaneId,
+                    ),
                 ),
                 recentFocusedChatTabIds: recordRecentChatFocus(
                     [],
-                    getPaneChatTabId(hydratedState, snapshot.activePaneId),
+                    getPaneChatTabId(
+                        hydratedState,
+                        hydratedState.activePaneId,
+                    ),
                 ),
+                scopeEpoch,
             });
             ensureActiveHydratedSessions(hydratedState);
-            void hydrateRuntimeTabs(snapshot, get, set);
+            if (activeContextKey) {
+                void hydrateRuntimeTabs(
+                    workspaceStateToSnapshot(hydratedState),
+                    get,
+                    set,
+                    { contextKey: activeContextKey, scopeEpoch },
+                );
+            }
+            if (!isWorkspaceNavigationSnapshot(persistedSnapshot)) {
+                await persistWorkspaceState(get);
+            }
         } catch (error) {
             set({
                 ...createDefaultWorkspaceState(),
+                activeContextKey: null,
+                contextsByKey: {},
                 error:
                     error instanceof Error
                         ? error.message
                         : "Could not restore the workspace layout.",
                 hydrated: true,
+                openContextKeys: [],
+                scopeEpoch: get().scopeEpoch + 1,
             });
         }
     },
@@ -1307,7 +1560,12 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 }));
 
                 if (!sourceTab.document && !sourceTab.isDirty) {
-                    await loadFileTabDocument(get, set, duplicatedTab.id);
+                    await loadFileTabDocument(
+                        get,
+                        set,
+                        duplicatedTab.id,
+                        getCurrentWorkspaceScope(get),
+                    );
                 }
 
                 await persistWorkspaceState(get);
@@ -1362,7 +1620,12 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 ),
             }));
             await persistWorkspaceState(get);
-            await loadFileTabDocument(get, set, tab.id);
+            await loadFileTabDocument(
+                get,
+                set,
+                tab.id,
+                getCurrentWorkspaceScope(get),
+            );
         } catch (error) {
             set({
                 error:
@@ -1536,7 +1799,12 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     },
 
     reloadFileTab: async (tabId) => {
-        await loadFileTabDocument(get, set, tabId);
+        await loadFileTabDocument(
+            get,
+            set,
+            tabId,
+            getCurrentWorkspaceScope(get),
+        );
     },
 
     refreshProjectTabs: async (
@@ -1569,7 +1837,12 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                     return;
                 }
 
-                await loadFileTabDocument(get, set, tab.id);
+                await loadFileTabDocument(
+                    get,
+                    set,
+                    tab.id,
+                    getCurrentWorkspaceScope(get),
+                );
             }),
         );
     },
@@ -2683,8 +2956,111 @@ function getExistingTabMoveTargetIndex(
     return targetIndex - 1;
 }
 
+function captureVisibleWorkspaceContext(
+    state: WorkspaceStore,
+): Record<string, RuntimeWorkspaceContext> {
+    if (!state.activeContextKey) {
+        return state.contextsByKey;
+    }
+
+    const activeContext = state.contextsByKey[state.activeContextKey];
+    if (!activeContext) {
+        return state.contextsByKey;
+    }
+
+    return {
+        ...state.contextsByKey,
+        [state.activeContextKey]: {
+            ...activeContext,
+            workspace: {
+                activePaneId: state.activePaneId,
+                rootNode: state.rootNode,
+                tabsById: state.tabsById,
+            },
+        },
+    };
+}
+
+function isWorkspaceNavigationSnapshot(
+    snapshot: PersistedWorkspaceSnapshot,
+): snapshot is WorkspaceNavigationSnapshot {
+    return "version" in snapshot && snapshot.version === 2;
+}
+
+function resolveWorkspaceNavigationSnapshot(
+    snapshot: PersistedWorkspaceSnapshot,
+    activeProjectId: string | null,
+    activeWorktreeId: string | null,
+): WorkspaceNavigationSnapshot {
+    if (isWorkspaceNavigationSnapshot(snapshot)) {
+        return snapshot;
+    }
+
+    const firstScopedTab = snapshot.tabs.find(
+        (tab) => typeof tab.projectId === "string" && tab.projectId.length > 0,
+    );
+    const projectId = activeProjectId ?? firstScopedTab?.projectId ?? null;
+    if (!projectId) {
+        return {
+            activeContextKey: null,
+            contexts: [],
+            openContextKeys: [],
+            version: 2,
+        };
+    }
+
+    const worktreeId = activeWorktreeId ?? firstScopedTab?.worktreeId ?? null;
+    const key = getProjectContextKey(projectId, worktreeId);
+    return {
+        activeContextKey: key,
+        contexts: [
+            {
+                key,
+                lastActivatedAt: new Date().toISOString(),
+                projectId,
+                workspace: snapshot,
+                worktreeId,
+            },
+        ],
+        openContextKeys: [key],
+        version: 2,
+    };
+}
+
+function workspaceStoreToNavigationSnapshot(
+    state: WorkspaceStore,
+): WorkspaceNavigationSnapshot {
+    const contextsByKey = captureVisibleWorkspaceContext(state);
+    const contexts = state.openContextKeys.flatMap((key) => {
+        const context = contextsByKey[key];
+        if (!context) {
+            return [];
+        }
+
+        return [
+            {
+                key: context.key,
+                lastActivatedAt: context.lastActivatedAt,
+                projectId: context.projectId,
+                workspace: workspaceStateToSnapshot(context.workspace),
+                worktreeId: context.worktreeId,
+            },
+        ];
+    });
+
+    return {
+        activeContextKey:
+            state.activeContextKey && contextsByKey[state.activeContextKey]
+                ? state.activeContextKey
+                : null,
+        contexts,
+        openContextKeys: contexts.map((context) => context.key),
+        version: 2,
+    };
+}
+
 function createHydratedRuntimeTabs(
-    snapshot: WorkspaceSnapshot,
+    snapshot: WorkspaceLayoutSnapshot,
 ): Record<string, RuntimeWorkspaceTab> {
     return Object.fromEntries(
         snapshot.tabs.map((tab) => {
@@ -2793,9 +3169,13 @@ function prewarmFocusedAiSession(
 }
 
 async function hydrateRuntimeTabs(
-    snapshot: WorkspaceSnapshot,
+    snapshot: WorkspaceLayoutSnapshot,
     get: GetWorkspaceState,
     set: WorkspaceSetState,
+    scope?: {
+        readonly contextKey: string;
+        readonly scopeEpoch: number;
+    },
 ): Promise<void> {
     await Promise.all(
         snapshot.tabs.map(async (tab) => {
@@ -2807,6 +3187,10 @@ async function hydrateRuntimeTabs(
                         );
 
                     if (!persistedSession) {
+                        return;
+                    }
+
+                    if (!isWorkspaceScopeCurrent(get, scope)) {
                         return;
                     }
 
@@ -2859,9 +3243,42 @@ async function hydrateRuntimeTabs(
                 return;
             }
 
-            await loadFileTabDocument(get, set, tab.id);
+            await loadFileTabDocument(get, set, tab.id, scope);
         }),
     );
+}
+
+function isWorkspaceScopeCurrent(
+    get: GetWorkspaceState,
+    scope?: {
+        readonly contextKey: string;
+        readonly scopeEpoch: number;
+    },
+): boolean {
+    if (!scope) {
+        return true;
+    }
+
+    const state = get();
+    return (
+        state.activeContextKey === scope.contextKey &&
+        state.scopeEpoch === scope.scopeEpoch
+    );
+}
+
+function getCurrentWorkspaceScope(get: GetWorkspaceState):
+    | {
+          readonly contextKey: string;
+          readonly scopeEpoch: number;
+      }
+    | undefined {
+    const state = get();
+    return state.activeContextKey
+        ? {
+              contextKey: state.activeContextKey,
+              scopeEpoch: state.scopeEpoch,
+          }
+        : undefined;
 }
 
 function persistWorkspaceState(get: GetWorkspaceState): Promise<void> {
@@ -2960,7 +3377,7 @@ async function persistWorkspaceStateNow(get: GetWorkspaceState): Promise<void> {
     try {
         const state = get();
         await getComandoApi().saveWorkspaceSnapshot(
-            workspaceStateToSnapshot(state),
+            workspaceStoreToNavigationSnapshot(state),
         );
     } catch (error) {
         // Workspace persistence failure silently loses layout/tabs on restart;
@@ -2976,7 +3393,14 @@ async function loadFileTabDocument(
     get: GetWorkspaceState,
     set: WorkspaceSetState,
     tabId: string,
+    scope?: {
+        readonly contextKey: string;
+        readonly scopeEpoch: number;
+    },
 ): Promise<void> {
+    if (!isWorkspaceScopeCurrent(get, scope)) {
+        return;
+    }
     const tab = get().tabsById[tabId];
     if (!tab || tab.kind !== "file" || tab.isTransient) {
         return;
@@ -3008,11 +3432,18 @@ async function loadFileTabDocument(
             worktreeId: tab.worktreeId ?? null,
         });
 
+        if (!isWorkspaceScopeCurrent(get, scope)) {
+            return;
+        }
+
         set((state) => ({
             ...replaceFileDocument(state, tabId, document),
             error: null,
         }));
     } catch (error) {
+        if (!isWorkspaceScopeCurrent(get, scope)) {
+            return;
+        }
         set((state) => ({
             ...setFileTabLoadError(
                 state,
@@ -3069,7 +3500,12 @@ async function restoreTabSideEffects(
 
     if (tab.kind === "file") {
         if (!tab.document && !tab.isDirty) {
-            await loadFileTabDocument(get, set, tab.id);
+            await loadFileTabDocument(
+                get,
+                set,
+                tab.id,
+                getCurrentWorkspaceScope(get),
+            );
             return;
         }
 

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -448,8 +448,8 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         });
 
         ensureActiveHydratedSessions(targetWorkspace);
-        void hydrateRuntimeTabs(
-            workspaceStateToSnapshot(targetWorkspace),
+        void hydrateActiveRuntimeTabs(
+            targetWorkspace,
             get,
             set,
             { contextKey, scopeEpoch },
@@ -527,8 +527,8 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
 
         if (nextContextKey) {
             ensureActiveHydratedSessions(nextWorkspace);
-            void hydrateRuntimeTabs(
-                workspaceStateToSnapshot(nextWorkspace),
+            void hydrateActiveRuntimeTabs(
+                nextWorkspace,
                 get,
                 set,
                 { contextKey: nextContextKey, scopeEpoch: get().scopeEpoch },
@@ -1265,8 +1265,8 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             });
             ensureActiveHydratedSessions(hydratedState);
             if (activeContextKey) {
-                void hydrateRuntimeTabs(
-                    workspaceStateToSnapshot(hydratedState),
+                void hydrateActiveRuntimeTabs(
+                    hydratedState,
                     get,
                     set,
                     { contextKey: activeContextKey, scopeEpoch },
@@ -1625,6 +1625,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 set,
                 tab.id,
                 getCurrentWorkspaceScope(get),
+                { force: true },
             );
         } catch (error) {
             set({
@@ -1804,6 +1805,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             set,
             tabId,
             getCurrentWorkspaceScope(get),
+            { force: true },
         );
     },
 
@@ -1842,6 +1844,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                     set,
                     tab.id,
                     getCurrentWorkspaceScope(get),
+                    { force: true },
                 );
             }),
         );
@@ -2028,9 +2031,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         }));
         const activeTabId = getPaneActiveTabId(get(), paneId);
         const activeTab = activeTabId ? get().tabsById[activeTabId] : null;
-        if (activeTab?.kind === "chat" || activeTab?.kind === "review") {
-            prewarmFocusedAiSession(activeTab);
-        }
+        prepareFocusedWorkspaceTab(activeTab, get, set);
         await persistWorkspaceState(get);
     },
 
@@ -2061,9 +2062,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             })(),
         }));
         const tab = get().tabsById[tabId];
-        if (tab?.kind === "chat" || tab?.kind === "review") {
-            prewarmFocusedAiSession(tab);
-        }
+        prepareFocusedWorkspaceTab(tab, get, set);
         await persistWorkspaceState(get);
     },
 
@@ -2105,9 +2104,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         }));
         const activeTabId = getPaneActiveTabId(get(), paneId);
         const activeTab = activeTabId ? get().tabsById[activeTabId] : null;
-        if (activeTab?.kind === "chat" || activeTab?.kind === "review") {
-            prewarmFocusedAiSession(activeTab);
-        }
+        prepareFocusedWorkspaceTab(activeTab, get, set);
         await persistWorkspaceState(get);
     },
 
@@ -2302,6 +2299,7 @@ let pendingWorkspacePersistTimer: ReturnType<typeof setTimeout> | null = null;
 let workspacePersistDirty = false;
 let workspacePersistGet: GetWorkspaceState | null = null;
 let workspacePersistInFlight: Promise<void> | null = null;
+const pendingFileDocumentLoads = new Map<string, Promise<ProjectFileDocument>>();
 
 export function getWorkspaceTabRuntimeId(
     tab: RuntimeWorkspaceTab | null | undefined,
@@ -3131,7 +3129,7 @@ function createHydratedRuntimeTabs(
                     draftContent: "",
                     hasExternalChange: false,
                     isDirty: false,
-                    isLoading: true,
+                    isLoading: false,
                     isSaving: false,
                     loadError: null,
                     reviewContext: null,
@@ -3156,6 +3154,26 @@ function ensureActiveHydratedSessions(state: WorkspaceTreeState): void {
     }
 }
 
+function prepareFocusedWorkspaceTab(
+    tab: RuntimeWorkspaceTab | null | undefined,
+    get: GetWorkspaceState,
+    set: WorkspaceSetState,
+): void {
+    if (tab?.kind === "file") {
+        void loadFileTabDocument(
+            get,
+            set,
+            tab.id,
+            getCurrentWorkspaceScope(get),
+        );
+        return;
+    }
+
+    if (tab?.kind === "chat" || tab?.kind === "review") {
+        prewarmFocusedAiSession(tab);
+    }
+}
+
 function prewarmFocusedAiSession(
     tab: RuntimeWorkspaceTab,
 ): void {
@@ -3168,8 +3186,8 @@ function prewarmFocusedAiSession(
     void useAiStore.getState().ensureSession(tab);
 }
 
-async function hydrateRuntimeTabs(
-    snapshot: WorkspaceLayoutSnapshot,
+async function hydrateActiveRuntimeTabs(
+    workspace: WorkspaceTreeState,
     get: GetWorkspaceState,
     set: WorkspaceSetState,
     scope?: {
@@ -3177,73 +3195,18 @@ async function hydrateRuntimeTabs(
         readonly scopeEpoch: number;
     },
 ): Promise<void> {
+    const activeTabIds = new Set(
+        collectPaneNodes(workspace.rootNode).flatMap((pane) =>
+            pane.activeTabId ? [pane.activeTabId] : [],
+        ),
+    );
+
     await Promise.all(
-        snapshot.tabs.map(async (tab) => {
-            if (tab.kind === "chat") {
-                try {
-                    const persistedSession =
-                        await getComandoApi().getChatSessionState(
-                            tab.sessionId,
-                        );
-
-                    if (!persistedSession) {
-                        return;
-                    }
-
-                    if (!isWorkspaceScopeCurrent(get, scope)) {
-                        return;
-                    }
-
-                    set((state) => ({
-                        error: null,
-                        tabsById: {
-                            ...state.tabsById,
-                            [tab.id]: {
-                                ...tab,
-                                draft: persistedSession.draft,
-                                projectId: persistedSession.projectId,
-                                title: persistedSession.title,
-                                worktreeId: persistedSession.worktreeId ?? null,
-                            },
-                        },
-                    }));
-                } catch {
-                    return;
-                }
-
-                return;
+        [...activeTabIds].map(async (tabId) => {
+            const tab = workspace.tabsById[tabId];
+            if (tab?.kind === "file") {
+                await loadFileTabDocument(get, set, tab.id, scope);
             }
-
-            if (tab.kind === "git") {
-                return;
-            }
-
-            if (tab.kind === "chat_history") {
-                return;
-            }
-
-            if (tab.kind === "git_commit") {
-                return;
-            }
-
-            if (
-                tab.kind === "github_issues" ||
-                tab.kind === "github_issue" ||
-                tab.kind === "github_pull_requests" ||
-                tab.kind === "github_pull_request"
-            ) {
-                return;
-            }
-
-            if (tab.kind === "review") {
-                return;
-            }
-
-            if (tab.kind === "terminal") {
-                return;
-            }
-
-            await loadFileTabDocument(get, set, tab.id, scope);
         }),
     );
 }
@@ -3299,6 +3262,7 @@ export function resetWorkspacePersistenceForTests(): void {
     workspacePersistDirty = false;
     workspacePersistGet = null;
     workspacePersistInFlight = null;
+    pendingFileDocumentLoads.clear();
 }
 
 function scheduleWorkspacePersistence(get: GetWorkspaceState): void {
@@ -3397,6 +3361,9 @@ async function loadFileTabDocument(
         readonly contextKey: string;
         readonly scopeEpoch: number;
     },
+    options: {
+        readonly force?: boolean;
+    } = {},
 ): Promise<void> {
     if (!isWorkspaceScopeCurrent(get, scope)) {
         return;
@@ -3406,17 +3373,7 @@ async function loadFileTabDocument(
         return;
     }
 
-    const hasSiblingLoadInFlight = Object.values(get().tabsById).some(
-        (candidate): candidate is RuntimeWorkspaceFileTab =>
-            candidate.kind === "file" &&
-            candidate.id !== tab.id &&
-            candidate.projectId === tab.projectId &&
-            normalizeWorktreeId(candidate.worktreeId) ===
-                normalizeWorktreeId(tab.worktreeId) &&
-            candidate.relativePath === tab.relativePath &&
-            candidate.isLoading,
-    );
-    if (hasSiblingLoadInFlight) {
+    if (!options.force && tab.document) {
         return;
     }
 
@@ -3426,13 +3383,10 @@ async function loadFileTabDocument(
             error: null,
         }));
 
-        const document = await getComandoApi().openProjectFile({
-            projectId: tab.projectId,
-            relativePath: tab.relativePath,
-            worktreeId: tab.worktreeId ?? null,
-        });
+        const document = await getOrCreateFileDocumentLoad(tab);
 
         if (!isWorkspaceScopeCurrent(get, scope)) {
+            clearStaleFileTabLoading(set, tabId, scope);
             return;
         }
 
@@ -3442,6 +3396,7 @@ async function loadFileTabDocument(
         }));
     } catch (error) {
         if (!isWorkspaceScopeCurrent(get, scope)) {
+            clearStaleFileTabLoading(set, tabId, scope);
             return;
         }
         set((state) => ({
@@ -3458,6 +3413,84 @@ async function loadFileTabDocument(
                     : "Could not refresh the open workspace tabs.",
         }));
     }
+}
+
+function getOrCreateFileDocumentLoad(
+    tab: RuntimeWorkspaceFileTab,
+): Promise<ProjectFileDocument> {
+    const key = getWorkspaceFileLoadKey(tab);
+    const existingLoad = pendingFileDocumentLoads.get(key);
+    if (existingLoad) {
+        return existingLoad;
+    }
+
+    const load = getComandoApi().openProjectFile({
+        projectId: tab.projectId,
+        relativePath: tab.relativePath,
+        worktreeId: tab.worktreeId ?? null,
+    });
+    pendingFileDocumentLoads.set(key, load);
+    void load.then(
+        () => {
+            if (pendingFileDocumentLoads.get(key) === load) {
+                pendingFileDocumentLoads.delete(key);
+            }
+        },
+        () => {
+            if (pendingFileDocumentLoads.get(key) === load) {
+                pendingFileDocumentLoads.delete(key);
+            }
+        },
+    );
+    return load;
+}
+
+function getWorkspaceFileLoadKey(tab: RuntimeWorkspaceFileTab): string {
+    return [
+        tab.projectId,
+        normalizeWorktreeId(tab.worktreeId) ?? "__primary__",
+        tab.relativePath,
+    ].join("\u0000");
+}
+
+function clearStaleFileTabLoading(
+    set: WorkspaceSetState,
+    tabId: string,
+    scope: { readonly contextKey: string; readonly scopeEpoch: number } | undefined,
+): void {
+    if (!scope) {
+        return;
+    }
+
+    set((state) => {
+        if (state.activeContextKey === scope.contextKey) {
+            // A newer activation already owns the visible tab state.
+            return state;
+        }
+
+        const context = state.contextsByKey[scope.contextKey];
+        const tab = context?.workspace.tabsById[tabId];
+        if (!context || !tab || tab.kind !== "file" || !tab.isLoading) {
+            return state;
+        }
+
+        return {
+            ...state,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [scope.contextKey]: {
+                    ...context,
+                    workspace: {
+                        ...context.workspace,
+                        tabsById: {
+                            ...context.workspace.tabsById,
+                            [tabId]: { ...tab, isLoading: false },
+                        },
+                    },
+                },
+            },
+        };
+    });
 }
 
 async function closeTabSideEffects(tab: RuntimeWorkspaceTab): Promise<void> {

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -24,6 +24,7 @@ import {
     getAiRuntimeDisplayName,
     type ActiveAiRuntimeId,
 } from "@shared/ai-runtimes";
+import { normalizeWorkspaceNavigationSnapshot } from "@shared/workspace-restore";
 
 import {
     activatePane,
@@ -2367,6 +2368,7 @@ let pendingWorkspacePersistTimer: ReturnType<typeof setTimeout> | null = null;
 let workspacePersistDirty = false;
 let workspacePersistGet: GetWorkspaceState | null = null;
 let workspacePersistInFlight: Promise<void> | null = null;
+let workspacePersistFailureCount = 0;
 const pendingFileDocumentLoads = new Map<string, Promise<ProjectFileDocument>>();
 
 export function getWorkspaceTabRuntimeId(
@@ -3120,39 +3122,10 @@ function resolveWorkspaceNavigationSnapshot(
     activeProjectId: string | null,
     activeWorktreeId: string | null,
 ): WorkspaceNavigationSnapshot {
-    if (isWorkspaceNavigationSnapshot(snapshot)) {
-        return snapshot;
-    }
-
-    const firstScopedTab = snapshot.tabs.find(
-        (tab) => typeof tab.projectId === "string" && tab.projectId.length > 0,
-    );
-    const projectId = activeProjectId ?? firstScopedTab?.projectId ?? null;
-    if (!projectId) {
-        return {
-            activeContextKey: null,
-            contexts: [],
-            openContextKeys: [],
-            version: 2,
-        };
-    }
-
-    const worktreeId = activeWorktreeId ?? firstScopedTab?.worktreeId ?? null;
-    const key = getProjectContextKey(projectId, worktreeId);
-    return {
-        activeContextKey: key,
-        contexts: [
-            {
-                key,
-                lastActivatedAt: new Date().toISOString(),
-                projectId,
-                workspace: snapshot,
-                worktreeId,
-            },
-        ],
-        openContextKeys: [key],
-        version: 2,
-    };
+    return normalizeWorkspaceNavigationSnapshot(snapshot, {
+        projectId: activeProjectId,
+        worktreeId: activeWorktreeId,
+    }).snapshot;
 }
 
 function workspaceStoreToNavigationSnapshot(
@@ -3383,6 +3356,20 @@ export async function flushWorkspacePersistenceForTests(): Promise<void> {
     await flushWorkspacePersistence(undefined, { force: true });
 }
 
+export async function flushWorkspacePersistenceNow(): Promise<void> {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+        if (pendingWorkspacePersistTimer !== null) {
+            clearTimeout(pendingWorkspacePersistTimer);
+            pendingWorkspacePersistTimer = null;
+        }
+        await flushWorkspacePersistence(undefined, { force: true });
+        if (!workspacePersistDirty) {
+            return;
+        }
+    }
+    throw new Error("Could not persist the workspace before closing.");
+}
+
 export function resetWorkspacePersistenceForTests(): void {
     if (pendingWorkspacePersistTimer !== null) {
         clearTimeout(pendingWorkspacePersistTimer);
@@ -3392,6 +3379,7 @@ export function resetWorkspacePersistenceForTests(): void {
     workspacePersistDirty = false;
     workspacePersistGet = null;
     workspacePersistInFlight = null;
+    workspacePersistFailureCount = 0;
     pendingFileDocumentLoads.clear();
 }
 
@@ -3439,7 +3427,7 @@ async function flushWorkspacePersistence(
     if (workspacePersistInFlight) {
         await workspacePersistInFlight;
 
-        if (workspacePersistDirty) {
+        if (workspacePersistDirty && workspacePersistFailureCount === 0) {
             await flushWorkspacePersistence();
         }
 
@@ -3462,7 +3450,7 @@ async function flushWorkspacePersistence(
         }
     }
 
-    if (workspacePersistDirty) {
+    if (workspacePersistDirty && workspacePersistFailureCount === 0) {
         await flushWorkspacePersistence();
     }
 }
@@ -3473,6 +3461,7 @@ async function persistWorkspaceStateNow(get: GetWorkspaceState): Promise<void> {
         await getComandoApi().saveWorkspaceSnapshot(
             workspaceStoreToNavigationSnapshot(state),
         );
+        workspacePersistFailureCount = 0;
     } catch (error) {
         // Workspace persistence failure silently loses layout/tabs on restart;
         // surface it at error level so diagnostics don't start from scratch.
@@ -3480,6 +3469,17 @@ async function persistWorkspaceStateNow(get: GetWorkspaceState): Promise<void> {
             "[workspace-store] saveWorkspaceSnapshot failed",
             error,
         );
+        workspacePersistDirty = true;
+        workspacePersistFailureCount += 1;
+        if (
+            pendingWorkspacePersistTimer === null &&
+            workspacePersistFailureCount <= 3
+        ) {
+            pendingWorkspacePersistTimer = setTimeout(() => {
+                pendingWorkspacePersistTimer = null;
+                void flushWorkspacePersistence();
+            }, Math.min(1_000 * workspacePersistFailureCount, 3_000));
+        }
     }
 }
 

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -298,6 +298,7 @@ interface WorkspaceStore extends WorkspaceTreeState {
         tabId: string,
         targetIndex: number,
     ) => Promise<void>;
+    reorderContext: (contextKey: string, targetIndex: number) => Promise<void>;
     closeTabsForProjectPath: (
         projectId: string,
         worktreeId: string | null,
@@ -1895,6 +1896,36 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             ...reorderTabInPane(state, paneId, tabId, targetIndex),
             error: null,
         }));
+        await persistWorkspaceState(get);
+    },
+
+    reorderContext: async (contextKey, targetIndex) => {
+        const state = get();
+        const sourceIndex = state.openContextKeys.indexOf(contextKey);
+        if (sourceIndex < 0 || state.openContextKeys.length < 2) {
+            return;
+        }
+
+        const normalizedTargetIndex = Math.max(
+            0,
+            Math.min(
+                state.openContextKeys.length - 1,
+                Number.isFinite(targetIndex)
+                    ? Math.trunc(targetIndex)
+                    : sourceIndex,
+            ),
+        );
+        if (normalizedTargetIndex === sourceIndex) {
+            return;
+        }
+
+        const openContextKeys = [...state.openContextKeys];
+        openContextKeys.splice(sourceIndex, 1);
+        openContextKeys.splice(normalizedTargetIndex, 0, contextKey);
+        set({
+            contextsByKey: captureVisibleWorkspaceContext(state),
+            openContextKeys,
+        });
         await persistWorkspaceState(get);
     },
 

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -123,6 +123,9 @@ export interface RuntimeWorkspaceContext {
 interface WorkspaceStore extends WorkspaceTreeState {
     readonly activeContextKey: string | null;
     readonly contextsByKey: Record<string, RuntimeWorkspaceContext>;
+    getContextNavigationSnapshot: (
+        contextKey: string,
+    ) => WorkspaceNavigationSnapshot | null;
     readonly openContextKeys: readonly string[];
     readonly scopeEpoch: number;
     activateContext: (contextKey: string) => Promise<void>;
@@ -395,6 +398,28 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     recentFocusedChatTabIds: [],
     openContextKeys: [],
     scopeEpoch: 0,
+
+    getContextNavigationSnapshot: (contextKey) => {
+        const context = captureVisibleWorkspaceContext(get())[contextKey];
+        if (!context) {
+            return null;
+        }
+
+        return {
+            activeContextKey: context.key,
+            contexts: [
+                {
+                    key: context.key,
+                    lastActivatedAt: context.lastActivatedAt,
+                    projectId: context.projectId,
+                    workspace: workspaceStateToSnapshot(context.workspace),
+                    worktreeId: context.worktreeId,
+                },
+            ],
+            openContextKeys: [context.key],
+            version: 2,
+        };
+    },
 
     activateContext: async (contextKey) => {
         const currentState = get();

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -1814,6 +1814,18 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         worktreeId: string | null = null,
         invalidatedRelativePaths: readonly string[] | null = null,
     ) => {
+        set((state) => {
+            const contextsByKey = invalidateInactiveContextFileDocuments(
+                state,
+                projectId,
+                worktreeId,
+                invalidatedRelativePaths,
+            );
+            return contextsByKey === state.contextsByKey
+                ? state
+                : { contextsByKey };
+        });
+
         const fileTabs = Object.values(get().tabsById).filter(
             (tab): tab is RuntimeWorkspaceFileTab =>
                 tab.kind === "file" &&
@@ -2977,6 +2989,68 @@ function captureVisibleWorkspaceContext(
             },
         },
     };
+}
+
+function invalidateInactiveContextFileDocuments(
+    state: WorkspaceStore,
+    projectId: string,
+    worktreeId: string | null,
+    invalidatedRelativePaths: readonly string[] | null,
+): Record<string, RuntimeWorkspaceContext> {
+    let nextContextsByKey = state.contextsByKey;
+
+    for (const [contextKey, context] of Object.entries(state.contextsByKey)) {
+        if (contextKey === state.activeContextKey) {
+            continue;
+        }
+
+        let nextTabsById = context.workspace.tabsById;
+        for (const [tabId, tab] of Object.entries(
+            context.workspace.tabsById,
+        )) {
+            if (
+                tab.kind !== "file" ||
+                tab.projectId !== projectId ||
+                normalizeWorktreeId(tab.worktreeId) !==
+                    normalizeWorktreeId(worktreeId) ||
+                !isFileTabAffectedByProjectInvalidation(
+                    tab.relativePath,
+                    invalidatedRelativePaths,
+                ) ||
+                tab.isDirty ||
+                tab.isSaving ||
+                !tab.document
+            ) {
+                continue;
+            }
+
+            if (nextTabsById === context.workspace.tabsById) {
+                nextTabsById = { ...context.workspace.tabsById };
+            }
+            nextTabsById[tabId] = {
+                ...tab,
+                document: null,
+                isLoading: false,
+                loadError: null,
+            };
+        }
+
+        if (nextTabsById === context.workspace.tabsById) {
+            continue;
+        }
+        if (nextContextsByKey === state.contextsByKey) {
+            nextContextsByKey = { ...state.contextsByKey };
+        }
+        nextContextsByKey[contextKey] = {
+            ...context,
+            workspace: {
+                ...context.workspace,
+                tabsById: nextTabsById,
+            },
+        };
+    }
+
+    return nextContextsByKey;
 }
 
 function isWorkspaceNavigationSnapshot(

--- a/src/renderer/src/app/workspace/tree.test.ts
+++ b/src/renderer/src/app/workspace/tree.test.ts
@@ -17,6 +17,7 @@ import {
     renameWorkspaceTabsForProjectPath,
     replaceFileDocument,
     selectAdjacentPaneTab,
+    selectPaneTab,
     setFileTabExternalChange,
     setFileTabMarkdownPreviewScrollTop,
     setFileTabSaving,
@@ -26,6 +27,7 @@ import {
     updateFileDraft,
     type RuntimeWorkspaceFileTab,
     type RuntimeWorkspaceTab,
+    type WorkspaceTreeState,
     workspaceStateFromSnapshot,
     workspaceStateToSnapshot,
 } from "./tree";
@@ -314,6 +316,60 @@ describe("workspace tree helpers", () => {
 
         expect(selected.rootNode.activeTabId).toBe("tab-2");
         expect(selected.activePaneId).toBe("pane-root");
+    });
+
+    it("preserves untouched split branches when selecting a tab", () => {
+        const targetPane = {
+            activeTabId: "tab-1",
+            id: "pane-target",
+            tabIds: ["tab-1", "tab-2"],
+            type: "pane" as const,
+        };
+        const targetBranch = {
+            axis: "vertical" as const,
+            children: [targetPane],
+            id: "split-target",
+            sizes: [1],
+            type: "split" as const,
+        };
+        const untouchedBranch = {
+            axis: "vertical" as const,
+            children: [
+                {
+                    activeTabId: "tab-3",
+                    id: "pane-untouched",
+                    tabIds: ["tab-3"],
+                    type: "pane" as const,
+                },
+            ],
+            id: "split-untouched",
+            sizes: [1],
+            type: "split" as const,
+        };
+        const state: WorkspaceTreeState = {
+            activePaneId: targetPane.id,
+            rootNode: {
+                axis: "horizontal",
+                children: [targetBranch, untouchedBranch],
+                id: "split-root",
+                sizes: [0.5, 0.5],
+                type: "split",
+            },
+            tabsById: {
+                "tab-1": makeChatTab("tab-1"),
+                "tab-2": makeChatTab("tab-2"),
+                "tab-3": makeChatTab("tab-3"),
+            },
+        };
+
+        const selected = selectPaneTab(state, targetPane.id, "tab-2");
+
+        expect(selected.rootNode.type).toBe("split");
+        if (selected.rootNode.type !== "split") {
+            return;
+        }
+
+        expect(selected.rootNode.children[1]).toBe(untouchedBranch);
     });
 
     it("omits transient file tabs from the persisted snapshot", () => {

--- a/src/renderer/src/app/workspace/tree.ts
+++ b/src/renderer/src/app/workspace/tree.ts
@@ -354,6 +354,10 @@ export function selectPaneTab(
                 return node;
             }
 
+            if (node.activeTabId === tabId) {
+                return node;
+            }
+
             return {
                 ...node,
                 activeTabId: tabId,
@@ -1317,12 +1321,19 @@ function replaceNode(
         return node;
     }
 
-    return {
-        ...node,
-        children: node.children.map((child) =>
-            replaceNode(child, targetId, updater),
-        ),
-    };
+    for (let index = 0; index < node.children.length; index += 1) {
+        const child = node.children[index];
+        const nextChild = replaceNode(child, targetId, updater);
+        if (nextChild === child) {
+            continue;
+        }
+
+        const nextChildren = [...node.children];
+        nextChildren[index] = nextChild;
+        return { ...node, children: nextChildren };
+    }
+
+    return node;
 }
 
 function removePane(node: WorkspaceNode, paneId: string): WorkspaceNode | null {

--- a/src/renderer/src/components/DesktopTopBar.context-menu.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.context-menu.test.tsx
@@ -62,6 +62,7 @@ function renderTopBar() {
                 onReorderContext: vi.fn(),
                 onToggleLeftSidebar: vi.fn(),
                 platform: "darwin",
+                settingsLabel: null,
             }),
         );
     });

--- a/src/renderer/src/components/DesktopTopBar.context-menu.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.context-menu.test.tsx
@@ -1,0 +1,114 @@
+/** @vitest-environment jsdom */
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DesktopTopBar } from "./DesktopTopBar";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLDivElement[] = [];
+
+afterEach(() => {
+    for (const root of mountedRoots.splice(0)) {
+        act(() => root.unmount());
+    }
+    for (const container of mountedContainers.splice(0)) {
+        container.remove();
+    }
+});
+
+function renderTopBar() {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    mountedContainers.push(container);
+
+    const onCloseContext = vi.fn();
+    const onMoveContextToNewWindow = vi.fn();
+    const root = createRoot(container);
+    mountedRoots.push(root);
+    act(() => {
+        root.render(
+            createElement(DesktopTopBar, {
+                activeContextKey: "project-1::__primary__",
+                contexts: [
+                    {
+                        key: "project-1::__primary__",
+                        projectId: "project-1",
+                        projectName: "Comando",
+                        worktreeId: null,
+                        worktreeLabel: "main",
+                    },
+                    {
+                        key: "project-2::__primary__",
+                        projectId: "project-2",
+                        projectName: "Sandbox",
+                        worktreeId: null,
+                        worktreeLabel: "main",
+                    },
+                ],
+                leftSidebarCollapsed: false,
+                menuProjects: [],
+                onActivateContext: vi.fn(),
+                onCloneRepository: vi.fn(() => Promise.resolve(true)),
+                onCloseContext,
+                onMoveContextToNewWindow,
+                onOpenProject: vi.fn(),
+                onOpenProjects: vi.fn(),
+                onOpenSettings: vi.fn(),
+                onOpenWorktree: vi.fn(),
+                onReorderContext: vi.fn(),
+                onToggleLeftSidebar: vi.fn(),
+                platform: "darwin",
+            }),
+        );
+    });
+
+    return { container, onCloseContext, onMoveContextToNewWindow };
+}
+
+function getContextMenuButton(label: string): HTMLButtonElement {
+    const button = document.body.querySelector<HTMLButtonElement>(
+        `button[aria-label="${label}"]`,
+    );
+    if (!button) {
+        throw new Error(`Context menu action "${label}" was not rendered.`);
+    }
+    return button;
+}
+
+describe("DesktopTopBar context menu", () => {
+    it("offers move and close actions for the context clicked with the secondary button", async () => {
+        const { container, onCloseContext, onMoveContextToNewWindow } =
+            renderTopBar();
+        const tab = container.querySelector<HTMLElement>(
+            '[data-project-context-tab-key="project-2::__primary__"]',
+        );
+        expect(tab).toBeTruthy();
+
+        act(() => {
+            tab?.dispatchEvent(
+                new MouseEvent("contextmenu", {
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: 120,
+                    clientY: 40,
+                }),
+            );
+        });
+
+        expect(getContextMenuButton("Move to New Window")).toBeTruthy();
+        expect(getContextMenuButton("Close")).toBeTruthy();
+
+        await act(async () => {
+            getContextMenuButton("Move to New Window").click();
+            await Promise.resolve();
+        });
+        expect(onMoveContextToNewWindow).toHaveBeenCalledWith(
+            "project-2::__primary__",
+        );
+        expect(onCloseContext).not.toHaveBeenCalled();
+    });
+});

--- a/src/renderer/src/components/DesktopTopBar.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.test.tsx
@@ -29,6 +29,7 @@ describe("DesktopTopBar", () => {
                 onActivateContext={vi.fn()}
                 onCloneRepository={vi.fn(() => Promise.resolve(true))}
                 onCloseContext={vi.fn()}
+                onMoveContextToNewWindow={vi.fn()}
                 onOpenProject={vi.fn()}
                 onOpenProjects={vi.fn()}
                 onOpenSettings={vi.fn()}

--- a/src/renderer/src/components/DesktopTopBar.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.test.tsx
@@ -33,6 +33,7 @@ describe("DesktopTopBar", () => {
                 onOpenProjects={vi.fn()}
                 onOpenSettings={vi.fn()}
                 onOpenWorktree={vi.fn()}
+                onReorderContext={vi.fn()}
                 onToggleLeftSidebar={vi.fn()}
                 platform="darwin"
             />,
@@ -45,5 +46,7 @@ describe("DesktopTopBar", () => {
         expect(markup).toContain("feature/navigation");
         expect(markup).toContain("sidebar-git-scope-trigger--titlebar");
         expect(markup).toContain("app-no-drag");
+        expect(markup).toContain("data-project-context-tab-key");
+        expect(markup).toContain("data-project-context-tab-action");
     });
 });

--- a/src/renderer/src/components/DesktopTopBar.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.test.tsx
@@ -24,6 +24,7 @@ describe("DesktopTopBar", () => {
                         worktreeLabel: "feature/navigation",
                     },
                 ]}
+                leftSidebarCollapsed={false}
                 menuProjects={[]}
                 onActivateContext={vi.fn()}
                 onCloneRepository={vi.fn(() => Promise.resolve(true))}
@@ -32,6 +33,7 @@ describe("DesktopTopBar", () => {
                 onOpenProjects={vi.fn()}
                 onOpenSettings={vi.fn()}
                 onOpenWorktree={vi.fn()}
+                onToggleLeftSidebar={vi.fn()}
                 platform="darwin"
             />,
         );
@@ -41,6 +43,7 @@ describe("DesktopTopBar", () => {
         expect(markup).toContain('role="tab"');
         expect(markup).toContain('aria-selected="true"');
         expect(markup).toContain("feature/navigation");
+        expect(markup).toContain("sidebar-git-scope-trigger--titlebar");
         expect(markup).toContain("app-no-drag");
     });
 });

--- a/src/renderer/src/components/DesktopTopBar.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.test.tsx
@@ -37,6 +37,7 @@ describe("DesktopTopBar", () => {
                 onReorderContext={vi.fn()}
                 onToggleLeftSidebar={vi.fn()}
                 platform="darwin"
+                settingsLabel={null}
             />,
         );
 

--- a/src/renderer/src/components/DesktopTopBar.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.test.tsx
@@ -1,0 +1,46 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { DesktopTopBar } from "./DesktopTopBar";
+
+describe("DesktopTopBar", () => {
+    it("renders accessible project context tabs inside the draggable chrome", () => {
+        const markup = renderToStaticMarkup(
+            <DesktopTopBar
+                activeContextKey="project-1::__primary__"
+                contexts={[
+                    {
+                        key: "project-1::__primary__",
+                        projectId: "project-1",
+                        projectName: "Comando",
+                        worktreeId: null,
+                        worktreeLabel: "main",
+                    },
+                    {
+                        key: "project-1::worktree-1",
+                        projectId: "project-1",
+                        projectName: "Comando",
+                        worktreeId: "worktree-1",
+                        worktreeLabel: "feature/navigation",
+                    },
+                ]}
+                menuProjects={[]}
+                onActivateContext={vi.fn()}
+                onCloneRepository={vi.fn(() => Promise.resolve(true))}
+                onCloseContext={vi.fn()}
+                onOpenProject={vi.fn()}
+                onOpenProjects={vi.fn()}
+                onOpenSettings={vi.fn()}
+                onOpenWorktree={vi.fn()}
+                platform="darwin"
+            />,
+        );
+
+        expect(markup).toContain("app-drag desktop-titlebar");
+        expect(markup).toContain('role="tablist"');
+        expect(markup).toContain('role="tab"');
+        expect(markup).toContain('aria-selected="true"');
+        expect(markup).toContain("feature/navigation");
+        expect(markup).toContain("app-no-drag");
+    });
+});

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -1,26 +1,250 @@
-interface DesktopTopBarProps {
-    readonly title: string;
+import {
+    useEffect,
+    useRef,
+    useState,
+    type KeyboardEvent as ReactKeyboardEvent,
+    type WheelEvent as ReactWheelEvent,
+} from "react";
+
+import {
+    ProjectContextMenu,
+    type ProjectContextMenuProject,
+} from "./ProjectContextMenu";
+
+export type { ProjectContextMenuProject } from "./ProjectContextMenu";
+
+export interface ProjectContextTabItem {
+    readonly key: string;
+    readonly projectId: string;
+    readonly projectName: string;
+    readonly worktreeId: string | null;
+    readonly worktreeLabel: string | null;
 }
 
-export function DesktopTopBar({ title }: DesktopTopBarProps) {
+interface DesktopTopBarProps {
+    readonly activeContextKey: string | null;
+    readonly contexts: readonly ProjectContextTabItem[];
+    readonly menuProjects: readonly ProjectContextMenuProject[];
+    readonly onActivateContext: (contextKey: string) => void;
+    readonly onCloneRepository: (repositoryUrl: string) => Promise<boolean>;
+    readonly onCloseContext: (contextKey: string) => void;
+    readonly onOpenProject: (projectId: string) => void;
+    readonly onOpenProjects: () => void;
+    readonly onOpenSettings: () => void;
+    readonly onOpenWorktree: (projectId: string, worktreeId: string) => void;
+    readonly platform: string | null;
+}
+
+export function DesktopTopBar({
+    activeContextKey,
+    contexts,
+    menuProjects,
+    onActivateContext,
+    onCloneRepository,
+    onCloseContext,
+    onOpenProject,
+    onOpenProjects,
+    onOpenSettings,
+    onOpenWorktree,
+    platform,
+}: DesktopTopBarProps) {
+    const [menuOpen, setMenuOpen] = useState(false);
+    const menuRootRef = useRef<HTMLDivElement | null>(null);
+    const tabsRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (!menuOpen) {
+            return;
+        }
+
+        const handlePointerDown = (event: MouseEvent) => {
+            if (!menuRootRef.current?.contains(event.target as Node)) {
+                setMenuOpen(false);
+            }
+        };
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                setMenuOpen(false);
+            }
+        };
+
+        document.addEventListener("mousedown", handlePointerDown);
+        window.addEventListener("keydown", handleKeyDown);
+        return () => {
+            document.removeEventListener("mousedown", handlePointerDown);
+            window.removeEventListener("keydown", handleKeyDown);
+        };
+    }, [menuOpen]);
+
+    const handleTabsWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
+        if (!tabsRef.current || Math.abs(event.deltaY) <= Math.abs(event.deltaX)) {
+            return;
+        }
+        tabsRef.current.scrollLeft += event.deltaY;
+        event.preventDefault();
+    };
+
+    const handleTabKeyDown = (
+        event: ReactKeyboardEvent<HTMLButtonElement>,
+        index: number,
+    ) => {
+        if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+            return;
+        }
+
+        event.preventDefault();
+        const direction = event.key === "ArrowRight" ? 1 : -1;
+        const targetIndex =
+            (index + direction + contexts.length) % contexts.length;
+        const target = contexts[targetIndex];
+        if (!target) {
+            return;
+        }
+        onActivateContext(target.key);
+        requestAnimationFrame(() => {
+            document
+                .querySelector<HTMLButtonElement>(
+                    `[data-project-context-key="${CSS.escape(target.key)}"]`,
+                )
+                ?.focus();
+        });
+    };
+
     return (
-        <div
-            aria-hidden
-            className="app-drag desktop-titlebar relative flex shrink-0 items-center justify-center select-none"
+        <header
+            className="app-drag desktop-titlebar project-context-titlebar relative flex shrink-0 items-center select-none"
             style={{
                 height: "var(--desktop-titlebar-height, 40px)",
-                paddingLeft: 12,
-                paddingRight: "var(--titlebar-controls-width, 138px)",
+                paddingLeft: platform === "darwin" ? 84 : 8,
+                paddingRight:
+                    platform === "win32" || platform === "linux"
+                        ? "var(--titlebar-controls-width, 138px)"
+                        : 8,
             }}
         >
-            <span
-                className="text-[12px] font-medium tracking-[0.01em] text-text-secondary"
-                style={{
-                    fontFamily: "var(--font-sans)",
-                }}
+            <div
+                aria-label="Open project workspaces"
+                className="project-context-tabs app-no-drag"
+                onWheel={handleTabsWheel}
+                ref={tabsRef}
+                role="tablist"
             >
-                {title}
-            </span>
-        </div>
+                {contexts.map((context, index) => {
+                    const isActive = context.key === activeContextKey;
+                    return (
+                        <div
+                            className="project-context-tab-shell"
+                            data-active={isActive || undefined}
+                            key={context.key}
+                        >
+                            <button
+                                aria-selected={isActive}
+                                className="project-context-tab"
+                                data-project-context-key={context.key}
+                                onClick={() => onActivateContext(context.key)}
+                                onKeyDown={(event) =>
+                                    handleTabKeyDown(event, index)
+                                }
+                                role="tab"
+                                tabIndex={isActive ? 0 : -1}
+                                title={
+                                    context.worktreeLabel
+                                        ? `${context.projectName} — ${context.worktreeLabel}`
+                                        : context.projectName
+                                }
+                                type="button"
+                            >
+                                <span className="project-context-tab-copy">
+                                    <span className="project-context-tab-title">
+                                        {context.projectName}
+                                    </span>
+                                    {context.worktreeLabel && (
+                                        <span className="project-context-tab-subtitle">
+                                            {context.worktreeLabel}
+                                        </span>
+                                    )}
+                                </span>
+                            </button>
+                            <button
+                                aria-label={`Close ${context.projectName}`}
+                                className="project-context-tab-close"
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    onCloseContext(context.key);
+                                }}
+                                tabIndex={isActive ? 0 : -1}
+                                title="Close workspace"
+                                type="button"
+                            >
+                                <svg
+                                    aria-hidden="true"
+                                    fill="none"
+                                    height="12"
+                                    viewBox="0 0 12 12"
+                                    width="12"
+                                >
+                                    <path
+                                        d="m3 3 6 6M9 3 3 9"
+                                        stroke="currentColor"
+                                        strokeLinecap="round"
+                                        strokeWidth="1.25"
+                                    />
+                                </svg>
+                            </button>
+                        </div>
+                    );
+                })}
+            </div>
+
+            <div className="app-no-drag project-context-menu-root" ref={menuRootRef}>
+                <button
+                    aria-expanded={menuOpen}
+                    aria-haspopup="dialog"
+                    aria-label="Open project or worktree"
+                    className="project-context-add"
+                    onClick={() => {
+                        setMenuOpen((open) => !open);
+                    }}
+                    title="Open project or worktree"
+                    type="button"
+                >
+                    <svg
+                        aria-hidden="true"
+                        fill="none"
+                        height="14"
+                        viewBox="0 0 14 14"
+                        width="14"
+                    >
+                        <path
+                            d="M7 2v10M2 7h10"
+                            stroke="currentColor"
+                            strokeLinecap="round"
+                            strokeWidth="1.4"
+                        />
+                    </svg>
+                </button>
+
+                {menuOpen && (
+                    <ProjectContextMenu
+                        anchorLeft={Math.max(
+                            8,
+                            Math.min(
+                                menuRootRef.current?.getBoundingClientRect()
+                                    .left ?? 8,
+                                window.innerWidth - 348,
+                            ),
+                        )}
+                        onCloneRepository={onCloneRepository}
+                        onClose={() => setMenuOpen(false)}
+                        onOpenProject={onOpenProject}
+                        onOpenProjects={onOpenProjects}
+                        onOpenSettings={onOpenSettings}
+                        onOpenWorktree={onOpenWorktree}
+                        projects={menuProjects}
+                    />
+                )}
+            </div>
+            <div className="min-w-4 flex-1" />
+        </header>
     );
 }

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -11,6 +11,7 @@ import {
     type ProjectContextMenuProject,
 } from "./ProjectContextMenu";
 import { SidebarGitScopePicker } from "./sidebar/SidebarGitScopePicker";
+import { useProjectContextTabDrag } from "./useProjectContextTabDrag";
 
 export type { ProjectContextMenuProject } from "./ProjectContextMenu";
 
@@ -49,6 +50,10 @@ interface DesktopTopBarProps {
     readonly onOpenProjects: () => void;
     readonly onOpenSettings: () => void;
     readonly onOpenWorktree: (projectId: string, worktreeId: string) => void;
+    readonly onReorderContext: (
+        contextKey: string,
+        targetIndex: number,
+    ) => Promise<void> | void;
     readonly onToggleLeftSidebar: () => void;
     readonly platform: string | null;
 }
@@ -65,12 +70,18 @@ export function DesktopTopBar({
     onOpenProjects,
     onOpenSettings,
     onOpenWorktree,
+    onReorderContext,
     onToggleLeftSidebar,
     platform,
 }: DesktopTopBarProps) {
     const [menuOpen, setMenuOpen] = useState(false);
     const menuRootRef = useRef<HTMLDivElement | null>(null);
     const tabsRef = useRef<HTMLDivElement | null>(null);
+    const contextTabDrag = useProjectContextTabDrag({
+        contextKeys: contexts.map((context) => context.key),
+        onReorder: onReorderContext,
+        stripRef: tabsRef,
+    });
 
     useEffect(() => {
         if (!menuOpen) {
@@ -189,7 +200,25 @@ export function DesktopTopBar({
                         <div
                             className="project-context-tab-shell"
                             data-active={isActive || undefined}
+                            data-dragging={
+                                contextTabDrag.isDragging &&
+                                contextTabDrag.draggedContextKey === context.key
+                                    ? "true"
+                                    : undefined
+                            }
+                            data-drop-position={
+                                contextTabDrag.target?.contextKey === context.key
+                                    ? contextTabDrag.target.position
+                                    : undefined
+                            }
+                            data-project-context-tab-key={context.key}
                             key={context.key}
+                            onPointerDown={(event) =>
+                                contextTabDrag.beginTabPointerDown(
+                                    context.key,
+                                    event,
+                                )
+                            }
                         >
                             <span
                                 aria-hidden="true"
@@ -246,6 +275,7 @@ export function DesktopTopBar({
                             <button
                                 aria-label={`Close ${context.projectName}`}
                                 className="project-context-tab-close"
+                                data-project-context-tab-action="true"
                                 onClick={(event) => {
                                     event.stopPropagation();
                                     onCloseContext(context.key);

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -353,14 +353,6 @@ export function DesktopTopBar({
 
                 {menuOpen && (
                     <ProjectContextMenu
-                        anchorLeft={Math.max(
-                            8,
-                            Math.min(
-                                menuRootRef.current?.getBoundingClientRect()
-                                    .left ?? 8,
-                                window.innerWidth - 348,
-                            ),
-                        )}
                         onCloneRepository={onCloneRepository}
                         onClose={() => setMenuOpen(false)}
                         onOpenProject={onOpenProject}

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -10,6 +10,7 @@ import {
     ProjectContextMenu,
     type ProjectContextMenuProject,
 } from "./ProjectContextMenu";
+import { SidebarGitScopePicker } from "./sidebar/SidebarGitScopePicker";
 
 export type { ProjectContextMenuProject } from "./ProjectContextMenu";
 
@@ -21,9 +22,25 @@ export interface ProjectContextTabItem {
     readonly worktreeLabel: string | null;
 }
 
+const PROJECT_AVATAR_HUES = [142, 210, 265, 320, 20, 45, 190, 355] as const;
+
+function projectAvatarColor(projectId: string): string {
+    let hash = 0;
+    for (let index = 0; index < projectId.length; index += 1) {
+        hash = (hash * 31 + projectId.charCodeAt(index)) >>> 0;
+    }
+    const hue = PROJECT_AVATAR_HUES[hash % PROJECT_AVATAR_HUES.length];
+    return `hsl(${hue} 58% 42%)`;
+}
+
+function projectAvatarInitial(projectName: string): string {
+    return projectName.trim().charAt(0).toUpperCase() || "?";
+}
+
 interface DesktopTopBarProps {
     readonly activeContextKey: string | null;
     readonly contexts: readonly ProjectContextTabItem[];
+    readonly leftSidebarCollapsed: boolean;
     readonly menuProjects: readonly ProjectContextMenuProject[];
     readonly onActivateContext: (contextKey: string) => void;
     readonly onCloneRepository: (repositoryUrl: string) => Promise<boolean>;
@@ -32,12 +49,14 @@ interface DesktopTopBarProps {
     readonly onOpenProjects: () => void;
     readonly onOpenSettings: () => void;
     readonly onOpenWorktree: (projectId: string, worktreeId: string) => void;
+    readonly onToggleLeftSidebar: () => void;
     readonly platform: string | null;
 }
 
 export function DesktopTopBar({
     activeContextKey,
     contexts,
+    leftSidebarCollapsed,
     menuProjects,
     onActivateContext,
     onCloneRepository,
@@ -46,6 +65,7 @@ export function DesktopTopBar({
     onOpenProjects,
     onOpenSettings,
     onOpenWorktree,
+    onToggleLeftSidebar,
     platform,
 }: DesktopTopBarProps) {
     const [menuOpen, setMenuOpen] = useState(false);
@@ -122,6 +142,40 @@ export function DesktopTopBar({
                         : 8,
             }}
         >
+            <button
+                aria-pressed={leftSidebarCollapsed}
+                className="sidebar-collapse-toggle sidebar-collapse-toggle--inline app-no-drag"
+                onClick={onToggleLeftSidebar}
+                style={{ marginRight: 8 }}
+                title={leftSidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+                type="button"
+            >
+                <svg
+                    aria-hidden="true"
+                    fill="none"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                >
+                    <rect
+                        height="11"
+                        rx="1.5"
+                        stroke="currentColor"
+                        strokeWidth="1.2"
+                        width="13"
+                        x="1.5"
+                        y="2.5"
+                    />
+                    <line
+                        stroke="currentColor"
+                        strokeWidth="1.2"
+                        x1="5.5"
+                        x2="5.5"
+                        y1="2.5"
+                        y2="13.5"
+                    />
+                </svg>
+            </button>
             <div
                 aria-label="Open project workspaces"
                 className="project-context-tabs app-no-drag"
@@ -137,34 +191,58 @@ export function DesktopTopBar({
                             data-active={isActive || undefined}
                             key={context.key}
                         >
-                            <button
-                                aria-selected={isActive}
-                                className="project-context-tab"
-                                data-project-context-key={context.key}
-                                onClick={() => onActivateContext(context.key)}
-                                onKeyDown={(event) =>
-                                    handleTabKeyDown(event, index)
-                                }
-                                role="tab"
-                                tabIndex={isActive ? 0 : -1}
-                                title={
-                                    context.worktreeLabel
-                                        ? `${context.projectName} — ${context.worktreeLabel}`
-                                        : context.projectName
-                                }
-                                type="button"
+                            <span
+                                aria-hidden="true"
+                                className="project-context-tab-icon"
+                                style={{
+                                    background: projectAvatarColor(
+                                        context.projectId,
+                                    ),
+                                }}
                             >
-                                <span className="project-context-tab-copy">
-                                    <span className="project-context-tab-title">
-                                        {context.projectName}
-                                    </span>
-                                    {context.worktreeLabel && (
-                                        <span className="project-context-tab-subtitle">
-                                            {context.worktreeLabel}
+                                {projectAvatarInitial(context.projectName)}
+                            </span>
+                            {isActive ? (
+                                <SidebarGitScopePicker
+                                    onTitlebarKeyDown={(event) =>
+                                        handleTabKeyDown(event, index)
+                                    }
+                                    projectId={context.projectId}
+                                    title={context.projectName}
+                                    titlebarContextKey={context.key}
+                                    triggerVariant="titlebar"
+                                    worktreeId={context.worktreeId}
+                                />
+                            ) : (
+                                <button
+                                    aria-selected={false}
+                                    className="project-context-tab"
+                                    data-project-context-key={context.key}
+                                    onClick={() => onActivateContext(context.key)}
+                                    onKeyDown={(event) =>
+                                        handleTabKeyDown(event, index)
+                                    }
+                                    role="tab"
+                                    tabIndex={-1}
+                                    title={
+                                        context.worktreeLabel
+                                            ? `${context.projectName} — ${context.worktreeLabel}`
+                                            : context.projectName
+                                    }
+                                    type="button"
+                                >
+                                    <span className="project-context-tab-copy">
+                                        <span className="project-context-tab-title">
+                                            {context.projectName}
                                         </span>
-                                    )}
-                                </span>
-                            </button>
+                                        {context.worktreeLabel && (
+                                            <span className="project-context-tab-subtitle">
+                                                {context.worktreeLabel}
+                                            </span>
+                                        )}
+                                    </span>
+                                </button>
+                            )}
                             <button
                                 aria-label={`Close ${context.projectName}`}
                                 className="project-context-tab-close"
@@ -179,9 +257,9 @@ export function DesktopTopBar({
                                 <svg
                                     aria-hidden="true"
                                     fill="none"
-                                    height="12"
+                                    height="10"
                                     viewBox="0 0 12 12"
-                                    width="12"
+                                    width="10"
                                 >
                                     <path
                                         d="m3 3 6 6M9 3 3 9"
@@ -211,9 +289,9 @@ export function DesktopTopBar({
                     <svg
                         aria-hidden="true"
                         fill="none"
-                        height="14"
+                        height="12"
                         viewBox="0 0 14 14"
-                        width="14"
+                        width="12"
                     >
                         <path
                             d="M7 2v10M2 7h10"

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -14,6 +14,10 @@ import {
     ContextMenu,
     type ContextMenuState,
 } from "./context-menu/ContextMenu";
+import {
+    projectAvatarColor,
+    projectAvatarInitial,
+} from "./projectAvatar";
 import { SidebarGitScopePicker } from "./sidebar/SidebarGitScopePicker";
 import { useProjectContextTabDrag } from "./useProjectContextTabDrag";
 
@@ -25,21 +29,6 @@ export interface ProjectContextTabItem {
     readonly projectName: string;
     readonly worktreeId: string | null;
     readonly worktreeLabel: string | null;
-}
-
-const PROJECT_AVATAR_HUES = [142, 210, 265, 320, 20, 45, 190, 355] as const;
-
-function projectAvatarColor(projectId: string): string {
-    let hash = 0;
-    for (let index = 0; index < projectId.length; index += 1) {
-        hash = (hash * 31 + projectId.charCodeAt(index)) >>> 0;
-    }
-    const hue = PROJECT_AVATAR_HUES[hash % PROJECT_AVATAR_HUES.length];
-    return `hsl(${hue} 58% 42%)`;
-}
-
-function projectAvatarInitial(projectName: string): string {
-    return projectName.trim().charAt(0).toUpperCase() || "?";
 }
 
 interface DesktopTopBarProps {

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -53,7 +53,7 @@ interface DesktopTopBarProps {
     readonly onMoveContextToNewWindow: (contextKey: string) => void;
     readonly onOpenProject: (projectId: string) => void;
     readonly onOpenProjects: () => void;
-    readonly onOpenSettings: () => void;
+    readonly onOpenSettings: (initialCategory?: "updates") => void;
     readonly onOpenWorktree: (projectId: string, worktreeId: string) => void;
     readonly onReorderContext: (
         contextKey: string,
@@ -61,6 +61,7 @@ interface DesktopTopBarProps {
     ) => Promise<void> | void;
     readonly onToggleLeftSidebar: () => void;
     readonly platform: string | null;
+    readonly settingsLabel: string | null;
 }
 
 export function DesktopTopBar({
@@ -79,6 +80,7 @@ export function DesktopTopBar({
     onReorderContext,
     onToggleLeftSidebar,
     platform,
+    settingsLabel,
 }: DesktopTopBarProps) {
     const [menuOpen, setMenuOpen] = useState(false);
     const [contextMenu, setContextMenu] =
@@ -366,6 +368,7 @@ export function DesktopTopBar({
                         onOpenSettings={onOpenSettings}
                         onOpenWorktree={onOpenWorktree}
                         projects={menuProjects}
+                        settingsLabel={settingsLabel}
                     />
                 )}
             </div>

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -10,6 +10,10 @@ import {
     ProjectContextMenu,
     type ProjectContextMenuProject,
 } from "./ProjectContextMenu";
+import {
+    ContextMenu,
+    type ContextMenuState,
+} from "./context-menu/ContextMenu";
 import { SidebarGitScopePicker } from "./sidebar/SidebarGitScopePicker";
 import { useProjectContextTabDrag } from "./useProjectContextTabDrag";
 
@@ -46,6 +50,7 @@ interface DesktopTopBarProps {
     readonly onActivateContext: (contextKey: string) => void;
     readonly onCloneRepository: (repositoryUrl: string) => Promise<boolean>;
     readonly onCloseContext: (contextKey: string) => void;
+    readonly onMoveContextToNewWindow: (contextKey: string) => void;
     readonly onOpenProject: (projectId: string) => void;
     readonly onOpenProjects: () => void;
     readonly onOpenSettings: () => void;
@@ -66,6 +71,7 @@ export function DesktopTopBar({
     onActivateContext,
     onCloneRepository,
     onCloseContext,
+    onMoveContextToNewWindow,
     onOpenProject,
     onOpenProjects,
     onOpenSettings,
@@ -75,6 +81,8 @@ export function DesktopTopBar({
     platform,
 }: DesktopTopBarProps) {
     const [menuOpen, setMenuOpen] = useState(false);
+    const [contextMenu, setContextMenu] =
+        useState<ContextMenuState<ProjectContextTabItem> | null>(null);
     const menuRootRef = useRef<HTMLDivElement | null>(null);
     const tabsRef = useRef<HTMLDivElement | null>(null);
     const contextTabDrag = useProjectContextTabDrag({
@@ -213,6 +221,15 @@ export function DesktopTopBar({
                             }
                             data-project-context-tab-key={context.key}
                             key={context.key}
+                            onContextMenu={(event) => {
+                                event.preventDefault();
+                                setMenuOpen(false);
+                                setContextMenu({
+                                    payload: context,
+                                    x: event.clientX,
+                                    y: event.clientY,
+                                });
+                            }}
                             onPointerDown={(event) =>
                                 contextTabDrag.beginTabPointerDown(
                                     context.key,
@@ -352,6 +369,28 @@ export function DesktopTopBar({
                     />
                 )}
             </div>
+            {contextMenu ? (
+                <ContextMenu
+                    entries={[
+                        {
+                            action: () =>
+                                onMoveContextToNewWindow(
+                                    contextMenu.payload.key,
+                                ),
+                            label: "Move to New Window",
+                        },
+                        { type: "separator" },
+                        {
+                            action: () =>
+                                onCloseContext(contextMenu.payload.key),
+                            danger: true,
+                            label: "Close",
+                        },
+                    ]}
+                    menu={contextMenu}
+                    onClose={() => setContextMenu(null)}
+                />
+            ) : null}
             <div className="min-w-4 flex-1" />
         </header>
     );

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -153,26 +153,26 @@ export function DesktopTopBar({
                 <svg
                     aria-hidden="true"
                     fill="none"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
+                    height="14"
+                    viewBox="0 0 14 14"
+                    width="14"
                 >
                     <rect
-                        height="11"
-                        rx="1.5"
+                        height="9"
+                        rx="1.3"
                         stroke="currentColor"
-                        strokeWidth="1.2"
-                        width="13"
+                        strokeWidth="1.1"
+                        width="11"
                         x="1.5"
                         y="2.5"
                     />
-                    <line
+                    <path
+                        d="M5 3.4v7.2"
+                        fill="none"
                         stroke="currentColor"
-                        strokeWidth="1.2"
-                        x1="5.5"
-                        x2="5.5"
-                        y1="2.5"
-                        y2="13.5"
+                        strokeLinecap="round"
+                        strokeOpacity="0.55"
+                        strokeWidth="2.4"
                     />
                 </svg>
             </button>

--- a/src/renderer/src/components/ProjectContextMenu.test.tsx
+++ b/src/renderer/src/components/ProjectContextMenu.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProjectContextMenu } from "./ProjectContextMenu";
+
+describe("ProjectContextMenu", () => {
+    it("groups worktrees under projects and exposes workspace actions", () => {
+        const markup = renderToStaticMarkup(
+            <ProjectContextMenu
+                anchorLeft={84}
+                onCloneRepository={vi.fn(() => Promise.resolve(true))}
+                onClose={vi.fn()}
+                onOpenProject={vi.fn()}
+                onOpenProjects={vi.fn()}
+                onOpenSettings={vi.fn()}
+                onOpenWorktree={vi.fn()}
+                projects={[
+                    {
+                        id: "project-1",
+                        mainIsActive: true,
+                        mainIsOpen: true,
+                        name: "Comando",
+                        worktrees: [
+                            {
+                                id: "worktree-1",
+                                isActive: false,
+                                isOpen: true,
+                                label: "feature/navigation",
+                            },
+                        ],
+                    },
+                ]}
+            />,
+        );
+
+        expect(markup).toContain("Search projects and worktrees");
+        expect(markup).toContain("Comando");
+        expect(markup).toContain("feature/navigation");
+        expect(markup).toContain("Open");
+        expect(markup).toContain("Open folder…");
+        expect(markup).toContain("Clone repository…");
+        expect(markup).toContain("Settings");
+        expect(markup).toContain('aria-expanded="true"');
+    });
+});

--- a/src/renderer/src/components/ProjectContextMenu.test.tsx
+++ b/src/renderer/src/components/ProjectContextMenu.test.tsx
@@ -39,11 +39,11 @@ describe("ProjectContextMenu", () => {
         expect(markup).toContain("Open");
         expect(markup).toContain("Open folder…");
         expect(markup).toContain("Clone repository…");
+        expect(markup).toContain("New worktree");
         expect(markup).toContain("Settings");
         expect(markup).toContain("Update ready");
         expect(markup).toContain("project-context-update-dot");
         expect(markup).toContain("project-context-menu-backdrop");
         expect(markup).toContain("Navigate");
-        expect(markup).toContain('aria-expanded="true"');
     });
 });

--- a/src/renderer/src/components/ProjectContextMenu.test.tsx
+++ b/src/renderer/src/components/ProjectContextMenu.test.tsx
@@ -30,6 +30,7 @@ describe("ProjectContextMenu", () => {
                         ],
                     },
                 ]}
+                settingsLabel="Settings · Update ready"
             />,
         );
 
@@ -40,6 +41,8 @@ describe("ProjectContextMenu", () => {
         expect(markup).toContain("Open folder…");
         expect(markup).toContain("Clone repository…");
         expect(markup).toContain("Settings");
+        expect(markup).toContain("Update ready");
+        expect(markup).toContain("project-context-update-dot");
         expect(markup).toContain('aria-expanded="true"');
     });
 });

--- a/src/renderer/src/components/ProjectContextMenu.test.tsx
+++ b/src/renderer/src/components/ProjectContextMenu.test.tsx
@@ -7,7 +7,6 @@ describe("ProjectContextMenu", () => {
     it("groups worktrees under projects and exposes workspace actions", () => {
         const markup = renderToStaticMarkup(
             <ProjectContextMenu
-                anchorLeft={84}
                 onCloneRepository={vi.fn(() => Promise.resolve(true))}
                 onClose={vi.fn()}
                 onOpenProject={vi.fn()}
@@ -43,6 +42,8 @@ describe("ProjectContextMenu", () => {
         expect(markup).toContain("Settings");
         expect(markup).toContain("Update ready");
         expect(markup).toContain("project-context-update-dot");
+        expect(markup).toContain("project-context-menu-backdrop");
+        expect(markup).toContain("Navigate");
         expect(markup).toContain('aria-expanded="true"');
     });
 });

--- a/src/renderer/src/components/ProjectContextMenu.tsx
+++ b/src/renderer/src/components/ProjectContextMenu.tsx
@@ -7,6 +7,12 @@ import {
     type ReactNode,
 } from "react";
 
+import type { GitRepositorySnapshot, GitWorktreeSummary } from "@shared/ipc";
+
+import { useGitStore } from "@renderer/app/store/git-store";
+import { useProjectsStore } from "@renderer/app/store/projects-store";
+import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
+
 export interface ProjectContextMenuProject {
     readonly id: string;
     readonly mainIsActive: boolean;
@@ -47,22 +53,18 @@ export function ProjectContextMenu({
     const [cloneUrl, setCloneUrl] = useState("");
     const [cloneError, setCloneError] = useState<string | null>(null);
     const [cloneSubmitting, setCloneSubmitting] = useState(false);
-    const [expandedProjectIds, setExpandedProjectIds] = useState<
-        ReadonlySet<string>
-    >(
-        () =>
-            new Set(
-                projects
-                    .filter(
-                        (project) =>
-                            project.mainIsActive ||
-                            project.worktrees.some((worktree) => worktree.isActive),
-                    )
-                    .map((project) => project.id),
-            ),
+    const [worktreeBranchName, setWorktreeBranchName] = useState("");
+    const [worktreeError, setWorktreeError] = useState<string | null>(null);
+    const [worktreeProjectId, setWorktreeProjectId] = useState<string | null>(
+        null,
     );
+    const [worktreeSubmitting, setWorktreeSubmitting] = useState(false);
     const normalizedQuery = query.trim().toLowerCase();
     const searchRef = useRef<HTMLInputElement | null>(null);
+    const projectSummaries = useProjectsStore((state) => state.projects);
+    const gitSnapshots = useGitStore((state) => state.snapshots);
+    const createWorktree = useGitStore((state) => state.createWorktree);
+    const openContext = useWorkspaceStore((state) => state.openContext);
     const filteredProjects = useMemo(
         () =>
             projects.flatMap((project) => {
@@ -95,20 +97,15 @@ export function ProjectContextMenu({
     const selectableEntries = useMemo(
         () =>
             filteredProjects.flatMap((project) => {
-                const expanded =
-                    normalizedQuery.length > 0 ||
-                    expandedProjectIds.has(project.id);
                 return [
                     { projectId: project.id, worktreeId: null },
-                    ...(expanded
-                        ? project.worktrees.map((worktree) => ({
-                              projectId: project.id,
-                              worktreeId: worktree.id,
-                          }))
-                        : []),
+                    ...project.worktrees.map((worktree) => ({
+                        projectId: project.id,
+                        worktreeId: worktree.id,
+                    })),
                 ];
             }),
-        [expandedProjectIds, filteredProjects, normalizedQuery],
+        [filteredProjects],
     );
 
     useEffect(() => {
@@ -196,6 +193,125 @@ export function ProjectContextMenu({
             );
         }
     };
+
+    const worktreeProject = worktreeProjectId
+        ? (projects.find((project) => project.id === worktreeProjectId) ?? null)
+        : null;
+    const worktreeProjectSummary = worktreeProject
+        ? (projectSummaries.find(
+              (project) => project.id === worktreeProject.id,
+          ) ?? null)
+        : null;
+    const worktreeSnapshot = worktreeProject
+        ? findProjectSnapshot(gitSnapshots, worktreeProject.id)
+        : null;
+    const worktreeBaseBranch = resolveWorktreeBaseBranch(worktreeSnapshot);
+
+    const handleCreateWorktree = async () => {
+        const branchName = worktreeBranchName.trim();
+        if (!worktreeProject || !worktreeProjectSummary || !branchName) {
+            setWorktreeError("Enter a branch name to create the worktree.");
+            return;
+        }
+        if (!worktreeSnapshot || !worktreeBaseBranch) {
+            setWorktreeError("This project does not have a branch to use as a base.");
+            return;
+        }
+
+        setWorktreeError(null);
+        setWorktreeSubmitting(true);
+        try {
+            const createdWorktree = await createWorktree({
+                branchName,
+                path: buildSuggestedWorktreePath(
+                    worktreeProjectSummary.rootPath,
+                    branchName,
+                    worktreeSnapshot.worktrees,
+                ),
+                projectId: worktreeProject.id,
+                startPoint: worktreeBaseBranch,
+                worktreeId: null,
+            });
+            await openContext(worktreeProject.id, createdWorktree.id, {
+                emptyLayout: true,
+            });
+            onClose();
+        } catch (error) {
+            setWorktreeError(
+                error instanceof Error
+                    ? error.message
+                    : "Could not create the worktree.",
+            );
+        } finally {
+            setWorktreeSubmitting(false);
+        }
+    };
+
+    if (worktreeProject) {
+        return (
+            <ProjectContextModal onClose={onClose}>
+                <div className="project-context-worktree-form">
+                    <div className="project-context-menu-heading">
+                        New worktree
+                    </div>
+                    <div className="project-context-worktree-project">
+                        {worktreeProject.name}
+                    </div>
+                    <input
+                        autoFocus
+                        className="project-context-clone-input"
+                        disabled={worktreeSubmitting}
+                        onChange={(event) => {
+                            setWorktreeBranchName(event.target.value);
+                            setWorktreeError(null);
+                        }}
+                        onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                                event.preventDefault();
+                                void handleCreateWorktree();
+                            }
+                        }}
+                        placeholder="feature/my-branch"
+                        spellCheck={false}
+                        value={worktreeBranchName}
+                    />
+                    <div className="project-context-worktree-hint">
+                        {worktreeBaseBranch
+                            ? `Creates a branch from ${worktreeBaseBranch}`
+                            : "A Git branch is required"}
+                    </div>
+                    {worktreeError && (
+                        <div className="project-context-clone-error">
+                            {worktreeError}
+                        </div>
+                    )}
+                    <div className="project-context-clone-actions">
+                        <button
+                            disabled={worktreeSubmitting}
+                            onClick={() => {
+                                setWorktreeProjectId(null);
+                                setWorktreeError(null);
+                            }}
+                            type="button"
+                        >
+                            Back
+                        </button>
+                        <button
+                            disabled={
+                                worktreeSubmitting ||
+                                !worktreeBranchName.trim() ||
+                                !worktreeBaseBranch
+                            }
+                            onClick={() => void handleCreateWorktree()}
+                            type="button"
+                        >
+                            {worktreeSubmitting ? "Creating…" : "Create worktree"}
+                        </button>
+                    </div>
+                </div>
+            </ProjectContextModal>
+        );
+    }
 
     if (cloneMode) {
         return (
@@ -285,9 +401,6 @@ export function ProjectContextMenu({
 
             <div className="project-context-project-list">
                 {filteredProjects.map((project) => {
-                    const expanded =
-                        normalizedQuery.length > 0 ||
-                        expandedProjectIds.has(project.id);
                     return (
                         <div
                             className="project-context-project-group"
@@ -322,56 +435,19 @@ export function ProjectContextMenu({
                                         Main
                                     </span>
                                 </button>
-                                {project.worktrees.length > 0 && (
-                                    <button
-                                        aria-expanded={expanded}
-                                        aria-label={`${expanded ? "Collapse" : "Expand"} ${project.name} worktrees`}
-                                        className="project-context-disclosure"
-                                        onClick={() => {
-                                            setExpandedProjectIds(
-                                                (currentProjectIds) => {
-                                                    const nextProjectIds = new Set(
-                                                        currentProjectIds,
-                                                    );
-                                                    if (expanded) {
-                                                        nextProjectIds.delete(
-                                                            project.id,
-                                                        );
-                                                    } else {
-                                                        nextProjectIds.add(
-                                                            project.id,
-                                                        );
-                                                    }
-                                                    return nextProjectIds;
-                                                },
-                                            );
-                                        }}
-                                        type="button"
-                                    >
-                                        <svg
-                                            aria-hidden="true"
-                                            fill="none"
-                                            height="12"
-                                            viewBox="0 0 12 12"
-                                            width="12"
-                                        >
-                                            <path
-                                                d="m4.5 3 3 3-3 3"
-                                                stroke="currentColor"
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                                style={{
-                                                    transform: expanded
-                                                        ? "rotate(90deg)"
-                                                        : undefined,
-                                                    transformOrigin: "center",
-                                                }}
-                                            />
-                                        </svg>
-                                    </button>
-                                )}
+                                <button
+                                    className="project-context-new-worktree-trigger"
+                                    onClick={() => {
+                                        setWorktreeBranchName("");
+                                        setWorktreeError(null);
+                                        setWorktreeProjectId(project.id);
+                                    }}
+                                    type="button"
+                                >
+                                    New worktree
+                                </button>
                             </div>
-                            {expanded && project.worktrees.length > 0 && (
+                            {project.worktrees.length > 0 && (
                                 <div className="project-context-worktree-list">
                                     {project.worktrees.map((worktree) => (
                                         <button
@@ -497,6 +573,54 @@ function ProjectContextModal({
             </div>
         </div>
     );
+}
+
+function findProjectSnapshot(
+    snapshots: Record<string, GitRepositorySnapshot | null>,
+    projectId: string,
+): GitRepositorySnapshot | null {
+    return (
+        Object.values(snapshots).find(
+            (snapshot) => snapshot?.projectId === projectId,
+        ) ?? null
+    );
+}
+
+function resolveWorktreeBaseBranch(
+    snapshot: GitRepositorySnapshot | null,
+): string | null {
+    const primaryWorktree = snapshot?.worktrees.find(
+        (worktree) => worktree.isPrimary,
+    );
+    return primaryWorktree?.branchName ?? snapshot?.branch?.name ?? null;
+}
+
+function buildSuggestedWorktreePath(
+    rootPath: string,
+    branchName: string,
+    worktrees: readonly GitWorktreeSummary[],
+): string {
+    const normalizedRoot = rootPath.replace(/[\\/]+$/, "");
+    const suffix = branchName
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9._/-]+/g, "-")
+        .replace(/[\\/]+/g, "-")
+        .replace(/^-+|-+$/g, "") || "worktree";
+    const existingPaths = new Set(
+        worktrees.map((worktree) =>
+            worktree.rootPath.replace(/[\\/]+$/, ""),
+        ),
+    );
+    let candidate = `${normalizedRoot}-${suffix}`;
+    let index = 2;
+
+    while (existingPaths.has(candidate)) {
+        candidate = `${normalizedRoot}-${suffix}-${index}`;
+        index += 1;
+    }
+
+    return candidate;
 }
 
 function ContextStateIndicator({

--- a/src/renderer/src/components/ProjectContextMenu.tsx
+++ b/src/renderer/src/components/ProjectContextMenu.tsx
@@ -1,4 +1,11 @@
-import { useMemo, useState } from "react";
+import {
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type KeyboardEvent,
+    type ReactNode,
+} from "react";
 
 export interface ProjectContextMenuProject {
     readonly id: string;
@@ -14,7 +21,6 @@ export interface ProjectContextMenuProject {
 }
 
 interface ProjectContextMenuProps {
-    readonly anchorLeft: number;
     readonly onCloneRepository: (repositoryUrl: string) => Promise<boolean>;
     readonly onClose: () => void;
     readonly onOpenProject: (projectId: string) => void;
@@ -26,7 +32,6 @@ interface ProjectContextMenuProps {
 }
 
 export function ProjectContextMenu({
-    anchorLeft,
     onCloneRepository,
     onClose,
     onOpenProject,
@@ -37,6 +42,7 @@ export function ProjectContextMenu({
     settingsLabel,
 }: ProjectContextMenuProps) {
     const [query, setQuery] = useState("");
+    const [selectedIndex, setSelectedIndex] = useState(0);
     const [cloneMode, setCloneMode] = useState(false);
     const [cloneUrl, setCloneUrl] = useState("");
     const [cloneError, setCloneError] = useState<string | null>(null);
@@ -56,6 +62,7 @@ export function ProjectContextMenu({
             ),
     );
     const normalizedQuery = query.trim().toLowerCase();
+    const searchRef = useRef<HTMLInputElement | null>(null);
     const filteredProjects = useMemo(
         () =>
             projects.flatMap((project) => {
@@ -85,9 +92,84 @@ export function ProjectContextMenu({
         [normalizedQuery, projects],
     );
 
+    const selectableEntries = useMemo(
+        () =>
+            filteredProjects.flatMap((project) => {
+                const expanded =
+                    normalizedQuery.length > 0 ||
+                    expandedProjectIds.has(project.id);
+                return [
+                    { projectId: project.id, worktreeId: null },
+                    ...(expanded
+                        ? project.worktrees.map((worktree) => ({
+                              projectId: project.id,
+                              worktreeId: worktree.id,
+                          }))
+                        : []),
+                ];
+            }),
+        [expandedProjectIds, filteredProjects, normalizedQuery],
+    );
+
+    useEffect(() => {
+        searchRef.current?.focus();
+    }, []);
+
+    useEffect(() => {
+        setSelectedIndex((currentIndex) =>
+            Math.min(currentIndex, Math.max(selectableEntries.length - 1, 0)),
+        );
+    }, [selectableEntries.length]);
+
     const runAndClose = (action: () => void) => {
         onClose();
         queueMicrotask(action);
+    };
+
+    const openSelectableEntry = (index: number) => {
+        const entry = selectableEntries[index];
+        if (!entry) {
+            return;
+        }
+
+        runAndClose(() => {
+            if (entry.worktreeId) {
+                onOpenWorktree(entry.projectId, entry.worktreeId);
+                return;
+            }
+            onOpenProject(entry.projectId);
+        });
+    };
+
+    const handleSearchKeyDown = (
+        event: KeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.key === "Escape") {
+            event.preventDefault();
+            onClose();
+            return;
+        }
+
+        if (event.key === "Enter") {
+            event.preventDefault();
+            openSelectableEntry(selectedIndex);
+            return;
+        }
+
+        if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+            return;
+        }
+
+        event.preventDefault();
+        if (selectableEntries.length === 0) {
+            return;
+        }
+        const direction = event.key === "ArrowDown" ? 1 : -1;
+        setSelectedIndex(
+            (currentIndex) =>
+                (currentIndex + direction + selectableEntries.length) %
+                selectableEntries.length,
+        );
     };
 
     const handleCloneSubmit = async () => {
@@ -117,13 +199,11 @@ export function ProjectContextMenu({
 
     if (cloneMode) {
         return (
-            <div
-                aria-label="Clone repository"
-                className="project-context-menu"
-                role="dialog"
-                style={{ left: anchorLeft }}
-            >
-                <div className="project-context-clone-form">
+            <ProjectContextModal onClose={onClose}>
+                <div
+                    aria-label="Clone repository"
+                    className="project-context-clone-form"
+                >
                     <div className="project-context-menu-heading">
                         Clone repository
                     </div>
@@ -169,17 +249,12 @@ export function ProjectContextMenu({
                         </button>
                     </div>
                 </div>
-            </div>
+            </ProjectContextModal>
         );
     }
 
     return (
-        <div
-            aria-label="Open workspace"
-            className="project-context-menu"
-            role="dialog"
-            style={{ left: anchorLeft }}
-        >
+        <ProjectContextModal onClose={onClose}>
             <div className="project-context-search-shell">
                 <svg
                     aria-hidden="true"
@@ -199,7 +274,9 @@ export function ProjectContextMenu({
                     aria-label="Search projects and worktrees"
                     autoFocus
                     onChange={(event) => setQuery(event.target.value)}
+                    onKeyDown={handleSearchKeyDown}
                     placeholder="Search projects and worktrees…"
+                    ref={searchRef}
                     spellCheck={false}
                     value={query}
                 />
@@ -219,6 +296,14 @@ export function ProjectContextMenu({
                             <div className="project-context-project-row">
                                 <button
                                     className="project-context-project-main"
+                                    data-selected={
+                                        selectableEntries[selectedIndex]
+                                            ?.projectId === project.id &&
+                                        selectableEntries[selectedIndex]
+                                            ?.worktreeId === null
+                                            ? "true"
+                                            : undefined
+                                    }
                                     onClick={() =>
                                         runAndClose(() =>
                                             onOpenProject(project.id),
@@ -291,6 +376,14 @@ export function ProjectContextMenu({
                                     {project.worktrees.map((worktree) => (
                                         <button
                                             className="project-context-worktree-row"
+                                            data-selected={
+                                                selectableEntries[selectedIndex]
+                                                    ?.projectId === project.id &&
+                                                selectableEntries[selectedIndex]
+                                                    ?.worktreeId === worktree.id
+                                                    ? "true"
+                                                    : undefined
+                                            }
                                             key={worktree.id}
                                             onClick={() =>
                                                 runAndClose(() =>
@@ -370,6 +463,37 @@ export function ProjectContextMenu({
                         />
                     ) : null}
                 </button>
+            </div>
+            <div className="project-context-menu-footer">
+                <span>↑↓ Navigate · Enter Open · Esc Close</span>
+            </div>
+        </ProjectContextModal>
+    );
+}
+
+function ProjectContextModal({
+    children,
+    onClose,
+}: {
+    readonly children: ReactNode;
+    readonly onClose: () => void;
+}) {
+    return (
+        <div
+            className="project-context-menu-backdrop"
+            onMouseDown={(event) => {
+                if (event.target === event.currentTarget) {
+                    onClose();
+                }
+            }}
+        >
+            <div
+                aria-label="Open workspace"
+                aria-modal="true"
+                className="project-context-menu"
+                role="dialog"
+            >
+                {children}
             </div>
         </div>
     );

--- a/src/renderer/src/components/ProjectContextMenu.tsx
+++ b/src/renderer/src/components/ProjectContextMenu.tsx
@@ -1,0 +1,381 @@
+import { useMemo, useState } from "react";
+
+export interface ProjectContextMenuProject {
+    readonly id: string;
+    readonly mainIsActive: boolean;
+    readonly mainIsOpen: boolean;
+    readonly name: string;
+    readonly worktrees: readonly {
+        readonly id: string;
+        readonly isActive: boolean;
+        readonly isOpen: boolean;
+        readonly label: string;
+    }[];
+}
+
+interface ProjectContextMenuProps {
+    readonly anchorLeft: number;
+    readonly onCloneRepository: (repositoryUrl: string) => Promise<boolean>;
+    readonly onClose: () => void;
+    readonly onOpenProject: (projectId: string) => void;
+    readonly onOpenProjects: () => void;
+    readonly onOpenSettings: () => void;
+    readonly onOpenWorktree: (projectId: string, worktreeId: string) => void;
+    readonly projects: readonly ProjectContextMenuProject[];
+}
+
+export function ProjectContextMenu({
+    anchorLeft,
+    onCloneRepository,
+    onClose,
+    onOpenProject,
+    onOpenProjects,
+    onOpenSettings,
+    onOpenWorktree,
+    projects,
+}: ProjectContextMenuProps) {
+    const [query, setQuery] = useState("");
+    const [cloneMode, setCloneMode] = useState(false);
+    const [cloneUrl, setCloneUrl] = useState("");
+    const [cloneError, setCloneError] = useState<string | null>(null);
+    const [cloneSubmitting, setCloneSubmitting] = useState(false);
+    const [expandedProjectIds, setExpandedProjectIds] = useState<
+        ReadonlySet<string>
+    >(
+        () =>
+            new Set(
+                projects
+                    .filter(
+                        (project) =>
+                            project.mainIsActive ||
+                            project.worktrees.some((worktree) => worktree.isActive),
+                    )
+                    .map((project) => project.id),
+            ),
+    );
+    const normalizedQuery = query.trim().toLowerCase();
+    const filteredProjects = useMemo(
+        () =>
+            projects.flatMap((project) => {
+                if (!normalizedQuery) {
+                    return [project];
+                }
+
+                const projectMatches = project.name
+                    .toLowerCase()
+                    .includes(normalizedQuery);
+                const matchingWorktrees = project.worktrees.filter((worktree) =>
+                    worktree.label.toLowerCase().includes(normalizedQuery),
+                );
+                if (!projectMatches && matchingWorktrees.length === 0) {
+                    return [];
+                }
+
+                return [
+                    {
+                        ...project,
+                        worktrees: projectMatches
+                            ? project.worktrees
+                            : matchingWorktrees,
+                    },
+                ];
+            }),
+        [normalizedQuery, projects],
+    );
+
+    const runAndClose = (action: () => void) => {
+        onClose();
+        queueMicrotask(action);
+    };
+
+    const handleCloneSubmit = async () => {
+        const repositoryUrl = cloneUrl.trim();
+        if (!repositoryUrl) {
+            setCloneError("Paste a repository URL before cloning.");
+            return;
+        }
+
+        setCloneSubmitting(true);
+        setCloneError(null);
+        try {
+            if (await onCloneRepository(repositoryUrl)) {
+                onClose();
+            } else {
+                setCloneSubmitting(false);
+            }
+        } catch (error) {
+            setCloneSubmitting(false);
+            setCloneError(
+                error instanceof Error
+                    ? error.message
+                    : "Could not clone the repository.",
+            );
+        }
+    };
+
+    if (cloneMode) {
+        return (
+            <div
+                aria-label="Clone repository"
+                className="project-context-menu"
+                role="dialog"
+                style={{ left: anchorLeft }}
+            >
+                <div className="project-context-clone-form">
+                    <div className="project-context-menu-heading">
+                        Clone repository
+                    </div>
+                    <input
+                        autoFocus
+                        className="project-context-clone-input"
+                        disabled={cloneSubmitting}
+                        onChange={(event) => {
+                            setCloneUrl(event.target.value);
+                            setCloneError(null);
+                        }}
+                        onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                                event.preventDefault();
+                                void handleCloneSubmit();
+                            }
+                        }}
+                        placeholder="https://github.com/user/repo.git"
+                        spellCheck={false}
+                        value={cloneUrl}
+                    />
+                    {cloneError && (
+                        <div className="project-context-clone-error">
+                            {cloneError}
+                        </div>
+                    )}
+                    <div className="project-context-clone-actions">
+                        <button
+                            onClick={() => {
+                                setCloneMode(false);
+                                setCloneError(null);
+                            }}
+                            type="button"
+                        >
+                            Back
+                        </button>
+                        <button
+                            disabled={cloneSubmitting}
+                            onClick={() => void handleCloneSubmit()}
+                            type="button"
+                        >
+                            {cloneSubmitting ? "Cloning…" : "Clone"}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            aria-label="Open workspace"
+            className="project-context-menu"
+            role="dialog"
+            style={{ left: anchorLeft }}
+        >
+            <div className="project-context-search-shell">
+                <svg
+                    aria-hidden="true"
+                    fill="none"
+                    height="13"
+                    viewBox="0 0 14 14"
+                    width="13"
+                >
+                    <circle cx="6" cy="6" r="3.5" stroke="currentColor" />
+                    <path
+                        d="m8.7 8.7 2.6 2.6"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                    />
+                </svg>
+                <input
+                    aria-label="Search projects and worktrees"
+                    autoFocus
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Search projects and worktrees…"
+                    spellCheck={false}
+                    value={query}
+                />
+                <span>{filteredProjects.length}/{projects.length}</span>
+            </div>
+
+            <div className="project-context-project-list">
+                {filteredProjects.map((project) => {
+                    const expanded =
+                        normalizedQuery.length > 0 ||
+                        expandedProjectIds.has(project.id);
+                    return (
+                        <div
+                            className="project-context-project-group"
+                            key={project.id}
+                        >
+                            <div className="project-context-project-row">
+                                <button
+                                    className="project-context-project-main"
+                                    onClick={() =>
+                                        runAndClose(() =>
+                                            onOpenProject(project.id),
+                                        )
+                                    }
+                                    type="button"
+                                >
+                                    <ContextStateIndicator
+                                        active={project.mainIsActive}
+                                        open={project.mainIsOpen}
+                                    />
+                                    <span className="truncate">
+                                        {project.name}
+                                    </span>
+                                    <span className="project-context-menu-hint">
+                                        Main
+                                    </span>
+                                </button>
+                                {project.worktrees.length > 0 && (
+                                    <button
+                                        aria-expanded={expanded}
+                                        aria-label={`${expanded ? "Collapse" : "Expand"} ${project.name} worktrees`}
+                                        className="project-context-disclosure"
+                                        onClick={() => {
+                                            setExpandedProjectIds(
+                                                (currentProjectIds) => {
+                                                    const nextProjectIds = new Set(
+                                                        currentProjectIds,
+                                                    );
+                                                    if (expanded) {
+                                                        nextProjectIds.delete(
+                                                            project.id,
+                                                        );
+                                                    } else {
+                                                        nextProjectIds.add(
+                                                            project.id,
+                                                        );
+                                                    }
+                                                    return nextProjectIds;
+                                                },
+                                            );
+                                        }}
+                                        type="button"
+                                    >
+                                        <svg
+                                            aria-hidden="true"
+                                            fill="none"
+                                            height="12"
+                                            viewBox="0 0 12 12"
+                                            width="12"
+                                        >
+                                            <path
+                                                d="m4.5 3 3 3-3 3"
+                                                stroke="currentColor"
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                                style={{
+                                                    transform: expanded
+                                                        ? "rotate(90deg)"
+                                                        : undefined,
+                                                    transformOrigin: "center",
+                                                }}
+                                            />
+                                        </svg>
+                                    </button>
+                                )}
+                            </div>
+                            {expanded && project.worktrees.length > 0 && (
+                                <div className="project-context-worktree-list">
+                                    {project.worktrees.map((worktree) => (
+                                        <button
+                                            className="project-context-worktree-row"
+                                            key={worktree.id}
+                                            onClick={() =>
+                                                runAndClose(() =>
+                                                    onOpenWorktree(
+                                                        project.id,
+                                                        worktree.id,
+                                                    ),
+                                                )
+                                            }
+                                            type="button"
+                                        >
+                                            <ContextStateIndicator
+                                                active={worktree.isActive}
+                                                open={worktree.isOpen}
+                                            />
+                                            <svg
+                                                aria-hidden="true"
+                                                className="project-context-branch-icon"
+                                                fill="none"
+                                                height="13"
+                                                viewBox="0 0 14 14"
+                                                width="13"
+                                            >
+                                                <circle cx="4" cy="3" r="1.25" />
+                                                <circle cx="4" cy="11" r="1.25" />
+                                                <circle cx="10" cy="5" r="1.25" />
+                                                <path d="M4 4.5v5M5.25 8c2.8 0 4.75-.8 4.75-1.75" />
+                                            </svg>
+                                            <span className="truncate">
+                                                {worktree.label}
+                                            </span>
+                                            {worktree.isOpen && (
+                                                <span className="project-context-open-label">
+                                                    Open
+                                                </span>
+                                            )}
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    );
+                })}
+                {filteredProjects.length === 0 && (
+                    <div className="project-context-menu-empty">
+                        No matching projects or worktrees
+                    </div>
+                )}
+            </div>
+
+            <div className="project-context-menu-separator" />
+            <div className="project-context-menu-actions">
+                <button
+                    onClick={() => runAndClose(onOpenProjects)}
+                    type="button"
+                >
+                    Open folder…
+                </button>
+                <button onClick={() => setCloneMode(true)} type="button">
+                    Clone repository…
+                </button>
+                <button
+                    onClick={() => runAndClose(onOpenSettings)}
+                    type="button"
+                >
+                    Settings
+                </button>
+            </div>
+        </div>
+    );
+}
+
+function ContextStateIndicator({
+    active,
+    open,
+}: {
+    readonly active: boolean;
+    readonly open: boolean;
+}) {
+    return (
+        <span
+            aria-hidden="true"
+            className="project-context-state-indicator"
+            data-active={active || undefined}
+            data-open={open || undefined}
+        >
+            {active ? "✓" : ""}
+        </span>
+    );
+}

--- a/src/renderer/src/components/ProjectContextMenu.tsx
+++ b/src/renderer/src/components/ProjectContextMenu.tsx
@@ -19,9 +19,10 @@ interface ProjectContextMenuProps {
     readonly onClose: () => void;
     readonly onOpenProject: (projectId: string) => void;
     readonly onOpenProjects: () => void;
-    readonly onOpenSettings: () => void;
+    readonly onOpenSettings: (initialCategory?: "updates") => void;
     readonly onOpenWorktree: (projectId: string, worktreeId: string) => void;
     readonly projects: readonly ProjectContextMenuProject[];
+    readonly settingsLabel: string | null;
 }
 
 export function ProjectContextMenu({
@@ -33,6 +34,7 @@ export function ProjectContextMenu({
     onOpenSettings,
     onOpenWorktree,
     projects,
+    settingsLabel,
 }: ProjectContextMenuProps) {
     const [query, setQuery] = useState("");
     const [cloneMode, setCloneMode] = useState(false);
@@ -351,10 +353,22 @@ export function ProjectContextMenu({
                     Clone repository…
                 </button>
                 <button
-                    onClick={() => runAndClose(onOpenSettings)}
+                    onClick={() =>
+                        runAndClose(() =>
+                            onOpenSettings(
+                                settingsLabel ? "updates" : undefined,
+                            ),
+                        )
+                    }
                     type="button"
                 >
-                    Settings
+                    <span>{settingsLabel ?? "Settings"}</span>
+                    {settingsLabel ? (
+                        <span
+                            aria-hidden="true"
+                            className="project-context-update-dot"
+                        />
+                    ) : null}
                 </button>
             </div>
         </div>

--- a/src/renderer/src/components/projectAvatar.ts
+++ b/src/renderer/src/components/projectAvatar.ts
@@ -1,0 +1,14 @@
+const PROJECT_AVATAR_HUES = [142, 210, 265, 320, 20, 45, 190, 355] as const;
+
+export function projectAvatarColor(projectId: string): string {
+    let hash = 0;
+    for (let index = 0; index < projectId.length; index += 1) {
+        hash = (hash * 31 + projectId.charCodeAt(index)) >>> 0;
+    }
+    const hue = PROJECT_AVATAR_HUES[hash % PROJECT_AVATAR_HUES.length];
+    return `hsl(${hue} 58% 42%)`;
+}
+
+export function projectAvatarInitial(projectName: string): string {
+    return projectName.trim().charAt(0).toUpperCase() || "?";
+}

--- a/src/renderer/src/components/settings/SettingsWindow.test.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.test.tsx
@@ -50,6 +50,7 @@ function createSettingsWindowProps(
         },
         appAppearance: {
             boostCodeContrast: false,
+            chromeTransparency: 45,
             mode: "system",
             presetId: "default",
             presets: [],

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -13,6 +13,10 @@ import {
     clampAppZoomFactor,
 } from "@shared/app-zoom";
 import {
+    CHROME_TRANSPARENCY_MAX,
+    CHROME_TRANSPARENCY_MIN,
+} from "@shared/chrome-transparency";
+import {
     EDITOR_AUTOSAVE_DELAY_MS_MAX,
     EDITOR_AUTOSAVE_DELAY_MS_MIN,
 } from "@shared/editor-autosave";
@@ -1639,6 +1643,10 @@ function AppearanceContent({
             "Window transparency",
             "Use native acrylic transparency on Windows and vibrancy on macOS.",
         ],
+        [
+            "Sidebar and top bar transparency",
+            "Set how much of the background shows through the sidebar and title bar.",
+        ],
     ]);
     const showMode = sectionHasMatches(searchQuery, "Mode", [
         [
@@ -1734,6 +1742,21 @@ function AppearanceContent({
                         onChange={(v) =>
                             state.onTransparencyEnabledChange?.(v)
                         }
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Workspace"
+                label="Sidebar and top bar transparency"
+                description="Set how much of the background shows through the sidebar and title bar."
+                control={
+                    <SliderField
+                        value={state.chromeTransparency}
+                        min={CHROME_TRANSPARENCY_MIN}
+                        max={CHROME_TRANSPARENCY_MAX}
+                        onChange={(v) => state.onChromeTransparencyChange?.(v)}
+                        formatValue={(v) => `${v}%`}
                     />
                 }
             />

--- a/src/renderer/src/components/settings/settings-types.ts
+++ b/src/renderer/src/components/settings/settings-types.ts
@@ -32,6 +32,7 @@ export interface ThemePresetOption {
 export interface SettingsThemeControlState {
     readonly agentsSidebarScale?: number;
     readonly boostCodeContrast: boolean;
+    readonly chromeTransparency: number;
     readonly fileTreeScale?: number;
     readonly mode: ThemeMode;
     readonly presetId: string;
@@ -42,6 +43,7 @@ export interface SettingsThemeControlState {
     readonly disabled?: boolean;
     readonly onAgentsSidebarScaleChange?: (agentsSidebarScale: number) => void;
     readonly onBoostCodeContrastChange?: (enabled: boolean) => void;
+    readonly onChromeTransparencyChange?: (chromeTransparency: number) => void;
     readonly onFileTreeScaleChange?: (fileTreeScale: number) => void;
     readonly onModeChange?: (mode: ThemeMode) => void;
     readonly onPresetChange?: (presetId: string) => void;

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -7,6 +7,7 @@ import {
     useRef,
     useState,
     type FormEvent,
+    type KeyboardEvent as ReactKeyboardEvent,
     type MouseEvent as ReactMouseEvent,
     type PointerEvent as ReactPointerEvent,
 } from "react";
@@ -63,7 +64,13 @@ interface GitScopeMenuSize {
 }
 
 interface SidebarGitScopePickerProps {
+    readonly onTitlebarKeyDown?: (
+        event: ReactKeyboardEvent<HTMLButtonElement>,
+    ) => void;
     readonly projectId: string | null;
+    readonly titlebarContextKey?: string;
+    readonly triggerVariant?: "sidebar" | "titlebar";
+    readonly title?: string;
     readonly worktreeId: string | null;
 }
 
@@ -96,7 +103,14 @@ export function compareGitScopeBranchNames(left: string, right: string): number 
 
 function getStorage(): Storage | null {
     try {
-        return globalThis.localStorage ?? null;
+        const storage = globalThis.localStorage;
+        return (
+            storage &&
+            typeof storage.getItem === "function" &&
+            typeof storage.setItem === "function"
+        )
+                ? storage
+                : null;
     } catch {
         return null;
     }
@@ -258,7 +272,11 @@ type SelectableListItem =
       };
 
 export function SidebarGitScopePicker({
+    onTitlebarKeyDown,
     projectId,
+    title,
+    titlebarContextKey,
+    triggerVariant = "sidebar",
     worktreeId,
 }: SidebarGitScopePickerProps) {
     const [isOpen, setIsOpen] = useState(false);
@@ -1989,15 +2007,32 @@ export function SidebarGitScopePicker({
     );
 
     return (
-        <div className="relative app-no-drag" ref={containerRef}>
+        <div
+            className={[
+                "relative app-no-drag",
+                triggerVariant === "titlebar"
+                    ? "sidebar-git-scope-picker--titlebar"
+                    : "",
+            ]
+                .filter(Boolean)
+                .join(" ")}
+            ref={containerRef}
+        >
             <button
+                aria-selected={
+                    triggerVariant === "titlebar" ? true : undefined
+                }
                 className={[
                     "sidebar-git-scope-trigger",
+                    triggerVariant === "titlebar"
+                        ? "sidebar-git-scope-trigger--titlebar"
+                        : "",
                     isOpen ? "sidebar-git-scope-trigger--open" : "",
                 ]
                     .filter(Boolean)
                     .join(" ")}
                 disabled={!projectId}
+                data-project-context-key={titlebarContextKey}
                 onClick={() => {
                     if (!projectId) {
                         return;
@@ -2007,7 +2042,10 @@ export function SidebarGitScopePicker({
                     setActionError(null);
                     setQuery("");
                 }}
+                onKeyDown={onTitlebarKeyDown}
                 ref={buttonRef}
+                role={triggerVariant === "titlebar" ? "tab" : undefined}
+                tabIndex={triggerVariant === "titlebar" ? 0 : undefined}
                 title={
                     projectId
                         ? activeRootPath
@@ -2017,13 +2055,26 @@ export function SidebarGitScopePicker({
                 }
                 type="button"
             >
-                <div className="sidebar-git-scope-trigger__icon">
-                    <BranchGlyph />
-                </div>
+                {triggerVariant === "titlebar" ? (
+                    <span className="sidebar-git-scope-trigger__titlebar-copy">
+                        <span className="sidebar-git-scope-trigger__titlebar-project">
+                            {title ?? project?.name ?? "Project"}
+                        </span>
+                        <span className="sidebar-git-scope-trigger__titlebar-branch">
+                            {projectId ? activeBranchName : "Git scope"}
+                        </span>
+                    </span>
+                ) : (
+                    <>
+                        <div className="sidebar-git-scope-trigger__icon">
+                            <BranchGlyph />
+                        </div>
 
-                <span className="min-w-0 flex-1 truncate sidebar-git-scope-trigger__title">
-                    {projectId ? activeBranchName : "Git scope"}
-                </span>
+                        <span className="min-w-0 flex-1 truncate sidebar-git-scope-trigger__title">
+                            {projectId ? activeBranchName : "Git scope"}
+                        </span>
+                    </>
+                )}
 
                 <ChevronIcon open={isOpen} />
             </button>

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -911,7 +911,7 @@ export function SidebarGitScopePicker({
         setFocusIndex(-1);
     }, [query]);
 
-    const handleSelectWorktree = useCallback(
+    const handleOpenWorktreeInNewTab = useCallback(
         async (nextWorktreeId: string | null) => {
             if (!projectId || isBusy) {
                 return;
@@ -948,7 +948,7 @@ export function SidebarGitScopePicker({
                 setActionError(
                     error instanceof Error
                         ? error.message
-                        : "Could not switch worktrees.",
+                        : "Could not open this worktree in a new tab.",
                 );
             } finally {
                 setIsBusy(false);
@@ -996,7 +996,7 @@ export function SidebarGitScopePicker({
                     worktreeId ?? snapshot?.currentWorktreeId ?? null,
                 )
             ) {
-                await handleSelectWorktree(linkedWorktree.id);
+                await handleOpenWorktreeInNewTab(linkedWorktree.id);
                 return;
             }
 
@@ -1054,7 +1054,7 @@ export function SidebarGitScopePicker({
         [
             branches,
             checkoutBranch,
-            handleSelectWorktree,
+            handleOpenWorktreeInNewTab,
             isBusy,
             projectId,
             refreshProjectTree,
@@ -1652,9 +1652,10 @@ export function SidebarGitScopePicker({
 
         return [
             {
-                action: () => void handleSelectWorktree(row.worktree.id),
+                action: () =>
+                    void handleOpenWorktreeInNewTab(row.worktree.id),
                 disabled: isBusy || row.isActive,
-                label: "Switch Here",
+                label: "Open in New Tab",
             },
             {
                 action: () =>
@@ -1688,7 +1689,7 @@ export function SidebarGitScopePicker({
         handleRemoveWorktree,
         handleRevealWorktreeInFinder,
         handleSelectBranch,
-        handleSelectWorktree,
+        handleOpenWorktreeInNewTab,
         isBusy,
         itemContextMenu,
         openBranchCreationForm,
@@ -1711,14 +1712,14 @@ export function SidebarGitScopePicker({
         } else if (item.kind === "branch") {
             void handleSelectBranch(item.branch);
         } else {
-            void handleSelectWorktree(item.worktree.id);
+            void handleOpenWorktreeInNewTab(item.worktree.id);
         }
     }, [
         defaultBranchCreationBase,
         flatItems,
         focusIndex,
         handleSelectBranch,
-        handleSelectWorktree,
+        handleOpenWorktreeInNewTab,
         openBranchCreationForm,
     ]);
 
@@ -1973,7 +1974,7 @@ export function SidebarGitScopePicker({
                             isBusy
                                 ? undefined
                                 : () =>
-                                      void handleSelectWorktree(
+                                      void handleOpenWorktreeInNewTab(
                                           row.worktree.id,
                                       )
                         }
@@ -1999,7 +2000,7 @@ export function SidebarGitScopePicker({
             handleBranchContextMenu,
             handleMenuTriggerClick,
             handleSelectBranch,
-            handleSelectWorktree,
+            handleOpenWorktreeInNewTab,
             handleWorktreeContextMenu,
             isBusy,
             toggleSection,

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -25,6 +25,7 @@ import {
 } from "@renderer/app/git/context-key";
 import { useGitStore } from "@renderer/app/store/git-store";
 import { useProjectsStore } from "@renderer/app/store/projects-store";
+import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
 import { getViewportSafeMenuPosition } from "@renderer/app/utils/menu-position";
 import {
     ContextMenu,
@@ -327,7 +328,7 @@ export function SidebarGitScopePicker({
     const refreshGitHistory = useGitStore((state) => state.refreshHistory);
     const refreshGitProject = useGitStore((state) => state.refreshProject);
     const removeWorktree = useGitStore((state) => state.removeWorktree);
-    const setActiveWorktree = useGitStore((state) => state.setActiveWorktree);
+    const openContext = useWorkspaceStore((state) => state.openContext);
 
     const activeWorktree =
         snapshot?.worktrees.find(
@@ -898,11 +899,18 @@ export function SidebarGitScopePicker({
                 return;
             }
 
+            const normalizedWorktreeId =
+                snapshot?.worktrees.find(
+                    (candidate) => candidate.id === nextWorktreeId,
+                )?.isPrimary === true
+                    ? null
+                    : nextWorktreeId;
+
             if (
                 areGitScopeWorktreeIdsEqual(
                     projectId,
                     worktreeId,
-                    nextWorktreeId,
+                    normalizedWorktreeId,
                 )
             ) {
                 setIsOpen(false);
@@ -915,12 +923,7 @@ export function SidebarGitScopePicker({
             setIsBusy(true);
 
             try {
-                await setActiveWorktree(projectId, nextWorktreeId);
-                await Promise.all([
-                    refreshGitProject(projectId, nextWorktreeId),
-                    refreshGitHistory(projectId, nextWorktreeId),
-                    refreshProjectTree(projectId, nextWorktreeId),
-                ]);
+                await openContext(projectId, normalizedWorktreeId);
                 setIsOpen(false);
                 setQuery("");
             } catch (error) {
@@ -936,10 +939,8 @@ export function SidebarGitScopePicker({
         [
             isBusy,
             projectId,
-            refreshGitHistory,
-            refreshGitProject,
-            refreshProjectTree,
-            setActiveWorktree,
+            snapshot?.worktrees,
+            openContext,
             worktreeId,
         ],
     );
@@ -1074,10 +1075,8 @@ export function SidebarGitScopePicker({
                     worktreeId: worktreeId ?? snapshot?.currentWorktreeId ?? null,
                 });
 
-                await getComandoApi().openProjectWindow({
-                    forceNewWindow: true,
-                    projectId,
-                    worktreeId: createdWorktree.id,
+                await openContext(projectId, createdWorktree.id, {
+                    emptyLayout: true,
                 });
 
                 setIsOpen(false);
@@ -1096,6 +1095,7 @@ export function SidebarGitScopePicker({
             branches,
             createWorktree,
             isBusy,
+            openContext,
             project,
             projectId,
             snapshot?.currentWorktreeId,

--- a/src/renderer/src/components/useProjectContextTabDrag.test.ts
+++ b/src/renderer/src/components/useProjectContextTabDrag.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveProjectContextTabDropTarget } from "./useProjectContextTabDrag";
+
+const contextKeys = ["project-a", "project-b", "project-c"];
+const hitboxes = contextKeys.map((contextKey, index) => ({
+    bottom: 28,
+    contextKey,
+    left: index * 100,
+    right: index * 100 + 96,
+    top: 0,
+}));
+
+describe("resolveProjectContextTabDropTarget", () => {
+    it("resolves a final insertion index after the hovered tab", () => {
+        expect(
+            resolveProjectContextTabDropTarget({
+                contextKeys,
+                draggedContextKey: "project-a",
+                hitboxes,
+                pointer: { x: 290, y: 14 },
+            }),
+        ).toEqual({
+            contextKey: "project-c",
+            position: "after",
+            targetIndex: 2,
+        });
+    });
+
+    it("resolves a final insertion index before the hovered tab", () => {
+        expect(
+            resolveProjectContextTabDropTarget({
+                contextKeys,
+                draggedContextKey: "project-c",
+                hitboxes,
+                pointer: { x: 10, y: 14 },
+            }),
+        ).toEqual({
+            contextKey: "project-a",
+            position: "before",
+            targetIndex: 0,
+        });
+    });
+
+    it("does not return a target when the order would not change", () => {
+        expect(
+            resolveProjectContextTabDropTarget({
+                contextKeys,
+                draggedContextKey: "project-b",
+                hitboxes,
+                pointer: { x: 140, y: 14 },
+            }),
+        ).toBeNull();
+    });
+});

--- a/src/renderer/src/components/useProjectContextTabDrag.ts
+++ b/src/renderer/src/components/useProjectContextTabDrag.ts
@@ -1,0 +1,390 @@
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type PointerEvent as ReactPointerEvent,
+    type RefObject,
+} from "react";
+
+type Point = {
+    readonly x: number;
+    readonly y: number;
+};
+
+export type ProjectContextTabDropPosition = "after" | "before";
+
+export interface ProjectContextTabDropTarget {
+    readonly contextKey: string;
+    readonly position: ProjectContextTabDropPosition;
+    readonly targetIndex: number;
+}
+
+export interface ProjectContextTabHitbox {
+    readonly bottom: number;
+    readonly contextKey: string;
+    readonly left: number;
+    readonly right: number;
+    readonly top: number;
+}
+
+interface ProjectContextTabDragState {
+    readonly draggedContextKey: string | null;
+    readonly phase: "dragging" | "idle" | "pending";
+    readonly pointerStart: Point | null;
+    readonly target: ProjectContextTabDropTarget | null;
+}
+
+interface UseProjectContextTabDragOptions {
+    readonly contextKeys: readonly string[];
+    readonly onReorder: (
+        contextKey: string,
+        targetIndex: number,
+    ) => Promise<void> | void;
+    readonly stripRef: RefObject<HTMLDivElement | null>;
+}
+
+const CLICK_SUPPRESSION_MS = 250;
+const DRAG_THRESHOLD = 6;
+const SCROLL_EDGE_PX = 40;
+
+const idleState: ProjectContextTabDragState = {
+    draggedContextKey: null,
+    phase: "idle",
+    pointerStart: null,
+    target: null,
+};
+
+export function resolveProjectContextTabDropTarget({
+    contextKeys,
+    draggedContextKey,
+    hitboxes,
+    pointer,
+}: {
+    readonly contextKeys: readonly string[];
+    readonly draggedContextKey: string;
+    readonly hitboxes: readonly ProjectContextTabHitbox[];
+    readonly pointer: Point;
+}): ProjectContextTabDropTarget | null {
+    if (hitboxes.length === 0) {
+        return null;
+    }
+
+    const stripTop = Math.min(...hitboxes.map((hitbox) => hitbox.top));
+    const stripBottom = Math.max(...hitboxes.map((hitbox) => hitbox.bottom));
+    if (pointer.y < stripTop - 12 || pointer.y > stripBottom + 12) {
+        return null;
+    }
+
+    const sourceIndex = contextKeys.indexOf(draggedContextKey);
+    if (sourceIndex < 0) {
+        return null;
+    }
+
+    let targetHitbox = hitboxes.at(-1) ?? null;
+    let position: ProjectContextTabDropPosition = "after";
+    for (const hitbox of hitboxes) {
+        if (pointer.x < hitbox.left + (hitbox.right - hitbox.left) / 2) {
+            targetHitbox = hitbox;
+            position = "before";
+            break;
+        }
+    }
+
+    if (!targetHitbox) {
+        return null;
+    }
+
+    const hoveredIndex = contextKeys.indexOf(targetHitbox.contextKey);
+    if (hoveredIndex < 0) {
+        return null;
+    }
+
+    const insertionIndex =
+        hoveredIndex + (position === "after" ? 1 : 0);
+    const targetIndex =
+        insertionIndex > sourceIndex ? insertionIndex - 1 : insertionIndex;
+    if (targetIndex === sourceIndex) {
+        return null;
+    }
+
+    return {
+        contextKey: targetHitbox.contextKey,
+        position,
+        targetIndex: Math.max(0, Math.min(contextKeys.length - 1, targetIndex)),
+    };
+}
+
+export function useProjectContextTabDrag({
+    contextKeys,
+    onReorder,
+    stripRef,
+}: UseProjectContextTabDragOptions) {
+    const [dragState, setDragState] =
+        useState<ProjectContextTabDragState>(idleState);
+    const dragStateRef = useRef<ProjectContextTabDragState>(idleState);
+    const contextKeysRef = useRef(contextKeys);
+    const onReorderRef = useRef(onReorder);
+    const suppressClickContextKeyRef = useRef<string | null>(null);
+    const suppressClickUntilRef = useRef(0);
+
+    useEffect(() => {
+        dragStateRef.current = dragState;
+    }, [dragState]);
+
+    useEffect(() => {
+        contextKeysRef.current = contextKeys;
+        onReorderRef.current = onReorder;
+    }, [contextKeys, onReorder]);
+
+    const clearDragState = useCallback(() => {
+        setDragState(idleState);
+    }, []);
+
+    const suppressNextClick = useCallback((contextKey: string) => {
+        suppressClickContextKeyRef.current = contextKey;
+        suppressClickUntilRef.current = performance.now() + CLICK_SUPPRESSION_MS;
+    }, []);
+
+    useEffect(() => {
+        const handleCapturedClick = (event: MouseEvent) => {
+            if (performance.now() >= suppressClickUntilRef.current) {
+                return;
+            }
+
+            const target = event.target;
+            if (!(target instanceof Element)) {
+                return;
+            }
+
+            const tab = target.closest<HTMLElement>(
+                "[data-project-context-tab-key]",
+            );
+            if (
+                tab?.dataset.projectContextTabKey !==
+                suppressClickContextKeyRef.current
+            ) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopImmediatePropagation();
+        };
+
+        window.addEventListener("click", handleCapturedClick, true);
+        return () => {
+            window.removeEventListener("click", handleCapturedClick, true);
+        };
+    }, []);
+
+    const resolveDropTarget = useCallback(
+        (pointer: Point): ProjectContextTabDropTarget | null => {
+            const draggedContextKey = dragStateRef.current.draggedContextKey;
+            const strip = stripRef.current;
+            if (!draggedContextKey || !strip) {
+                return null;
+            }
+
+            const hitboxes = Array.from(
+                strip.querySelectorAll<HTMLElement>(
+                    ":scope > [data-project-context-tab-key]",
+                ),
+            ).map((element) => {
+                const rect = element.getBoundingClientRect();
+                return {
+                    bottom: rect.bottom,
+                    contextKey: element.dataset.projectContextTabKey ?? "",
+                    left: rect.left,
+                    right: rect.right,
+                    top: rect.top,
+                };
+            });
+
+            return resolveProjectContextTabDropTarget({
+                contextKeys: contextKeysRef.current,
+                draggedContextKey,
+                hitboxes,
+                pointer,
+            });
+        },
+        [stripRef],
+    );
+
+    const scrollAtEdge = useCallback(
+        (pointerX: number) => {
+            const strip = stripRef.current;
+            if (!strip || strip.scrollWidth <= strip.clientWidth) {
+                return;
+            }
+
+            const rect = strip.getBoundingClientRect();
+            const leftDistance = pointerX - rect.left;
+            const rightDistance = rect.right - pointerX;
+            if (leftDistance >= 0 && leftDistance < SCROLL_EDGE_PX) {
+                strip.scrollLeft -= Math.ceil(
+                    (SCROLL_EDGE_PX - leftDistance) / 4,
+                );
+            } else if (rightDistance >= 0 && rightDistance < SCROLL_EDGE_PX) {
+                strip.scrollLeft += Math.ceil(
+                    (SCROLL_EDGE_PX - rightDistance) / 4,
+                );
+            }
+        },
+        [stripRef],
+    );
+
+    const beginTabPointerDown = useCallback(
+        (contextKey: string, event: ReactPointerEvent<HTMLElement>) => {
+            if (event.button !== 0) {
+                return;
+            }
+
+            const target = event.target;
+            if (
+                target instanceof HTMLElement &&
+                target.closest("[data-project-context-tab-action='true']")
+            ) {
+                return;
+            }
+
+            setDragState({
+                draggedContextKey: contextKey,
+                phase: "pending",
+                pointerStart: { x: event.clientX, y: event.clientY },
+                target: null,
+            });
+        },
+        [],
+    );
+
+    useEffect(() => {
+        if (dragState.phase === "idle") {
+            return;
+        }
+
+        const previousCursor = document.body.style.cursor;
+        const previousUserSelect = document.body.style.userSelect;
+
+        const handlePointerMove = (event: PointerEvent) => {
+            const currentState = dragStateRef.current;
+            if (event.buttons & 1) {
+                const pointer = { x: event.clientX, y: event.clientY };
+                const distance = currentState.pointerStart
+                    ? Math.hypot(
+                          pointer.x - currentState.pointerStart.x,
+                          pointer.y - currentState.pointerStart.y,
+                      )
+                    : 0;
+                const isDragging =
+                    currentState.phase === "dragging" ||
+                    distance >= DRAG_THRESHOLD;
+                if (!isDragging) {
+                    return;
+                }
+
+                document.body.style.cursor = "grabbing";
+                document.body.style.userSelect = "none";
+                scrollAtEdge(pointer.x);
+                setDragState((state) => ({
+                    ...state,
+                    phase: "dragging",
+                    target: resolveDropTarget(pointer),
+                }));
+                return;
+            }
+
+            if (currentState.phase === "dragging" && currentState.draggedContextKey) {
+                suppressNextClick(currentState.draggedContextKey);
+            }
+            clearDragState();
+        };
+
+        const handlePointerUp = (event: PointerEvent) => {
+            const currentState = dragStateRef.current;
+            if (
+                currentState.phase !== "dragging" ||
+                !currentState.draggedContextKey
+            ) {
+                clearDragState();
+                return;
+            }
+
+            const target = resolveDropTarget({
+                x: event.clientX,
+                y: event.clientY,
+            });
+            suppressNextClick(currentState.draggedContextKey);
+            clearDragState();
+            if (target) {
+                void onReorderRef.current(
+                    currentState.draggedContextKey,
+                    target.targetIndex,
+                );
+            }
+        };
+
+        const cancelDrag = () => {
+            const currentState = dragStateRef.current;
+            if (currentState.phase === "dragging" && currentState.draggedContextKey) {
+                suppressNextClick(currentState.draggedContextKey);
+            }
+            clearDragState();
+        };
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== "Escape") {
+                return;
+            }
+            event.preventDefault();
+            cancelDrag();
+        };
+
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === "hidden") {
+                cancelDrag();
+            }
+        };
+
+        window.addEventListener("pointermove", handlePointerMove);
+        window.addEventListener("pointerup", handlePointerUp);
+        window.addEventListener("pointercancel", cancelDrag);
+        window.addEventListener("blur", cancelDrag);
+        window.addEventListener("keydown", handleKeyDown);
+        document.addEventListener("visibilitychange", handleVisibilityChange);
+        return () => {
+            document.body.style.cursor = previousCursor;
+            document.body.style.userSelect = previousUserSelect;
+            window.removeEventListener("pointermove", handlePointerMove);
+            window.removeEventListener("pointerup", handlePointerUp);
+            window.removeEventListener("pointercancel", cancelDrag);
+            window.removeEventListener("blur", cancelDrag);
+            window.removeEventListener("keydown", handleKeyDown);
+            document.removeEventListener(
+                "visibilitychange",
+                handleVisibilityChange,
+            );
+        };
+    }, [
+        clearDragState,
+        dragState.phase,
+        resolveDropTarget,
+        scrollAtEdge,
+        suppressNextClick,
+    ]);
+
+    return useMemo(
+        () => ({
+            beginTabPointerDown,
+            draggedContextKey: dragState.draggedContextKey,
+            isDragging: dragState.phase === "dragging",
+            target: dragState.target,
+        }),
+        [
+            beginTabPointerDown,
+            dragState.draggedContextKey,
+            dragState.phase,
+            dragState.target,
+        ],
+    );
+}

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -411,48 +411,16 @@ export const ChatTabView = memo(function ChatTabView({
     );
     const sessionPreparationKey = getChatSessionPreparationKey(sessionTab);
     const latestSessionTabRef = useRef(sessionTab);
-    const liveSessionTab = useMemo(
-        () => ({
-            ...sessionTab,
-            sessionOpenMode: "live" as const,
-        }),
-        [sessionTab],
-    );
-    const ensureLiveAgentSession = useCallback(async (force = false) => {
-        const currentSession = useAiStore.getState().sessions[tab.sessionId] ?? null;
-        if (
-            !force &&
-            currentSession?.runtimeState === "live" &&
-            currentSession.snapshot?.runtimeSessionId
-        ) {
-            return;
-        }
-        await ensureSession(liveSessionTab, { force: true });
-    }, [ensureSession, liveSessionTab, tab.sessionId]);
     const runAgentControlMutation = useCallback(
         (mutation: () => Promise<void>) => {
-            void (async () => {
-                try {
-                    await mutation();
-                    return;
-                } catch (error) {
-                    // A live snapshot can outlast its remote session. Recreate it
-                    // only after a mutation fails, then retry the stale RPC once.
-                    await ensureLiveAgentSession(true);
-                    await mutation();
-                    console.warn(
-                        "[comando] Recovered AI session control update after live session prepare.",
-                        error,
-                    );
-                }
-            })().catch((error: unknown) => {
+            void mutation().catch((error: unknown) => {
                 console.warn(
                     "[comando] Failed to update AI session control.",
                     error,
                 );
             });
         },
-        [ensureLiveAgentSession],
+        [],
     );
 
     useEffect(() => {

--- a/src/renderer/src/components/workspace/WorkspacePaneEmptyState.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspacePaneEmptyState.test.tsx
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WorkspacePaneEmptyState } from "./WorkspacePaneEmptyState";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLDivElement[] = [];
+
+afterEach(() => {
+    for (const root of mountedRoots.splice(0)) {
+        act(() => root.unmount());
+    }
+    for (const container of mountedContainers.splice(0)) {
+        container.remove();
+    }
+});
+
+function renderEmptyState(
+    props: Partial<Parameters<typeof WorkspacePaneEmptyState>[0]> = {},
+) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    mountedContainers.push(container);
+
+    const onOpenProject = vi.fn();
+    const onOpenProjects = vi.fn();
+    const root = createRoot(container);
+    mountedRoots.push(root);
+    act(() => {
+        root.render(
+            createElement(WorkspacePaneEmptyState, {
+                onOpenProject,
+                onOpenProjects,
+                recentProjects: [],
+                ...props,
+            }),
+        );
+    });
+
+    return { container, onOpenProject, onOpenProjects };
+}
+
+describe("WorkspacePaneEmptyState", () => {
+    it("shows the open project CTA as the dominant action when there are no recent projects", () => {
+        const { container } = renderEmptyState();
+        const cta = container.querySelector<HTMLButtonElement>(
+            'button[type="button"]',
+        );
+        expect(cta?.textContent).toContain("Open existing project");
+    });
+
+    it("renders the name of each recent project", () => {
+        const { container } = renderEmptyState({
+            recentProjects: [
+                { id: "project-1", name: "Comando" },
+                { id: "project-2", name: "Sandbox" },
+            ],
+        });
+
+        expect(container.textContent).toContain("Comando");
+        expect(container.textContent).toContain("Sandbox");
+    });
+
+    it("opens the exact project id clicked", () => {
+        const { container, onOpenProject } = renderEmptyState({
+            recentProjects: [
+                { id: "project-1", name: "Comando" },
+                { id: "project-2", name: "Sandbox" },
+            ],
+        });
+
+        const sandboxButton = Array.from(
+            container.querySelectorAll("button"),
+        ).find((button) => button.textContent?.includes("Sandbox"));
+        expect(sandboxButton).toBeTruthy();
+
+        act(() => {
+            sandboxButton?.click();
+        });
+
+        expect(onOpenProject).toHaveBeenCalledOnce();
+        expect(onOpenProject).toHaveBeenCalledWith("project-2");
+    });
+
+    it("invokes the open projects callback from the CTA", () => {
+        const { container, onOpenProjects } = renderEmptyState({
+            recentProjects: [{ id: "project-1", name: "Comando" }],
+        });
+
+        const cta = Array.from(container.querySelectorAll("button")).find(
+            (button) => button.textContent?.includes("Open existing project"),
+        );
+        expect(cta).toBeTruthy();
+
+        act(() => {
+            cta?.click();
+        });
+
+        expect(onOpenProjects).toHaveBeenCalledOnce();
+    });
+});

--- a/src/renderer/src/components/workspace/WorkspacePaneEmptyState.tsx
+++ b/src/renderer/src/components/workspace/WorkspacePaneEmptyState.tsx
@@ -2,6 +2,10 @@ import {
     formatShortcutSymbols,
     type ShortcutDefinition,
 } from "@renderer/app/shortcuts/registry";
+import {
+    projectAvatarColor,
+    projectAvatarInitial,
+} from "@renderer/components/projectAvatar";
 
 // Resolve the binding from the shortcut registry at render time so the hint
 // stays accurate (and uses the correct platform modifier) if it ever changes.
@@ -25,18 +29,99 @@ function ShortcutHint({ action }: { action: ShortcutDefinition["id"] }) {
     );
 }
 
-// Shown in a workspace pane that has no open tabs, pointing at the primary
-// actions and their shortcuts.
-export function WorkspacePaneEmptyState() {
+function FolderIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="13"
+            viewBox="0 0 14 14"
+            width="14"
+        >
+            <path
+                d="M1.5 3.5a1 1 0 0 1 1-1h2.6l1.1 1.3h5.3a1 1 0 0 1 1 1v6.2a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1v-7.5Z"
+                stroke="currentColor"
+                strokeLinejoin="round"
+                strokeWidth="1.1"
+            />
+        </svg>
+    );
+}
+
+export interface WorkspacePaneRecentProject {
+    readonly id: string;
+    readonly name: string;
+}
+
+interface WorkspacePaneEmptyStateProps {
+    readonly onOpenProject: (projectId: string) => void;
+    readonly onOpenProjects: () => void;
+    readonly recentProjects: readonly WorkspacePaneRecentProject[];
+}
+
+// Shown in a workspace pane that has no open tabs. Offers the most recently
+// opened projects, a way to open another one, and a reminder of the
+// file/chat/terminal shortcuts.
+export function WorkspacePaneEmptyState({
+    onOpenProject,
+    onOpenProjects,
+    recentProjects,
+}: WorkspacePaneEmptyStateProps) {
+    const hasRecentProjects = recentProjects.length > 0;
+
     return (
         <div className="flex h-full items-center justify-center p-6">
-            <p className="max-w-md text-center text-[13px] leading-8 text-text-secondary">
-                Open a file
-                <ShortcutHint action="open_file_picker" />, start a chat
-                <ShortcutHint action="new_agent_from_focused_provider" />, or
-                launch a terminal
-                <ShortcutHint action="new_terminal" />.
-            </p>
+            <div className="flex w-full max-w-[260px] flex-col items-center gap-4">
+                <p className="max-w-[240px] text-center text-[11px] leading-6 text-text-secondary">
+                    Open a file
+                    <ShortcutHint action="open_file_picker" />, start a chat
+                    <ShortcutHint action="new_agent_from_focused_provider" />,
+                    or launch a terminal
+                    <ShortcutHint action="new_terminal" />.
+                </p>
+
+                {hasRecentProjects && (
+                    <div className="flex w-full flex-col gap-0.5">
+                        {recentProjects.map((project) => (
+                            <button
+                                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-text-primary hover:bg-accent-soft focus-visible:outline-2 focus-visible:outline-accent focus-visible:[outline-offset:-2px]"
+                                key={project.id}
+                                onClick={() => onOpenProject(project.id)}
+                                title={project.name}
+                                type="button"
+                            >
+                                <span
+                                    aria-hidden="true"
+                                    className="grid h-5 w-5 flex-none place-items-center rounded-[5px] text-[9.5px] font-bold text-white"
+                                    style={{
+                                        background: projectAvatarColor(
+                                            project.id,
+                                        ),
+                                    }}
+                                >
+                                    {projectAvatarInitial(project.name)}
+                                </span>
+                                <span className="min-w-0 flex-1 truncate text-[12px] font-medium">
+                                    {project.name}
+                                </span>
+                            </button>
+                        ))}
+                    </div>
+                )}
+
+                <button
+                    className={
+                        hasRecentProjects
+                            ? "flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] text-text-secondary hover:bg-accent-soft hover:text-text-primary focus-visible:outline-2 focus-visible:outline-accent focus-visible:[outline-offset:-2px]"
+                            : "flex items-center gap-2 rounded-lg border border-border px-4 py-2.5 text-[13px] font-medium text-text-primary hover:border-border-strong hover:bg-accent-soft focus-visible:outline-2 focus-visible:outline-accent"
+                    }
+                    onClick={onOpenProjects}
+                    type="button"
+                >
+                    <FolderIcon />
+                    Open existing project
+                </button>
+            </div>
         </div>
     );
 }

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -2625,7 +2625,7 @@ function WorkspacePaneView({
                                                 ? "opacity-35"
                                                 : "",
                                             isActive
-                                                ? "z-10 bg-bg-primary text-text-primary shadow-[inset_0_-2px_0_0_var(--color-accent)] duration-0"
+                                                ? "z-10 bg-bg-primary font-medium text-text-primary shadow-[inset_0_2px_0_0_var(--color-accent),inset_0_-1px_0_0_var(--color-accent)] duration-0"
                                                 : "z-0 bg-bg-chrome text-text-secondary hover:bg-bg-tertiary hover:text-text-primary",
                                         ].join(" ")}
                                         data-workspace-tab-id={tab.id}

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -2708,16 +2708,13 @@ function WorkspacePaneView({
                 </div>
 
                 <div className="relative min-h-0 flex-1 overflow-hidden bg-editor">
-                    {paneTabs
-                        .filter((tab) => tab.kind === "terminal")
-                        .map((tab) => (
-                            <WorkspaceTerminalView
-                                key={tab.id}
-                                active={tab.id === paneActiveTabId}
-                                activePane={isActivePane}
-                                tab={tab}
-                            />
-                        ))}
+                    {activeTab?.kind === "terminal" ? (
+                        <WorkspaceTerminalView
+                            active
+                            activePane={isActivePane}
+                            tab={activeTab}
+                        />
+                    ) : null}
                     <WorkspaceFileEditorHost
                         activeFileTab={activeFileTab}
                         fileTabs={paneFileTabs}

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -130,7 +130,10 @@ import { GitWorktreeDiffTabView } from "@renderer/components/workspace/GitWorktr
 import { GitTabView } from "@renderer/components/workspace/GitTabView";
 import { ProviderIcon } from "@renderer/components/workspace/ProviderIcon";
 import { ReviewTabView } from "@renderer/components/workspace/ReviewTabView";
-import { WorkspacePaneEmptyState } from "@renderer/components/workspace/WorkspacePaneEmptyState";
+import {
+    WorkspacePaneEmptyState,
+    type WorkspacePaneRecentProject,
+} from "@renderer/components/workspace/WorkspacePaneEmptyState";
 import { MarkdownFilePreview } from "@renderer/components/workspace/MarkdownFilePreview";
 import { persistChatDraftForTab } from "@renderer/components/workspace/chatDraftPersistence";
 import {
@@ -208,6 +211,9 @@ import {
 interface WorkspaceViewProps {
     readonly defaultProjectId: string | null;
     readonly defaultWorktreeId: string | null;
+    readonly recentProjects: readonly WorkspacePaneRecentProject[];
+    readonly onOpenProject: (projectId: string) => void;
+    readonly onOpenProjects: () => void;
     readonly onRequestCreateFile: () => void;
 }
 
@@ -668,6 +674,9 @@ function resolveActiveRuntimeId(runtimeId: AiRuntimeId): ActiveAiRuntimeId {
 export function WorkspaceView({
     defaultProjectId,
     defaultWorktreeId,
+    recentProjects,
+    onOpenProject,
+    onOpenProjects,
     onRequestCreateFile,
 }: WorkspaceViewProps) {
     const closeTab = useWorkspaceStore((state) => state.closeTab);
@@ -1051,7 +1060,10 @@ export function WorkspaceView({
             <WorkspaceNodeView
                 defaultProjectId={defaultProjectId}
                 defaultWorktreeId={defaultWorktreeId}
+                recentProjects={recentProjects}
                 nodeId={rootNodeId}
+                onOpenProject={onOpenProject}
+                onOpenProjects={onOpenProjects}
                 onRequestCreateFile={onRequestCreateFile}
                 tabDrag={tabDrag}
             />
@@ -1075,13 +1087,19 @@ export function WorkspaceView({
 function WorkspaceNodeView({
     defaultProjectId,
     defaultWorktreeId,
+    recentProjects,
     nodeId,
+    onOpenProject,
+    onOpenProjects,
     onRequestCreateFile,
     tabDrag,
 }: {
     readonly defaultProjectId: string | null;
     readonly defaultWorktreeId: string | null;
+    readonly recentProjects: readonly WorkspacePaneRecentProject[];
     readonly nodeId: string;
+    readonly onOpenProject: (projectId: string) => void;
+    readonly onOpenProjects: () => void;
     readonly onRequestCreateFile: () => void;
     readonly tabDrag: ReturnType<typeof useWorkspaceTabDrag>;
 }) {
@@ -1101,7 +1119,10 @@ function WorkspaceNodeView({
             <WorkspacePaneView
                 defaultProjectId={defaultProjectId}
                 defaultWorktreeId={defaultWorktreeId}
+                recentProjects={recentProjects}
                 paneId={node.id}
+                onOpenProject={onOpenProject}
+                onOpenProjects={onOpenProjects}
                 onRequestCreateFile={onRequestCreateFile}
                 tabDrag={tabDrag}
             />
@@ -1112,7 +1133,10 @@ function WorkspaceNodeView({
         <WorkspaceSplitView
             defaultProjectId={defaultProjectId}
             defaultWorktreeId={defaultWorktreeId}
+            recentProjects={recentProjects}
             splitId={node.id}
+            onOpenProject={onOpenProject}
+            onOpenProjects={onOpenProjects}
             onRequestCreateFile={onRequestCreateFile}
             tabDrag={tabDrag}
         />
@@ -1326,13 +1350,19 @@ function findPaneIdForWorkspaceTab(
 function WorkspaceSplitView({
     defaultProjectId,
     defaultWorktreeId,
+    recentProjects,
     splitId,
+    onOpenProject,
+    onOpenProjects,
     onRequestCreateFile,
     tabDrag,
 }: {
     readonly defaultProjectId: string | null;
     readonly defaultWorktreeId: string | null;
+    readonly recentProjects: readonly WorkspacePaneRecentProject[];
     readonly splitId: string;
+    readonly onOpenProject: (projectId: string) => void;
+    readonly onOpenProjects: () => void;
     readonly onRequestCreateFile: () => void;
     readonly tabDrag: ReturnType<typeof useWorkspaceTabDrag>;
 }) {
@@ -1457,10 +1487,13 @@ function WorkspaceSplitView({
                     axis={node.axis}
                     defaultProjectId={defaultProjectId}
                     defaultWorktreeId={defaultWorktreeId}
+                    recentProjects={recentProjects}
                     handleIndex={index}
                     isLast={index === node.children.length - 1}
                     key={child.id}
                     nodeId={child.id}
+                    onOpenProject={onOpenProject}
+                    onOpenProjects={onOpenProjects}
                     onRequestCreateFile={onRequestCreateFile}
                     onPointerDown={(event) => {
                         if (!isPrimaryPointerButton(event.button)) {
@@ -1500,9 +1533,12 @@ function FragmentPane({
     axis,
     defaultProjectId,
     defaultWorktreeId,
+    recentProjects,
     handleIndex,
     isLast,
     nodeId,
+    onOpenProject,
+    onOpenProjects,
     onRequestCreateFile,
     onPointerDown,
     size,
@@ -1511,9 +1547,12 @@ function FragmentPane({
     readonly axis: "horizontal" | "vertical";
     readonly defaultProjectId: string | null;
     readonly defaultWorktreeId: string | null;
+    readonly recentProjects: readonly WorkspacePaneRecentProject[];
     readonly handleIndex: number;
     readonly isLast: boolean;
     readonly nodeId: string;
+    readonly onOpenProject: (projectId: string) => void;
+    readonly onOpenProjects: () => void;
     readonly onRequestCreateFile: () => void;
     readonly onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
     readonly size: number;
@@ -1532,7 +1571,10 @@ function FragmentPane({
                 <WorkspaceNodeView
                     defaultProjectId={defaultProjectId}
                     defaultWorktreeId={defaultWorktreeId}
+                    recentProjects={recentProjects}
                     nodeId={nodeId}
+                    onOpenProject={onOpenProject}
+                    onOpenProjects={onOpenProjects}
                     onRequestCreateFile={onRequestCreateFile}
                     tabDrag={tabDrag}
                 />
@@ -1575,13 +1617,19 @@ function FragmentPane({
 function WorkspacePaneView({
     defaultProjectId,
     defaultWorktreeId,
+    recentProjects,
     paneId,
+    onOpenProject,
+    onOpenProjects,
     onRequestCreateFile,
     tabDrag,
 }: {
     readonly defaultProjectId: string | null;
     readonly defaultWorktreeId: string | null;
+    readonly recentProjects: readonly WorkspacePaneRecentProject[];
     readonly paneId: string;
+    readonly onOpenProject: (projectId: string) => void;
+    readonly onOpenProjects: () => void;
     readonly onRequestCreateFile: () => void;
     readonly tabDrag: ReturnType<typeof useWorkspaceTabDrag>;
 }) {
@@ -2778,7 +2826,11 @@ function WorkspacePaneView({
                             <GitHubPullRequestTabView tab={activeTab} />
                         ) : null
                     ) : (
-                        <WorkspacePaneEmptyState />
+                        <WorkspacePaneEmptyState
+                            onOpenProject={onOpenProject}
+                            onOpenProjects={onOpenProjects}
+                            recentProjects={recentProjects}
+                        />
                     )}
                 </div>
             </section>

--- a/src/renderer/src/components/workspace/chat/ChangeReviewPanel.test.ts
+++ b/src/renderer/src/components/workspace/chat/ChangeReviewPanel.test.ts
@@ -107,6 +107,26 @@ function createTrackedFile(
 }
 
 describe("ChangeReviewPanel", () => {
+    it("keeps the review rail surface while an edit is pending its diff", () => {
+        const markup = renderToStaticMarkup(
+            createElement(ChangeReviewPanel, {
+                activity: createActivity({
+                    diffs: [],
+                    status: "in_progress",
+                    title: "Write src/app.ts",
+                }),
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                trackedFiles: [],
+            }),
+        );
+
+        expect(markup).toContain('data-change-review-surface="rail-row"');
+        expect(markup).toContain('data-change-review-pending="true"');
+        expect(markup).toContain(">Edited<");
+        expect(markup).toContain(">app.ts<");
+    });
+
     it("renders a single-file terminal row with a linked file and collapsed diff", () => {
         const markup = renderToStaticMarkup(
             createElement(ChangeReviewPanel, {

--- a/src/renderer/src/components/workspace/chat/ChangeReviewPanel.tsx
+++ b/src/renderer/src/components/workspace/chat/ChangeReviewPanel.tsx
@@ -17,6 +17,7 @@ import {
     deriveChangeReviewItems,
     type ChangeReviewItem,
 } from "./toolActivityReviewModel";
+import { getStructuredToolTarget } from "./toolActivityDescriptor";
 import { ResizableDiffContainer } from "./ResizableDiffContainer";
 import { usePersistentToolExpansion } from "./toolExpansionStore";
 
@@ -318,6 +319,53 @@ function ChangeReviewRailRow({
     );
 }
 
+function PendingChangeReviewRailRow({
+    activity,
+}: {
+    readonly activity: AiToolActivity;
+}) {
+    const target = getStructuredToolTarget(activity);
+    const actionLabel = getActivityActionLabel(activity.kind);
+
+    return (
+        <div
+            className="min-w-0 max-w-full select-none"
+            data-change-review-pending="true"
+            data-change-review-surface="rail-row"
+            style={{
+                color: "var(--color-text-secondary)",
+                fontFamily: "var(--font-mono), ui-monospace, monospace",
+                fontSize: "0.82em",
+            }}
+        >
+            <div className="flex min-h-7 w-full min-w-0 items-center gap-2">
+                <span
+                    aria-hidden="true"
+                    className="shrink-0"
+                    style={{
+                        color: getPanelAccent(activity),
+                        display: "inline-flex",
+                    }}
+                >
+                    <FileTypeIcon
+                        fileName={target ?? activity.title}
+                        opacity={0.85}
+                        size={14}
+                    />
+                </span>
+                <span className="shrink-0 opacity-70">{actionLabel}</span>
+                <span
+                    className="min-w-0 flex-1 truncate text-text-primary"
+                    title={target ?? activity.title}
+                >
+                    {target ? getFileNameFromPath(target) : activity.title}
+                </span>
+                {renderStatus(activity)}
+            </div>
+        </div>
+    );
+}
+
 export interface ChangeReviewPanelProps {
     readonly activity: AiToolActivity;
     readonly onOpenFile: (
@@ -381,6 +429,13 @@ export const ChangeReviewPanel = memo(function ChangeReviewPanel({
     );
 
     if (items.length === 0) {
+        if (
+            activity.status === "in_progress" ||
+            activity.status === "pending"
+        ) {
+            return <PendingChangeReviewRailRow activity={activity} />;
+        }
+
         return null;
     }
 

--- a/src/renderer/src/components/workspace/chat/PlanMessage.tsx
+++ b/src/renderer/src/components/workspace/chat/PlanMessage.tsx
@@ -4,10 +4,12 @@ import type { AiPlan, AiPlanEntry } from "@shared/ipc";
 
 /* ─── Status helpers ─── */
 
+const DONE_COLOR = "#84cc16";
+
 function getStatusDotColor(status: AiPlanEntry["status"]): string {
     switch (status) {
         case "completed":
-            return "#84cc16";
+            return DONE_COLOR;
         case "in_progress":
             return "var(--color-accent)";
         case "pending":
@@ -15,15 +17,28 @@ function getStatusDotColor(status: AiPlanEntry["status"]): string {
     }
 }
 
-function getPlanStatusLabel(entries: readonly AiPlanEntry[]): string {
+type PlanTone = "done" | "active" | "planned";
+
+function getPlanTone(entries: readonly AiPlanEntry[]): PlanTone {
     const completed = entries.filter((e) => e.status === "completed").length;
     const total = entries.length;
-    if (completed === total) return "All Done";
-    if (completed > 0) return "In Progress";
-    const hasInProgress = entries.some((e) => e.status === "in_progress");
-    if (hasInProgress) return "In Progress";
-    return "Planned";
+    if (total > 0 && completed === total) return "done";
+    if (completed > 0) return "active";
+    if (entries.some((e) => e.status === "in_progress")) return "active";
+    return "planned";
 }
+
+const PLAN_TONE_LABEL: Record<PlanTone, string> = {
+    done: "All Done",
+    active: "In Progress",
+    planned: "Planned",
+};
+
+const PLAN_TONE_COLOR: Record<PlanTone, string> = {
+    done: DONE_COLOR,
+    active: "var(--color-accent)",
+    planned: "var(--color-text-secondary)",
+};
 
 /* ─── Component ─── */
 
@@ -41,23 +56,25 @@ export function PlanMessage({
         (e) => e.status === "completed",
     ).length;
     const totalCount = plan.entries.length;
-    const statusLabel = getPlanStatusLabel(plan.entries);
+    const tone = getPlanTone(plan.entries);
+    const toneColor = PLAN_TONE_COLOR[tone];
     const title = plan.title ?? "Plan";
+    const progressRatio = totalCount > 0 ? completedCount / totalCount : 0;
 
     return (
         <div
             className="min-w-0 max-w-full overflow-hidden rounded-xl"
             style={{
                 backgroundColor:
-                    "color-mix(in srgb, var(--color-bg-tertiary) 84%, transparent)",
-                border: "1px solid color-mix(in srgb, var(--color-border) 88%, transparent)",
+                    "color-mix(in srgb, var(--color-bg-tertiary) 78%, transparent)",
+                border: "1px solid color-mix(in srgb, var(--color-border) 76%, transparent)",
             }}
         >
             {/* Header */}
-            <div className="flex items-center gap-1 px-1 py-1">
+            <div className="flex items-center gap-1.5 px-2.5 py-2">
                 <button
                     aria-expanded={expanded}
-                    className="flex min-w-0 flex-1 items-center gap-2.5 rounded-lg px-1.5 py-0.5 text-left"
+                    className="flex min-w-0 flex-1 items-center gap-2 text-left"
                     onClick={() => {
                         if (canExpand) {
                             setExpanded((current) => !current);
@@ -67,52 +84,87 @@ export function PlanMessage({
                         background: "none",
                         border: "none",
                         cursor: canExpand ? "pointer" : "default",
+                        padding: 0,
                     }}
                     type="button"
                 >
                     <span
-                        className="inline-flex shrink-0 items-center justify-center rounded-md px-1.5 py-0.5 text-xs"
-                        style={{
-                            backgroundColor:
-                                "color-mix(in srgb, var(--color-bg-secondary) 74%, transparent)",
-                            border: "1px solid color-mix(in srgb, var(--color-border) 82%, transparent)",
-                            color: "var(--color-text-secondary)",
-                            fontWeight: 500,
-                        }}
+                        className="inline-grid shrink-0 place-items-center"
+                        style={{ height: 16, width: 16 }}
                     >
-                        {canExpand ? (expanded ? "▾" : "▸") : "•"}
+                        {canExpand ? (
+                            <svg
+                                aria-hidden="true"
+                                fill="none"
+                                height="10"
+                                style={{
+                                    color: "var(--color-text-secondary)",
+                                    opacity: 0.75,
+                                    transform: expanded
+                                        ? "rotate(0deg)"
+                                        : "rotate(-90deg)",
+                                    transition: "transform 160ms ease",
+                                }}
+                                viewBox="0 0 16 16"
+                                width="10"
+                            >
+                                <path
+                                    d="M4.5 6.5 8 10l3.5-3.5"
+                                    stroke="currentColor"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth="1.6"
+                                />
+                            </svg>
+                        ) : (
+                            <span
+                                style={{
+                                    background: "var(--color-text-secondary)",
+                                    borderRadius: "50%",
+                                    display: "block",
+                                    height: 4,
+                                    opacity: 0.6,
+                                    width: 4,
+                                }}
+                            />
+                        )}
                     </span>
                     <span
-                        className="min-w-0 flex-1 font-medium"
+                        className="min-w-0 flex-1 truncate"
                         style={{
-                            color: "var(--color-text-secondary)",
-                            fontSize: "0.875rem",
+                            color: "var(--color-text-primary)",
+                            fontSize: "0.8125rem",
+                            fontWeight: 600,
                         }}
                     >
                         {title}
                     </span>
                     <span
+                        className="shrink-0 rounded-full"
                         style={{
-                            color: "var(--color-text-secondary)",
-                            fontSize: "0.76em",
+                            background: `color-mix(in srgb, ${toneColor} 16%, transparent)`,
+                            color: toneColor,
+                            fontSize: "0.7em",
+                            fontWeight: 500,
+                            padding: "2px 8px",
                         }}
                     >
-                        {statusLabel}
+                        {PLAN_TONE_LABEL[tone]}
                     </span>
                 </button>
                 {onDismiss ? (
                     <button
                         aria-label="Dismiss plan banner"
-                        className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
+                        className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md"
                         onClick={onDismiss}
                         style={{
                             background: "transparent",
                             border: "none",
                             color: "var(--color-text-secondary)",
                             cursor: "pointer",
-                            fontSize: 14,
+                            fontSize: 13,
                             lineHeight: 1,
-                            opacity: 0.72,
+                            opacity: 0.6,
                             transition:
                                 "opacity 140ms ease, background-color 140ms ease",
                         }}
@@ -126,22 +178,11 @@ export function PlanMessage({
 
             {/* Entries */}
             {expanded ? (
-                <div
-                    style={{
-                        borderTop:
-                            "1px solid color-mix(in srgb, var(--color-border) 72%, transparent)",
-                    }}
-                >
+                <div className="flex flex-col gap-1 px-2.5 pb-2">
                     {plan.entries.map((entry, i) => (
                         <div
-                            className="flex min-w-0 items-start gap-2.5 px-2.5 py-1.5"
+                            className="flex min-w-0 items-start gap-2.5 py-0.5"
                             key={`${entry.content}-${i}`}
-                            style={{
-                                borderBottom:
-                                    i < plan.entries.length - 1
-                                        ? "1px solid color-mix(in srgb, var(--color-border) 72%, transparent)"
-                                        : undefined,
-                            }}
                         >
                             <span
                                 className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full"
@@ -151,7 +192,7 @@ export function PlanMessage({
                                     ),
                                     opacity:
                                         entry.status === "completed"
-                                            ? 0.9
+                                            ? 0.85
                                             : 0.8,
                                 }}
                             />
@@ -165,7 +206,7 @@ export function PlanMessage({
                                     fontSize: "12px",
                                     lineHeight: 1.45,
                                     opacity:
-                                        entry.status === "completed" ? 0.74 : 1,
+                                        entry.status === "completed" ? 0.7 : 1,
                                     textDecoration:
                                         entry.status === "completed"
                                             ? "line-through"
@@ -179,15 +220,37 @@ export function PlanMessage({
                     ))}
 
                     {/* Progress footer */}
-                    <div
-                        className="px-2.5 pb-1.5 pt-0.5"
-                        style={{
-                            color: "var(--color-text-secondary)",
-                            fontSize: "0.74em",
-                            opacity: 0.68,
-                        }}
-                    >
-                        {completedCount}/{totalCount}
+                    <div className="mt-1 flex items-center gap-2">
+                        <div
+                            style={{
+                                background:
+                                    "color-mix(in srgb, var(--color-border) 60%, transparent)",
+                                borderRadius: 2,
+                                flex: 1,
+                                height: 3,
+                                overflow: "hidden",
+                            }}
+                        >
+                            <div
+                                style={{
+                                    background: toneColor,
+                                    borderRadius: 2,
+                                    height: "100%",
+                                    transition: "width 200ms ease",
+                                    width: `${progressRatio * 100}%`,
+                                }}
+                            />
+                        </div>
+                        <span
+                            style={{
+                                color: "var(--color-text-secondary)",
+                                fontSize: "0.7em",
+                                fontVariantNumeric: "tabular-nums",
+                                opacity: 0.6,
+                            }}
+                        >
+                            {completedCount}/{totalCount}
+                        </span>
                     </div>
                 </div>
             ) : null}

--- a/src/renderer/src/components/workspace/chat/PlanMessage.tsx
+++ b/src/renderer/src/components/workspace/chat/PlanMessage.tsx
@@ -59,7 +59,6 @@ export function PlanMessage({
     const tone = getPlanTone(plan.entries);
     const toneColor = PLAN_TONE_COLOR[tone];
     const title = plan.title ?? "Plan";
-    const progressRatio = totalCount > 0 ? completedCount / totalCount : 0;
 
     return (
         <div
@@ -220,27 +219,7 @@ export function PlanMessage({
                     ))}
 
                     {/* Progress footer */}
-                    <div className="mt-1 flex items-center gap-2">
-                        <div
-                            style={{
-                                background:
-                                    "color-mix(in srgb, var(--color-border) 60%, transparent)",
-                                borderRadius: 2,
-                                flex: 1,
-                                height: 3,
-                                overflow: "hidden",
-                            }}
-                        >
-                            <div
-                                style={{
-                                    background: toneColor,
-                                    borderRadius: 2,
-                                    height: "100%",
-                                    transition: "width 200ms ease",
-                                    width: `${progressRatio * 100}%`,
-                                }}
-                            />
-                        </div>
+                    <div className="mt-1 flex justify-end">
                         <span
                             style={{
                                 color: "var(--color-text-secondary)",

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
@@ -441,6 +441,25 @@ describe("ToolActivityItem", () => {
         expect(markup).not.toContain("Reject");
     });
 
+    it("uses the review rail while a file edit is waiting for its diff", () => {
+        const markup = renderToStaticMarkup(
+            createElement(ToolActivityItem, {
+                activity: createActivity({
+                    diffs: [],
+                    status: "in_progress",
+                    title: "Write src/app.ts",
+                }),
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                trackedFiles: [],
+                worktreeId: null,
+            }),
+        );
+
+        expect(markup).toContain('data-change-review-pending="true"');
+        expect(markup).not.toContain("border-radius:0.5rem");
+    });
+
     it("keeps change review behind the compact rail disclosure", () => {
         const container = renderInteractiveToolActivityItem({
             activity: createActivity({

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
@@ -34,6 +34,7 @@ import {
     getStructuredToolTarget,
 } from "./toolActivityDescriptor";
 import {
+    isEditedFileToolActivity,
     isFileToolActivity,
     isStatusToolActivity,
     isTerminalToolActivity,
@@ -2058,6 +2059,9 @@ export const ToolActivityItem = memo(function ToolActivityItem({
         isAiTrackedFileUnresolved,
     );
     const hasInlineReview = trackedFiles.length > 0 || activity.diffs.length > 0;
+    const hasPendingChangeReview =
+        isEditedFileToolActivity(activity, trackedFiles) &&
+        (activity.status === "in_progress" || activity.status === "pending");
 
     // Validate file references in tool summaries against the real project file
     // index so only existing files become clickable pills (mirrors chat
@@ -2118,7 +2122,7 @@ export const ToolActivityItem = memo(function ToolActivityItem({
     }
 
     if (isFileToolActivity(activity, trackedFiles)) {
-        if (hasInlineReview) {
+        if (hasInlineReview || hasPendingChangeReview) {
             const reviewPanel = (
                 <ChangeReviewPanel
                     activity={activity}

--- a/src/renderer/src/components/workspace/workspaceCloseGuard.test.ts
+++ b/src/renderer/src/components/workspace/workspaceCloseGuard.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { RuntimeWorkspaceTab } from "@renderer/app/workspace/tree";
 
-import { getWorkspaceTabCloseConfirmationMessage } from "./workspaceCloseGuard";
+import {
+    closeWorkspaceTabsWithConfirmation,
+    getWorkspaceTabCloseConfirmationMessage,
+} from "./workspaceCloseGuard";
 
 function createChatTab(
     id: string,
@@ -17,6 +20,31 @@ function createChatTab(
         runtimeId: "codex",
         sessionId,
         title: `Chat ${id}`,
+        worktreeId: null,
+    };
+}
+
+function createFileTab(
+    id: string,
+    isDirty: boolean,
+): Extract<RuntimeWorkspaceTab, { kind: "file" }> {
+    return {
+        createdAt: "2026-04-19T00:00:00.000Z",
+        document: null,
+        draftContent: isDirty ? "unsaved" : "",
+        hasExternalChange: false,
+        id,
+        isDirty,
+        isLoading: false,
+        isSaving: false,
+        kind: "file",
+        loadError: null,
+        projectId: "project-1",
+        relativePath: `${id}.ts`,
+        reviewContext: null,
+        saveError: null,
+        savedContent: "",
+        title: `${id}.ts`,
         worktreeId: null,
     };
 }
@@ -95,5 +123,37 @@ describe("getWorkspaceTabCloseConfirmationMessage", () => {
                 },
             }),
         ).toBeNull();
+    });
+
+    it("warns before a workspace discards dirty files", async () => {
+        const tabsById = {
+            "file-1": createFileTab("file-1", true),
+            "file-2": createFileTab("file-2", false),
+        };
+        let closed = false;
+
+        expect(
+            getWorkspaceTabCloseConfirmationMessage({
+                sessions: {},
+                tabIds: Object.keys(tabsById),
+                tabsById,
+            }),
+        ).toBe(
+            "This workspace contains an unsaved file. Close it and discard the changes?",
+        );
+
+        await closeWorkspaceTabsWithConfirmation(
+            Object.keys(tabsById),
+            () => {
+                closed = true;
+                return Promise.resolve();
+            },
+            {
+                confirm: () => false,
+                tabsById,
+            },
+        );
+
+        expect(closed).toBe(false);
     });
 });

--- a/src/renderer/src/components/workspace/workspaceCloseGuard.test.ts
+++ b/src/renderer/src/components/workspace/workspaceCloseGuard.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import type { RuntimeWorkspaceTab } from "@renderer/app/workspace/tree";
 
 import {
+    closeWorkspaceContextWithConfirmation,
     closeWorkspaceTabsWithConfirmation,
+    getWorkspaceCloseSummary,
     getWorkspaceTabCloseConfirmationMessage,
 } from "./workspaceCloseGuard";
 
@@ -152,6 +154,130 @@ describe("getWorkspaceTabCloseConfirmationMessage", () => {
                 confirm: () => false,
                 tabsById,
             },
+        );
+
+        expect(closed).toBe(false);
+    });
+});
+
+describe("getWorkspaceCloseSummary", () => {
+    it("protects active agents that belong to the workspace, including subagents without tabs", () => {
+        expect(
+            getWorkspaceCloseSummary({
+                projectId: "project-1",
+                sessions: {
+                    "session-1": {
+                        meta: {
+                            projectId: "project-1",
+                            title: "Parent",
+                            worktreeId: null,
+                        },
+                        snapshot: {
+                            projectId: "project-1",
+                            sessionId: "session-1",
+                            status: "streaming",
+                            title: "Parent",
+                            worktreeId: null,
+                        },
+                    },
+                    "subagent-1": {
+                        meta: {
+                            projectId: "project-1",
+                            title: "Ada",
+                            worktreeId: null,
+                        },
+                        snapshot: {
+                            projectId: "project-1",
+                            sessionId: "subagent-1",
+                            status: "waiting_permission",
+                            title: "Ada",
+                            worktreeId: null,
+                        },
+                    },
+                    "other-worktree": {
+                        meta: {
+                            projectId: "project-1",
+                            title: "Other worktree",
+                            worktreeId: "worktree-2",
+                        },
+                        snapshot: {
+                            projectId: "project-1",
+                            sessionId: "other-worktree",
+                            status: "streaming",
+                            title: "Other worktree",
+                            worktreeId: "worktree-2",
+                        },
+                    },
+                },
+                tabsById: {
+                    "chat-1": createChatTab("chat-1", "session-1"),
+                    "file-1": createFileTab("file-1", true),
+                },
+                worktreeId: null,
+            }),
+        ).toEqual({
+            activeAgentCount: 2,
+            dirtyFileCount: 1,
+        });
+    });
+
+    it("does not request confirmation when the workspace is safe to close", async () => {
+        let closed = false;
+        let confirmationRequested = false;
+
+        await closeWorkspaceContextWithConfirmation(
+            {
+                projectId: "project-1",
+                sessions: {},
+                tabsById: { "file-1": createFileTab("file-1", false) },
+                worktreeId: null,
+            },
+            () => {
+                closed = true;
+                return Promise.resolve();
+            },
+            {
+                confirm: () => {
+                    confirmationRequested = true;
+                    return Promise.resolve(false);
+                },
+            },
+        );
+
+        expect(closed).toBe(true);
+        expect(confirmationRequested).toBe(false);
+    });
+
+    it("keeps the workspace open when native confirmation is declined", async () => {
+        let closed = false;
+
+        await closeWorkspaceContextWithConfirmation(
+            {
+                projectId: "project-1",
+                sessions: {
+                    "session-1": {
+                        meta: {
+                            projectId: "project-1",
+                            title: "Agent",
+                            worktreeId: null,
+                        },
+                        snapshot: {
+                            projectId: "project-1",
+                            sessionId: "session-1",
+                            status: "starting",
+                            title: "Agent",
+                            worktreeId: null,
+                        },
+                    },
+                },
+                tabsById: {},
+                worktreeId: null,
+            },
+            () => {
+                closed = true;
+                return Promise.resolve();
+            },
+            { confirm: () => Promise.resolve(false) },
         );
 
         expect(closed).toBe(false);

--- a/src/renderer/src/components/workspace/workspaceCloseGuard.ts
+++ b/src/renderer/src/components/workspace/workspaceCloseGuard.ts
@@ -5,14 +5,40 @@ export function getWorkspaceTabCloseConfirmationMessage(input: {
     readonly tabsById: Record<string, RuntimeWorkspaceTab | undefined>;
     readonly sessions: Record<string, unknown>;
 }): string | null {
-    void input;
-    return null;
+    const dirtyFileCount = input.tabIds.reduce((count, tabId) => {
+        const tab = input.tabsById[tabId];
+        return count + (tab?.kind === "file" && tab.isDirty ? 1 : 0);
+    }, 0);
+
+    if (dirtyFileCount === 0) {
+        return null;
+    }
+
+    return dirtyFileCount === 1
+        ? "This workspace contains an unsaved file. Close it and discard the changes?"
+        : `This workspace contains ${dirtyFileCount} unsaved files. Close it and discard the changes?`;
 }
 
 export async function closeWorkspaceTabsWithConfirmation(
     tabIds: readonly string[],
     closeAction: () => Promise<void>,
+    options: {
+        readonly confirm?: (message: string) => boolean;
+        readonly sessions?: Record<string, unknown>;
+        readonly tabsById?: Record<string, RuntimeWorkspaceTab | undefined>;
+    } = {},
 ): Promise<void> {
-    void tabIds;
+    if (options.tabsById) {
+        const message = getWorkspaceTabCloseConfirmationMessage({
+            sessions: options.sessions ?? {},
+            tabIds,
+            tabsById: options.tabsById,
+        });
+        const confirm = options.confirm ?? globalThis.window?.confirm;
+        if (message && (!confirm || !confirm(message))) {
+            return;
+        }
+    }
+
     await closeAction();
 }

--- a/src/renderer/src/components/workspace/workspaceCloseGuard.ts
+++ b/src/renderer/src/components/workspace/workspaceCloseGuard.ts
@@ -1,4 +1,23 @@
+import type { AiSessionSnapshot } from "@shared/ipc";
 import type { RuntimeWorkspaceTab } from "@renderer/app/workspace/tree";
+import { areGitWorktreeIdsEquivalent } from "@renderer/app/git/context-key";
+
+type WorkspaceCloseSession = {
+    readonly meta: {
+        readonly projectId: string | null;
+        readonly title: string;
+        readonly worktreeId: string | null;
+    } | null;
+    readonly snapshot: Pick<
+        AiSessionSnapshot,
+        "projectId" | "sessionId" | "status" | "title" | "worktreeId"
+    > | null;
+};
+
+export type WorkspaceCloseSummary = {
+    readonly activeAgentCount: number;
+    readonly dirtyFileCount: number;
+};
 
 export function getWorkspaceTabCloseConfirmationMessage(input: {
     readonly tabIds: readonly string[];
@@ -17,6 +36,74 @@ export function getWorkspaceTabCloseConfirmationMessage(input: {
     return dirtyFileCount === 1
         ? "This workspace contains an unsaved file. Close it and discard the changes?"
         : `This workspace contains ${dirtyFileCount} unsaved files. Close it and discard the changes?`;
+}
+
+export function getWorkspaceCloseSummary(input: {
+    readonly projectId: string;
+    readonly sessions: Record<string, WorkspaceCloseSession | undefined>;
+    readonly tabsById: Record<string, RuntimeWorkspaceTab | undefined>;
+    readonly worktreeId: string | null;
+}): WorkspaceCloseSummary {
+    const tabSessionIds = new Set(
+        Object.values(input.tabsById).flatMap((tab) =>
+            tab?.kind === "chat" || tab?.kind === "review" ? [tab.sessionId] : [],
+        ),
+    );
+    const activeAgents = Object.values(input.sessions).filter(
+        (session): session is WorkspaceCloseSession => {
+            if (!session?.snapshot || !isBusyAiSession(session.snapshot)) {
+                return false;
+            }
+
+            if (tabSessionIds.has(session.snapshot.sessionId)) {
+                return true;
+            }
+
+            const scope = session.snapshot?.projectId
+                ? session.snapshot
+                : session.meta;
+            return (
+                scope?.projectId === input.projectId &&
+                areGitWorktreeIdsEquivalent(
+                    input.projectId,
+                    scope.worktreeId ?? null,
+                    input.worktreeId,
+                )
+            );
+        },
+    );
+    const dirtyFileCount = Object.values(input.tabsById).reduce(
+        (count, tab) => count + (tab?.kind === "file" && tab.isDirty ? 1 : 0),
+        0,
+    );
+
+    return {
+        activeAgentCount: activeAgents.length,
+        dirtyFileCount,
+    };
+}
+
+export async function closeWorkspaceContextWithConfirmation(
+    input: {
+        readonly projectId: string;
+        readonly sessions: Record<string, WorkspaceCloseSession | undefined>;
+        readonly tabsById: Record<string, RuntimeWorkspaceTab | undefined>;
+        readonly worktreeId: string | null;
+    },
+    closeAction: () => Promise<void>,
+    options: {
+        readonly confirm: (summary: WorkspaceCloseSummary) => Promise<boolean>;
+    },
+): Promise<void> {
+    const summary = getWorkspaceCloseSummary(input);
+    if (
+        (summary.activeAgentCount > 0 || summary.dirtyFileCount > 0) &&
+        !(await options.confirm(summary))
+    ) {
+        return;
+    }
+
+    await closeAction();
 }
 
 export async function closeWorkspaceTabsWithConfirmation(
@@ -41,4 +128,15 @@ export async function closeWorkspaceTabsWithConfirmation(
     }
 
     await closeAction();
+}
+
+function isBusyAiSession(
+    snapshot: Pick<AiSessionSnapshot, "status">,
+): boolean {
+    return (
+        snapshot.status === "starting" ||
+        snapshot.status === "streaming" ||
+        snapshot.status === "waiting_permission" ||
+        snapshot.status === "waiting_user_input"
+    );
 }

--- a/src/renderer/src/features/terminal/WorkspaceTerminalHost.tsx
+++ b/src/renderer/src/features/terminal/WorkspaceTerminalHost.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
@@ -14,14 +14,38 @@ function getComandoApiOrNull() {
 }
 
 export function WorkspaceTerminalHost() {
-    const terminalTabs = useWorkspaceStore(
-        useShallow((state) =>
-            Object.values(state.tabsById).filter(
+    const { activeContextKey, contextsByKey, tabsById } = useWorkspaceStore(
+        useShallow((state) => ({
+            activeContextKey: state.activeContextKey,
+            contextsByKey: state.contextsByKey,
+            tabsById: state.tabsById,
+        })),
+    );
+    const visibleTerminalTabs = useMemo(
+        () =>
+            Object.values(tabsById).filter(
                 (tab): tab is RuntimeWorkspaceTerminalTab =>
                     tab.kind === "terminal",
             ),
-        ),
+        [tabsById],
     );
+    const liveTerminalIds = useMemo(() => {
+        const inactiveTerminalIds = Object.values(contextsByKey)
+            .filter((context) => context.key !== activeContextKey)
+            .flatMap((context) =>
+                Object.values(context.workspace.tabsById)
+                    .filter(
+                        (tab): tab is RuntimeWorkspaceTerminalTab =>
+                            tab.kind === "terminal",
+                    )
+                    .map((tab) => tab.terminalId),
+            );
+
+        return [
+            ...visibleTerminalTabs.map((tab) => tab.terminalId),
+            ...inactiveTerminalIds,
+        ];
+    }, [activeContextKey, contextsByKey, visibleTerminalTabs]);
     const ensureTerminal = useTerminalRuntimeStore(
         (state) => state.ensureTerminal,
     );
@@ -120,11 +144,16 @@ export function WorkspaceTerminalHost() {
     }, []);
 
     useEffect(() => {
-        for (const tab of terminalTabs) {
+        for (const tab of visibleTerminalTabs) {
             ensureTerminal(tab);
         }
-        closeMissingTerminals(terminalTabs.map((tab) => tab.terminalId));
-    }, [closeMissingTerminals, ensureTerminal, terminalTabs]);
+        closeMissingTerminals(liveTerminalIds);
+    }, [
+        closeMissingTerminals,
+        ensureTerminal,
+        liveTerminalIds,
+        visibleTerminalTabs,
+    ]);
 
     useEffect(
         () => () => {

--- a/src/renderer/src/features/terminal/WorkspaceTerminalHost.tsx
+++ b/src/renderer/src/features/terminal/WorkspaceTerminalHost.tsx
@@ -2,7 +2,10 @@ import { useEffect, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
-import type { RuntimeWorkspaceTerminalTab } from "@renderer/app/workspace/tree";
+import {
+    collectPaneNodes,
+    type RuntimeWorkspaceTerminalTab,
+} from "@renderer/app/workspace/tree";
 
 import { useTerminalRuntimeStore } from "./terminalRuntimeStore";
 
@@ -14,10 +17,11 @@ function getComandoApiOrNull() {
 }
 
 export function WorkspaceTerminalHost() {
-    const { activeContextKey, contextsByKey, tabsById } = useWorkspaceStore(
+    const { activeContextKey, contextsByKey, rootNode, tabsById } = useWorkspaceStore(
         useShallow((state) => ({
             activeContextKey: state.activeContextKey,
             contextsByKey: state.contextsByKey,
+            rootNode: state.rootNode,
             tabsById: state.tabsById,
         })),
     );
@@ -29,6 +33,15 @@ export function WorkspaceTerminalHost() {
             ),
         [tabsById],
     );
+    const activeTerminalTabs = useMemo(() => {
+        const activeTabIds = new Set(
+            collectPaneNodes(rootNode).flatMap((pane) =>
+                pane.activeTabId ? [pane.activeTabId] : [],
+            ),
+        );
+
+        return visibleTerminalTabs.filter((tab) => activeTabIds.has(tab.id));
+    }, [rootNode, visibleTerminalTabs]);
     const liveTerminalIds = useMemo(() => {
         const inactiveTerminalIds = Object.values(contextsByKey)
             .filter((context) => context.key !== activeContextKey)
@@ -144,15 +157,15 @@ export function WorkspaceTerminalHost() {
     }, []);
 
     useEffect(() => {
-        for (const tab of visibleTerminalTabs) {
+        for (const tab of activeTerminalTabs) {
             ensureTerminal(tab);
         }
         closeMissingTerminals(liveTerminalIds);
     }, [
+        activeTerminalTabs,
         closeMissingTerminals,
         ensureTerminal,
         liveTerminalIds,
-        visibleTerminalTabs,
     ]);
 
     useEffect(

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -816,8 +816,20 @@
 }
 
 .project-context-menu-actions button {
+    display: flex;
     min-height: 30px;
+    align-items: center;
+    gap: 7px;
     padding: 5px 8px 5px 26px;
+}
+
+.project-context-update-dot {
+    width: 6px;
+    height: 6px;
+    margin-left: auto;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    background: linear-gradient(180deg, #f97316, #ef4444);
 }
 
 .project-context-clone-form {
@@ -2903,173 +2915,6 @@ button {
     width: 26px;
     height: 26px;
     flex-shrink: 0;
-}
-
-.project-switcher-menu {
-    position: absolute;
-    bottom: 100%;
-    left: 0;
-    right: 0;
-    z-index: 9999;
-    margin-bottom: 4px;
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
-    background: var(--color-bg-secondary);
-    padding: 4px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-}
-
-.project-switcher-search {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin-bottom: 4px;
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    background: var(--color-bg-primary);
-    padding: 5px 8px;
-}
-
-.project-switcher-search-input {
-    flex: 1;
-    min-width: 0;
-    border: none;
-    background: transparent;
-    color: var(--color-text-primary);
-    font-family: inherit;
-    font-size: 12px;
-    outline: none;
-}
-
-.project-switcher-search-count {
-    flex-shrink: 0;
-    color: var(--color-text-secondary);
-    font-family: monospace;
-    font-size: 10px;
-}
-
-.project-switcher-list {
-    max-height: 240px;
-    overflow-y: auto;
-}
-
-.project-switcher-empty {
-    padding: 6px 8px 8px;
-    color: var(--color-text-secondary);
-    font-size: 12px;
-}
-
-.project-switcher-menu-item {
-    display: flex;
-    width: 100%;
-    align-items: center;
-    gap: 8px;
-    border-radius: 4px;
-    padding: 5px 10px;
-    font-size: 12px;
-    text-align: left;
-    color: var(--color-text-primary);
-    transition: background-color 100ms ease;
-}
-
-.project-switcher-menu-item:hover {
-    background: var(--color-bg-tertiary);
-}
-
-.project-switcher-check {
-    width: 12px;
-    flex-shrink: 0;
-    color: var(--color-accent);
-}
-
-.project-switcher-update-dot {
-    width: 6px;
-    height: 6px;
-    flex-shrink: 0;
-    border-radius: 999px;
-    background: linear-gradient(180deg, #f97316, #ef4444);
-}
-
-.project-switcher-sep {
-    height: 1px;
-    margin: 4px 0;
-    background: var(--color-border);
-}
-
-.project-switcher-clone {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 6px;
-}
-
-.project-switcher-clone-label {
-    color: var(--color-text-secondary);
-    font-size: 11px;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-
-.project-switcher-clone-input {
-    width: 100%;
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    background: var(--color-bg-primary);
-    padding: 6px 8px;
-    color: var(--color-text-primary);
-    font-family: inherit;
-    font-size: 12px;
-    outline: none;
-}
-
-.project-switcher-clone-input:focus {
-    border-color: var(--color-accent);
-}
-
-.project-switcher-clone-input:disabled {
-    opacity: 0.6;
-}
-
-.project-switcher-clone-error {
-    color: var(--color-danger, #f87171);
-    font-size: 11px;
-    line-height: 1.3;
-}
-
-.project-switcher-clone-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 6px;
-}
-
-.project-switcher-clone-btn {
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    background: var(--color-bg-primary);
-    padding: 4px 10px;
-    color: var(--color-text-primary);
-    font-size: 11px;
-    transition: background-color 100ms ease;
-}
-
-.project-switcher-clone-btn:hover:not(:disabled) {
-    background: var(--color-bg-tertiary);
-}
-
-.project-switcher-clone-btn:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
-}
-
-.project-switcher-clone-btn-primary {
-    border-color: var(--color-accent);
-    background: var(--color-accent);
-    color: var(--color-accent-foreground, #fff);
-}
-
-.project-switcher-clone-btn-primary:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--color-accent) 85%, black);
 }
 
 .tree-row {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -434,7 +434,7 @@
 .project-context-tab-shell {
     position: relative;
     display: flex;
-    min-width: 156px;
+    min-width: 180px;
     max-width: 364px;
     height: 26px;
     flex: 0 1 286px;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -720,9 +720,7 @@
 .project-context-worktree-row:focus-visible,
 .project-context-worktree-row[data-selected="true"],
 .project-context-menu-actions button:hover,
-.project-context-menu-actions button:focus-visible,
-.project-context-disclosure:hover,
-.project-context-disclosure:focus-visible {
+.project-context-menu-actions button:focus-visible {
     background: var(--color-accent-soft);
     outline: none;
 }
@@ -733,22 +731,6 @@
     flex: 0 0 auto;
     color: var(--color-text-secondary);
     font-size: 10px;
-}
-
-.project-context-disclosure {
-    display: grid;
-    width: 28px;
-    flex: 0 0 28px;
-    place-items: center;
-    border: 0;
-    border-radius: 6px;
-    background: transparent;
-    color: var(--color-text-secondary);
-    cursor: default;
-}
-
-.project-context-disclosure path {
-    transition: transform 120ms ease;
 }
 
 .project-context-worktree-list {
@@ -782,6 +764,26 @@
 .project-context-worktree-row:hover,
 .project-context-worktree-row:focus-visible {
     color: var(--color-text-primary);
+}
+
+.project-context-new-worktree-trigger {
+    flex: 0 0 auto;
+    margin: 4px 5px 4px 0;
+    border: 0;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--color-text-secondary);
+    cursor: default;
+    font: inherit;
+    font-size: 10px;
+    padding: 3px 5px;
+}
+
+.project-context-new-worktree-trigger:hover,
+.project-context-new-worktree-trigger:focus-visible {
+    background: var(--color-accent-soft);
+    color: var(--color-text-primary);
+    outline: none;
 }
 
 .project-context-branch-icon {
@@ -857,6 +859,22 @@
 
 .project-context-clone-form {
     padding: 16px;
+}
+
+.project-context-worktree-form {
+    padding: 16px;
+}
+
+.project-context-worktree-project {
+    margin: -3px 0 10px;
+    color: var(--color-text-secondary);
+    font-size: 11px;
+}
+
+.project-context-worktree-hint {
+    margin-top: 7px;
+    color: var(--color-text-secondary);
+    font-size: 11px;
 }
 
 .project-context-menu-heading {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -581,7 +581,6 @@
 }
 
 .project-context-menu-root {
-    position: relative;
     flex: 0 0 auto;
 }
 
@@ -604,42 +603,56 @@
     color: var(--color-text-primary);
 }
 
-.project-context-menu {
+.project-context-menu-backdrop {
     position: fixed;
     z-index: 80;
-    top: 38px;
-    width: min(340px, calc(100vw - 16px));
-    max-height: min(560px, calc(100vh - 52px));
-    overflow: hidden;
-    border: 1px solid var(--color-border);
-    border-radius: 10px;
-    background: color-mix(in srgb, var(--color-bg-elevated) 94%, transparent);
-    box-shadow: var(--shadow-soft);
-    padding: 6px;
-    backdrop-filter: blur(22px) saturate(135%);
+    inset: 0;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    background: color-mix(in srgb, var(--color-bg-primary) 72%, transparent);
+    padding: clamp(56px, 15vh, 160px) 16px 24px;
+    backdrop-filter: blur(10px);
 }
 
-:root[data-transparency-enabled="false"] .project-context-menu {
+.project-context-menu {
+    width: min(620px, 100%);
+    max-height: min(620px, calc(100vh - 80px));
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+    border-radius: 12px;
     background: var(--color-bg-elevated);
+    box-shadow:
+        0 24px 80px rgb(0 0 0 / 0.22),
+        0 0 0 1px color-mix(in srgb, var(--color-border) 40%, transparent);
+    padding: 0;
+}
+
+:root[data-transparency-enabled="false"] .project-context-menu-backdrop {
     backdrop-filter: none;
 }
 
 .project-context-search-shell {
     display: flex;
     width: 100%;
-    height: 32px;
+    height: 42px;
     align-items: center;
     gap: 7px;
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    background: color-mix(in srgb, var(--color-bg-primary) 72%, transparent);
+    border: 0;
+    border-bottom: 1px solid var(--color-border-subtle);
+    border-radius: 0;
+    background: transparent;
     color: var(--color-text-secondary);
-    padding: 0 8px;
+    padding: 0 14px;
 }
 
 .project-context-search-shell:focus-within {
-    border-color: color-mix(in srgb, var(--color-accent) 72%, transparent);
-    box-shadow: 0 0 0 1px
+    border-bottom-color: color-mix(
+        in srgb,
+        var(--color-accent) 58%,
+        var(--color-border)
+    );
+    box-shadow: inset 0 -1px 0
         color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 
@@ -660,8 +673,10 @@
 }
 
 .project-context-project-list {
-    max-height: min(390px, calc(100vh - 170px));
-    margin-top: 5px;
+    max-height: min(390px, calc(100vh - 220px));
+    min-height: 146px;
+    margin: 0;
+    padding: 8px;
     overflow-y: auto;
     overscroll-behavior: contain;
     scrollbar-width: thin;
@@ -700,8 +715,10 @@
 
 .project-context-project-main:hover,
 .project-context-project-main:focus-visible,
+.project-context-project-main[data-selected="true"],
 .project-context-worktree-row:hover,
 .project-context-worktree-row:focus-visible,
+.project-context-worktree-row[data-selected="true"],
 .project-context-menu-actions button:hover,
 .project-context-menu-actions button:focus-visible,
 .project-context-disclosure:hover,
@@ -798,6 +815,9 @@
 }
 
 .project-context-menu-empty {
+    display: grid;
+    min-height: 130px;
+    place-items: center;
     padding: 22px 12px;
     color: var(--color-text-secondary);
     font-size: 12px;
@@ -806,13 +826,14 @@
 
 .project-context-menu-separator {
     height: 1px;
-    margin: 5px 4px;
+    margin: 0;
     background: var(--color-border-subtle);
 }
 
 .project-context-menu-actions {
-    display: grid;
-    gap: 1px;
+    display: flex;
+    gap: 2px;
+    padding: 7px 8px;
 }
 
 .project-context-menu-actions button {
@@ -820,7 +841,9 @@
     min-height: 30px;
     align-items: center;
     gap: 7px;
-    padding: 5px 8px 5px 26px;
+    padding: 5px 9px;
+    color: var(--color-text-secondary);
+    font-size: 11px;
 }
 
 .project-context-update-dot {
@@ -833,7 +856,7 @@
 }
 
 .project-context-clone-form {
-    padding: 6px;
+    padding: 16px;
 }
 
 .project-context-menu-heading {
@@ -877,6 +900,15 @@
     background: var(--color-bg-panel);
     color: var(--color-text-primary);
     padding: 0 10px;
+}
+
+.project-context-menu-footer {
+    display: flex;
+    justify-content: flex-end;
+    border-top: 1px solid color-mix(in srgb, var(--color-border) 50%, transparent);
+    padding: 6px 14px;
+    color: color-mix(in srgb, var(--color-text-secondary) 70%, transparent);
+    font-size: 11px;
 }
 
 * {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -471,6 +471,19 @@
     color: var(--color-text-primary);
 }
 
+.project-context-tab-shell[data-dragging="true"] {
+    cursor: grabbing;
+    opacity: 0.4;
+}
+
+.project-context-tab-shell[data-drop-position="before"] {
+    box-shadow: inset 2px 0 var(--color-accent);
+}
+
+.project-context-tab-shell[data-drop-position="after"] {
+    box-shadow: inset -2px 0 var(--color-accent);
+}
+
 :root[data-transparency-enabled="false"] .project-context-tab-shell[data-active] {
     background: var(--color-bg-elevated);
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -434,10 +434,10 @@
 .project-context-tab-shell {
     position: relative;
     display: flex;
-    min-width: 120px;
-    max-width: 280px;
+    min-width: 156px;
+    max-width: 364px;
     height: 26px;
-    flex: 0 1 220px;
+    flex: 0 1 286px;
     align-items: center;
     overflow: hidden;
     border: 1px solid

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -395,6 +395,444 @@
     border-bottom: 1px solid var(--color-border-subtle);
 }
 
+.project-context-titlebar {
+    min-width: 0;
+    gap: 6px;
+    overflow: hidden;
+    border-bottom: 1px solid
+        color-mix(in srgb, var(--color-border) 42%, transparent);
+}
+
+.project-context-tabs {
+    display: flex;
+    width: max-content;
+    min-width: 0;
+    max-width: min(72vw, 980px, calc(100% - 40px));
+    height: 32px;
+    flex: 0 1 auto;
+    align-items: center;
+    gap: 3px;
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+.project-context-tabs::-webkit-scrollbar {
+    display: none;
+}
+
+.project-context-tab-shell {
+    position: relative;
+    display: flex;
+    min-width: 118px;
+    max-width: 220px;
+    height: 30px;
+    flex: 0 1 190px;
+    align-items: center;
+    overflow: hidden;
+    border: 1px solid
+        color-mix(in srgb, var(--color-border) 26%, transparent);
+    border-radius: 7px;
+    background: color-mix(
+        in srgb,
+        var(--color-bg-elevated) 22%,
+        transparent
+    );
+    color: var(--color-text-secondary);
+    transition:
+        background-color 120ms ease,
+        border-color 120ms ease,
+        color 120ms ease;
+}
+
+.project-context-tab-shell:hover {
+    border-color: color-mix(
+        in srgb,
+        var(--color-border-strong) 42%,
+        transparent
+    );
+    background: color-mix(in srgb, var(--color-bg-elevated) 42%, transparent);
+    color: var(--color-text-primary);
+}
+
+.project-context-tab-shell[data-active] {
+    border-color: color-mix(
+        in srgb,
+        var(--color-border-strong) 62%,
+        transparent
+    );
+    background: color-mix(in srgb, var(--color-bg-elevated) 68%, transparent);
+    color: var(--color-text-primary);
+    box-shadow: 0 1px 7px color-mix(in srgb, #000 10%, transparent);
+}
+
+:root[data-transparency-enabled="false"] .project-context-tab-shell[data-active] {
+    background: var(--color-bg-elevated);
+}
+
+:root[data-transparency-enabled="false"] .project-context-tab-shell:not([data-active]) {
+    background: var(--color-bg-panel);
+}
+
+.project-context-tab {
+    display: flex;
+    min-width: 0;
+    height: 100%;
+    flex: 1;
+    align-items: center;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: default;
+    padding: 0 27px 0 10px;
+    text-align: left;
+}
+
+.project-context-tab-copy {
+    display: flex;
+    min-width: 0;
+    flex: 1;
+    flex-direction: column;
+    line-height: 1.05;
+}
+
+.project-context-tab-title,
+.project-context-tab-subtitle {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.project-context-tab-title {
+    font-size: 11.5px;
+    font-weight: 570;
+}
+
+.project-context-tab-subtitle {
+    margin-top: 2px;
+    color: var(--color-text-secondary);
+    font-size: 9.5px;
+}
+
+.project-context-tab-close {
+    position: absolute;
+    right: 5px;
+    display: grid;
+    width: 20px;
+    height: 20px;
+    place-items: center;
+    border: 0;
+    border-radius: 5px;
+    background: transparent;
+    color: currentColor;
+    cursor: default;
+    opacity: 0;
+}
+
+.project-context-tab-shell:hover .project-context-tab-close,
+.project-context-tab-shell[data-active] .project-context-tab-close,
+.project-context-tab-close:focus-visible {
+    opacity: 0.72;
+}
+
+.project-context-tab-close:hover {
+    background: color-mix(in srgb, var(--color-text-primary) 10%, transparent);
+    opacity: 1;
+}
+
+.project-context-tab:focus-visible,
+.project-context-tab-close:focus-visible,
+.project-context-add:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
+}
+
+.project-context-menu-root {
+    position: relative;
+    flex: 0 0 auto;
+}
+
+.project-context-add {
+    display: grid;
+    width: 28px;
+    height: 28px;
+    place-items: center;
+    border: 1px solid transparent;
+    border-radius: 7px;
+    background: transparent;
+    color: var(--color-text-secondary);
+    cursor: default;
+}
+
+.project-context-add:hover,
+.project-context-add[aria-expanded="true"] {
+    border-color: color-mix(in srgb, var(--color-border) 55%, transparent);
+    background: color-mix(in srgb, var(--color-bg-elevated) 56%, transparent);
+    color: var(--color-text-primary);
+}
+
+.project-context-menu {
+    position: fixed;
+    z-index: 80;
+    top: 38px;
+    width: min(340px, calc(100vw - 16px));
+    max-height: min(560px, calc(100vh - 52px));
+    overflow: hidden;
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--color-bg-elevated) 94%, transparent);
+    box-shadow: var(--shadow-soft);
+    padding: 6px;
+    backdrop-filter: blur(22px) saturate(135%);
+}
+
+:root[data-transparency-enabled="false"] .project-context-menu {
+    background: var(--color-bg-elevated);
+    backdrop-filter: none;
+}
+
+.project-context-search-shell {
+    display: flex;
+    width: 100%;
+    height: 32px;
+    align-items: center;
+    gap: 7px;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--color-bg-primary) 72%, transparent);
+    color: var(--color-text-secondary);
+    padding: 0 8px;
+}
+
+.project-context-search-shell:focus-within {
+    border-color: color-mix(in srgb, var(--color-accent) 72%, transparent);
+    box-shadow: 0 0 0 1px
+        color-mix(in srgb, var(--color-accent) 18%, transparent);
+}
+
+.project-context-search-shell input {
+    min-width: 0;
+    height: 100%;
+    flex: 1;
+    border: 0;
+    background: transparent;
+    color: var(--color-text-primary);
+    font: inherit;
+    outline: none;
+}
+
+.project-context-search-shell > span {
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+}
+
+.project-context-project-list {
+    max-height: min(390px, calc(100vh - 170px));
+    margin-top: 5px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+}
+
+.project-context-project-group + .project-context-project-group {
+    margin-top: 1px;
+}
+
+.project-context-project-row {
+    display: flex;
+    align-items: stretch;
+}
+
+.project-context-project-main,
+.project-context-worktree-row,
+.project-context-menu-actions button {
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--color-text-primary);
+    cursor: default;
+    font: inherit;
+    text-align: left;
+}
+
+.project-context-project-main {
+    display: flex;
+    min-width: 0;
+    min-height: 32px;
+    flex: 1;
+    align-items: center;
+    gap: 7px;
+    padding: 5px 5px 5px 7px;
+}
+
+.project-context-project-main:hover,
+.project-context-project-main:focus-visible,
+.project-context-worktree-row:hover,
+.project-context-worktree-row:focus-visible,
+.project-context-menu-actions button:hover,
+.project-context-menu-actions button:focus-visible,
+.project-context-disclosure:hover,
+.project-context-disclosure:focus-visible {
+    background: var(--color-accent-soft);
+    outline: none;
+}
+
+.project-context-menu-hint,
+.project-context-open-label {
+    margin-left: auto;
+    flex: 0 0 auto;
+    color: var(--color-text-secondary);
+    font-size: 10px;
+}
+
+.project-context-disclosure {
+    display: grid;
+    width: 28px;
+    flex: 0 0 28px;
+    place-items: center;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--color-text-secondary);
+    cursor: default;
+}
+
+.project-context-disclosure path {
+    transition: transform 120ms ease;
+}
+
+.project-context-worktree-list {
+    position: relative;
+    margin: 0 4px 2px 16px;
+    padding-left: 10px;
+}
+
+.project-context-worktree-list::before {
+    position: absolute;
+    top: 1px;
+    bottom: 4px;
+    left: 4px;
+    width: 1px;
+    background: color-mix(in srgb, var(--color-border) 72%, transparent);
+    content: "";
+}
+
+.project-context-worktree-row {
+    position: relative;
+    display: flex;
+    width: 100%;
+    min-height: 29px;
+    align-items: center;
+    gap: 7px;
+    padding: 4px 7px;
+    color: var(--color-text-secondary);
+    font-size: 12px;
+}
+
+.project-context-worktree-row:hover,
+.project-context-worktree-row:focus-visible {
+    color: var(--color-text-primary);
+}
+
+.project-context-branch-icon {
+    flex: 0 0 auto;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    opacity: 0.7;
+}
+
+.project-context-state-indicator {
+    position: relative;
+    display: grid;
+    width: 14px;
+    height: 14px;
+    flex: 0 0 14px;
+    place-items: center;
+    color: var(--color-accent);
+    font-size: 11px;
+    font-weight: 650;
+}
+
+.project-context-state-indicator[data-open]:not([data-active])::after {
+    width: 5px;
+    height: 5px;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    background: var(--color-accent);
+    content: "";
+    opacity: 0.72;
+}
+
+.project-context-menu-empty {
+    padding: 22px 12px;
+    color: var(--color-text-secondary);
+    font-size: 12px;
+    text-align: center;
+}
+
+.project-context-menu-separator {
+    height: 1px;
+    margin: 5px 4px;
+    background: var(--color-border-subtle);
+}
+
+.project-context-menu-actions {
+    display: grid;
+    gap: 1px;
+}
+
+.project-context-menu-actions button {
+    min-height: 30px;
+    padding: 5px 8px 5px 26px;
+}
+
+.project-context-clone-form {
+    padding: 6px;
+}
+
+.project-context-menu-heading {
+    margin-bottom: 8px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.project-context-clone-input {
+    width: 100%;
+    height: 30px;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg-primary);
+    color: var(--color-text-primary);
+    padding: 0 8px;
+    outline: none;
+}
+
+.project-context-clone-input:focus {
+    border-color: var(--color-accent);
+}
+
+.project-context-clone-error {
+    margin-top: 6px;
+    color: var(--diff-remove);
+    font-size: 11px;
+}
+
+.project-context-clone-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 6px;
+    margin-top: 8px;
+}
+
+.project-context-clone-actions button {
+    min-height: 27px;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg-panel);
+    color: var(--color-text-primary);
+    padding: 0 10px;
+}
+
 * {
     box-sizing: border-box;
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -437,7 +437,7 @@
     min-width: 180px;
     max-width: 364px;
     height: 26px;
-    flex: 0 0 286px;
+    flex: 0 0 240px;
     align-items: center;
     overflow: hidden;
     border: 1px solid

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -268,6 +268,7 @@
 
 :root {
     color-scheme: light;
+    --chrome-background-opacity: calc(100% - var(--chrome-transparency, 45%));
     font-family: var(--font-sans);
     --sidebar-list-scale: 1;
     --agents-sidebar-scale: var(--sidebar-list-scale);
@@ -359,7 +360,7 @@
     --desktop-titlebar-height: 40px;
     --windows-acrylic-tint: color-mix(
         in srgb,
-        var(--color-bg-panel) 55%,
+        var(--color-bg-panel) var(--chrome-background-opacity),
         transparent
     );
     background: transparent;
@@ -373,6 +374,16 @@
 :root[data-platform="win32"] .desktop-titlebar,
 :root[data-platform="win32"] .settings-chrome {
     background: var(--windows-acrylic-tint);
+}
+
+:root[data-platform="darwin"] .app-sidebar,
+:root[data-platform="darwin"] .desktop-titlebar,
+:root[data-platform="darwin"] .settings-chrome {
+    background: color-mix(
+        in srgb,
+        var(--color-bg-panel) var(--chrome-background-opacity),
+        transparent
+    );
 }
 
 :root[data-transparency-enabled="false"],

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2887,8 +2887,8 @@ button {
     position: static;
     top: auto;
     right: auto;
-    width: 28px;
-    height: 28px;
+    width: 26px;
+    height: 26px;
     flex-shrink: 0;
 }
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -419,10 +419,10 @@
     width: max-content;
     min-width: 0;
     max-width: min(72vw, 980px, calc(100% - 40px));
-    height: 32px;
+    height: 28px;
     flex: 0 1 auto;
     align-items: center;
-    gap: 3px;
+    gap: 4px;
     overflow-x: auto;
     scrollbar-width: none;
 }
@@ -434,20 +434,16 @@
 .project-context-tab-shell {
     position: relative;
     display: flex;
-    min-width: 118px;
-    max-width: 220px;
-    height: 30px;
-    flex: 0 1 190px;
+    min-width: 120px;
+    max-width: 280px;
+    height: 26px;
+    flex: 0 1 220px;
     align-items: center;
     overflow: hidden;
     border: 1px solid
-        color-mix(in srgb, var(--color-border) 26%, transparent);
-    border-radius: 7px;
-    background: color-mix(
-        in srgb,
-        var(--color-bg-elevated) 22%,
-        transparent
-    );
+        color-mix(in srgb, var(--color-border) 30%, transparent);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--color-bg-elevated) 26%, transparent);
     color: var(--color-text-secondary);
     transition:
         background-color 120ms ease,
@@ -458,22 +454,21 @@
 .project-context-tab-shell:hover {
     border-color: color-mix(
         in srgb,
-        var(--color-border-strong) 42%,
+        var(--color-border-strong) 44%,
         transparent
     );
-    background: color-mix(in srgb, var(--color-bg-elevated) 42%, transparent);
+    background: color-mix(in srgb, var(--color-bg-elevated) 44%, transparent);
     color: var(--color-text-primary);
 }
 
 .project-context-tab-shell[data-active] {
     border-color: color-mix(
         in srgb,
-        var(--color-border-strong) 62%,
+        var(--color-border-strong) 60%,
         transparent
     );
-    background: color-mix(in srgb, var(--color-bg-elevated) 68%, transparent);
+    background: color-mix(in srgb, var(--color-bg-elevated) 66%, transparent);
     color: var(--color-text-primary);
-    box-shadow: 0 1px 7px color-mix(in srgb, #000 10%, transparent);
 }
 
 :root[data-transparency-enabled="false"] .project-context-tab-shell[data-active] {
@@ -482,6 +477,20 @@
 
 :root[data-transparency-enabled="false"] .project-context-tab-shell:not([data-active]) {
     background: var(--color-bg-panel);
+}
+
+.project-context-tab-icon {
+    display: grid;
+    width: 16px;
+    height: 16px;
+    flex: 0 0 auto;
+    place-items: center;
+    margin: 0 5px 0 6px;
+    border-radius: 5px;
+    color: #fff;
+    font-size: 9.5px;
+    font-weight: 700;
+    line-height: 1;
 }
 
 .project-context-tab {
@@ -494,45 +503,46 @@
     background: transparent;
     color: inherit;
     cursor: default;
-    padding: 0 27px 0 10px;
+    padding: 0 20px 0 0;
     text-align: left;
 }
 
 .project-context-tab-copy {
-    display: flex;
+    display: block;
     min-width: 0;
     flex: 1;
-    flex-direction: column;
-    line-height: 1.05;
-}
-
-.project-context-tab-title,
-.project-context-tab-subtitle {
     overflow: hidden;
-    text-overflow: ellipsis;
     white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .project-context-tab-title {
-    font-size: 11.5px;
-    font-weight: 570;
+    font-size: 11px;
+    font-weight: 600;
 }
 
 .project-context-tab-subtitle {
-    margin-top: 2px;
+    margin-left: 5px;
     color: var(--color-text-secondary);
-    font-size: 9.5px;
+    font-size: 10px;
+    font-weight: 450;
+}
+
+.project-context-tab-subtitle::before {
+    margin-right: 5px;
+    color: color-mix(in srgb, var(--color-text-secondary) 60%, transparent);
+    content: "·";
 }
 
 .project-context-tab-close {
     position: absolute;
-    right: 5px;
+    right: 4px;
     display: grid;
-    width: 20px;
-    height: 20px;
+    width: 16px;
+    height: 16px;
     place-items: center;
     border: 0;
-    border-radius: 5px;
+    border-radius: 4px;
     background: transparent;
     color: currentColor;
     cursor: default;
@@ -564,11 +574,11 @@
 
 .project-context-add {
     display: grid;
-    width: 28px;
-    height: 28px;
+    width: 24px;
+    height: 24px;
     place-items: center;
     border: 1px solid transparent;
-    border-radius: 7px;
+    border-radius: 6px;
     background: transparent;
     color: var(--color-text-secondary);
     cursor: default;
@@ -2156,6 +2166,72 @@ button {
     font-size: 13px;
     font-weight: 600;
     color: var(--color-text-primary);
+}
+
+.sidebar-git-scope-picker--titlebar {
+    display: flex;
+    min-width: 0;
+    flex: 1;
+    align-self: stretch;
+}
+
+.sidebar-git-scope-trigger--titlebar {
+    min-width: 0;
+    height: 100%;
+    flex: 1;
+    gap: 4px;
+    border: 0;
+    border-radius: inherit;
+    background: transparent;
+    padding: 0 20px 0 0;
+    color: inherit;
+    text-align: left;
+    transform: none;
+}
+
+.sidebar-git-scope-trigger--titlebar:hover,
+.sidebar-git-scope-trigger--titlebar:active:not(:disabled),
+.sidebar-git-scope-trigger--titlebar.sidebar-git-scope-trigger--open {
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    color: inherit;
+    transform: none;
+}
+
+.sidebar-git-scope-trigger__titlebar-copy {
+    display: block;
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.sidebar-git-scope-trigger__titlebar-project {
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.sidebar-git-scope-trigger__titlebar-branch {
+    margin-left: 5px;
+    color: var(--color-text-secondary);
+    font-size: 10px;
+    font-weight: 450;
+}
+
+.sidebar-git-scope-trigger__titlebar-branch::before {
+    margin-right: 5px;
+    color: color-mix(in srgb, var(--color-text-secondary) 60%, transparent);
+    content: "·";
+}
+
+.sidebar-git-scope-trigger--titlebar > svg {
+    width: 10px;
+    height: 10px;
+    flex: 0 0 auto;
+    margin-right: 1px;
+    color: var(--color-text-secondary);
 }
 
 .sidebar-git-scope-menu {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -437,7 +437,7 @@
     min-width: 180px;
     max-width: 364px;
     height: 26px;
-    flex: 0 0 240px;
+    flex: 0 0 220px;
     align-items: center;
     overflow: hidden;
     border: 1px solid

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -416,11 +416,11 @@
 
 .project-context-tabs {
     display: flex;
-    width: max-content;
+    width: auto;
     min-width: 0;
-    max-width: min(72vw, 980px, calc(100% - 40px));
+    max-width: none;
     height: 28px;
-    flex: 0 1 auto;
+    flex: 1 1 auto;
     align-items: center;
     gap: 4px;
     overflow-x: auto;
@@ -437,7 +437,7 @@
     min-width: 180px;
     max-width: 364px;
     height: 26px;
-    flex: 0 1 286px;
+    flex: 0 0 286px;
     align-items: center;
     overflow: hidden;
     border: 1px solid

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -462,12 +462,8 @@
 }
 
 .project-context-tab-shell[data-active] {
-    border-color: color-mix(
-        in srgb,
-        var(--color-border-strong) 60%,
-        transparent
-    );
-    background: color-mix(in srgb, var(--color-bg-elevated) 66%, transparent);
+    border-color: color-mix(in srgb, var(--color-accent) 48%, transparent);
+    background: color-mix(in srgb, var(--color-bg-elevated) 78%, transparent);
     color: var(--color-text-primary);
 }
 

--- a/src/shared/chrome-transparency.ts
+++ b/src/shared/chrome-transparency.ts
@@ -1,0 +1,10 @@
+export const CHROME_TRANSPARENCY_DEFAULT = 45;
+export const CHROME_TRANSPARENCY_MIN = 0;
+export const CHROME_TRANSPARENCY_MAX = 80;
+
+export function clampChromeTransparency(value: number): number {
+    return Math.min(
+        CHROME_TRANSPARENCY_MAX,
+        Math.max(CHROME_TRANSPARENCY_MIN, value),
+    );
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -180,6 +180,8 @@ export const IPC_EVENTS = {
     projectSettingsUpdated: "settings:project-updated",
     workspaceCloseActiveTab: "workspace:close-active-tab",
     workspaceReopenLastClosedTab: "workspace:reopen-last-closed-tab",
+    workspaceFlushRequested: "workspace:flush-requested",
+    workspaceFlushAcknowledged: "workspace:flush-acknowledged",
     gitRepositoryInvalidated: "git:repository-invalidated",
     gitRepositorySnapshotUpdated: "git:repository-snapshot-updated",
     gitWorktreesUpdated: "git:worktrees-updated",
@@ -2097,6 +2099,13 @@ export interface WorkspaceNavigationSnapshot {
     readonly version: 2;
 }
 
+export interface WindowWorkspaceRestoreRecord {
+    readonly revision: number;
+    readonly schemaVersion: 1;
+    readonly snapshot: WorkspaceNavigationSnapshot;
+    readonly updatedAt: string;
+}
+
 export type PersistedWorkspaceSnapshot =
     | WorkspaceLayoutSnapshot
     | WorkspaceNavigationSnapshot;
@@ -3272,6 +3281,9 @@ export interface ComandoApi {
     ) => () => void;
     onWorkspaceCloseActiveTab: (listener: () => void) => () => void;
     onWorkspaceReopenLastClosedTab: (listener: () => void) => () => void;
+    onWorkspaceFlushRequested: (
+        listener: () => Promise<void> | void,
+    ) => () => void;
     onTerminalData: (
         listener: (event: TerminalDataEvent) => void,
     ) => () => void;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -22,6 +22,7 @@ export const IPC_CHANNELS = {
     openGeneratedImage: "app:open-generated-image",
     revealGeneratedImage: "app:reveal-generated-image",
     openProjectWindow: "app:open-project-window",
+    confirmWorkspaceClose: "workspace:confirm-close",
     checkCommandAvailability: "app:check-command-availability",
     readClaudeCodeTranscript: "app:read-claude-code-transcript",
     getSettingsSnapshot: "settings:get-snapshot",
@@ -2897,6 +2898,12 @@ export interface AiTrackedFileHunkMutationInput {
     readonly trackedFileId?: string | null;
 }
 
+export interface ConfirmWorkspaceCloseInput {
+    readonly activeAgentCount: number;
+    readonly dirtyFileCount: number;
+    readonly workspaceName: string;
+}
+
 export interface ComandoApi {
     getBootstrapSnapshot: () => Promise<AppBootstrapSnapshot>;
     getAppUpdateState: () => Promise<AppUpdateState>;
@@ -2913,6 +2920,9 @@ export interface ComandoApi {
     openGeneratedImage: (path: string) => Promise<void>;
     revealGeneratedImage: (path: string) => Promise<void>;
     openProjectWindow: (input: OpenProjectWindowInput) => Promise<void>;
+    confirmWorkspaceClose: (
+        input: ConfirmWorkspaceCloseInput,
+    ) => Promise<boolean>;
     checkCommandAvailability: (
         input: CheckCommandAvailabilityInput,
     ) => Promise<CheckCommandAvailabilityResult>;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -241,6 +241,7 @@ export interface AppAiChatSettings {
 export interface AppAppearanceSettings {
     readonly agentsSidebarScale: number;
     readonly boostCodeContrast: boolean;
+    readonly chromeTransparency: number;
     readonly fileTreeScale: number;
     readonly stickyFoldersEnabled: boolean;
     readonly themeMode: ThemeMode;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -675,6 +675,7 @@ export interface OpenProjectWindowInput {
     readonly branchName?: string | null;
     readonly forceNewWindow?: boolean;
     readonly projectId: string;
+    readonly workspaceSnapshot?: WorkspaceNavigationSnapshot;
     readonly worktreeId?: string | null;
 }
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -2069,11 +2069,35 @@ export type WorkspaceTab =
     | WorkspaceReviewTab
     | WorkspaceTerminalTab;
 
-export interface WorkspaceSnapshot {
+export interface WorkspaceLayoutSnapshot {
     readonly activePaneId: string;
     readonly rootNode: WorkspaceNode;
     readonly tabs: readonly WorkspaceTab[];
 }
+
+// Kept as an alias while persisted v1 layouts are migrated to navigation v2.
+export type WorkspaceSnapshot = WorkspaceLayoutSnapshot;
+
+export type WorkspaceContextKey = string;
+
+export interface PersistedWorkspaceContext {
+    readonly key: WorkspaceContextKey;
+    readonly lastActivatedAt: string;
+    readonly projectId: string;
+    readonly workspace: WorkspaceLayoutSnapshot;
+    readonly worktreeId: string | null;
+}
+
+export interface WorkspaceNavigationSnapshot {
+    readonly activeContextKey: WorkspaceContextKey | null;
+    readonly contexts: readonly PersistedWorkspaceContext[];
+    readonly openContextKeys: readonly WorkspaceContextKey[];
+    readonly version: 2;
+}
+
+export type PersistedWorkspaceSnapshot =
+    | WorkspaceLayoutSnapshot
+    | WorkspaceNavigationSnapshot;
 
 export interface PersistedChatSessionState {
     readonly draft: string;
@@ -3118,8 +3142,10 @@ export interface ComandoApi {
         input: OpenProjectEntryExternallyInput,
     ) => Promise<void>;
     revealProjectEntry: (input: RevealProjectEntryInput) => Promise<void>;
-    getWorkspaceSnapshot: () => Promise<WorkspaceSnapshot>;
-    saveWorkspaceSnapshot: (snapshot: WorkspaceSnapshot) => Promise<void>;
+    getWorkspaceSnapshot: () => Promise<PersistedWorkspaceSnapshot>;
+    saveWorkspaceSnapshot: (
+        snapshot: WorkspaceNavigationSnapshot,
+    ) => Promise<void>;
     notifyFileBuffer: (input: FileBufferNotificationInput) => Promise<void>;
     getChatSessionState: (
         sessionId: string,

--- a/src/shared/workspace-restore.test.ts
+++ b/src/shared/workspace-restore.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    normalizeWindowWorkspaceRestoreRecord,
+    normalizeWorkspaceNavigationSnapshot,
+} from "./workspace-restore";
+
+describe("workspace restore normalization", () => {
+    it("migrates a legacy layout into the supplied window scope", () => {
+        const result = normalizeWorkspaceNavigationSnapshot(
+            {
+                activePaneId: "pane-root",
+                rootNode: {
+                    activeTabId: "file-1",
+                    id: "pane-root",
+                    tabIds: ["file-1"],
+                    type: "pane",
+                },
+                tabs: [
+                    {
+                        createdAt: "2026-01-01T00:00:00.000Z",
+                        id: "file-1",
+                        kind: "file",
+                        projectId: "project-1",
+                        relativePath: "README.md",
+                        title: "README.md",
+                    },
+                ],
+            },
+            { projectId: "project-1", worktreeId: "worktree-1" },
+        );
+
+        expect(result.snapshot.activeContextKey).toBe(
+            "project-1::worktree-1",
+        );
+        expect(result.snapshot.contexts).toHaveLength(1);
+    });
+
+    it("drops only an invalid context and repairs pane references", () => {
+        const result = normalizeWorkspaceNavigationSnapshot({
+            activeContextKey: "missing",
+            contexts: [
+                {
+                    key: "wrong-key",
+                    lastActivatedAt: "2026-01-01T00:00:00.000Z",
+                    projectId: "project-1",
+                    workspace: {
+                        activePaneId: "missing-pane",
+                        rootNode: {
+                            activeTabId: "missing-tab",
+                            id: "pane-root",
+                            pinnedTabIds: ["missing-tab"],
+                            tabIds: ["missing-tab"],
+                            type: "pane",
+                        },
+                        tabs: [],
+                    },
+                    worktreeId: null,
+                },
+                { key: "broken", projectId: "project-2" },
+            ],
+            openContextKeys: ["missing", "wrong-key"],
+            version: 2,
+        });
+
+        expect(result.droppedContextCount).toBe(1);
+        expect(result.snapshot.openContextKeys).toEqual([
+            "project-1::__primary__",
+        ]);
+        expect(result.snapshot.contexts[0]?.workspace).toMatchObject({
+            activePaneId: "pane-root",
+            rootNode: { activeTabId: null, pinnedTabIds: [], tabIds: [] },
+        });
+    });
+
+    it("preserves and normalizes restore revisions", () => {
+        const record = normalizeWindowWorkspaceRestoreRecord({
+            revision: 4.9,
+            schemaVersion: 1,
+            snapshot: {
+                activeContextKey: null,
+                contexts: [],
+                openContextKeys: [],
+                version: 2,
+            },
+            updatedAt: "2026-01-01T00:00:00.000Z",
+        });
+
+        expect(record.revision).toBe(4);
+        expect(record.schemaVersion).toBe(1);
+    });
+});

--- a/src/shared/workspace-restore.ts
+++ b/src/shared/workspace-restore.ts
@@ -1,0 +1,243 @@
+import type {
+    PersistedWorkspaceContext,
+    WindowWorkspaceRestoreRecord,
+    WorkspaceLayoutSnapshot,
+    WorkspaceNavigationSnapshot,
+    WorkspaceNode,
+    WorkspacePaneNode,
+    WorkspaceTab,
+} from "./ipc";
+
+export const WINDOW_WORKSPACE_RESTORE_SCHEMA_VERSION = 1 as const;
+
+export interface WorkspaceRestoreNormalizationResult {
+    readonly droppedContextCount: number;
+    readonly repaired: boolean;
+    readonly snapshot: WorkspaceNavigationSnapshot;
+}
+
+export function createEmptyWorkspaceLayoutSnapshot(): WorkspaceLayoutSnapshot {
+    return {
+        activePaneId: "pane-root",
+        rootNode: { activeTabId: null, id: "pane-root", tabIds: [], type: "pane" },
+        tabs: [],
+    };
+}
+
+export function createWindowWorkspaceRestoreRecord(
+    snapshot: WorkspaceNavigationSnapshot,
+    revision = 0,
+    updatedAt = new Date().toISOString(),
+): WindowWorkspaceRestoreRecord {
+    return { revision, schemaVersion: 1, snapshot, updatedAt };
+}
+
+export function normalizeWorkspaceNavigationSnapshot(
+    value: unknown,
+    fallbackScope: { readonly projectId?: string | null; readonly worktreeId?: string | null } = {},
+): WorkspaceRestoreNormalizationResult {
+    if (!isRecord(value) || value.version !== 2) {
+        const legacy = normalizeLayout(value);
+        const projectId = fallbackScope.projectId ?? firstTabProjectId(legacy);
+        if (!legacy || !projectId) {
+            return { droppedContextCount: 0, repaired: true, snapshot: emptyNavigation() };
+        }
+        const worktreeId = normalizePrimaryWorktree(
+            projectId,
+            fallbackScope.worktreeId ?? firstTabWorktreeId(legacy),
+        );
+        const key = workspaceContextKey(projectId, worktreeId);
+        return {
+            droppedContextCount: 0,
+            repaired: true,
+            snapshot: {
+                activeContextKey: key,
+                contexts: [{ key, lastActivatedAt: new Date().toISOString(), projectId, workspace: legacy, worktreeId }],
+                openContextKeys: [key],
+                version: 2,
+            },
+        };
+    }
+
+    const rawContexts = Array.isArray(value.contexts) ? value.contexts : [];
+    const contexts: PersistedWorkspaceContext[] = [];
+    const seen = new Set<string>();
+    let repaired = !Array.isArray(value.contexts) || !Array.isArray(value.openContextKeys);
+    for (const rawContext of rawContexts) {
+        const context = normalizeContext(rawContext);
+        if (!context || seen.has(context.key)) {
+            repaired = true;
+            continue;
+        }
+        seen.add(context.key);
+        contexts.push(context);
+        repaired ||= !isRecord(rawContext) || rawContext.key !== context.key;
+    }
+
+    const requestedKeys = Array.isArray(value.openContextKeys)
+        ? value.openContextKeys.filter((key): key is string => typeof key === "string")
+        : [];
+    const openContextKeys = requestedKeys.filter(
+        (key, index) => seen.has(key) && requestedKeys.indexOf(key) === index,
+    );
+    for (const context of contexts) {
+        if (!openContextKeys.includes(context.key)) openContextKeys.push(context.key);
+    }
+    const requestedActive = typeof value.activeContextKey === "string" ? value.activeContextKey : null;
+    const activeContextKey = requestedActive && openContextKeys.includes(requestedActive)
+        ? requestedActive
+        : (openContextKeys[0] ?? null);
+    repaired ||= activeContextKey !== requestedActive || contexts.length !== rawContexts.length;
+    return {
+        droppedContextCount: rawContexts.length - contexts.length,
+        repaired,
+        snapshot: { activeContextKey, contexts, openContextKeys, version: 2 },
+    };
+}
+
+export function normalizeWindowWorkspaceRestoreRecord(
+    value: unknown,
+    fallbackScope: { readonly projectId?: string | null; readonly worktreeId?: string | null } = {},
+): WindowWorkspaceRestoreRecord {
+    if (isRecord(value) && value.schemaVersion === 1 && typeof value.revision === "number") {
+        return createWindowWorkspaceRestoreRecord(
+            normalizeWorkspaceNavigationSnapshot(value.snapshot, fallbackScope).snapshot,
+            Math.max(0, Math.trunc(value.revision)),
+            typeof value.updatedAt === "string" ? value.updatedAt : new Date().toISOString(),
+        );
+    }
+    return createWindowWorkspaceRestoreRecord(
+        normalizeWorkspaceNavigationSnapshot(value, fallbackScope).snapshot,
+    );
+}
+
+function normalizeContext(value: unknown): PersistedWorkspaceContext | null {
+    if (!isRecord(value) || typeof value.projectId !== "string" || value.projectId.length === 0) return null;
+    const rawWorktreeId = typeof value.worktreeId === "string" ? value.worktreeId : null;
+    const worktreeId = normalizePrimaryWorktree(value.projectId, rawWorktreeId);
+    const workspace = normalizeLayout(value.workspace);
+    if (!workspace) return null;
+    const scopedWorkspace: WorkspaceLayoutSnapshot = {
+        ...workspace,
+        tabs: workspace.tabs.map((tab) => ({
+            ...tab,
+            projectId: value.projectId,
+            worktreeId,
+        })) as readonly WorkspaceTab[],
+    };
+    return {
+        key: workspaceContextKey(value.projectId, worktreeId),
+        lastActivatedAt: typeof value.lastActivatedAt === "string" ? value.lastActivatedAt : new Date().toISOString(),
+        projectId: value.projectId,
+        workspace: scopedWorkspace,
+        worktreeId,
+    };
+}
+
+function normalizeLayout(value: unknown): WorkspaceLayoutSnapshot | null {
+    if (!isRecord(value) || !Array.isArray(value.tabs)) return null;
+    const tabs = value.tabs.filter(isWorkspaceTab);
+    const rootNode = normalizeNode(
+        value.rootNode,
+        new Set(tabs.map((tab) => tab.id)),
+        new Set<string>(),
+        new Set<string>(),
+    );
+    if (!rootNode) return null;
+    const paneIds = collectPaneIds(rootNode);
+    return {
+        activePaneId: typeof value.activePaneId === "string" && paneIds.has(value.activePaneId)
+            ? value.activePaneId
+            : (paneIds.values().next().value ?? "pane-root"),
+        rootNode,
+        tabs,
+    };
+}
+
+function normalizeNode(
+    value: unknown,
+    tabIds: ReadonlySet<string>,
+    nodeIds: Set<string>,
+    ownedTabIds: Set<string>,
+): WorkspaceNode | null {
+    if (
+        !isRecord(value) ||
+        typeof value.id !== "string" ||
+        nodeIds.has(value.id)
+    ) return null;
+    nodeIds.add(value.id);
+    if (value.type === "pane") {
+        const ids = Array.isArray(value.tabIds)
+            ? value.tabIds.filter((id): id is string =>
+                  typeof id === "string" &&
+                  tabIds.has(id) &&
+                  !ownedTabIds.has(id),
+              )
+            : [];
+        const uniqueIds = [...new Set(ids)];
+        for (const id of uniqueIds) ownedTabIds.add(id);
+        const pinned = Array.isArray(value.pinnedTabIds)
+            ? value.pinnedTabIds.filter((id): id is string => typeof id === "string" && uniqueIds.includes(id))
+            : [];
+        return {
+            activeTabId: typeof value.activeTabId === "string" && uniqueIds.includes(value.activeTabId)
+                ? value.activeTabId
+                : (uniqueIds[0] ?? null),
+            id: value.id,
+            pinnedTabIds: [...new Set(pinned)],
+            tabIds: uniqueIds,
+            type: "pane",
+        } satisfies WorkspacePaneNode;
+    }
+    if (value.type !== "split" || !Array.isArray(value.children)) return null;
+    const children = value.children
+        .map((child) => normalizeNode(child, tabIds, nodeIds, ownedTabIds))
+        .filter((child): child is WorkspaceNode => child !== null);
+    if (children.length === 0) return null;
+    const sizes = Array.isArray(value.sizes) && value.sizes.length === children.length &&
+        value.sizes.every((size) => typeof size === "number" && size > 0)
+        ? value.sizes
+        : children.map(() => 1 / children.length);
+    return {
+        axis: value.axis === "vertical" ? "vertical" : "horizontal",
+        children,
+        id: value.id,
+        sizes,
+        type: "split",
+    };
+}
+
+function isWorkspaceTab(value: unknown): value is WorkspaceTab {
+    return isRecord(value) && typeof value.id === "string" &&
+        typeof value.kind === "string" && typeof value.title === "string";
+}
+
+function collectPaneIds(node: WorkspaceNode, output = new Set<string>()): Set<string> {
+    if (node.type === "pane") output.add(node.id);
+    else for (const child of node.children) collectPaneIds(child, output);
+    return output;
+}
+
+function firstTabProjectId(layout: WorkspaceLayoutSnapshot | null): string | null {
+    return layout?.tabs.find((tab) => typeof tab.projectId === "string" && tab.projectId.length > 0)?.projectId ?? null;
+}
+
+function firstTabWorktreeId(layout: WorkspaceLayoutSnapshot | null): string | null {
+    return layout?.tabs.find((tab) => typeof tab.worktreeId === "string")?.worktreeId ?? null;
+}
+
+function workspaceContextKey(projectId: string, worktreeId: string | null): string {
+    return `${projectId}::${worktreeId ?? "__primary__"}`;
+}
+
+function normalizePrimaryWorktree(projectId: string, worktreeId: string | null): string | null {
+    return worktreeId === `${projectId}:primary` ? null : worktreeId;
+}
+
+function emptyNavigation(): WorkspaceNavigationSnapshot {
+    return { activeContextKey: null, contexts: [], openContextKeys: [], version: 2 };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

Redesigns project and worktree navigation as persistent contexts in the title bar, each with its own independent workspace layout.

## Key changes

- Adds context tabs for projects and worktrees, with drag reordering and the option to detach them into a new window.
- Moves the project/worktree switcher into a centered modal with search and keyboard navigation.
- Allows creating worktrees from the switcher and opening them directly as contexts.
- Preserves and restores independent layouts per context, including projectless windows and app shutdown.
- Lazily loads active-context resources to avoid unnecessary work.
- Shows recent projects in empty panes.
- Normalizes the primary tree context and hardens close, refresh, and multi-window restore flows.
- Recovers live AI sessions evicted by the runtime before updating their controls.
- Keeps pending edits visible in the review panel.
- Updates the desktop chrome with compact avatar tabs, a persistent sidebar toggle, configurable transparency, and macOS alignment adjustments.
- Simplifies plan presentation in chat.

## Coverage

Adds or updates tests for workspace persistence and restoration, context tabs, dragging, the switcher, empty states, change review, and macOS controls.

## Validation

- Not run as part of this review.