### PR TITLE
fix(ai): stabilize agent control selection

### DIFF
--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -436,6 +436,79 @@ describe("AiService prepareSession", () => {
         });
     });
 
+    it("projects saved selections over the persisted runtime catalog", async () => {
+        const runtimeCatalog = {
+            availableCommands: [],
+            configOptions: [
+                createModelConfig("gpt-5.4-mini"),
+                createReasoningConfig("low"),
+            ],
+            modeId: "default",
+            modes: [
+                {
+                    description: null,
+                    id: "default",
+                    name: "Default",
+                },
+                {
+                    description: null,
+                    id: "full-access",
+                    name: "Full Access",
+                },
+            ],
+            modelId: "gpt-5.4-mini",
+            models: [
+                {
+                    description: null,
+                    id: "gpt-5.4-mini",
+                    name: "GPT 5.4 Mini",
+                },
+                {
+                    description: null,
+                    id: "gpt-5.5",
+                    name: "GPT 5.5",
+                },
+            ],
+        };
+        const service = createPrepareService({
+            nativeAi: createNativeAi({
+                getRuntimeStatus: vi.fn(() => Promise.resolve(readyStatus)),
+            }),
+            persistence: {
+                loadLatestRuntimeCatalog: vi.fn(() => runtimeCatalog),
+                loadRuntimeSelectionPreferences: vi.fn(() => ({
+                    configOptions: {
+                        model: "gpt-5.5",
+                        reasoning_effort: "high",
+                    },
+                    modeId: "full-access",
+                    modelId: "gpt-5.5",
+                })),
+                loadSessionSnapshot: vi.fn(() => null),
+                saveRuntimeSelectionPreferenceOption: vi.fn(),
+                saveRuntimeModePreference: vi.fn(),
+                saveRuntimeModelPreference: vi.fn(),
+                saveSessionSnapshot: vi.fn(),
+            } as never,
+        });
+
+        const status = await service.getRuntimeStatus("codex");
+
+        expect(status).toMatchObject({
+            modeId: "full-access",
+            modelId: "gpt-5.5",
+        });
+        expect(
+            status.configOptions?.find((option) => option.id === "model")
+                ?.value,
+        ).toBe("gpt-5.5");
+        expect(
+            status.configOptions?.find(
+                (option) => option.id === "reasoning_effort",
+            )?.value,
+        ).toBe("high");
+    });
+
     it("normalizes restored active snapshots before native startup", async () => {
         const persistedSnapshot = createSnapshot({
             activeTurnStartedAt: "2026-04-15T22:23:13.000Z",

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -84,6 +84,7 @@ import {
     createEmptyAiSessionSnapshot,
     type AiPersistenceGateway,
     type PersistedRuntimeCatalogSnapshot,
+    type PersistedRuntimeSelectionPreferences,
 } from "./persistence";
 import { createAiEnvironmentDiagnostics } from "./environment-diagnostics";
 import { AiPromptQueue } from "./prompt-queue";
@@ -618,7 +619,7 @@ export class AiService {
     }
 
     handleNativeRuntimeStatus(status: AiRuntimeStatus): void {
-        this.#onRuntimeStatus(status);
+        this.#onRuntimeStatus(this.#withPersistedRuntimeCatalog(status));
     }
 
     handleNativeSessionClosed(payload: {
@@ -2201,7 +2202,9 @@ export class AiService {
             return null;
         }
 
-        return await nativeAi.saveRuntimeSettings(input);
+        return this.#withPersistedRuntimeCatalog(
+            await nativeAi.saveRuntimeSettings(input),
+        );
     }
 
     async #migrateNativeRuntimeSettingsIfNeeded(
@@ -4971,12 +4974,19 @@ export class AiService {
         const catalog = this.#persistence.loadLatestRuntimeCatalog(
             status.runtimeId,
         );
-
-        if (!catalog) {
-            return status;
+        const catalogMergedStatus = catalog
+            ? mergePersistedCatalogIntoRuntimeStatus(status, catalog)
+            : status;
+        const loadPreferences = (
+            this.#persistence as Partial<AiPersistenceGateway>
+        ).loadRuntimeSelectionPreferences;
+        if (!loadPreferences) {
+            return catalogMergedStatus;
         }
-
-        return mergePersistedCatalogIntoRuntimeStatus(status, catalog);
+        return applyRuntimeSelectionPreferencesToStatus(
+            catalogMergedStatus,
+            loadPreferences.call(this.#persistence, status.runtimeId),
+        );
     }
 
     #hydrateSnapshotRuntimeCatalog(snapshot: AiSessionSnapshot): AiSessionSnapshot {
@@ -5455,6 +5465,69 @@ function mergePersistedCatalogIntoRuntimeStatus(
                 ? status.models
                 : catalog.models,
     };
+}
+
+function applyRuntimeSelectionPreferencesToStatus(
+    status: AiRuntimeStatus,
+    preferences: PersistedRuntimeSelectionPreferences,
+): AiRuntimeStatus {
+    const configOptions = status.configOptions ?? [];
+    const preferredModeId = resolveAvailableRuntimeSelectionPreference(
+        preferences.modeId,
+        preferences.configOptions,
+        configOptions,
+        (status.modes ?? []).map((mode) => mode.id),
+        isModeConfigOption,
+    );
+    const preferredModelId = resolveAvailableRuntimeSelectionPreference(
+        preferences.modelId,
+        preferences.configOptions,
+        configOptions,
+        (status.models ?? []).map((model) => model.id),
+        isModelConfigOption,
+    );
+
+    return {
+        ...status,
+        configOptions: applyCapturedRuntimeDefaultsToConfigOptions(
+            configOptions,
+            preferences.configOptions,
+            preferredModeId,
+            preferredModelId,
+        ),
+        modeId: preferredModeId ?? status.modeId,
+        modelId: preferredModelId ?? status.modelId,
+    };
+}
+
+function resolveAvailableRuntimeSelectionPreference(
+    topLevelPreference: string | null,
+    configPreferences: Record<string, boolean | string>,
+    configOptions: readonly AiSessionConfigOption[],
+    availableIds: readonly string[],
+    matchesOption: (option: AiSessionConfigOption) => boolean,
+): string | null {
+    const configPreference = getPreferredConfigSelectionId(
+        configPreferences,
+        configOptions,
+        matchesOption,
+    );
+    const matchingConfig = configOptions.find(matchesOption) ?? null;
+
+    for (const candidate of [topLevelPreference, configPreference]) {
+        if (!candidate) {
+            continue;
+        }
+        if (
+            availableIds.includes(candidate) ||
+            (matchingConfig?.type === "select" &&
+                hasSelectConfigValue(matchingConfig, candidate))
+        ) {
+            return candidate;
+        }
+    }
+
+    return null;
 }
 
 function buildPersistedRuntimeCatalogPatch(

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -647,6 +647,27 @@ describe("ai-store queue", () => {
 
         await second;
 
+        const staleSnapshot =
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot ?? null;
+        if (!staleSnapshot) {
+            throw new Error("Expected the optimistic session snapshot.");
+        }
+        useAiStore.getState().applySessionSnapshot({
+            ...staleSnapshot,
+            configOptions: staleSnapshot.configOptions.map((option) =>
+                option.type === "select" &&
+                option.id === "reasoning_effort"
+                    ? { ...option, value: "low" }
+                    : option,
+            ),
+            reasoningEffort: "low",
+            updatedAt: "2026-04-14T00:00:01.000Z",
+        });
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot
+                ?.reasoningEffort,
+        ).toBe("high");
+
         const third = useAiStore.getState().setSessionConfigOption({
             optionId: "reasoning_effort",
             sessionId: TAB.sessionId,
@@ -663,6 +684,405 @@ describe("ai-store queue", () => {
 
         thirdMutation.resolve();
         await third;
+    });
+
+    it("restores the authoritative value when consecutive selections for one control both fail", async () => {
+        let rejectMediumMutation!: (reason: unknown) => void;
+        let rejectHighMutation!: (reason: unknown) => void;
+        const mediumMutation = new Promise<void>((_resolve, reject) => {
+            rejectMediumMutation = reject;
+        });
+        const highMutation = new Promise<void>((_resolve, reject) => {
+            rejectHighMutation = reject;
+        });
+        const setAiSessionConfigOption = vi
+            .fn()
+            .mockReturnValueOnce(mediumMutation)
+            .mockReturnValueOnce(highMutation);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: { comando: { setAiSessionConfigOption } },
+            writable: true,
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                configOptions: [
+                    {
+                        category: "reasoning",
+                        description: null,
+                        id: "reasoning_effort",
+                        label: "Reasoning",
+                        options: [
+                            {
+                                description: null,
+                                groupLabel: null,
+                                label: "Low",
+                                value: "low",
+                            },
+                            {
+                                description: null,
+                                groupLabel: null,
+                                label: "Medium",
+                                value: "medium",
+                            },
+                            {
+                                description: null,
+                                groupLabel: null,
+                                label: "High",
+                                value: "high",
+                            },
+                        ],
+                        type: "select",
+                        value: "low",
+                    },
+                ],
+                reasoningEffort: "low",
+            }),
+        );
+
+        const medium = useAiStore.getState().setSessionConfigOption({
+            optionId: "reasoning_effort",
+            sessionId: TAB.sessionId,
+            value: "medium",
+        });
+        const high = useAiStore.getState().setSessionConfigOption({
+            optionId: "reasoning_effort",
+            sessionId: TAB.sessionId,
+            value: "high",
+        });
+
+        rejectMediumMutation(new Error("Medium failed."));
+        await expect(medium).rejects.toThrow("Medium failed.");
+        rejectHighMutation(new Error("High failed."));
+        await expect(high).rejects.toThrow("High failed.");
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot
+                ?.reasoningEffort,
+        ).toBe("low");
+    });
+
+    it("rolls back a failed control without reverting a newer different control", async () => {
+        let rejectReasoningMutation!: (reason: unknown) => void;
+        const reasoningMutation = new Promise<void>((_resolve, reject) => {
+            rejectReasoningMutation = reject;
+        });
+        const fastMutation = createDeferred<void>();
+        const setAiSessionConfigOption = vi
+            .fn()
+            .mockReturnValueOnce(reasoningMutation)
+            .mockReturnValueOnce(fastMutation.promise);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    setAiSessionConfigOption,
+                },
+            },
+            writable: true,
+        });
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                configOptions: [
+                    {
+                        category: "reasoning",
+                        description: null,
+                        id: "reasoning_effort",
+                        label: "Reasoning",
+                        options: [
+                            {
+                                description: null,
+                                groupLabel: null,
+                                label: "Low",
+                                value: "low",
+                            },
+                            {
+                                description: null,
+                                groupLabel: null,
+                                label: "High",
+                                value: "high",
+                            },
+                        ],
+                        type: "select",
+                        value: "low",
+                    },
+                    {
+                        category: "other",
+                        description: null,
+                        id: "fast",
+                        label: "Fast",
+                        type: "boolean",
+                        value: false,
+                    },
+                ],
+                reasoningEffort: "low",
+            }),
+        );
+
+        const reasoning = useAiStore.getState().setSessionConfigOption({
+            optionId: "reasoning_effort",
+            sessionId: TAB.sessionId,
+            value: "high",
+        });
+        const fast = useAiStore.getState().setSessionConfigOption({
+            optionId: "fast",
+            sessionId: TAB.sessionId,
+            value: true,
+        });
+
+        rejectReasoningMutation(new Error("Reasoning failed."));
+        await expect(reasoning).rejects.toThrow("Reasoning failed.");
+
+        const snapshot = useAiStore.getState().sessions[TAB.sessionId]?.snapshot;
+        expect(snapshot?.reasoningEffort).toBe("low");
+        expect(
+            snapshot?.configOptions.find((option) => option.id === "fast")
+                ?.value,
+        ).toBe(true);
+
+        fastMutation.resolve();
+        await fast;
+    });
+
+    it("keeps a cold-session selection visible while the provider is prepared", async () => {
+        const preparation = createDeferred<void>();
+        const setAiSessionConfigOption = vi.fn().mockResolvedValue(undefined);
+        const ensureLiveSession = vi.fn(() => preparation.promise);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    setAiSessionConfigOption,
+                },
+            },
+            writable: true,
+        });
+
+        const reasoningConfig = {
+            category: "reasoning" as const,
+            description: null,
+            id: "reasoning_effort",
+            label: "Reasoning",
+            options: [
+                {
+                    description: null,
+                    groupLabel: null,
+                    label: "Low",
+                    value: "low",
+                },
+                {
+                    description: null,
+                    groupLabel: null,
+                    label: "High",
+                    value: "high",
+                },
+            ],
+            type: "select" as const,
+            value: "low",
+        };
+        useAiStore.getState().applyRuntimeStatus(
+            createRuntimeStatus({ configOptions: [reasoningConfig] }),
+        );
+        useAiStore.getState().registerSessionTab(TAB);
+
+        const mutation = useAiStore.getState().setSessionConfigOption(
+            {
+                optionId: "reasoning_effort",
+                sessionId: TAB.sessionId,
+                value: "high",
+            },
+            { ensureLiveSession },
+        );
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot
+                ?.reasoningEffort,
+        ).toBe("high");
+        expect(setAiSessionConfigOption).not.toHaveBeenCalled();
+
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                configOptions: [reasoningConfig],
+                reasoningEffort: "low",
+                runtimeSessionId: "runtime-session-prepared",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot
+                ?.reasoningEffort,
+        ).toBe("high");
+
+        preparation.resolve();
+        await mutation;
+
+        expect(ensureLiveSession).toHaveBeenCalledWith(false);
+        expect(setAiSessionConfigOption).toHaveBeenCalledOnce();
+    });
+
+    it("does not publish a pending selection into the inherited runtime catalog", async () => {
+        let rejectMutation!: (reason: unknown) => void;
+        const remoteMutation = new Promise<void>((_resolve, reject) => {
+            rejectMutation = reject;
+        });
+        const setAiSessionConfigOption = vi.fn(() => remoteMutation);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    setAiSessionConfigOption,
+                },
+            },
+            writable: true,
+        });
+
+        const reasoningConfig = {
+            category: "reasoning" as const,
+            description: null,
+            id: "reasoning_effort",
+            label: "Reasoning",
+            options: [
+                {
+                    description: null,
+                    groupLabel: null,
+                    label: "Low",
+                    value: "low",
+                },
+                {
+                    description: null,
+                    groupLabel: null,
+                    label: "High",
+                    value: "high",
+                },
+            ],
+            type: "select" as const,
+            value: "low",
+        };
+        useAiStore.getState().applyRuntimeStatus(
+            createRuntimeStatus({ configOptions: [reasoningConfig] }),
+        );
+        useAiStore.getState().registerSessionTab(TAB);
+
+        const mutation = useAiStore.getState().setSessionConfigOption({
+            optionId: "reasoning_effort",
+            sessionId: TAB.sessionId,
+            value: "high",
+        });
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                configOptions: [reasoningConfig],
+                reasoningEffort: "low",
+                runtimeSessionId: "runtime-session-prepared",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+            }),
+        );
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot
+                ?.reasoningEffort,
+        ).toBe("high");
+        expect(
+            useAiStore
+                .getState()
+                .runtimeCatalogById.codex?.configOptions.find(
+                    (option) => option.id === "reasoning_effort",
+                )?.value,
+        ).toBe("low");
+
+        rejectMutation(new Error("Provider rejected the selection."));
+        await expect(mutation).rejects.toThrow(
+            "Provider rejected the selection.",
+        );
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot
+                ?.reasoningEffort,
+        ).toBe("low");
+        expect(
+            useAiStore
+                .getState()
+                .runtimeCatalogById.codex?.configOptions.find(
+                    (option) => option.id === "reasoning_effort",
+                )?.value,
+        ).toBe("low");
+    });
+
+    it("reprepares a retained session when its control target was evicted", async () => {
+        const setAiSessionConfigOption = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("The AI session was not found."))
+            .mockResolvedValueOnce(undefined);
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                comando: {
+                    setAiSessionConfigOption,
+                },
+            },
+            writable: true,
+        });
+
+        const reasoningConfig = {
+            category: "reasoning" as const,
+            description: null,
+            id: "reasoning_effort",
+            label: "Reasoning",
+            options: [
+                {
+                    description: null,
+                    groupLabel: null,
+                    label: "Low",
+                    value: "low",
+                },
+                {
+                    description: null,
+                    groupLabel: null,
+                    label: "High",
+                    value: "high",
+                },
+            ],
+            type: "select" as const,
+            value: "low",
+        };
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                configOptions: [reasoningConfig],
+                reasoningEffort: "low",
+            }),
+        );
+        const ensureLiveSession = vi.fn((force: boolean) => {
+            if (!force) {
+                return Promise.resolve();
+            }
+            useAiStore.getState().applySessionSnapshot(
+                createSnapshot({
+                    configOptions: [reasoningConfig],
+                    reasoningEffort: "low",
+                    runtimeSessionId: "runtime-session-reprepared",
+                    updatedAt: "2026-04-14T00:00:01.000Z",
+                }),
+            );
+            return Promise.resolve();
+        });
+
+        await useAiStore.getState().setSessionConfigOption(
+            {
+                optionId: "reasoning_effort",
+                sessionId: TAB.sessionId,
+                value: "high",
+            },
+            { ensureLiveSession },
+        );
+
+        expect(ensureLiveSession.mock.calls).toEqual([[false], [true]]);
+        expect(setAiSessionConfigOption).toHaveBeenCalledTimes(2);
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.snapshot
+                ?.reasoningEffort,
+        ).toBe("high");
     });
 
     it("applies inferred titles from status events", () => {

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -93,14 +93,26 @@ type RuntimeAiSessionTab = RuntimeWorkspaceChatTab | RuntimeWorkspaceReviewTab;
 type AiSessionRuntimeState = "history" | "live";
 
 const ensureSessionInFlight = new Map<string, Promise<void>>();
+type OptimisticSnapshotMutator = (
+    snapshot: AiSessionSnapshot,
+) => AiSessionSnapshot;
+
 const optimisticSnapshotMutationStates = new Map<
     string,
     {
         latestVersion: number;
+        latestVersionByConflictKey: Map<string, number>;
         nextVersion: number;
+        pendingVersionsByConflictKey: Map<string, Set<number>>;
+        preservedMutations: Map<number, OptimisticSnapshotMutator>;
+        rollbackBaseSnapshotsByConflictKey: Map<string, AiSessionSnapshot>;
         pendingVersions: Set<number>;
     }
 >();
+
+interface AiSessionControlMutationOptions {
+    readonly ensureLiveSession?: (force: boolean) => Promise<void>;
+}
 
 interface RegisteredSessionMeta {
     readonly projectId: string | null;
@@ -301,10 +313,17 @@ interface AiStore {
         status: QueuedPrompt["status"],
     ) => void;
     setSessionDiffZoom: (sessionId: string, diffZoom: number) => void;
-    setSessionMode: (input: AiSessionModeMutationInput) => Promise<void>;
-    setSessionModel: (input: AiSessionModelMutationInput) => Promise<void>;
+    setSessionMode: (
+        input: AiSessionModeMutationInput,
+        options?: AiSessionControlMutationOptions,
+    ) => Promise<void>;
+    setSessionModel: (
+        input: AiSessionModelMutationInput,
+        options?: AiSessionControlMutationOptions,
+    ) => Promise<void>;
     setSessionConfigOption: (
         input: AiSessionConfigOptionMutationInput,
+        options?: AiSessionControlMutationOptions,
     ) => Promise<void>;
     renameSession: (input: AiSessionRenameMutationInput) => Promise<void>;
     sendQueuedPromptNow: (sessionId: string, promptId: string) => Promise<void>;
@@ -1060,9 +1079,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
             );
             const nextSnapshot = resolved.snapshot;
             const nextTranscript = resolved.transcript;
-            const resolvedCatalog = hasCatalogChanges(update.patch.changes)
-                ? extractRuntimeCatalog(nextSnapshot)
-                : null;
+            const resolvedCatalog = nextCatalog;
             const nextMeta = session.meta
                 ? session.meta.title === nextSnapshot.title
                     ? session.meta
@@ -1115,7 +1132,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
                 state.sessions[snapshot.sessionId] ?? createSessionState();
             const existingCatalog =
                 state.runtimeCatalogById[snapshot.runtimeId] ?? null;
-            const nextSnapshot =
+            const incomingSnapshot =
                 existingCatalog && hasRuntimeCatalog(existingCatalog)
                     ? mergeRuntimeCatalogIntoSnapshot(
                           snapshot,
@@ -1123,7 +1140,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
                       )
                     : snapshot;
             const resolved = resolveIncomingSessionSnapshot(
-                nextSnapshot,
+                incomingSnapshot,
                 session,
                 {
                     preserveCurrentReviewState: true,
@@ -1139,7 +1156,9 @@ export const useAiStore = create<AiStore>((set, get) => ({
             if (nextMeta !== session.meta) {
                 syncedTitle = resolvedSnapshot.title;
             }
-            const nextCatalog = extractRuntimeCatalog(resolvedSnapshot);
+            // Runtime defaults must come from provider state, never from the
+            // optimistic session overlay applied by the resolver.
+            const nextCatalog = extractRuntimeCatalog(incomingSnapshot);
 
             return {
                 runtimeCatalogById: hasRuntimeCatalog(nextCatalog)
@@ -1154,7 +1173,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         ...session,
                         ...resolveIncomingSnapshotProgress(
                             session,
-                            nextSnapshot.updatedAt,
+                            incomingSnapshot.updatedAt,
                         ),
                         localError: resolvedSnapshot.lastError,
                         meta: nextMeta,
@@ -1715,62 +1734,141 @@ export const useAiStore = create<AiStore>((set, get) => ({
         return status;
     },
 
-    setSessionMode: async (input) => {
-        const snapshot = get().sessions[input.sessionId]?.snapshot ?? null;
+    setSessionMode: async (input, options) => {
+        const snapshot = getSelectionMutationSnapshot(input.sessionId, get);
         const modeConfig = snapshot ? getModeConfigOption(snapshot) : null;
 
         await runOptimisticSnapshotMutation(
             input.sessionId,
             (currentSnapshot) =>
-                setModeOnSnapshot(currentSnapshot, input.modeId),
+                setModeOnSnapshot(
+                    hydrateOptimisticSelectionSnapshot(currentSnapshot, get),
+                    input.modeId,
+                ),
             () =>
-                modeConfig?.type === "select" &&
-                hasSelectConfigValue(modeConfig, input.modeId)
-                    ? getComandoApi().setAiSessionConfigOption({
-                          optionId: modeConfig.id,
-                          sessionId: input.sessionId,
-                          value: input.modeId,
-                      })
-                    : getComandoApi().setAiSessionMode(input),
+                runAiSessionControlRemoteMutation(
+                    () =>
+                        modeConfig?.type === "select" &&
+                        hasSelectConfigValue(modeConfig, input.modeId)
+                            ? getComandoApi().setAiSessionConfigOption({
+                                  optionId: modeConfig.id,
+                                  sessionId: input.sessionId,
+                                  value: input.modeId,
+                              })
+                            : getComandoApi().setAiSessionMode(input),
+                    options?.ensureLiveSession,
+                ),
             set,
             get,
+            {
+                conflictKey: "mode",
+                preserveDuringIncomingSnapshots: true,
+                rollbackSnapshot: (currentSnapshot, rollbackBaseSnapshot) =>
+                    rollbackBaseSnapshot.modeId
+                        ? setModeOnSnapshot(
+                              hydrateOptimisticSelectionSnapshot(
+                                  currentSnapshot,
+                                  get,
+                              ),
+                              rollbackBaseSnapshot.modeId,
+                          )
+                        : {
+                              ...currentSnapshot,
+                              modeId: null,
+                              updatedAt: new Date().toISOString(),
+                          },
+            },
         );
     },
 
-    setSessionModel: async (input) => {
-        const snapshot = get().sessions[input.sessionId]?.snapshot ?? null;
+    setSessionModel: async (input, options) => {
+        const snapshot = getSelectionMutationSnapshot(input.sessionId, get);
         const modelConfig = snapshot ? getModelConfigOption(snapshot) : null;
 
         await runOptimisticSnapshotMutation(
             input.sessionId,
             (currentSnapshot) =>
-                setModelOnSnapshot(currentSnapshot, input.modelId),
+                setModelOnSnapshot(
+                    hydrateOptimisticSelectionSnapshot(currentSnapshot, get),
+                    input.modelId,
+                ),
             () =>
-                modelConfig?.type === "select" &&
-                hasSelectConfigValue(modelConfig, input.modelId)
-                    ? getComandoApi().setAiSessionConfigOption({
-                          optionId: modelConfig.id,
-                          sessionId: input.sessionId,
-                          value: input.modelId,
-                      })
-                    : getComandoApi().setAiSessionModel(input),
+                runAiSessionControlRemoteMutation(
+                    () =>
+                        modelConfig?.type === "select" &&
+                        hasSelectConfigValue(modelConfig, input.modelId)
+                            ? getComandoApi().setAiSessionConfigOption({
+                                  optionId: modelConfig.id,
+                                  sessionId: input.sessionId,
+                                  value: input.modelId,
+                              })
+                            : getComandoApi().setAiSessionModel(input),
+                    options?.ensureLiveSession,
+                ),
             set,
             get,
+            {
+                conflictKey: "model",
+                preserveDuringIncomingSnapshots: true,
+                rollbackSnapshot: (currentSnapshot, rollbackBaseSnapshot) =>
+                    rollbackBaseSnapshot.modelId
+                        ? setModelOnSnapshot(
+                              hydrateOptimisticSelectionSnapshot(
+                                  currentSnapshot,
+                                  get,
+                              ),
+                              rollbackBaseSnapshot.modelId,
+                          )
+                        : {
+                              ...currentSnapshot,
+                              modelId: null,
+                              updatedAt: new Date().toISOString(),
+                          },
+            },
         );
     },
 
-    setSessionConfigOption: async (input) => {
+    setSessionConfigOption: async (input, options) => {
+        const snapshot = getSelectionMutationSnapshot(input.sessionId, get);
+        const conflictKey = getConfigOptionConflictKey(
+            snapshot,
+            input.optionId,
+        );
+
         await runOptimisticSnapshotMutation(
             input.sessionId,
-            (snapshot) =>
+            (currentSnapshot) =>
                 setConfigOptionOnSnapshot(
-                    snapshot,
+                    hydrateOptimisticSelectionSnapshot(currentSnapshot, get),
                     input.optionId,
                     input.value,
                 ),
-            () => getComandoApi().setAiSessionConfigOption(input),
+            () =>
+                runAiSessionControlRemoteMutation(
+                    () => getComandoApi().setAiSessionConfigOption(input),
+                    options?.ensureLiveSession,
+                ),
             set,
             get,
+            {
+                conflictKey,
+                preserveDuringIncomingSnapshots: true,
+                rollbackSnapshot: (currentSnapshot, rollbackBaseSnapshot) => {
+                    const rollbackValue = rollbackBaseSnapshot.configOptions.find(
+                        (option) => option.id === input.optionId,
+                    )?.value;
+                    return rollbackValue !== undefined
+                        ? setConfigOptionOnSnapshot(
+                              hydrateOptimisticSelectionSnapshot(
+                                  currentSnapshot,
+                                  get,
+                              ),
+                              input.optionId,
+                              rollbackValue,
+                          )
+                        : currentSnapshot;
+                },
+            },
         );
     },
 
@@ -2813,6 +2911,51 @@ function resolveIncomingSessionSnapshot(
     currentSession: AiSessionClientState | null | undefined,
     options: ResolveIncomingSnapshotOptions = {},
 ): ResolvedIncomingSessionSnapshot {
+    const resolved = resolveIncomingSessionSnapshotBase(
+        incomingSnapshot,
+        currentSession,
+        options,
+    );
+    const snapshot = applyPendingOptimisticSelectionMutations(
+        resolved.snapshot,
+    );
+
+    return snapshot === resolved.snapshot
+        ? resolved
+        : {
+              ...resolved,
+              snapshot,
+          };
+}
+
+function applyPendingOptimisticSelectionMutations(
+    snapshot: AiSessionSnapshot,
+): AiSessionSnapshot {
+    const mutations = optimisticSnapshotMutationStates.get(snapshot.sessionId)
+        ?.preservedMutations;
+    if (!mutations || mutations.size === 0) {
+        return snapshot;
+    }
+
+    const authoritativeUpdatedAt = snapshot.updatedAt;
+    let nextSnapshot = snapshot;
+    for (const mutateSnapshot of mutations.values()) {
+        nextSnapshot = mutateSnapshot(nextSnapshot);
+    }
+
+    return nextSnapshot === snapshot
+        ? snapshot
+        : {
+              ...nextSnapshot,
+              updatedAt: authoritativeUpdatedAt,
+          };
+}
+
+function resolveIncomingSessionSnapshotBase(
+    incomingSnapshot: AiSessionSnapshot,
+    currentSession: AiSessionClientState | null | undefined,
+    options: ResolveIncomingSnapshotOptions = {},
+): ResolvedIncomingSessionSnapshot {
     const session = currentSession ?? null;
     const currentSnapshot = session?.snapshot ?? null;
     const normalizedIncomingSnapshot = normalizeIncomingActivePromptEcho(
@@ -3742,56 +3885,234 @@ function pauseQueue(sessionId: string, set: SetAiState): void {
     });
 }
 
-async function runOptimisticSnapshotMutation(
-    sessionId: string,
-    mutateSnapshot: (snapshot: AiSessionSnapshot) => AiSessionSnapshot,
-    runRemote: () => Promise<void>,
-    set: SetAiState,
-    get: GetAiState,
-): Promise<void> {
-    const mutationState = optimisticSnapshotMutationStates.get(sessionId) ?? {
-        latestVersion: 0,
-        nextVersion: 0,
-        pendingVersions: new Set<number>(),
-    };
-    const mutationVersion = mutationState.nextVersion + 1;
-    mutationState.latestVersion = mutationVersion;
-    mutationState.nextVersion = mutationVersion;
-    mutationState.pendingVersions.add(mutationVersion);
-    optimisticSnapshotMutationStates.set(sessionId, mutationState);
-    const previousSession = get().sessions[sessionId] ?? null;
-    const previousSnapshot = previousSession?.snapshot ?? null;
+interface OptimisticSnapshotMutationOptions {
+    readonly conflictKey?: string;
+    readonly preserveDuringIncomingSnapshots?: boolean;
+    readonly rollbackSnapshot?: (
+        currentSnapshot: AiSessionSnapshot,
+        previousSnapshot: AiSessionSnapshot,
+    ) => AiSessionSnapshot;
+}
 
-    if (previousSession && previousSnapshot) {
-        set((state) => ({
-            sessions: {
-                ...state.sessions,
-                [sessionId]: {
-                    ...previousSession,
-                    snapshot: mutateSnapshot(previousSnapshot),
-                },
-            },
-        }));
+function getSelectionMutationSnapshot(
+    sessionId: string,
+    get: GetAiState,
+): AiSessionSnapshot | null {
+    const snapshot = get().sessions[sessionId]?.snapshot ?? null;
+    return snapshot
+        ? hydrateOptimisticSelectionSnapshot(snapshot, get)
+        : null;
+}
+
+function getConfigOptionConflictKey(
+    snapshot: AiSessionSnapshot | null,
+    optionId: string,
+): string {
+    if (snapshot && getModelConfigOption(snapshot)?.id === optionId) {
+        return "model";
     }
+    if (snapshot && getModeConfigOption(snapshot)?.id === optionId) {
+        return "mode";
+    }
+    return `config:${optionId}`;
+}
+
+function hydrateOptimisticSelectionSnapshot(
+    snapshot: AiSessionSnapshot,
+    get: GetAiState,
+): AiSessionSnapshot {
+    const runtimeCatalog = get().runtimeCatalogById[snapshot.runtimeId] ?? null;
+    return runtimeCatalog && hasRuntimeCatalog(runtimeCatalog)
+        ? mergeRuntimeCatalogIntoSnapshot(snapshot, runtimeCatalog)
+        : snapshot;
+}
+
+async function runAiSessionControlRemoteMutation(
+    runRemote: () => Promise<void>,
+    ensureLiveSession?: (force: boolean) => Promise<void>,
+): Promise<void> {
+    await ensureLiveSession?.(false);
 
     try {
         await runRemote();
     } catch (error) {
-        if (
-            previousSession &&
-            optimisticSnapshotMutationStates.get(sessionId)?.latestVersion ===
-                mutationVersion
-        ) {
-            set((state) => ({
+        if (!ensureLiveSession || !isMissingAiSessionControlError(error)) {
+            throw error;
+        }
+
+        await ensureLiveSession(true);
+        await runRemote();
+    }
+}
+
+function isMissingAiSessionControlError(error: unknown): boolean {
+    const message =
+        error instanceof Error
+            ? error.message
+            : typeof error === "string"
+              ? error
+              : "";
+    const normalizedMessage = message.toLowerCase();
+    return (
+        normalizedMessage.includes("ai session was not found") ||
+        normalizedMessage.includes("ai session is no longer open")
+    );
+}
+
+async function runOptimisticSnapshotMutation(
+    sessionId: string,
+    mutateSnapshot: OptimisticSnapshotMutator,
+    runRemote: () => Promise<void>,
+    set: SetAiState,
+    get: GetAiState,
+    options: OptimisticSnapshotMutationOptions = {},
+): Promise<void> {
+    const mutationState = optimisticSnapshotMutationStates.get(sessionId) ?? {
+        latestVersion: 0,
+        latestVersionByConflictKey: new Map<string, number>(),
+        nextVersion: 0,
+        pendingVersionsByConflictKey: new Map<string, Set<number>>(),
+        preservedMutations: new Map<number, OptimisticSnapshotMutator>(),
+        rollbackBaseSnapshotsByConflictKey: new Map<
+            string,
+            AiSessionSnapshot
+        >(),
+        pendingVersions: new Set<number>(),
+    };
+    const previousSession = get().sessions[sessionId] ?? null;
+    const previousSnapshot = previousSession?.snapshot ?? null;
+    const mutationVersion = mutationState.nextVersion + 1;
+    mutationState.latestVersion = mutationVersion;
+    mutationState.nextVersion = mutationVersion;
+    mutationState.pendingVersions.add(mutationVersion);
+    if (options.conflictKey) {
+        mutationState.latestVersionByConflictKey.set(
+            options.conflictKey,
+            mutationVersion,
+        );
+        const pendingConflictVersions =
+            mutationState.pendingVersionsByConflictKey.get(
+                options.conflictKey,
+            ) ?? new Set<number>();
+        if (pendingConflictVersions.size === 0 && previousSnapshot) {
+            mutationState.rollbackBaseSnapshotsByConflictKey.set(
+                options.conflictKey,
+                previousSnapshot,
+            );
+        }
+        pendingConflictVersions.add(mutationVersion);
+        mutationState.pendingVersionsByConflictKey.set(
+            options.conflictKey,
+            pendingConflictVersions,
+        );
+    }
+    if (options.preserveDuringIncomingSnapshots) {
+        mutationState.preservedMutations.set(mutationVersion, mutateSnapshot);
+    }
+    optimisticSnapshotMutationStates.set(sessionId, mutationState);
+
+    if (previousSession && previousSnapshot) {
+        set((state) => {
+            const currentSession = state.sessions[sessionId];
+            if (!currentSession?.snapshot) {
+                return state;
+            }
+
+            return {
                 sessions: {
                     ...state.sessions,
-                    [sessionId]: previousSession,
+                    [sessionId]: {
+                        ...currentSession,
+                        snapshot: mutateSnapshot(currentSession.snapshot),
+                    },
                 },
-            }));
+            };
+        });
+    }
+
+    try {
+        await runRemote();
+        if (options.conflictKey) {
+            const pendingConflictVersions =
+                mutationState.pendingVersionsByConflictKey.get(
+                    options.conflictKey,
+                );
+            const hasNewerPendingMutation = Boolean(
+                pendingConflictVersions &&
+                    [...pendingConflictVersions].some(
+                        (version) => version > mutationVersion,
+                    ),
+            );
+            const rollbackBase =
+                mutationState.rollbackBaseSnapshotsByConflictKey.get(
+                    options.conflictKey,
+                );
+            if (hasNewerPendingMutation && rollbackBase) {
+                mutationState.rollbackBaseSnapshotsByConflictKey.set(
+                    options.conflictKey,
+                    mutateSnapshot(rollbackBase),
+                );
+            }
+        }
+    } catch (error) {
+        mutationState.preservedMutations.delete(mutationVersion);
+        const latestMutationVersion = options.conflictKey
+            ? mutationState.latestVersionByConflictKey.get(options.conflictKey)
+            : mutationState.latestVersion;
+        if (
+            previousSession &&
+            optimisticSnapshotMutationStates.get(sessionId) === mutationState &&
+            latestMutationVersion === mutationVersion
+        ) {
+            set((state) => {
+                const currentSession = state.sessions[sessionId];
+                if (!currentSession) {
+                    return state;
+                }
+
+                const currentSnapshot = currentSession.snapshot;
+                const rollbackBaseSnapshot = options.conflictKey
+                    ? (mutationState.rollbackBaseSnapshotsByConflictKey.get(
+                          options.conflictKey,
+                      ) ?? previousSnapshot)
+                    : previousSnapshot;
+                const rollbackSnapshot =
+                    currentSnapshot && rollbackBaseSnapshot
+                        ? (options.rollbackSnapshot?.(
+                              currentSnapshot,
+                              rollbackBaseSnapshot,
+                          ) ?? rollbackBaseSnapshot)
+                        : rollbackBaseSnapshot;
+
+                return {
+                    sessions: {
+                        ...state.sessions,
+                        [sessionId]: {
+                            ...currentSession,
+                            snapshot: rollbackSnapshot,
+                        },
+                    },
+                };
+            });
         }
         throw error;
     } finally {
         mutationState.pendingVersions.delete(mutationVersion);
+        if (options.conflictKey) {
+            const pendingConflictVersions =
+                mutationState.pendingVersionsByConflictKey.get(
+                    options.conflictKey,
+                );
+            pendingConflictVersions?.delete(mutationVersion);
+            if (!pendingConflictVersions?.size) {
+                mutationState.pendingVersionsByConflictKey.delete(
+                    options.conflictKey,
+                );
+                mutationState.rollbackBaseSnapshotsByConflictKey.delete(
+                    options.conflictKey,
+                );
+            }
+        }
         if (mutationState.pendingVersions.size === 0) {
             optimisticSnapshotMutationStates.delete(sessionId);
         }

--- a/src/renderer/src/components/workspace/AIChatAgentControls.tsx
+++ b/src/renderer/src/components/workspace/AIChatAgentControls.tsx
@@ -87,13 +87,15 @@ function groupDropdownOptions(
     options: readonly DropdownOption[],
 ): readonly DropdownOptionGroup[] {
     const groups: Array<{ label: string | null; options: DropdownOption[] }> = [];
+    const groupIndexes = new Map<string | null, number>();
 
     for (const option of options) {
         const label = option.groupLabel?.trim() || null;
-        const group = groups.find((candidate) => candidate.label === label);
-        if (group) {
-            group.options.push(option);
+        const groupIndex = groupIndexes.get(label);
+        if (groupIndex !== undefined) {
+            groups[groupIndex].options.push(option);
         } else {
+            groupIndexes.set(label, groups.length);
             groups.push({ label, options: [option] });
         }
     }
@@ -467,13 +469,13 @@ function DropdownField({
                                                             }`}
                                                             key={`${option.groupLabel ?? "default"}:${option.value}`}
                                                             onClick={() => {
-                                                                onChange(
-                                                                    option.value,
-                                                                );
                                                                 setIsOpen(false);
                                                                 setQuery("");
                                                                 setExpandedGroups(
                                                                     new Set(),
+                                                                );
+                                                                onChange(
+                                                                    option.value,
                                                                 );
                                                             }}
                                                             onMouseEnter={(e) => {
@@ -690,22 +692,28 @@ export function AIChatAgentControls({
         },
         [modelConfig, onConfigOptionChange, onModelChange],
     );
-    const visibleModes =
-        modeConfig?.type === "select"
-            ? mapConfigOption(modeConfig)
-            : modes.map((mode) => ({
-                  description: mode.description,
-                  label: formatFallbackLabel(mode.name),
-                  value: mode.id,
-              }));
-    const visibleModels =
-        modelConfig?.type === "select"
-            ? mapConfigOption(modelConfig, false)
-            : models.map((model) => ({
-                  description: model.description,
-                  label: formatFallbackLabel(model.name),
-                  value: model.id,
-              }));
+    const visibleModes = useMemo(
+        () =>
+            modeConfig?.type === "select"
+                ? mapConfigOption(modeConfig)
+                : modes.map((mode) => ({
+                      description: mode.description,
+                      label: formatFallbackLabel(mode.name),
+                      value: mode.id,
+                  })),
+        [modeConfig, modes],
+    );
+    const visibleModels = useMemo(
+        () =>
+            modelConfig?.type === "select"
+                ? mapConfigOption(modelConfig, false)
+                : models.map((model) => ({
+                      description: model.description,
+                      label: formatFallbackLabel(model.name),
+                      value: model.id,
+                  })),
+        [modelConfig, models],
+    );
     const extraConfigs = useMemo(
         () =>
             [...configOptions]

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -172,6 +172,25 @@ type AiRuntimeCatalog = Pick<
     | "models"
 >;
 
+interface AgentControlDiscoveryAttempt {
+    readonly attemptCount: number;
+    readonly status: "completed" | "exhausted" | "idle" | "loading" | "retrying";
+}
+
+const MAX_AGENT_CONTROL_DISCOVERY_ATTEMPTS = 3;
+const AGENT_CONTROL_DISCOVERY_RETRY_DELAY_MS = 250;
+
+function hasAgentControlCatalog(
+    catalog: AiRuntimeCatalog | null | undefined,
+): boolean {
+    return Boolean(
+        catalog &&
+        (catalog.configOptions.length > 0 ||
+            catalog.models.length > 0 ||
+            catalog.modes.length > 0),
+    );
+}
+
 /* ─── Main component ─── */
 
 export const ChatTabView = memo(function ChatTabView({
@@ -187,6 +206,8 @@ export const ChatTabView = memo(function ChatTabView({
     const clearQueuedPrompts = useAiStore((s) => s.clearQueuedPrompts);
     const ensureSession = useAiStore((s) => s.ensureSession);
     const editQueuedPrompt = useAiStore((s) => s.editQueuedPrompt);
+    const refreshRuntimeStatus = useAiStore((s) => s.refreshRuntimeStatus);
+    const registerSessionTab = useAiStore((s) => s.registerSessionTab);
     const removeQueuedPrompt = useAiStore((s) => s.removeQueuedPrompt);
     const respondPermission = useAiStore((s) => s.respondPermission);
     const respondUserInput = useAiStore((s) => s.respondUserInput);
@@ -411,6 +432,40 @@ export const ChatTabView = memo(function ChatTabView({
     );
     const sessionPreparationKey = getChatSessionPreparationKey(sessionTab);
     const latestSessionTabRef = useRef(sessionTab);
+    const agentControlDiscoveryAttemptsRef = useRef(
+        new Map<string, AgentControlDiscoveryAttempt>(),
+    );
+    const agentControlDiscoveryMountedRef = useRef(true);
+    const agentControlDiscoveryRetryTimersRef = useRef(new Set<number>());
+    const [agentControlDiscoveryRetryNonce, setAgentControlDiscoveryRetryNonce] =
+        useState(0);
+    const liveSessionTab = useMemo(
+        () => ({
+            ...sessionTab,
+            sessionOpenMode: "live" as const,
+        }),
+        [sessionTab],
+    );
+    const ensureLiveAgentSession = useCallback(
+        async (force: boolean) => {
+            const currentSession =
+                useAiStore.getState().sessions[tab.sessionId] ?? null;
+            if (
+                !force &&
+                currentSession?.runtimeState === "live" &&
+                currentSession.snapshot?.runtimeSessionId
+            ) {
+                return;
+            }
+
+            await ensureSession(liveSessionTab, { force: true });
+        },
+        [ensureSession, liveSessionTab, tab.sessionId],
+    );
+    const agentControlMutationOptions = useMemo(
+        () => ({ ensureLiveSession: ensureLiveAgentSession }),
+        [ensureLiveAgentSession],
+    );
     const runAgentControlMutation = useCallback(
         (mutation: () => Promise<void>) => {
             void mutation().catch((error: unknown) => {
@@ -426,6 +481,22 @@ export const ChatTabView = memo(function ChatTabView({
     useEffect(() => {
         latestSessionTabRef.current = sessionTab;
     }, [sessionTab]);
+
+    useEffect(() => {
+        agentControlDiscoveryMountedRef.current = true;
+        const retryTimers = agentControlDiscoveryRetryTimersRef.current;
+        return () => {
+            agentControlDiscoveryMountedRef.current = false;
+            for (const retryTimer of retryTimers) {
+                window.clearTimeout(retryTimer);
+            }
+            retryTimers.clear();
+        };
+    }, []);
+
+    useEffect(() => {
+        registerSessionTab(sessionTab);
+    }, [registerSessionTab, sessionTab]);
 
     useEffect(() => {
         if (
@@ -581,6 +652,116 @@ export const ChatTabView = memo(function ChatTabView({
         agentConfigOptions.length > 0 ||
         agentModels.length > 0 ||
         agentModes.length > 0;
+
+    useEffect(() => {
+        const discoveryKey = `${tab.sessionId}:${tab.runtimeId}`;
+        const previousAttempt =
+            agentControlDiscoveryAttemptsRef.current.get(discoveryKey);
+        if (
+            !active ||
+            latestSessionTabRef.current.sessionOpenMode === "history" ||
+            hasAgentControls ||
+            previousAttempt?.status === "completed" ||
+            previousAttempt?.status === "exhausted" ||
+            previousAttempt?.status === "loading" ||
+            previousAttempt?.status === "retrying"
+        ) {
+            return;
+        }
+
+        const attemptCount = (previousAttempt?.attemptCount ?? 0) + 1;
+        agentControlDiscoveryAttemptsRef.current.set(discoveryKey, {
+            attemptCount,
+            status: "loading",
+        });
+        void (async () => {
+            try {
+                if (!runtimeCatalog) {
+                    await refreshRuntimeStatus(tab.runtimeId);
+                }
+
+                const state = useAiStore.getState();
+                const currentSnapshot =
+                    state.sessions[tab.sessionId]?.snapshot ?? null;
+                const currentCatalog =
+                    state.runtimeCatalogById[tab.runtimeId] ?? null;
+                if (
+                    hasAgentControlCatalog(currentSnapshot) ||
+                    hasAgentControlCatalog(currentCatalog)
+                ) {
+                    agentControlDiscoveryAttemptsRef.current.set(discoveryKey, {
+                        attemptCount,
+                        status: "completed",
+                    });
+                    return;
+                }
+
+                // A provider without a cached catalog must start once to
+                // discover its controls before the first prompt.
+                await ensureSession(liveSessionTab, { force: true });
+                agentControlDiscoveryAttemptsRef.current.set(discoveryKey, {
+                    attemptCount,
+                    status: "completed",
+                });
+            } catch (error) {
+                console.warn(
+                    "[comando] Failed to load AI session controls.",
+                    error,
+                );
+                if (!agentControlDiscoveryMountedRef.current) {
+                    return;
+                }
+
+                if (
+                    attemptCount >= MAX_AGENT_CONTROL_DISCOVERY_ATTEMPTS
+                ) {
+                    agentControlDiscoveryAttemptsRef.current.set(discoveryKey, {
+                        attemptCount,
+                        status: "exhausted",
+                    });
+                    return;
+                }
+
+                agentControlDiscoveryAttemptsRef.current.set(discoveryKey, {
+                    attemptCount,
+                    status: "retrying",
+                });
+                const retryTimer = window.setTimeout(() => {
+                    agentControlDiscoveryRetryTimersRef.current.delete(
+                        retryTimer,
+                    );
+                    const pendingAttempt =
+                        agentControlDiscoveryAttemptsRef.current.get(
+                            discoveryKey,
+                        );
+                    if (
+                        !agentControlDiscoveryMountedRef.current ||
+                        pendingAttempt?.attemptCount !== attemptCount ||
+                        pendingAttempt.status !== "retrying"
+                    ) {
+                        return;
+                    }
+
+                    agentControlDiscoveryAttemptsRef.current.set(discoveryKey, {
+                        attemptCount,
+                        status: "idle",
+                    });
+                    setAgentControlDiscoveryRetryNonce((nonce) => nonce + 1);
+                }, AGENT_CONTROL_DISCOVERY_RETRY_DELAY_MS * 2 ** (attemptCount - 1));
+                agentControlDiscoveryRetryTimersRef.current.add(retryTimer);
+            }
+        })();
+    }, [
+        active,
+        agentControlDiscoveryRetryNonce,
+        ensureSession,
+        hasAgentControls,
+        liveSessionTab,
+        refreshRuntimeStatus,
+        runtimeCatalog,
+        tab.runtimeId,
+        tab.sessionId,
+    ]);
 
     const canonicalTrackedFiles = useMemo(
         () =>
@@ -2032,27 +2213,39 @@ export const ChatTabView = memo(function ChatTabView({
                                             value,
                                         ) => {
                                             runAgentControlMutation(() =>
-                                                setSessionConfigOption({
-                                                    optionId,
-                                                    sessionId: tab.sessionId,
-                                                    value,
-                                                }),
+                                                setSessionConfigOption(
+                                                    {
+                                                        optionId,
+                                                        sessionId:
+                                                            tab.sessionId,
+                                                        value,
+                                                    },
+                                                    agentControlMutationOptions,
+                                                ),
                                             );
                                         }}
                                         onModeChange={(modeId) => {
                                             runAgentControlMutation(() =>
-                                                setSessionMode({
-                                                    modeId,
-                                                    sessionId: tab.sessionId,
-                                                }),
+                                                setSessionMode(
+                                                    {
+                                                        modeId,
+                                                        sessionId:
+                                                            tab.sessionId,
+                                                    },
+                                                    agentControlMutationOptions,
+                                                ),
                                             );
                                         }}
                                         onModelChange={(modelId) => {
                                             runAgentControlMutation(() =>
-                                                setSessionModel({
-                                                    modelId,
-                                                    sessionId: tab.sessionId,
-                                                }),
+                                                setSessionModel(
+                                                    {
+                                                        modelId,
+                                                        sessionId:
+                                                            tab.sessionId,
+                                                    },
+                                                    agentControlMutationOptions,
+                                                ),
                                             );
                                         }}
                                         runtimeId={tab.runtimeId}


### PR DESCRIPTION
## Summary

Improves AI agent control reliability across runtime startup, session preparation, and optimistic UI updates.

- Restores saved runtime selections for models, modes, and supported configuration options when runtime status is loaded.
- Discovers agent controls before the first prompt when a provider has no cached catalog.
- Prepares or re-prepares sessions before applying control changes, including retrying when a retained runtime session was evicted.
- Keeps optimistic control changes visible through stale incoming snapshots and prevents failed requests from reverting newer selections.
- Prevents pending per-session selections from leaking into the shared runtime catalog.
- Stabilizes agent-control rendering by memoizing visible options and improving dropdown grouping.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec vitest run src/main/ai/service.prepare.test.ts src/renderer/src/app/store/ai-store.test.ts`
- `pnpm exec vitest run src/renderer/src/components/workspace/AIChatAgentControls.test.tsx`