### PR TITLE
fix(workspace): polish pane and project tabs

### DIFF
--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -375,7 +375,6 @@ export function DesktopTopBar({
                     onClose={() => setContextMenu(null)}
                 />
             ) : null}
-            <div className="min-w-4 flex-1" />
         </header>
     );
 }

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -2625,7 +2625,7 @@ function WorkspacePaneView({
                                                 ? "opacity-35"
                                                 : "",
                                             isActive
-                                                ? "z-10 bg-bg-primary font-medium text-text-primary shadow-[inset_0_2px_0_0_var(--color-accent),inset_0_-1px_0_0_var(--color-accent)] duration-0"
+                                                ? "z-10 bg-bg-primary font-medium text-text-primary shadow-[inset_0_-1px_0_0_var(--color-accent)] duration-0"
                                                 : "z-0 bg-bg-chrome text-text-secondary hover:bg-bg-tertiary hover:text-text-primary",
                                         ].join(" ")}
                                         data-workspace-tab-id={tab.id}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -420,7 +420,7 @@
     min-width: 0;
     max-width: none;
     height: 28px;
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     align-items: center;
     gap: 4px;
     overflow-x: auto;


### PR DESCRIPTION
## Summary

- remove the top accent highlight from active pane tabs
- keep the project add button next to the workspace tabs
- allow the workspace tab strip to use the full available titlebar width

## Validation

- `pnpm exec vitest run src/renderer/src/components/DesktopTopBar.test.tsx src/renderer/src/components/DesktopTopBar.context-menu.test.tsx`
- `pnpm run typecheck`
- ESLint on the changed TypeScript components
- `git diff --check`