### PR TITLE
perf(workspace): speed up context switching and retained views

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -35,6 +35,7 @@ import {
 import { createGitProjectRefreshScheduler } from "./app/git/refresh-scheduler";
 import {
     areGitWorktreeIdsEquivalent,
+    getGitContextKey,
     resolveProjectContextWorktreeId,
 } from "./app/git/context-key";
 import {
@@ -55,6 +56,10 @@ import {
 } from "./app/projects/quick-open";
 import { filterProjectEntriesForTreeFilter } from "./app/projects/tree-filter";
 import { getProjectContextKey } from "./app/projects/context-key";
+import {
+    resolveWorkspaceContextRefreshPlan,
+    runDeduplicatedContextRefresh,
+} from "./app/workspace/context-activation-refresh";
 import { shellLayoutConstraints } from "./app/layout/shell-layout";
 import {
     edgePeekConfig,
@@ -519,6 +524,12 @@ export function App() {
     const [persistenceReady, setPersistenceReady] = useState(false);
     const [sidebarOverlayVisible, setSidebarOverlayVisible] = useState(false);
     const [sidebarOverlayClosing, setSidebarOverlayClosing] = useState(false);
+    const pendingContextTreeRefreshesRef = useRef(
+        new Map<string, Promise<void>>(),
+    );
+    const pendingContextGitRefreshesRef = useRef(
+        new Map<string, Promise<GitRepositorySnapshot | null>>(),
+    );
     const [gitChangesFilter, setGitChangesFilter] = useState("");
     const [agentsFilter, setAgentsFilter] = useState("");
     const [issuesFilter, setIssuesFilter] = useState("");
@@ -1022,40 +1033,54 @@ export function App() {
         activeProjectId,
         activeWorktreeId,
     );
-    const activeGitContextKey = getGitContextKey(
-        activeProjectId,
-        activeWorktreeId,
-    );
+    const activeGitContextKey = activeProjectId
+        ? getGitContextKey(activeProjectId, activeWorktreeId)
+        : null;
 
     useEffect(() => {
         if (!activeWorkspaceContext) {
             return;
         }
 
-        let cancelled = false;
         const { projectId, worktreeId } = activeWorkspaceContext;
-        void (async () => {
-            await setActiveWorktree(projectId, worktreeId);
-            if (cancelled) {
-                return;
-            }
+        void setActiveWorktree(projectId, worktreeId);
 
-            await Promise.all([
-                refreshProjectTree(projectId, worktreeId),
-                refreshGitProject(projectId, worktreeId),
-                refreshGitHistory(projectId, worktreeId),
-            ]);
-        })();
+        const projectContextKey = getProjectContextKey(projectId, worktreeId);
+        const gitContextKey = getGitContextKey(projectId, worktreeId);
+        const projectsState = useProjectsStore.getState();
+        const gitState = useGitStore.getState();
+        const refreshPlan = resolveWorkspaceContextRefreshPlan({
+            hasGitSnapshot: Object.hasOwn(gitState.snapshots, gitContextKey),
+            hasProjectTree: Object.hasOwn(
+                projectsState.treeNodes[projectContextKey] ?? {},
+                ROOT_NODE_KEY,
+            ),
+            sidebarView,
+            sidebarVisible: !leftCollapsed || sidebarOverlayVisible,
+        });
 
-        return () => {
-            cancelled = true;
-        };
+        if (refreshPlan.projectTree) {
+            void runDeduplicatedContextRefresh(
+                pendingContextTreeRefreshesRef.current,
+                projectContextKey,
+                () => refreshProjectTree(projectId, worktreeId),
+            );
+        }
+        if (refreshPlan.gitSnapshot) {
+            void runDeduplicatedContextRefresh(
+                pendingContextGitRefreshesRef.current,
+                gitContextKey,
+                () => refreshGitProject(projectId, worktreeId),
+            );
+        }
     }, [
         activeWorkspaceContext,
-        refreshGitHistory,
+        leftCollapsed,
         refreshGitProject,
         refreshProjectTree,
         setActiveWorktree,
+        sidebarOverlayVisible,
+        sidebarView,
     ]);
 
     useEffect(() => {
@@ -1732,7 +1757,9 @@ export function App() {
             }),
         [activeProjectId, activeWorkspaceTab, activeWorktreeId],
     );
-    const activeGitError = gitErrors[activeGitContextKey] ?? null;
+    const activeGitError = activeGitContextKey
+        ? (gitErrors[activeGitContextKey] ?? null)
+        : null;
     const isMac = bootstrap?.platform === "darwin";
     const topStatus = [
         bootstrapError,
@@ -4976,13 +5003,6 @@ function getSettingsUpdateMenuLabel(state: AppUpdateState): string | null {
     }
 
     return null;
-}
-
-function getGitContextKey(
-    projectId: string | null,
-    worktreeId: string | null,
-): string {
-    return `${projectId ?? "__none__"}::${worktreeId ?? "__primary__"}`;
 }
 
 function joinProjectPath(rootPath: string, relativePath: string): string {

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -131,6 +131,18 @@ function createDeferred<T>() {
     };
 }
 
+function installActivationFrameQueue(): FrameRequestCallback[] {
+    const activationFrames: FrameRequestCallback[] = [];
+    Object.assign(window, {
+        cancelAnimationFrame: vi.fn(),
+        requestAnimationFrame: vi.fn((callback: FrameRequestCallback) => {
+            activationFrames.push(callback);
+            return activationFrames.length;
+        }),
+    });
+    return activationFrames;
+}
+
 describe("workspace file opening", () => {
     beforeEach(() => {
         resetWorkspacePersistenceForTests();
@@ -234,6 +246,7 @@ describe("workspace file opening", () => {
                 },
             },
             error: null,
+            deferredPaneIds: new Set(),
             hydrated: true,
             lastFocusedChatTabId: null,
             lastFocusedRuntimeId: "codex",
@@ -447,7 +460,9 @@ describe("workspace file opening", () => {
 
         await useWorkspaceStore.getState().hydrate();
 
-        expect(ensureSessionMock).toHaveBeenCalledTimes(2);
+        await vi.waitFor(() => {
+            expect(ensureSessionMock).toHaveBeenCalledTimes(2);
+        });
         expect(ensureSessionMock).toHaveBeenCalledWith(
             expect.objectContaining({ sessionId: "session-left" }),
         );
@@ -527,6 +542,474 @@ describe("workspace file opening", () => {
             relativePath: inactiveFile.relativePath,
             worktreeId: null,
         });
+    });
+
+    it("defers secondary pane hydration until after the activation frame", async () => {
+        const activationFrames = installActivationFrameQueue();
+
+        const focusedFile = createWorkspaceFileTab(
+            "focused-file",
+            "src/focused.ts",
+        );
+        const secondaryFile = createWorkspaceFileTab(
+            "secondary-file",
+            "src/secondary.ts",
+        );
+        const tertiaryFile = createWorkspaceFileTab(
+            "tertiary-file",
+            "src/tertiary.ts",
+        );
+        const targetContextKey = "project-2::__primary__";
+        const targetWorkspace: WorkspaceTreeState = {
+            activePaneId: "pane-left",
+            rootNode: {
+                axis: "horizontal",
+                children: [
+                    {
+                        activeTabId: focusedFile.id,
+                        id: "pane-left",
+                        tabIds: [focusedFile.id],
+                        type: "pane",
+                    },
+                    {
+                        activeTabId: secondaryFile.id,
+                        id: "pane-right",
+                        tabIds: [secondaryFile.id],
+                        type: "pane",
+                    },
+                    {
+                        activeTabId: tertiaryFile.id,
+                        id: "pane-far-right",
+                        tabIds: [tertiaryFile.id],
+                        type: "pane",
+                    },
+                ],
+                id: "split-root",
+                sizes: [0.34, 0.33, 0.33],
+                type: "split",
+            },
+            tabsById: {
+                [focusedFile.id]: { ...focusedFile, projectId: "project-2" },
+                [secondaryFile.id]: {
+                    ...secondaryFile,
+                    projectId: "project-2",
+                },
+                [tertiaryFile.id]: {
+                    ...tertiaryFile,
+                    projectId: "project-2",
+                },
+            },
+        };
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [targetContextKey]: {
+                    key: targetContextKey,
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: targetWorkspace,
+                    worktreeId: null,
+                },
+            },
+            openContextKeys: [...state.openContextKeys, targetContextKey],
+        }));
+
+        await useWorkspaceStore.getState().activateContext(targetContextKey);
+
+        expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        expect(openProjectFileMock).toHaveBeenCalledWith({
+            projectId: "project-2",
+            relativePath: focusedFile.relativePath,
+            worktreeId: null,
+        });
+        expect(useWorkspaceStore.getState().deferredPaneIds).toEqual(
+            new Set(["pane-right", "pane-far-right"]),
+        );
+
+        activationFrames.shift()?.(performance.now());
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(2);
+        });
+        expect(openProjectFileMock).toHaveBeenLastCalledWith({
+            projectId: "project-2",
+            relativePath: secondaryFile.relativePath,
+            worktreeId: null,
+        });
+        expect(useWorkspaceStore.getState().deferredPaneIds).toEqual(
+            new Set(["pane-far-right"]),
+        );
+
+        expect(activationFrames).toHaveLength(1);
+        activationFrames.shift()?.(performance.now());
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(3);
+        });
+        expect(openProjectFileMock).toHaveBeenLastCalledWith({
+            projectId: "project-2",
+            relativePath: tertiaryFile.relativePath,
+            worktreeId: null,
+        });
+        expect(useWorkspaceStore.getState().deferredPaneIds.size).toBe(0);
+    });
+
+    it("does not promote a background tab when the focused pane is empty", async () => {
+        const activationFrames = installActivationFrameQueue();
+        const backgroundFile = createWorkspaceFileTab(
+            "background-file",
+            "src/background.ts",
+        );
+        const targetContextKey = "project-2::__primary__";
+        const targetWorkspace: WorkspaceTreeState = {
+            activePaneId: "pane-empty",
+            rootNode: {
+                axis: "horizontal",
+                children: [
+                    {
+                        activeTabId: null,
+                        id: "pane-empty",
+                        tabIds: [],
+                        type: "pane",
+                    },
+                    {
+                        activeTabId: backgroundFile.id,
+                        id: "pane-background",
+                        tabIds: [backgroundFile.id],
+                        type: "pane",
+                    },
+                ],
+                id: "split-root",
+                sizes: [0.5, 0.5],
+                type: "split",
+            },
+            tabsById: {
+                [backgroundFile.id]: {
+                    ...backgroundFile,
+                    projectId: "project-2",
+                },
+            },
+        };
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [targetContextKey]: {
+                    key: targetContextKey,
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: targetWorkspace,
+                    worktreeId: null,
+                },
+            },
+            openContextKeys: [...state.openContextKeys, targetContextKey],
+        }));
+
+        await useWorkspaceStore.getState().activateContext(targetContextKey);
+
+        expect(openProjectFileMock).not.toHaveBeenCalled();
+        expect(useWorkspaceStore.getState().deferredPaneIds).toEqual(
+            new Set(["pane-background"]),
+        );
+
+        activationFrames.shift()?.(performance.now());
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        });
+        expect(openProjectFileMock).toHaveBeenCalledWith({
+            projectId: "project-2",
+            relativePath: backgroundFile.relativePath,
+            worktreeId: null,
+        });
+    });
+
+    it("resolves the current pane tab when its deferred frame arrives", async () => {
+        const activationFrames = installActivationFrameQueue();
+        const focusedFile = createWorkspaceFileTab(
+            "focused-file",
+            "src/focused.ts",
+        );
+        const staleFile = createWorkspaceFileTab("stale-file", "src/stale.ts");
+        const currentFile = createWorkspaceFileTab(
+            "current-file",
+            "src/current.ts",
+        );
+        const targetContextKey = "project-2::__primary__";
+        const targetWorkspace: WorkspaceTreeState = {
+            activePaneId: "pane-left",
+            rootNode: {
+                axis: "horizontal",
+                children: [
+                    {
+                        activeTabId: focusedFile.id,
+                        id: "pane-left",
+                        tabIds: [focusedFile.id],
+                        type: "pane",
+                    },
+                    {
+                        activeTabId: staleFile.id,
+                        id: "pane-right",
+                        tabIds: [staleFile.id, currentFile.id],
+                        type: "pane",
+                    },
+                ],
+                id: "split-root",
+                sizes: [0.5, 0.5],
+                type: "split",
+            },
+            tabsById: Object.fromEntries(
+                [focusedFile, staleFile, currentFile].map((tab) => [
+                    tab.id,
+                    { ...tab, projectId: "project-2" },
+                ]),
+            ),
+        };
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [targetContextKey]: {
+                    key: targetContextKey,
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: targetWorkspace,
+                    worktreeId: null,
+                },
+            },
+            openContextKeys: [...state.openContextKeys, targetContextKey],
+        }));
+
+        await useWorkspaceStore.getState().activateContext(targetContextKey);
+        await useWorkspaceStore
+            .getState()
+            .selectTab("pane-right", currentFile.id);
+        activationFrames.shift()?.(performance.now());
+
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledWith({
+                projectId: "project-2",
+                relativePath: currentFile.relativePath,
+                worktreeId: null,
+            });
+        });
+        expect(openProjectFileMock).not.toHaveBeenCalledWith(
+            expect.objectContaining({ relativePath: staleFile.relativePath }),
+        );
+    });
+
+    it("reveals and prepares a deferred pane immediately when it gains focus", async () => {
+        const activationFrames = installActivationFrameQueue();
+        const backgroundFile = createWorkspaceFileTab(
+            "background-file",
+            "src/background.ts",
+        );
+        const targetContextKey = "project-2::__primary__";
+        const targetWorkspace: WorkspaceTreeState = {
+            activePaneId: "pane-empty",
+            rootNode: {
+                axis: "horizontal",
+                children: [
+                    {
+                        activeTabId: null,
+                        id: "pane-empty",
+                        tabIds: [],
+                        type: "pane",
+                    },
+                    {
+                        activeTabId: backgroundFile.id,
+                        id: "pane-background",
+                        tabIds: [backgroundFile.id],
+                        type: "pane",
+                    },
+                ],
+                id: "split-root",
+                sizes: [0.5, 0.5],
+                type: "split",
+            },
+            tabsById: {
+                [backgroundFile.id]: {
+                    ...backgroundFile,
+                    projectId: "project-2",
+                },
+            },
+        };
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [targetContextKey]: {
+                    key: targetContextKey,
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: targetWorkspace,
+                    worktreeId: null,
+                },
+            },
+            openContextKeys: [...state.openContextKeys, targetContextKey],
+        }));
+
+        await useWorkspaceStore.getState().activateContext(targetContextKey);
+        await useWorkspaceStore.getState().setActivePane("pane-background");
+
+        expect(useWorkspaceStore.getState().deferredPaneIds.size).toBe(0);
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        });
+
+        activationFrames.shift()?.(performance.now());
+        await Promise.resolve();
+        expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the active pane outside the deferred queue after any mutation", () => {
+        useWorkspaceStore.setState({
+            activePaneId: "pane-background",
+            deferredPaneIds: new Set(["pane-background", "pane-other"]),
+        });
+
+        expect(useWorkspaceStore.getState().deferredPaneIds).toEqual(
+            new Set(["pane-other"]),
+        );
+    });
+
+    it("prepares a deferred fallback after closing the active pane", async () => {
+        const activationFrames = installActivationFrameQueue();
+        const fallbackFile = createWorkspaceFileTab(
+            "fallback-file",
+            "src/fallback.ts",
+        );
+        const targetContextKey = "project-2::__primary__";
+        const targetWorkspace: WorkspaceTreeState = {
+            activePaneId: "pane-empty",
+            rootNode: {
+                axis: "horizontal",
+                children: [
+                    {
+                        activeTabId: null,
+                        id: "pane-empty",
+                        tabIds: [],
+                        type: "pane",
+                    },
+                    {
+                        activeTabId: fallbackFile.id,
+                        id: "pane-fallback",
+                        tabIds: [fallbackFile.id],
+                        type: "pane",
+                    },
+                ],
+                id: "split-root",
+                sizes: [0.5, 0.5],
+                type: "split",
+            },
+            tabsById: {
+                [fallbackFile.id]: {
+                    ...fallbackFile,
+                    projectId: "project-2",
+                },
+            },
+        };
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [targetContextKey]: {
+                    key: targetContextKey,
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: targetWorkspace,
+                    worktreeId: null,
+                },
+            },
+            openContextKeys: [...state.openContextKeys, targetContextKey],
+        }));
+
+        await useWorkspaceStore.getState().activateContext(targetContextKey);
+        await useWorkspaceStore.getState().closePane("pane-empty");
+
+        expect(useWorkspaceStore.getState().activePaneId).toBe("pane-fallback");
+        expect(useWorkspaceStore.getState().deferredPaneIds.size).toBe(0);
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        });
+        expect(openProjectFileMock).toHaveBeenCalledWith({
+            projectId: "project-2",
+            relativePath: fallbackFile.relativePath,
+            worktreeId: null,
+        });
+
+        activationFrames.shift()?.(performance.now());
+        await Promise.resolve();
+        expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancels a deferred pane queue after a rapid context switch", async () => {
+        const activationFrames = installActivationFrameQueue();
+        const backgroundFile = createWorkspaceFileTab(
+            "background-file",
+            "src/background.ts",
+        );
+        const targetContextKey = "project-2::__primary__";
+        const targetWorkspace: WorkspaceTreeState = {
+            activePaneId: "pane-empty",
+            rootNode: {
+                axis: "horizontal",
+                children: [
+                    {
+                        activeTabId: null,
+                        id: "pane-empty",
+                        tabIds: [],
+                        type: "pane",
+                    },
+                    {
+                        activeTabId: backgroundFile.id,
+                        id: "pane-background",
+                        tabIds: [backgroundFile.id],
+                        type: "pane",
+                    },
+                ],
+                id: "split-root",
+                sizes: [0.5, 0.5],
+                type: "split",
+            },
+            tabsById: {
+                [backgroundFile.id]: {
+                    ...backgroundFile,
+                    projectId: "project-2",
+                },
+            },
+        };
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [targetContextKey]: {
+                    key: targetContextKey,
+                    lastActivatedAt: "2026-04-14T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: targetWorkspace,
+                    worktreeId: null,
+                },
+            },
+            openContextKeys: [...state.openContextKeys, targetContextKey],
+        }));
+
+        await useWorkspaceStore.getState().activateContext(targetContextKey);
+        await useWorkspaceStore
+            .getState()
+            .activateContext("project-1::__primary__");
+        activationFrames.shift()?.(performance.now());
+        await Promise.resolve();
+
+        expect(openProjectFileMock).not.toHaveBeenCalled();
+        expect(useWorkspaceStore.getState().activeContextKey).toBe(
+            "project-1::__primary__",
+        );
+        expect(useWorkspaceStore.getState().deferredPaneIds.size).toBe(0);
     });
 
     it("retries a file load after a rapid context switch", async () => {

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -124,6 +124,7 @@ export interface RuntimeWorkspaceContext {
 interface WorkspaceStore extends WorkspaceTreeState {
     readonly activeContextKey: string | null;
     readonly contextsByKey: Record<string, RuntimeWorkspaceContext>;
+    readonly deferredPaneIds: ReadonlySet<string>;
     getContextNavigationSnapshot: (
         contextKey: string,
     ) => WorkspaceNavigationSnapshot | null;
@@ -389,6 +390,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     ...createDefaultWorkspaceState(),
     activeContextKey: null,
     contextsByKey: {},
+    deferredPaneIds: new Set(),
     error: null,
     hydrated: false,
     lastFocusedChatTabId: null,
@@ -446,6 +448,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                     lastActivatedAt: new Date().toISOString(),
                 },
             },
+            deferredPaneIds: getDeferredWorkspacePaneIds(targetWorkspace),
             error: null,
             lastFocusedChatTabId: getPaneChatTabId(
                 targetWorkspace,
@@ -474,8 +477,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             scopeEpoch,
         });
 
-        ensureActiveHydratedSessions(targetWorkspace);
-        void hydrateActiveRuntimeTabs(
+        void activateWorkspaceRuntimePanes(
             targetWorkspace,
             get,
             set,
@@ -523,6 +525,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             ...nextWorkspace,
             activeContextKey: nextContextKey,
             contextsByKey: nextContextsByKey,
+            deferredPaneIds: getDeferredWorkspacePaneIds(nextWorkspace),
             error: null,
             lastFocusedChatTabId: getPaneChatTabId(
                 nextWorkspace,
@@ -553,8 +556,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         });
 
         if (nextContextKey) {
-            ensureActiveHydratedSessions(nextWorkspace);
-            void hydrateActiveRuntimeTabs(
+            void activateWorkspaceRuntimePanes(
                 nextWorkspace,
                 get,
                 set,
@@ -1262,6 +1264,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 ...hydratedState,
                 activeContextKey,
                 contextsByKey,
+                deferredPaneIds: getDeferredWorkspacePaneIds(hydratedState),
                 error: null,
                 hydrated: true,
                 openContextKeys,
@@ -1290,9 +1293,8 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 ),
                 scopeEpoch,
             });
-            ensureActiveHydratedSessions(hydratedState);
             if (activeContextKey) {
-                void hydrateActiveRuntimeTabs(
+                void activateWorkspaceRuntimePanes(
                     hydratedState,
                     get,
                     set,
@@ -1307,6 +1309,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 ...createDefaultWorkspaceState(),
                 activeContextKey: null,
                 contextsByKey: {},
+                deferredPaneIds: new Set(),
                 error:
                     error instanceof Error
                         ? error.message
@@ -2157,6 +2160,10 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 const chatTabId = getPaneChatTabId(nextState, paneId);
                 return {
                     ...nextState,
+                    deferredPaneIds: removeDeferredWorkspacePane(
+                        state.deferredPaneIds,
+                        paneId,
+                    ),
                     error: null,
                     ...(chatTabId ? { lastFocusedChatTabId: chatTabId } : {}),
                     ...(runtimeId ? { lastFocusedRuntimeId: runtimeId } : {}),
@@ -2358,6 +2365,34 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         await persistWorkspaceState(get);
     },
 }));
+
+// Every workspace mutation may choose a new active pane. Keep the active pane
+// outside the deferred queue regardless of which tree helper produced it.
+const unsubscribeActivePaneDeferredInvariant = useWorkspaceStore.subscribe(
+    (state) => {
+        if (!state.deferredPaneIds.has(state.activePaneId)) {
+            return;
+        }
+
+        const activeTabId = getPaneActiveTabId(state, state.activePaneId);
+        const activeTab = activeTabId ? state.tabsById[activeTabId] : null;
+        useWorkspaceStore.setState({
+            deferredPaneIds: removeDeferredWorkspacePane(
+                state.deferredPaneIds,
+                state.activePaneId,
+            ),
+        });
+        prepareFocusedWorkspaceTab(
+            activeTab,
+            useWorkspaceStore.getState,
+            useWorkspaceStore.setState,
+        );
+    },
+);
+
+if (import.meta.hot) {
+    import.meta.hot.dispose(unsubscribeActivePaneDeferredInvariant);
+}
 
 type WorkspaceSetState = typeof useWorkspaceStore.setState;
 
@@ -3246,17 +3281,6 @@ function createHydratedRuntimeTabs(
     ) as Record<string, RuntimeWorkspaceTab>;
 }
 
-function ensureActiveHydratedSessions(state: WorkspaceTreeState): void {
-    for (const pane of collectPaneNodes(state.rootNode)) {
-        const activeTab = pane.activeTabId
-            ? state.tabsById[pane.activeTabId]
-            : null;
-        if (activeTab?.kind === "chat" || activeTab?.kind === "review") {
-            prewarmFocusedAiSession(activeTab);
-        }
-    }
-}
-
 function prepareFocusedWorkspaceTab(
     tab: RuntimeWorkspaceTab | null | undefined,
     get: GetWorkspaceState,
@@ -3289,7 +3313,7 @@ function prewarmFocusedAiSession(
     void useAiStore.getState().ensureSession(tab);
 }
 
-async function hydrateActiveRuntimeTabs(
+async function activateWorkspaceRuntimePanes(
     workspace: WorkspaceTreeState,
     get: GetWorkspaceState,
     set: WorkspaceSetState,
@@ -3298,20 +3322,106 @@ async function hydrateActiveRuntimeTabs(
         readonly scopeEpoch: number;
     },
 ): Promise<void> {
-    const activeTabIds = new Set(
-        collectPaneNodes(workspace.rootNode).flatMap((pane) =>
-            pane.activeTabId ? [pane.activeTabId] : [],
-        ),
-    );
+    const panes = collectPaneNodes(workspace.rootNode);
+    const focusedPane = panes.find(
+        (pane) => pane.id === workspace.activePaneId,
+    ) ?? null;
+    const focusedTab = focusedPane?.activeTabId
+        ? workspace.tabsById[focusedPane.activeTabId]
+        : null;
+    const focusedLoad = focusedTab
+        ? hydrateWorkspaceRuntimeTab(focusedTab, get, set, scope)
+        : Promise.resolve();
+    const backgroundPaneIds = panes
+        .filter((pane) => pane.id !== workspace.activePaneId)
+        .map((pane) => pane.id);
 
-    await Promise.all(
-        [...activeTabIds].map(async (tabId) => {
-            const tab = workspace.tabsById[tabId];
-            if (tab?.kind === "file") {
-                await loadFileTabDocument(get, set, tab.id, scope);
-            }
-        }),
+    // Let the focused pane commit before secondary panes start file I/O and
+    // history hydration. This keeps context switching responsive on dense layouts.
+    const backgroundLoads: Promise<void>[] = [];
+    for (const paneId of backgroundPaneIds) {
+        await waitForWorkspaceActivationFrame();
+        if (!isWorkspaceScopeCurrent(get, scope)) {
+            break;
+        }
+
+        if (!get().deferredPaneIds.has(paneId)) {
+            continue;
+        }
+
+        set((state) => ({
+            deferredPaneIds: removeDeferredWorkspacePane(
+                state.deferredPaneIds,
+                paneId,
+            ),
+        }));
+
+        const currentState = get();
+        const currentPane = findPaneById(currentState.rootNode, paneId);
+        const currentTab = currentPane?.activeTabId
+            ? currentState.tabsById[currentPane.activeTabId]
+            : null;
+        if (currentTab) {
+            backgroundLoads.push(
+                hydrateWorkspaceRuntimeTab(currentTab, get, set, scope),
+            );
+        }
+    }
+
+    await Promise.all([focusedLoad, ...backgroundLoads]);
+}
+
+function getDeferredWorkspacePaneIds(
+    workspace: WorkspaceTreeState,
+): ReadonlySet<string> {
+    return new Set(
+        collectPaneNodes(workspace.rootNode)
+            .filter((pane) => pane.id !== workspace.activePaneId)
+            .map((pane) => pane.id),
     );
+}
+
+function removeDeferredWorkspacePane(
+    deferredPaneIds: ReadonlySet<string>,
+    paneId: string,
+): ReadonlySet<string> {
+    if (!deferredPaneIds.has(paneId)) {
+        return deferredPaneIds;
+    }
+
+    const nextDeferredPaneIds = new Set(deferredPaneIds);
+    nextDeferredPaneIds.delete(paneId);
+    return nextDeferredPaneIds;
+}
+
+async function hydrateWorkspaceRuntimeTab(
+    tab: RuntimeWorkspaceTab,
+    get: GetWorkspaceState,
+    set: WorkspaceSetState,
+    scope?: {
+        readonly contextKey: string;
+        readonly scopeEpoch: number;
+    },
+): Promise<void> {
+    if (tab.kind === "file") {
+        await loadFileTabDocument(get, set, tab.id, scope);
+        return;
+    }
+
+    if (tab.kind === "chat" || tab.kind === "review") {
+        prewarmFocusedAiSession(tab);
+    }
+}
+
+function waitForWorkspaceActivationFrame(): Promise<void> {
+    return new Promise((resolve) => {
+        if (typeof window.requestAnimationFrame === "function") {
+            window.requestAnimationFrame(() => resolve());
+            return;
+        }
+
+        queueMicrotask(resolve);
+    });
 }
 
 function isWorkspaceScopeCurrent(

--- a/src/renderer/src/app/workspace/context-activation-refresh.test.ts
+++ b/src/renderer/src/app/workspace/context-activation-refresh.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+    resolveWorkspaceContextRefreshPlan,
+    runDeduplicatedContextRefresh,
+} from "./context-activation-refresh";
+
+describe("resolveWorkspaceContextRefreshPlan", () => {
+    it("loads only a missing visible file tree", () => {
+        expect(
+            resolveWorkspaceContextRefreshPlan({
+                hasGitSnapshot: false,
+                hasProjectTree: false,
+                sidebarView: "files",
+                sidebarVisible: true,
+            }),
+        ).toEqual({ gitSnapshot: false, projectTree: true });
+    });
+
+    it("loads only a missing visible Git snapshot", () => {
+        expect(
+            resolveWorkspaceContextRefreshPlan({
+                hasGitSnapshot: false,
+                hasProjectTree: false,
+                sidebarView: "git",
+                sidebarVisible: true,
+            }),
+        ).toEqual({ gitSnapshot: true, projectTree: false });
+    });
+
+    it("keeps cached context data without revalidating on activation", () => {
+        expect(
+            resolveWorkspaceContextRefreshPlan({
+                hasGitSnapshot: true,
+                hasProjectTree: true,
+                sidebarView: "files",
+                sidebarVisible: true,
+            }),
+        ).toEqual({ gitSnapshot: false, projectTree: false });
+    });
+
+    it("defers loading while the sidebar is hidden", () => {
+        expect(
+            resolveWorkspaceContextRefreshPlan({
+                hasGitSnapshot: false,
+                hasProjectTree: false,
+                sidebarView: "git",
+                sidebarVisible: false,
+            }),
+        ).toEqual({ gitSnapshot: false, projectTree: false });
+    });
+});
+
+describe("runDeduplicatedContextRefresh", () => {
+    it("shares an in-flight refresh for the same context", async () => {
+        let resolveRefresh!: (value: string) => void;
+        const refresh = vi.fn(
+            () =>
+                new Promise<string>((resolve) => {
+                    resolveRefresh = resolve;
+                }),
+        );
+        const pending = new Map<string, Promise<string>>();
+
+        const first = runDeduplicatedContextRefresh(
+            pending,
+            "project::primary",
+            refresh,
+        );
+        const second = runDeduplicatedContextRefresh(
+            pending,
+            "project::primary",
+            refresh,
+        );
+
+        expect(first).toBe(second);
+        expect(refresh).toHaveBeenCalledTimes(0);
+
+        await Promise.resolve();
+        expect(refresh).toHaveBeenCalledTimes(1);
+        resolveRefresh("done");
+        await expect(first).resolves.toBe("done");
+        expect(pending.size).toBe(0);
+    });
+
+    it("allows a retry after a failed refresh", async () => {
+        const pending = new Map<string, Promise<void>>();
+        const failedRefresh = runDeduplicatedContextRefresh(
+            pending,
+            "project::primary",
+            () => Promise.reject(new Error("failed")),
+        );
+
+        await expect(failedRefresh).rejects.toThrow("failed");
+        expect(pending.size).toBe(0);
+
+        await expect(
+            runDeduplicatedContextRefresh(
+                pending,
+                "project::primary",
+                () => Promise.resolve(),
+            ),
+        ).resolves.toBeUndefined();
+    });
+});

--- a/src/renderer/src/app/workspace/context-activation-refresh.ts
+++ b/src/renderer/src/app/workspace/context-activation-refresh.ts
@@ -1,0 +1,55 @@
+export type WorkspaceContextSidebarView =
+    | "files"
+    | "git"
+    | "agents"
+    | "issues"
+    | "pull_requests";
+
+export interface WorkspaceContextRefreshPlan {
+    readonly gitSnapshot: boolean;
+    readonly projectTree: boolean;
+}
+
+export function resolveWorkspaceContextRefreshPlan(input: {
+    readonly hasGitSnapshot: boolean;
+    readonly hasProjectTree: boolean;
+    readonly sidebarView: WorkspaceContextSidebarView;
+    readonly sidebarVisible: boolean;
+}): WorkspaceContextRefreshPlan {
+    if (!input.sidebarVisible) {
+        return { gitSnapshot: false, projectTree: false };
+    }
+
+    return {
+        gitSnapshot: input.sidebarView === "git" && !input.hasGitSnapshot,
+        projectTree: input.sidebarView === "files" && !input.hasProjectTree,
+    };
+}
+
+export function runDeduplicatedContextRefresh<T>(
+    pendingByContext: Map<string, Promise<T>>,
+    contextKey: string,
+    refresh: () => Promise<T>,
+): Promise<T> {
+    const pending = pendingByContext.get(contextKey);
+    if (pending) {
+        return pending;
+    }
+
+    const nextRefresh = Promise.resolve().then(refresh);
+    pendingByContext.set(contextKey, nextRefresh);
+    void nextRefresh.then(
+        () => {
+            if (pendingByContext.get(contextKey) === nextRefresh) {
+                pendingByContext.delete(contextKey);
+            }
+        },
+        () => {
+            if (pendingByContext.get(contextKey) === nextRefresh) {
+                pendingByContext.delete(contextKey);
+            }
+        },
+    );
+
+    return nextRefresh;
+}

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.integration.test.tsx
@@ -117,6 +117,7 @@ interface MountConfig {
     readonly geometryCacheSignature?: string;
     readonly items: readonly Item[];
     readonly measurementCacheKey?: string;
+    readonly observeMeasurements?: boolean;
     readonly overscan: number;
     readonly preserveScrollAnchorOnItemsChange?: boolean;
     readonly preserveScrollAnchorOnMeasure: boolean;
@@ -133,6 +134,7 @@ interface MountedList {
     readonly rerender: (next?: {
         readonly items?: readonly Item[];
         readonly getItemMeasurementKey?: (item: Item, index: number) => string;
+        readonly observeMeasurements?: boolean;
     }) => void;
 }
 
@@ -153,6 +155,7 @@ function mountList(config: MountConfig): MountedList {
 
     let currentItems = config.items;
     let currentMeasurementKey = config.getItemMeasurementKey;
+    let currentObserveMeasurements = config.observeMeasurements;
 
     const element = () => (
         <MeasuredVirtualList
@@ -164,6 +167,7 @@ function mountList(config: MountConfig): MountedList {
             geometryCacheSignature={config.geometryCacheSignature}
             items={currentItems}
             measurementCacheKey={config.measurementCacheKey}
+            observeMeasurements={currentObserveMeasurements}
             overscan={config.overscan}
             preserveScrollAnchorOnItemsChange={
                 config.preserveScrollAnchorOnItemsChange
@@ -193,6 +197,9 @@ function mountList(config: MountConfig): MountedList {
         }
         if (next?.getItemMeasurementKey) {
             currentMeasurementKey = next.getItemMeasurementKey;
+        }
+        if (next?.observeMeasurements !== undefined) {
+            currentObserveMeasurements = next.observeMeasurements;
         }
         act(() => {
             root.render(element());
@@ -491,6 +498,27 @@ describe("MeasuredVirtualList scroll anchoring (integration)", () => {
 });
 
 describe("MeasuredVirtualList measurement wiring (integration)", () => {
+    it("disconnects row measurement observers while a retained view is hidden", () => {
+        const list = mountList({
+            items: createItems(60),
+            observeMeasurements: false,
+            overscan: 10,
+            preserveScrollAnchorOnMeasure: true,
+        });
+        const firstRow = rowWrapper(list.mountNode, 0);
+
+        expect(
+            observers.some((observer) => observer.elements.has(firstRow)),
+        ).toBe(false);
+
+        list.rerender({ observeMeasurements: true });
+
+        expect(
+            observers.some((observer) => observer.elements.has(firstRow)),
+        ).toBe(true);
+        list.root.unmount();
+    });
+
     it("recomputes long-chat geometry when returning to an already open tab", () => {
         const items = createItems(5000);
         const estimateSize = vi.fn(() => ITEM_HEIGHT);

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -112,6 +112,12 @@ export interface MeasuredVirtualListHandle {
 export interface MeasuredVirtualListProps<T> {
     readonly items: readonly T[];
     readonly enabled?: boolean;
+    /**
+     * Keeps virtual layout intact while temporarily disconnecting row observers.
+     * Useful for retained, hidden views that should preserve their DOM without
+     * doing background measurement work.
+     */
+    readonly observeMeasurements?: boolean;
     readonly overscan?: number;
     readonly defaultViewportHeight?: number;
     readonly scrollMarginTop?: number;
@@ -476,6 +482,7 @@ export function calculateMeasuredVirtualScrollAnchorAdjustment({
 export function MeasuredVirtualList<T>({
     items,
     enabled = true,
+    observeMeasurements = true,
     overscan = DEFAULT_OVERSCAN,
     defaultViewportHeight = DEFAULT_VIEWPORT_HEIGHT,
     scrollMarginTop = 0,
@@ -727,7 +734,11 @@ export function MeasuredVirtualList<T>({
     }, [shouldPreserveScrollAnchorOnMeasureNow, virtualizationEnabled]);
 
     useEffect(() => {
-        if (!virtualizationEnabled || typeof ResizeObserver === "undefined") {
+        if (
+            !virtualizationEnabled ||
+            !observeMeasurements ||
+            typeof ResizeObserver === "undefined"
+        ) {
             return;
         }
 
@@ -767,7 +778,7 @@ export function MeasuredVirtualList<T>({
             observer.disconnect();
             resizeObserverRef.current = null;
         };
-    }, [updateMeasuredSize, virtualizationEnabled]);
+    }, [observeMeasurements, updateMeasuredSize, virtualizationEnabled]);
 
     useLayoutEffect(() => {
         if (!virtualizationEnabled) {

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -137,6 +137,41 @@ interface ChatTabViewProps {
     readonly tab: RuntimeWorkspaceChatTab;
 }
 
+type ChatSessionViewState = Pick<
+    ReturnType<typeof useAiStore.getState>["sessions"][string],
+    | "dismissedPlanUpdatedAt"
+    | "draftAttachments"
+    | "draftComposerParts"
+    | "draftFileContexts"
+    | "editingQueuedPrompt"
+    | "localError"
+    | "queue"
+    | "snapshot"
+    | "transcript"
+>;
+
+function selectChatSessionViewState(
+    state: ReturnType<typeof useAiStore.getState>,
+    sessionId: string,
+): ChatSessionViewState | null {
+    const session = state.sessions[sessionId];
+    if (!session) {
+        return null;
+    }
+
+    return {
+        dismissedPlanUpdatedAt: session.dismissedPlanUpdatedAt,
+        draftAttachments: session.draftAttachments,
+        draftComposerParts: session.draftComposerParts,
+        draftFileContexts: session.draftFileContexts,
+        editingQueuedPrompt: session.editingQueuedPrompt,
+        localError: session.localError,
+        queue: session.queue,
+        snapshot: session.snapshot,
+        transcript: session.transcript,
+    };
+}
+
 /* ─── Constants ─── */
 
 const FALLBACK_COMMANDS: readonly AiAvailableCommand[] = [
@@ -240,26 +275,21 @@ export const ChatTabView = memo(function ChatTabView({
     const runtimeCatalog = useAiStore(
         (s) => s.runtimeCatalogById[tab.runtimeId] ?? null,
     );
+    const frozenSessionStateRef = useRef<ChatSessionViewState | null>(null);
     const sessionState = useAiStore(
         useShallow((s) => {
-            const session = s.sessions[tab.sessionId];
-            if (!session) {
-                return null;
+            if (!active) {
+                return frozenSessionStateRef.current;
             }
 
-            return {
-                dismissedPlanUpdatedAt: session.dismissedPlanUpdatedAt,
-                draftAttachments: session.draftAttachments,
-                draftComposerParts: session.draftComposerParts,
-                draftFileContexts: session.draftFileContexts,
-                editingQueuedPrompt: session.editingQueuedPrompt,
-                localError: session.localError,
-                queue: session.queue,
-                snapshot: session.snapshot,
-                transcript: session.transcript,
-            };
+            return selectChatSessionViewState(s, tab.sessionId);
         }),
     );
+    useEffect(() => {
+        if (active) {
+            frozenSessionStateRef.current = sessionState;
+        }
+    }, [active, sessionState]);
     const projectSummary = useProjectsStore((state) =>
         tab.projectId
             ? (state.projects.find((project) => project.id === tab.projectId) ??
@@ -2684,6 +2714,7 @@ const ChatTimeline = memo(function ChatTimeline({
                         }}
                     >
                         <ChatTimelineHistory
+                            active={active}
                             canRenderFileReference={
                                 canRenderFileReference
                             }
@@ -2800,6 +2831,7 @@ function ChatJumpToBottomButton(props: {
 }
 
 type ChatTimelineHistoryProps = {
+    readonly active: boolean;
     readonly canRenderFileReference?: (
         rawReference: string,
         reference: ResolvedProjectFileReference,
@@ -2841,6 +2873,7 @@ type ChatTimelineHistoryProps = {
 };
 
 const ChatTimelineHistory = memo(function ChatTimelineHistory({
+    active,
     canRenderFileReference,
     chatFontFamily,
     chatFontSize,
@@ -2902,6 +2935,7 @@ const ChatTimelineHistory = memo(function ChatTimelineHistory({
 
     return (
         <ChatTimelineHistoryRows
+            active={active}
             chatFontFamily={chatFontFamily}
             chatFontSize={chatFontSize}
             historyRows={historyRows}

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -131,6 +131,11 @@ import { GitTabView } from "@renderer/components/workspace/GitTabView";
 import { ProviderIcon } from "@renderer/components/workspace/ProviderIcon";
 import { ReviewTabView } from "@renderer/components/workspace/ReviewTabView";
 import {
+    getIndexedWorkspaceHasChat,
+    getIndexedWorkspaceNode,
+    getIndexedWorkspacePaneCount,
+} from "@renderer/components/workspace/workspaceViewIndex";
+import {
     WorkspacePaneEmptyState,
     type WorkspacePaneRecentProject,
 } from "@renderer/components/workspace/WorkspacePaneEmptyState";
@@ -1106,7 +1111,7 @@ function WorkspaceNodeView({
     const node = useWorkspaceStore(
         useCallback(
             (state: ReturnType<typeof useWorkspaceStore.getState>) =>
-                findWorkspaceNodeById(state.rootNode, nodeId),
+                getIndexedWorkspaceNode(state.rootNode, nodeId),
             [nodeId],
         ),
     );
@@ -1369,7 +1374,10 @@ function WorkspaceSplitView({
     const node = useWorkspaceStore(
         useCallback(
             (state: ReturnType<typeof useWorkspaceStore.getState>) => {
-                const match = findWorkspaceNodeById(state.rootNode, splitId);
+                const match = getIndexedWorkspaceNode(
+                    state.rootNode,
+                    splitId,
+                );
                 return match?.type === "split" ? match : null;
             },
             [splitId],
@@ -1633,23 +1641,83 @@ function WorkspacePaneView({
     readonly onRequestCreateFile: () => void;
     readonly tabDrag: ReturnType<typeof useWorkspaceTabDrag>;
 }) {
-    const node = useWorkspaceStore(
-        useCallback(
-            (state: ReturnType<typeof useWorkspaceStore.getState>) => {
-                const match = findWorkspaceNodeById(state.rootNode, paneId);
-                return match?.type === "pane" ? match : null;
-            },
-            [paneId],
-        ),
-    );
     const addDraftFileContext = useAiStore((s) => s.addDraftFileContext);
     const attachSelectionMention = useAiStore((s) => s.attachSelectionMention);
-    const activePaneId = useWorkspaceStore((state) => state.activePaneId);
-    const closeOtherTabs = useWorkspaceStore((state) => state.closeOtherTabs);
-    const closePane = useWorkspaceStore((state) => state.closePane);
-    const closeTab = useWorkspaceStore((state) => state.closeTab);
-    const closeTabsToRight = useWorkspaceStore(
-        (state) => state.closeTabsToRight,
+    const {
+        activePaneId,
+        closeOtherTabs,
+        closePane,
+        closeTab,
+        closeTabsToRight,
+        createChatTab,
+        createTerminalTab,
+        hasAnyChatTab,
+        lastFocusedRuntimeId,
+        lastQuickCreateAction,
+        moveTab,
+        node,
+        openChatHistoryTab,
+        openChatImageTab,
+        openFileTab,
+        openGitTab,
+        openReviewTab,
+        paneCount,
+        recentActiveTabIds,
+        reloadFileTab,
+        saveFileTab,
+        selectAdjacentTab,
+        selectTab,
+        setActivePane,
+        shouldRenderPaneContent,
+        togglePaneTabPinned,
+        updateChatDraft,
+        updateFileDraft,
+    } = useWorkspaceStore(
+        useShallow(
+            useCallback(
+                (state: ReturnType<typeof useWorkspaceStore.getState>) => {
+                    const candidate = getIndexedWorkspaceNode(
+                        state.rootNode,
+                        paneId,
+                    );
+                    return {
+                        activePaneId: state.activePaneId,
+                        closeOtherTabs: state.closeOtherTabs,
+                        closePane: state.closePane,
+                        closeTab: state.closeTab,
+                        closeTabsToRight: state.closeTabsToRight,
+                        createChatTab: state.createChatTab,
+                        createTerminalTab: state.createTerminalTab,
+                        hasAnyChatTab: getIndexedWorkspaceHasChat(
+                            state.tabsById,
+                        ),
+                        lastFocusedRuntimeId: state.lastFocusedRuntimeId,
+                        lastQuickCreateAction: state.lastQuickCreateAction,
+                        moveTab: state.moveTab,
+                        node: candidate?.type === "pane" ? candidate : null,
+                        openChatHistoryTab: state.openChatHistoryTab,
+                        openChatImageTab: state.openChatImageTab,
+                        openFileTab: state.openFileTab,
+                        openGitTab: state.openGitTab,
+                        openReviewTab: state.openReviewTab,
+                        paneCount: getIndexedWorkspacePaneCount(state.rootNode),
+                        recentActiveTabIds: state.recentActiveTabIds,
+                        reloadFileTab: state.reloadFileTab,
+                        saveFileTab: state.saveFileTab,
+                        selectAdjacentTab: state.selectAdjacentTab,
+                        selectTab: state.selectTab,
+                        setActivePane: state.setActivePane,
+                        shouldRenderPaneContent:
+                            state.activePaneId === paneId ||
+                            !state.deferredPaneIds.has(paneId),
+                        togglePaneTabPinned: state.togglePaneTabPinned,
+                        updateChatDraft: state.updateChatDraft,
+                        updateFileDraft: state.updateFileDraft,
+                    };
+                },
+                [paneId],
+            ),
+        ),
     );
     const confirmBeforeClose = useCallback(
         async (
@@ -1696,38 +1764,6 @@ function WorkspacePaneView({
         },
         [closeTabsToRight, collectPaneTabIds, confirmBeforeClose],
     );
-    const createChatTab = useWorkspaceStore((state) => state.createChatTab);
-    const createTerminalTab = useWorkspaceStore(
-        (state) => state.createTerminalTab,
-    );
-    const openChatHistoryTab = useWorkspaceStore(
-        (state) => state.openChatHistoryTab,
-    );
-    const openGitTab = useWorkspaceStore((state) => state.openGitTab);
-    const lastQuickCreateAction = useWorkspaceStore(
-        (state) => state.lastQuickCreateAction,
-    );
-    const lastFocusedRuntimeId = useWorkspaceStore(
-        (state) => state.lastFocusedRuntimeId,
-    );
-    const moveTab = useWorkspaceStore((state) => state.moveTab);
-    const togglePaneTabPinned = useWorkspaceStore(
-        (state) => state.togglePaneTabPinned,
-    );
-    const openFileTab: (
-        projectId: string,
-        relativePath: string,
-        worktreeId?: string | null,
-        reviewContext?: RuntimeWorkspaceFileReviewContext | null,
-        targetPaneId?: string | null,
-        targetIndex?: number,
-        openLocation?: RuntimeWorkspaceFileOpenLocation | null,
-    ) => Promise<void> = useWorkspaceStore((state) => state.openFileTab);
-    const openChatImageTab = useWorkspaceStore((state) => state.openChatImageTab);
-    const openReviewTab = useWorkspaceStore((state) => state.openReviewTab);
-    const paneCount = useWorkspaceStore(
-        (state) => collectPaneNodes(state.rootNode).length,
-    );
     const paneNodeId = node?.id ?? paneId;
     const paneTabIds = node?.tabIds ?? EMPTY_TAB_IDS;
     const panePinnedTabIds = node?.pinnedTabIds ?? EMPTY_TAB_IDS;
@@ -1748,18 +1784,6 @@ function WorkspacePaneView({
                 [paneTabIds],
             ),
         ),
-    );
-    const selectTab = useWorkspaceStore((state) => state.selectTab);
-    const setActivePane = useWorkspaceStore((state) => state.setActivePane);
-    const hasAnyChatTab = useWorkspaceStore((state) =>
-        Object.values(state.tabsById).some((tab) => tab.kind === "chat"),
-    );
-    const updateChatDraft = useWorkspaceStore((state) => state.updateChatDraft);
-    const updateFileDraft = useWorkspaceStore((state) => state.updateFileDraft);
-    const reloadFileTab = useWorkspaceStore((state) => state.reloadFileTab);
-    const saveFileTab = useWorkspaceStore((state) => state.saveFileTab);
-    const selectAdjacentTab = useWorkspaceStore(
-        (state) => state.selectAdjacentTab,
     );
     const tabStripRef = useRef<HTMLDivElement | null>(null);
     const [tabContextMenu, setTabContextMenu] =
@@ -1810,9 +1834,6 @@ function WorkspacePaneView({
                 (tab): tab is RuntimeWorkspaceFileTab => tab.kind === "file",
             ),
         [paneTabs],
-    );
-    const recentActiveTabIds = useWorkspaceStore(
-        (state) => state.recentActiveTabIds,
     );
     const isActivePane = activePaneId === paneNodeId;
 
@@ -1896,6 +1917,7 @@ function WorkspacePaneView({
 
     useRenderProbe("WorkspacePaneView", {
         activeTabId: activeTab?.id ?? null,
+        contentReady: shouldRenderPaneContent,
         paneId: node?.id ?? paneId,
         tabCount: node?.tabIds.length ?? 0,
     });
@@ -2755,83 +2777,91 @@ function WorkspacePaneView({
                     </div>
                 </div>
 
-                <div className="relative min-h-0 flex-1 overflow-hidden bg-editor">
-                    {activeTab?.kind === "terminal" ? (
-                        <WorkspaceTerminalView
-                            active
-                            activePane={isActivePane}
-                            tab={activeTab}
-                        />
-                    ) : null}
-                    <WorkspaceFileEditorHost
-                        activeFileTab={activeFileTab}
-                        fileTabs={paneFileTabs}
-                        isActivePane={isActivePane}
-                        onAttachLineFragment={handleAttachLineFragment}
-                        onDraftChange={updateFileDraft}
-                        onReload={reloadFileTab}
-                        onSave={saveFileTab}
-                        recentActiveTabIds={recentActiveTabIds}
-                    />
-                    {retainedChatTabs.map((tab) => {
-                        const isActiveChat = tab.id === activeTab?.id;
-
-                        return (
-                            <div
-                                aria-hidden={!isActiveChat}
-                                className={
-                                    isActiveChat
-                                        ? "relative z-1 h-full"
-                                        : "pointer-events-none invisible absolute inset-0"
-                                }
-                                inert={!isActiveChat}
-                                key={tab.id}
-                            >
-                                <ChatTabView
-                                    active={isActiveChat}
-                                    onDraftChange={handleChatDraftChange}
-                                    onOpenFile={handleOpenWorkspaceFile}
-                                    onOpenImage={handleOpenChatImage}
-                                    onOpenReview={() =>
-                                        handleOpenChatReview(tab)
-                                    }
-                                    tab={tab}
+                <div
+                    className="relative min-h-0 flex-1 overflow-hidden bg-editor"
+                    data-workspace-pane-content-ready={shouldRenderPaneContent}
+                >
+                    {shouldRenderPaneContent ? (
+                        <>
+                            {activeTab?.kind === "terminal" ? (
+                                <WorkspaceTerminalView
+                                    active
+                                    activePane={isActivePane}
+                                    tab={activeTab}
                                 />
-                            </div>
-                        );
-                    })}
-                    {activeTab ? (
-                        activeTab.kind === "file" ? (
-                            null
-                        ) : activeTab.kind === "git" ? (
-                            <GitTabView tab={activeTab} />
-                        ) : activeTab.kind === "git_worktree_diff" ? (
-                            <GitWorktreeDiffTabView tab={activeTab} />
-                        ) : activeTab.kind === "chat_history" ? (
-                            <ChatHistoryTabView tab={activeTab} />
-                        ) : activeTab.kind === "git_commit" ? (
-                            <GitCommitTabView tab={activeTab} />
-                        ) : activeTab.kind === "review" ? (
-                            <ReviewTabView
-                                onOpenFile={handleOpenWorkspaceFile}
-                                tab={activeTab}
+                            ) : null}
+                            <WorkspaceFileEditorHost
+                                activeFileTab={activeFileTab}
+                                fileTabs={paneFileTabs}
+                                isActivePane={isActivePane}
+                                onAttachLineFragment={handleAttachLineFragment}
+                                onDraftChange={updateFileDraft}
+                                onReload={reloadFileTab}
+                                onSave={saveFileTab}
+                                recentActiveTabIds={recentActiveTabIds}
                             />
-                        ) : activeTab.kind === "github_issues" ? (
-                            <GitHubIssuesTabView tab={activeTab} />
-                        ) : activeTab.kind === "github_issue" ? (
-                            <GitHubIssueTabView tab={activeTab} />
-                        ) : activeTab.kind === "github_pull_requests" ? (
-                            <GitHubPullRequestsTabView tab={activeTab} />
-                        ) : activeTab.kind === "github_pull_request" ? (
-                            <GitHubPullRequestTabView tab={activeTab} />
-                        ) : null
-                    ) : (
-                        <WorkspacePaneEmptyState
-                            onOpenProject={onOpenProject}
-                            onOpenProjects={onOpenProjects}
-                            recentProjects={recentProjects}
-                        />
-                    )}
+                            {retainedChatTabs.map((tab) => {
+                                const isActiveChat = tab.id === activeTab?.id;
+
+                                return (
+                                    <div
+                                        aria-hidden={!isActiveChat}
+                                        className={
+                                            isActiveChat
+                                                ? "relative z-1 h-full"
+                                                : "pointer-events-none invisible absolute inset-0"
+                                        }
+                                        inert={!isActiveChat}
+                                        key={tab.id}
+                                    >
+                                        <ChatTabView
+                                            active={isActiveChat}
+                                            onDraftChange={handleChatDraftChange}
+                                            onOpenFile={handleOpenWorkspaceFile}
+                                            onOpenImage={handleOpenChatImage}
+                                            onOpenReview={() =>
+                                                handleOpenChatReview(tab)
+                                            }
+                                            tab={tab}
+                                        />
+                                    </div>
+                                );
+                            })}
+                            {activeTab ? (
+                                activeTab.kind === "file" ? (
+                                    null
+                                ) : activeTab.kind === "git" ? (
+                                    <GitTabView tab={activeTab} />
+                                ) : activeTab.kind === "git_worktree_diff" ? (
+                                    <GitWorktreeDiffTabView tab={activeTab} />
+                                ) : activeTab.kind === "chat_history" ? (
+                                    <ChatHistoryTabView tab={activeTab} />
+                                ) : activeTab.kind === "git_commit" ? (
+                                    <GitCommitTabView tab={activeTab} />
+                                ) : activeTab.kind === "review" ? (
+                                    <ReviewTabView
+                                        onOpenFile={handleOpenWorkspaceFile}
+                                        tab={activeTab}
+                                    />
+                                ) : activeTab.kind === "github_issues" ? (
+                                    <GitHubIssuesTabView tab={activeTab} />
+                                ) : activeTab.kind === "github_issue" ? (
+                                    <GitHubIssueTabView tab={activeTab} />
+                                ) : activeTab.kind ===
+                                  "github_pull_requests" ? (
+                                    <GitHubPullRequestsTabView tab={activeTab} />
+                                ) : activeTab.kind === "github_pull_request" ? (
+                                    <GitHubPullRequestTabView tab={activeTab} />
+                                ) : null
+                            ) : (
+                                <WorkspacePaneEmptyState
+                                    onOpenProject={onOpenProject}
+                                    onOpenProjects={onOpenProjects}
+                                    recentProjects={recentProjects}
+                                />
+                            )}
+                        </>
+                    ) : null}
                 </div>
             </section>
 

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -22,6 +22,7 @@ interface MeasuredVirtualListMockSnapshot {
     readonly hasOnRangeChange: boolean;
     readonly hasOnReady: boolean;
     readonly itemCount: number;
+    readonly observeMeasurements?: boolean;
     readonly overscan?: number;
     readonly preserveScrollAnchorOnItemsChange?: boolean;
     readonly preserveScrollAnchorOnMeasure?: boolean;
@@ -51,6 +52,7 @@ vi.mock("@renderer/components/virtual/MeasuredVirtualList", async () => {
             items,
             onRangeChange,
             onReady,
+            observeMeasurements,
             overscan,
             preserveScrollAnchorOnItemsChange,
             preserveScrollAnchorOnMeasure,
@@ -66,6 +68,7 @@ vi.mock("@renderer/components/virtual/MeasuredVirtualList", async () => {
             readonly items: readonly T[];
             readonly onRangeChange?: () => void;
             readonly onReady?: () => void;
+            readonly observeMeasurements?: boolean;
             readonly overscan?: number;
             readonly preserveScrollAnchorOnItemsChange?: boolean;
             readonly preserveScrollAnchorOnMeasure?: boolean;
@@ -87,6 +90,7 @@ vi.mock("@renderer/components/virtual/MeasuredVirtualList", async () => {
                 hasOnRangeChange: typeof onRangeChange === "function",
                 hasOnReady: typeof onReady === "function",
                 itemCount: items.length,
+                observeMeasurements,
                 overscan,
                 preserveScrollAnchorOnItemsChange,
                 preserveScrollAnchorOnMeasure,
@@ -202,9 +206,13 @@ function createSegmentRow(entryCount = 1): ChatTimelineRow {
     };
 }
 
-function renderHistoryRows(historyRows: readonly ChatTimelineRow[]) {
+function renderHistoryRows(
+    historyRows: readonly ChatTimelineRow[],
+    active = true,
+) {
     return renderToStaticMarkup(
         <ChatTimelineHistoryRows
+            active={active}
             historyRows={historyRows}
             onVirtualRangeChange={() => {}}
             renderRow={({ row }) => (
@@ -355,6 +363,7 @@ describe("ChatTimelineHistoryRows", () => {
                 hasOnRangeChange: true,
                 hasOnReady: true,
                 itemCount: CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
+                observeMeasurements: true,
                 overscan: 10,
                 preserveScrollAnchorOnItemsChange: true,
                 preserveScrollAnchorOnMeasure: true,
@@ -369,6 +378,20 @@ describe("ChatTimelineHistoryRows", () => {
             `message:message-${CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD - 1}`,
         );
         expect(markup.match(/padding-bottom:8px/g)).toHaveLength(1);
+    });
+
+    it("keeps virtual layout but stops row measurements while retained and hidden", () => {
+        const rows = createRows(CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD);
+
+        const markup = renderHistoryRows(rows, false);
+
+        expect(measuredVirtualListMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                itemCount: CHAT_TIMELINE_VIRTUALIZATION_THRESHOLD,
+                observeMeasurements: false,
+            }),
+        );
+        expect(markup).toContain("mock-measured-virtual-list");
     });
 
     it("passes activity segments through the virtual list with their stable id", () => {

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -39,6 +39,7 @@ import {
 const MIN_FREEZABLE_CHAT_TIMELINE_WIDTH_PX = 240;
 
 interface ChatTimelineHistoryRowsProps {
+    readonly active?: boolean;
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
     readonly historyRows: readonly ChatTimelineRow[];
@@ -74,6 +75,7 @@ export function resolveChatTimelineFrozenContentWidth(input: {
 
 export const ChatTimelineHistoryRows = memo(
     function ChatTimelineHistoryRows({
+        active = true,
         chatFontFamily,
         chatFontSize,
         historyRows,
@@ -113,7 +115,9 @@ export const ChatTimelineHistoryRows = memo(
             number | null
         >(null);
         const isFreezeActiveRef = useRef(false);
+        const isActiveRef = useRef(active);
         isFreezeActiveRef.current = frozenContentWidth !== null;
+        isActiveRef.current = active;
         const virtualizationCost = calculateChatTimelineVirtualizationCost(
             historyRows,
         );
@@ -155,7 +159,7 @@ export const ChatTimelineHistoryRows = memo(
             // Frozen during an active splitter drag: skip every metric/anchor
             // update so the scroll stays put. The single re-sync happens when the
             // freeze lifts (see the freeze effects below).
-            if (isFreezeActiveRef.current) {
+            if (!isActiveRef.current || isFreezeActiveRef.current) {
                 return;
             }
 
@@ -213,15 +217,19 @@ export const ChatTimelineHistoryRows = memo(
         );
 
         useLayoutEffect(() => {
-            if (!shouldVirtualize) {
+            if (!active || !shouldVirtualize) {
                 return;
             }
 
             syncLayoutMetrics();
-        }, [historyRows.length, shouldVirtualize, syncLayoutMetrics]);
+        }, [active, historyRows.length, shouldVirtualize, syncLayoutMetrics]);
 
         useEffect(() => {
-            if (!shouldVirtualize || typeof ResizeObserver === "undefined") {
+            if (
+                !active ||
+                !shouldVirtualize ||
+                typeof ResizeObserver === "undefined"
+            ) {
                 return;
             }
 
@@ -245,7 +253,7 @@ export const ChatTimelineHistoryRows = memo(
                 observer.disconnect();
                 window.removeEventListener("resize", syncLayoutMetrics);
             };
-        }, [scrollRef, shouldVirtualize, syncLayoutMetrics]);
+        }, [active, scrollRef, shouldVirtualize, syncLayoutMetrics]);
 
         useLayoutEffect(() => {
             restorePendingResizeAnchor();
@@ -266,7 +274,7 @@ export const ChatTimelineHistoryRows = memo(
         // before the first width change lands (pointerdown precedes pointermove),
         // so the pinned width matches the pre-drag layout exactly.
         useLayoutEffect(() => {
-            if (!shouldVirtualize) {
+            if (!active || !shouldVirtualize) {
                 if (virtualResizeActiveRef.current) {
                     virtualResizeActiveRef.current = false;
                     pendingVirtualResizeEndRef.current = false;
@@ -298,6 +306,7 @@ export const ChatTimelineHistoryRows = memo(
                 setFrozenContentWidth(null);
             }
         }, [
+            active,
             isResizingPanel,
             onVirtualResizeEnd,
             onVirtualResizeStart,
@@ -308,7 +317,7 @@ export const ChatTimelineHistoryRows = memo(
         // Once the freeze lifts the DOM holds the real width again, so adopt it
         // and re-anchor exactly once — instead of on every drag frame.
         useLayoutEffect(() => {
-            if (!shouldVirtualize || frozenContentWidth !== null) {
+            if (!active || !shouldVirtualize || frozenContentWidth !== null) {
                 return;
             }
 
@@ -320,6 +329,7 @@ export const ChatTimelineHistoryRows = memo(
                 onVirtualResizeEnd?.();
             }
         }, [
+            active,
             frozenContentWidth,
             onVirtualResizeEnd,
             shouldVirtualize,
@@ -459,6 +469,7 @@ export const ChatTimelineHistoryRows = memo(
                             : null
                     }
                     items={historyRows}
+                    observeMeasurements={active}
                     measurementCacheKey={
                         sessionId ? `chat-timeline:${sessionId}` : undefined
                     }

--- a/src/renderer/src/components/workspace/workspaceViewIndex.test.ts
+++ b/src/renderer/src/components/workspace/workspaceViewIndex.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import type { RuntimeWorkspaceTab } from "@renderer/app/workspace/tree";
+import type { WorkspaceNode } from "@shared/ipc";
+
+import {
+    getIndexedWorkspaceHasChat,
+    getIndexedWorkspaceNode,
+    getIndexedWorkspacePaneCount,
+} from "./workspaceViewIndex";
+
+const ROOT: WorkspaceNode = {
+    axis: "horizontal",
+    children: [
+        {
+            activeTabId: "chat-1",
+            id: "pane-left",
+            pinnedTabIds: [],
+            tabIds: ["chat-1"],
+            type: "pane",
+        },
+        {
+            axis: "vertical",
+            children: [
+                {
+                    activeTabId: null,
+                    id: "pane-top-right",
+                    pinnedTabIds: [],
+                    tabIds: [],
+                    type: "pane",
+                },
+                {
+                    activeTabId: null,
+                    id: "pane-bottom-right",
+                    pinnedTabIds: [],
+                    tabIds: [],
+                    type: "pane",
+                },
+            ],
+            id: "split-right",
+            sizes: [0.5, 0.5],
+            type: "split",
+        },
+    ],
+    id: "split-root",
+    sizes: [0.5, 0.5],
+    type: "split",
+};
+
+describe("workspaceViewIndex", () => {
+    it("indexes nested workspace nodes and pane metadata", () => {
+        expect(getIndexedWorkspaceNode(ROOT, "split-right")).toBe(
+            ROOT.children[1],
+        );
+        expect(getIndexedWorkspaceNode(ROOT, "pane-bottom-right")).toBe(
+            ROOT.children[1]?.type === "split"
+                ? ROOT.children[1].children[1]
+                : null,
+        );
+        expect(getIndexedWorkspaceNode(ROOT, "missing")).toBeNull();
+        expect(getIndexedWorkspacePaneCount(ROOT)).toBe(3);
+    });
+
+    it("derives chat presence from a tabs snapshot", () => {
+        const tabsWithoutChat = {
+            terminal: { kind: "terminal" },
+        } as unknown as Record<string, RuntimeWorkspaceTab>;
+        const tabsWithChat = {
+            ...tabsWithoutChat,
+            chat: { kind: "chat" },
+        } as unknown as Record<string, RuntimeWorkspaceTab>;
+
+        expect(getIndexedWorkspaceHasChat(tabsWithoutChat)).toBe(false);
+        expect(getIndexedWorkspaceHasChat(tabsWithChat)).toBe(true);
+    });
+});

--- a/src/renderer/src/components/workspace/workspaceViewIndex.ts
+++ b/src/renderer/src/components/workspace/workspaceViewIndex.ts
@@ -1,0 +1,73 @@
+import type { RuntimeWorkspaceTab } from "@renderer/app/workspace/tree";
+import type { WorkspaceNode } from "@shared/ipc";
+
+interface WorkspaceViewIndex {
+    readonly nodesById: ReadonlyMap<string, WorkspaceNode>;
+    readonly paneCount: number;
+}
+
+const indexesByRoot = new WeakMap<WorkspaceNode, WorkspaceViewIndex>();
+const hasChatByTabs = new WeakMap<
+    Readonly<Record<string, RuntimeWorkspaceTab>>,
+    boolean
+>();
+
+function buildWorkspaceViewIndex(rootNode: WorkspaceNode): WorkspaceViewIndex {
+    const nodesById = new Map<string, WorkspaceNode>();
+    const pendingNodes = [rootNode];
+    let paneCount = 0;
+
+    while (pendingNodes.length > 0) {
+        const node = pendingNodes.pop();
+        if (!node) {
+            continue;
+        }
+
+        nodesById.set(node.id, node);
+        if (node.type === "pane") {
+            paneCount += 1;
+            continue;
+        }
+
+        for (let index = node.children.length - 1; index >= 0; index -= 1) {
+            pendingNodes.push(node.children[index]);
+        }
+    }
+
+    return { nodesById, paneCount };
+}
+
+function getWorkspaceViewIndex(rootNode: WorkspaceNode): WorkspaceViewIndex {
+    const cached = indexesByRoot.get(rootNode);
+    if (cached) {
+        return cached;
+    }
+
+    const index = buildWorkspaceViewIndex(rootNode);
+    indexesByRoot.set(rootNode, index);
+    return index;
+}
+
+export function getIndexedWorkspaceNode(
+    rootNode: WorkspaceNode,
+    nodeId: string,
+): WorkspaceNode | null {
+    return getWorkspaceViewIndex(rootNode).nodesById.get(nodeId) ?? null;
+}
+
+export function getIndexedWorkspacePaneCount(rootNode: WorkspaceNode): number {
+    return getWorkspaceViewIndex(rootNode).paneCount;
+}
+
+export function getIndexedWorkspaceHasChat(
+    tabsById: Readonly<Record<string, RuntimeWorkspaceTab>>,
+): boolean {
+    const cached = hasChatByTabs.get(tabsById);
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const hasChat = Object.values(tabsById).some((tab) => tab.kind === "chat");
+    hasChatByTabs.set(tabsById, hasChat);
+    return hasChat;
+}

--- a/src/renderer/src/features/terminal/WorkspaceTerminalHost.test.ts
+++ b/src/renderer/src/features/terminal/WorkspaceTerminalHost.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkspaceNode } from "@shared/ipc";
+
+import { getReadyActiveWorkspaceTabIds } from "./WorkspaceTerminalHost";
+
+describe("getReadyActiveWorkspaceTabIds", () => {
+    it("excludes active tabs whose pane is still deferred", () => {
+        const rootNode: WorkspaceNode = {
+            axis: "horizontal",
+            children: [
+                {
+                    activeTabId: "terminal-focused",
+                    id: "pane-focused",
+                    tabIds: ["terminal-focused"],
+                    type: "pane",
+                },
+                {
+                    activeTabId: "terminal-background",
+                    id: "pane-background",
+                    tabIds: ["terminal-background"],
+                    type: "pane",
+                },
+            ],
+            id: "split-root",
+            sizes: [0.5, 0.5],
+            type: "split",
+        };
+
+        expect(
+            getReadyActiveWorkspaceTabIds(
+                rootNode,
+                new Set(["pane-background"]),
+                "pane-focused",
+            ),
+        ).toEqual(new Set(["terminal-focused"]));
+        expect(
+            getReadyActiveWorkspaceTabIds(
+                rootNode,
+                new Set(["pane-background"]),
+                "pane-background",
+            ),
+        ).toEqual(new Set(["terminal-focused", "terminal-background"]));
+        expect(
+            getReadyActiveWorkspaceTabIds(
+                rootNode,
+                new Set(),
+                "pane-focused",
+            ),
+        ).toEqual(new Set(["terminal-focused", "terminal-background"]));
+    });
+});

--- a/src/renderer/src/features/terminal/WorkspaceTerminalHost.tsx
+++ b/src/renderer/src/features/terminal/WorkspaceTerminalHost.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 
+import type { WorkspaceNode } from "@shared/ipc";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
 import {
     collectPaneNodes,
@@ -16,11 +17,35 @@ function getComandoApiOrNull() {
     return globalThis.window?.comando ?? null;
 }
 
+export function getReadyActiveWorkspaceTabIds(
+    rootNode: WorkspaceNode,
+    deferredPaneIds: ReadonlySet<string>,
+    activePaneId: string,
+): ReadonlySet<string> {
+    return new Set(
+        collectPaneNodes(rootNode).flatMap((pane) =>
+            pane.activeTabId &&
+            (pane.id === activePaneId || !deferredPaneIds.has(pane.id))
+                ? [pane.activeTabId]
+                : [],
+        ),
+    );
+}
+
 export function WorkspaceTerminalHost() {
-    const { activeContextKey, contextsByKey, rootNode, tabsById } = useWorkspaceStore(
+    const {
+        activeContextKey,
+        activePaneId,
+        contextsByKey,
+        deferredPaneIds,
+        rootNode,
+        tabsById,
+    } = useWorkspaceStore(
         useShallow((state) => ({
             activeContextKey: state.activeContextKey,
+            activePaneId: state.activePaneId,
             contextsByKey: state.contextsByKey,
+            deferredPaneIds: state.deferredPaneIds,
             rootNode: state.rootNode,
             tabsById: state.tabsById,
         })),
@@ -34,14 +59,14 @@ export function WorkspaceTerminalHost() {
         [tabsById],
     );
     const activeTerminalTabs = useMemo(() => {
-        const activeTabIds = new Set(
-            collectPaneNodes(rootNode).flatMap((pane) =>
-                pane.activeTabId ? [pane.activeTabId] : [],
-            ),
+        const activeTabIds = getReadyActiveWorkspaceTabIds(
+            rootNode,
+            deferredPaneIds,
+            activePaneId,
         );
 
         return visibleTerminalTabs.filter((tab) => activeTabIds.has(tab.id));
-    }, [rootNode, visibleTerminalTabs]);
+    }, [activePaneId, deferredPaneIds, rootNode, visibleTerminalTabs]);
     const liveTerminalIds = useMemo(() => {
         const inactiveTerminalIds = Object.values(contextsByKey)
             .filter((context) => context.key !== activeContextKey)


### PR DESCRIPTION
## Summary

This PR improves workspace responsiveness when switching projects or worktrees, especially in layouts with multiple panes and long chat histories.

- Prioritizes hydration of the active pane and defers background panes across animation frames.
- Prevents terminals from starting in panes that are still deferred.
- Retains mounted chat tabs while hidden, freezing session updates and measurement observers until they become active again.
- Avoids redundant file-tree and Git refreshes when the sidebar is hidden or context data is already cached.
- Adds cached workspace-node indexes to remove repeated tree traversals during workspace rendering.

## Validation

- Focused Vitest suite: 102 tests across 6 files
- `pnpm run typecheck`
- `git diff --check`

All passed.