### PR TITLE
feat(sidebar): modernize git branch scope navigation

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts
@@ -5,7 +5,6 @@ import type { GitBranchSummary, GitWorktreeSummary } from "@shared/ipc";
 import {
     buildSuggestedWorktreePath,
     buildUniqueLocalBranchName,
-    compareGitScopeBranchNames,
     isGitScopeWorktreeActive,
     parseRemoteBranchReference,
     resolveRemoteBranchResolution,
@@ -57,17 +56,6 @@ function createWorktree(
 }
 
 describe("SidebarGitScopePicker helpers", () => {
-    it("keeps main first while preserving the remaining branch order", () => {
-        const branches = ["feature/zeta", "main", "alpha", "feature/beta"];
-
-        expect(branches.toSorted(compareGitScopeBranchNames)).toEqual([
-            "main",
-            "feature/zeta",
-            "alpha",
-            "feature/beta",
-        ]);
-    });
-
     it("resolves a remote branch to its tracking local branch and worktree", () => {
         const remoteBranch = createBranch({
             isRemote: true,

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -15,6 +15,7 @@ import { createPortal } from "react-dom";
 
 import type {
     GitBranchSummary,
+    GitHistoryCommitSummary,
     GitRepositorySnapshot,
     GitWorktreeSummary,
 } from "@shared/ipc";
@@ -48,8 +49,10 @@ import {
     type BranchCreationBaseOption,
     type BranchCreationDraft,
 } from "./sidebarGitBranchCreation";
+import { buildGitScopeBranchTopology } from "./sidebarGitBranchTopology";
 
 type GitScopeTabId = "branches" | "worktrees";
+type GitScopeBranchNodePosition = "first" | "last" | "middle" | "only";
 
 interface MenuPosition {
     readonly height: number;
@@ -75,10 +78,11 @@ interface SidebarGitScopePickerProps {
 }
 
 const EMPTY_BRANCHES: readonly GitBranchSummary[] = [];
+const EMPTY_HISTORY: readonly GitHistoryCommitSummary[] = [];
 const EMPTY_WORKTREES: readonly GitWorktreeSummary[] = [];
 const GIT_SCOPE_VIRTUALIZATION_THRESHOLD = 120;
 const GIT_SCOPE_VIRTUALIZATION_OVERSCAN = 6;
-const GIT_SCOPE_ROW_ESTIMATE = 52;
+const GIT_SCOPE_ROW_ESTIMATE = 44;
 const GIT_SCOPE_SECTION_ESTIMATE = 30;
 const GIT_SCOPE_MENU_CHROME_ESTIMATE = 144;
 const GIT_SCOPE_BRANCH_CREATION_FORM_ESTIMATE = 188;
@@ -90,16 +94,8 @@ const GIT_SCOPE_MENU_MAX_WIDTH = 720;
 const GIT_SCOPE_MENU_MIN_HEIGHT = 260;
 const GIT_SCOPE_MENU_DEFAULT_MAX_HEIGHT = 420;
 const GIT_SCOPE_MENU_MAX_HEIGHT = 720;
-
-export function compareGitScopeBranchNames(left: string, right: string): number {
-    const leftIsMain = left === "main";
-    const rightIsMain = right === "main";
-    if (leftIsMain === rightIsMain) {
-        return 0;
-    }
-
-    return leftIsMain ? -1 : 1;
-}
+const GIT_SCOPE_TOPOLOGY_INITIAL_HISTORY_LIMIT = 300;
+const GIT_SCOPE_TOPOLOGY_MAX_HISTORY_LIMIT = 2_400;
 
 function getStorage(): Storage | null {
     try {
@@ -301,6 +297,11 @@ export function SidebarGitScopePicker({
     const [userMenuSize, setUserMenuSize] = useState<GitScopeMenuSize | null>(
         () => readPersistedGitScopeMenuSize(),
     );
+    const [loadedTopologyHistory, setLoadedTopologyHistory] = useState<{
+        readonly contextKey: string;
+        readonly commits: readonly GitHistoryCommitSummary[];
+        readonly requestKey: string;
+    } | null>(null);
     const buttonRef = useRef<HTMLButtonElement | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
     const menuRef = useRef<HTMLDivElement | null>(null);
@@ -337,6 +338,17 @@ export function SidebarGitScopePicker({
             ? (state.branchesByProject[projectId] ?? EMPTY_BRANCHES)
             : EMPTY_BRANCHES,
     );
+    const gitContextKey = projectId
+        ? getGitContextKey(projectId, worktreeId)
+        : null;
+    const cachedHistory = useGitStore((state) =>
+        gitContextKey
+            ? (state.historyByContext[gitContextKey] ?? EMPTY_HISTORY)
+            : EMPTY_HISTORY,
+    );
+    const cachedHistorySearch = useGitStore((state) =>
+        gitContextKey ? state.historySearchesByContext[gitContextKey] : undefined,
+    );
     const checkoutBranch = useGitStore((state) => state.checkoutBranch);
     const createBranch = useGitStore((state) => state.createBranch);
     const createWorktree = useGitStore((state) => state.createWorktree);
@@ -369,6 +381,27 @@ export function SidebarGitScopePicker({
     const worktrees = snapshot?.worktrees ?? EMPTY_WORKTREES;
     const availableWorktrees = worktrees.length;
     const deferredQuery = useDeferredValue(query);
+    const topologyRequestKey = useMemo(
+        () =>
+            gitContextKey
+                ? `${gitContextKey}:${snapshot?.updatedAt ?? "pending"}:${branches
+                      .filter((branch) => !branch.isRemote)
+                      .map((branch) => `${branch.name}:${branch.commitSha ?? ""}`)
+                      .join("|")}`
+                : null,
+        [branches, gitContextKey, snapshot?.updatedAt],
+    );
+    const topologyHistory =
+        loadedTopologyHistory?.contextKey === gitContextKey &&
+        loadedTopologyHistory.requestKey === topologyRequestKey
+            ? loadedTopologyHistory.commits
+            : !cachedHistorySearch?.query
+              ? cachedHistory
+              : EMPTY_HISTORY;
+    const branchTopology = useMemo(
+        () => buildGitScopeBranchTopology(branches, topologyHistory),
+        [branches, topologyHistory],
+    );
     const branchCreationBaseOptions = useMemo(
         () => buildBranchCreationBaseOptions(branches),
         [branches],
@@ -549,17 +582,36 @@ export function SidebarGitScopePicker({
     }, [branchRows, normalizedQuery]);
 
     const localBranchRows = useMemo(
-        () =>
-            filteredBranchRows
-                .filter((row) => !row.branch.isRemote)
-                .toSorted((left, right) =>
-                    compareGitScopeBranchNames(
-                        left.branch.name,
-                        right.branch.name,
-                    ),
-                ),
-        [filteredBranchRows],
+        () => {
+            const filteredRowsByName = new Map(
+                filteredBranchRows
+                    .filter((row) => !row.branch.isRemote)
+                    .map((row) => [row.branch.name, row]),
+            );
+            return branchTopology.orderedBranchNames.flatMap((branchName) => {
+                const row = filteredRowsByName.get(branchName);
+                return row ? [row] : [];
+            });
+        },
+        [branchTopology.orderedBranchNames, filteredBranchRows],
     );
+    const branchNodePositionByName = useMemo(() => {
+        const positions = new Map<string, GitScopeBranchNodePosition>();
+        const lastIndex = localBranchRows.length - 1;
+        localBranchRows.forEach((row, index) => {
+            positions.set(
+                row.branch.name,
+                lastIndex === 0
+                    ? "only"
+                    : index === 0
+                      ? "first"
+                      : index === lastIndex
+                        ? "last"
+                        : "middle",
+            );
+        });
+        return positions;
+    }, [localBranchRows]);
     const remoteBranchRows = useMemo(
         () => filteredBranchRows.filter((row) => row.branch.isRemote),
         [filteredBranchRows],
@@ -784,6 +836,93 @@ export function SidebarGitScopePicker({
             setBranchCreationDraft(null);
         }
     }, [activeTab]);
+
+    useEffect(() => {
+        if (
+            !isOpen ||
+            activeTab !== "branches" ||
+            !projectId ||
+            !gitContextKey ||
+            !topologyRequestKey ||
+            loadedTopologyHistory?.requestKey === topologyRequestKey
+        ) {
+            return;
+        }
+
+        const localTipShas = new Set(
+            branches.flatMap((branch) =>
+                !branch.isRemote && branch.commitSha ? [branch.commitSha] : [],
+            ),
+        );
+        if (localTipShas.size === 0) {
+            return;
+        }
+
+        let cancelled = false;
+        void (async () => {
+            let limit = GIT_SCOPE_TOPOLOGY_INITIAL_HISTORY_LIMIT;
+            let commits: readonly GitHistoryCommitSummary[];
+
+            try {
+                while (true) {
+                    const result = await getComandoApi().listGitHistory({
+                        includeAllRefs: true,
+                        limit,
+                        projectId,
+                        worktreeId,
+                    });
+                    commits = result.commits;
+                    const loadedShas = new Set(
+                        commits.map((commit) => commit.sha),
+                    );
+                    const hasEveryLocalTip = [...localTipShas].every((sha) =>
+                        loadedShas.has(sha),
+                    );
+                    if (
+                        hasEveryLocalTip ||
+                        commits.length >= result.totalCount ||
+                        limit >= GIT_SCOPE_TOPOLOGY_MAX_HISTORY_LIMIT
+                    ) {
+                        break;
+                    }
+
+                    limit = Math.min(
+                        limit * 2,
+                        GIT_SCOPE_TOPOLOGY_MAX_HISTORY_LIMIT,
+                    );
+                }
+
+                if (!cancelled) {
+                    setLoadedTopologyHistory({
+                        commits,
+                        contextKey: gitContextKey,
+                        requestKey: topologyRequestKey,
+                    });
+                }
+            } catch {
+                if (!cancelled) {
+                    setLoadedTopologyHistory({
+                        commits: EMPTY_HISTORY,
+                        contextKey: gitContextKey,
+                        requestKey: topologyRequestKey,
+                    });
+                }
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [
+        activeTab,
+        branches,
+        gitContextKey,
+        isOpen,
+        loadedTopologyHistory?.requestKey,
+        projectId,
+        topologyRequestKey,
+        worktreeId,
+    ]);
 
     useEffect(() => {
         if (!branchCreationDraft) {
@@ -1916,15 +2055,39 @@ export function SidebarGitScopePicker({
 
             if (item.kind === "branch") {
                 const { row, selectableIndex } = item;
+                const nodePosition = row.branch.isRemote
+                    ? null
+                    : (branchNodePositionByName.get(row.branch.name) ?? "only");
 
                 return (
-                    <div data-row-index={selectableIndex}>
+                    <div
+                        className={
+                            nodePosition
+                                ? "sidebar-git-scope-menu__branch-node"
+                                : undefined
+                        }
+                        data-branch-node-position={nodePosition ?? undefined}
+                        data-row-index={selectableIndex}
+                    >
                         <SidebarNodeRow
                             badges={row.badges}
                             description={row.description}
                             isActive={row.isActive}
                             isSelected={selectableIndex === focusIndex}
-                            leading={<BranchGlyph />}
+                            leading={
+                                row.branch.isRemote ? (
+                                    <BranchGlyph />
+                                ) : (
+                                    <BranchTopologyBullet
+                                        connected={
+                                            branchTopology.byBranchName.get(
+                                                row.branch.name,
+                                            )?.connected ?? false
+                                        }
+                                        isCurrent={row.branch.isCurrent}
+                                    />
+                                )
+                            }
                             onContextMenu={(event) =>
                                 handleBranchContextMenu(
                                     event,
@@ -1996,6 +2159,8 @@ export function SidebarGitScopePicker({
             );
         },
         [
+            branchNodePositionByName,
+            branchTopology.byBranchName,
             focusIndex,
             handleBranchContextMenu,
             handleMenuTriggerClick,
@@ -2563,6 +2728,34 @@ function RowMenuTrigger({
         >
             <HorizontalDotsIcon />
         </button>
+    );
+}
+
+/**
+ * A single commit-graph node sitting on the branch list's dashed rail (see
+ * `.sidebar-git-scope-menu__branch-node` in styles.css). Deliberately
+ * monochrome instead of a multi-lane colored graph so it reads as one quiet
+ * timeline rather than competing with the rest of the glass menu.
+ */
+function BranchTopologyBullet({
+    connected,
+    isCurrent,
+}: {
+    readonly connected: boolean;
+    readonly isCurrent: boolean;
+}) {
+    return (
+        <svg aria-hidden="true" className="h-3.5 w-3.5" fill="none" viewBox="0 0 16 16">
+            <circle
+                cx="8"
+                cy="8"
+                fill={isCurrent ? "var(--color-accent)" : "var(--color-bg-elevated)"}
+                r={isCurrent ? 3.5 : 3}
+                stroke={isCurrent ? "var(--color-accent)" : "currentColor"}
+                strokeDasharray={connected ? undefined : "1.5 1.5"}
+                strokeWidth="1.4"
+            />
+        </svg>
     );
 }
 

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -50,7 +50,10 @@ import {
     type BranchCreationBaseOption,
     type BranchCreationDraft,
 } from "./sidebarGitBranchCreation";
-import { buildGitScopeBranchTopology } from "./sidebarGitBranchTopology";
+import {
+    buildGitScopeBranchTopology,
+    buildGitScopeBranchTopologyRequestKey,
+} from "./sidebarGitBranchTopology";
 
 type GitScopeTabId = "branches" | "worktrees";
 type GitScopeBranchNodePosition = "first" | "last" | "middle" | "only";
@@ -378,9 +381,11 @@ export function SidebarGitScopePicker({
         snapshot?.worktrees.find((entry) => entry.isPrimary) ??
         null;
     const canInitializeGit = snapshot?.repositoryState === "not_repo";
-    const activeBranchName =
+    const contextualActiveBranchName =
         activeWorktree?.branchName ??
-        snapshot?.branch?.name ??
+        (snapshot?.branch?.isDetached ? null : (snapshot?.branch?.name ?? null));
+    const activeBranchName =
+        contextualActiveBranchName ??
         (canInitializeGit ? "No Git Repository" : "Detached HEAD");
     const activeRootPath =
         activeWorktree?.rootPath ?? snapshot?.rootPath ?? null;
@@ -389,14 +394,8 @@ export function SidebarGitScopePicker({
     const availableWorktrees = worktrees.length;
     const deferredQuery = useDeferredValue(query);
     const topologyRequestKey = useMemo(
-        () =>
-            gitContextKey
-                ? `${gitContextKey}:${snapshot?.updatedAt ?? "pending"}:${branches
-                      .filter((branch) => !branch.isRemote)
-                      .map((branch) => `${branch.name}:${branch.commitSha ?? ""}`)
-                      .join("|")}`
-                : null,
-        [branches, gitContextKey, snapshot?.updatedAt],
+        () => buildGitScopeBranchTopologyRequestKey(gitContextKey, branches),
+        [branches, gitContextKey],
     );
     const topologyHistory =
         loadedTopologyHistory?.contextKey === gitContextKey &&
@@ -406,8 +405,13 @@ export function SidebarGitScopePicker({
               ? cachedHistory
               : EMPTY_HISTORY;
     const branchTopology = useMemo(
-        () => buildGitScopeBranchTopology(branches, topologyHistory),
-        [branches, topologyHistory],
+        () =>
+            buildGitScopeBranchTopology(
+                branches,
+                topologyHistory,
+                contextualActiveBranchName,
+            ),
+        [branches, contextualActiveBranchName, topologyHistory],
     );
     const branchCreationBaseOptions = useMemo(
         () => buildBranchCreationBaseOptions(branches),
@@ -517,15 +521,15 @@ export function SidebarGitScopePicker({
                 description,
                 isActive: branch.isRemote
                     ? snapshot?.branch?.upstreamName === branch.name
-                    : snapshot?.branch?.name === branch.name,
+                    : contextualActiveBranchName === branch.name,
                 remoteResolution,
                 searchText,
             } satisfies BranchListRow;
         });
     }, [
         branches,
+        contextualActiveBranchName,
         projectId,
-        snapshot?.branch?.name,
         snapshot?.branch?.upstreamName,
         worktreeId,
         worktrees,
@@ -920,12 +924,20 @@ export function SidebarGitScopePicker({
 
             try {
                 while (true) {
+                    if (cancelled) {
+                        return;
+                    }
+
                     const result = await getComandoApi().listGitHistory({
                         includeAllRefs: true,
                         limit,
                         projectId,
                         worktreeId,
                     });
+                    if (cancelled) {
+                        return;
+                    }
+
                     commits = result.commits;
                     const loadedShas = new Set(
                         commits.map((commit) => commit.sha),
@@ -2139,7 +2151,7 @@ export function SidebarGitScopePicker({
                                                 row.branch.name,
                                             )?.connected ?? false
                                         }
-                                        isCurrent={row.branch.isCurrent}
+                                        isCurrent={row.isActive}
                                     />
                                 )
                             }

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -6,6 +6,7 @@ import {
     useMemo,
     useRef,
     useState,
+    type AnimationEvent as ReactAnimationEvent,
     type FormEvent,
     type KeyboardEvent as ReactKeyboardEvent,
     type MouseEvent as ReactMouseEvent,
@@ -53,9 +54,11 @@ import { buildGitScopeBranchTopology } from "./sidebarGitBranchTopology";
 
 type GitScopeTabId = "branches" | "worktrees";
 type GitScopeBranchNodePosition = "first" | "last" | "middle" | "only";
+type GitScopeMenuAnimationState = "closing" | "open" | "opening";
 
 interface MenuPosition {
     readonly height: number;
+    readonly placement: "above" | "below";
     readonly width: number;
     readonly x: number;
     readonly y: number;
@@ -96,6 +99,7 @@ const GIT_SCOPE_MENU_DEFAULT_MAX_HEIGHT = 420;
 const GIT_SCOPE_MENU_MAX_HEIGHT = 720;
 const GIT_SCOPE_TOPOLOGY_INITIAL_HISTORY_LIMIT = 300;
 const GIT_SCOPE_TOPOLOGY_MAX_HISTORY_LIMIT = 2_400;
+const GIT_SCOPE_MENU_ANIMATION_FALLBACK_MS = 160;
 
 function getStorage(): Storage | null {
     try {
@@ -276,6 +280,9 @@ export function SidebarGitScopePicker({
     worktreeId,
 }: SidebarGitScopePickerProps) {
     const [isOpen, setIsOpen] = useState(false);
+    const [isMenuMounted, setIsMenuMounted] = useState(false);
+    const [menuAnimationState, setMenuAnimationState] =
+        useState<GitScopeMenuAnimationState>("open");
     const [activeTab, setActiveTab] = useState<GitScopeTabId>("branches");
     const [actionError, setActionError] = useState<string | null>(null);
     const [isBusy, setIsBusy] = useState(false);
@@ -796,6 +803,7 @@ export function SidebarGitScopePicker({
 
         setMenuPosition({
             height: size.height,
+            placement: openAbove ? "above" : "below",
             width: size.width,
             x: safePosition.x,
             y: safePosition.y,
@@ -827,9 +835,56 @@ export function SidebarGitScopePicker({
     useEffect(() => {
         if (!isOpen) {
             setItemContextMenu(null);
+        }
+        if (!isMenuMounted) {
             setBranchCreationDraft(null);
         }
-    }, [isOpen]);
+    }, [isMenuMounted, isOpen]);
+
+    useLayoutEffect(() => {
+        if (isOpen) {
+            setIsMenuMounted(true);
+            setMenuAnimationState("opening");
+            return;
+        }
+
+        if (isMenuMounted) {
+            setMenuAnimationState("closing");
+        }
+    }, [isMenuMounted, isOpen]);
+
+    const finishMenuAnimation = useCallback(() => {
+        if (menuAnimationState === "opening" && isOpen) {
+            setMenuAnimationState("open");
+            return;
+        }
+
+        if (menuAnimationState === "closing" && !isOpen) {
+            setIsMenuMounted(false);
+            setMenuAnimationState("open");
+        }
+    }, [isOpen, menuAnimationState]);
+
+    useEffect(() => {
+        if (menuAnimationState === "open") {
+            return;
+        }
+
+        const timeout = window.setTimeout(
+            finishMenuAnimation,
+            GIT_SCOPE_MENU_ANIMATION_FALLBACK_MS,
+        );
+        return () => window.clearTimeout(timeout);
+    }, [finishMenuAnimation, menuAnimationState]);
+
+    const handleMenuAnimationEnd = useCallback(
+        (event: ReactAnimationEvent<HTMLDivElement>) => {
+            if (event.target === event.currentTarget) {
+                finishMenuAnimation();
+            }
+        },
+        [finishMenuAnimation],
+    );
 
     useEffect(() => {
         if (activeTab !== "branches") {
@@ -2245,10 +2300,16 @@ export function SidebarGitScopePicker({
                 <ChevronIcon open={isOpen} />
             </button>
 
-            {isOpen
+            {isMenuMounted
                 ? createPortal(
                       <div
                           className="sidebar-git-scope-menu"
+                          data-animation-state={menuAnimationState}
+                          data-placement={
+                              menuPosition?.placement ?? "below"
+                          }
+                          inert={!isOpen}
+                          onAnimationEnd={handleMenuAnimationEnd}
                           onKeyDown={handleListKeyDown}
                           ref={menuRef}
                           style={{

--- a/src/renderer/src/components/sidebar/SidebarNodeRow.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNodeRow.tsx
@@ -50,7 +50,7 @@ function SidebarNodeRowComponent({
     trailing,
 }: SidebarNodeRowProps) {
     const rowClasses = [
-        "group flex min-h-8 items-center gap-2 rounded-md px-2 py-1.5 transition-colors",
+        "group flex min-h-7 items-center gap-1.5 rounded-md px-2 py-1 transition-colors",
         isActive
             ? "bg-accent/12 text-accent-strong"
             : isSelected
@@ -69,7 +69,7 @@ function SidebarNodeRowComponent({
         >
             {onClick ? (
                 <button
-                    className="app-no-drag flex min-w-0 flex-1 items-center gap-2 text-left"
+                    className="app-no-drag flex min-w-0 flex-1 items-center gap-1.5 text-left"
                     onClick={onClick}
                     type="button"
                 >
@@ -81,7 +81,7 @@ function SidebarNodeRowComponent({
                     />
                 </button>
             ) : (
-                <div className="flex min-w-0 flex-1 items-center gap-2">
+                <div className="flex min-w-0 flex-1 items-center gap-1.5">
                     <RowContent
                         badges={badges}
                         description={description}

--- a/src/renderer/src/components/sidebar/sidebarGitBranchTopology.test.ts
+++ b/src/renderer/src/components/sidebar/sidebarGitBranchTopology.test.ts
@@ -5,7 +5,10 @@ import type {
     GitHistoryCommitSummary,
 } from "@shared/ipc";
 
-import { buildGitScopeBranchTopology } from "./sidebarGitBranchTopology";
+import {
+    buildGitScopeBranchTopology,
+    buildGitScopeBranchTopologyRequestKey,
+} from "./sidebarGitBranchTopology";
 
 function createBranch(
     name: string,
@@ -71,6 +74,7 @@ describe("buildGitScopeBranchTopology", () => {
                 createBranch("older", "older"),
             ],
             [createCommit("shared"), createCommit("older")],
+            "main",
         );
 
         expect(result.orderedBranchNames).toEqual(["main", "alias", "older"]);
@@ -93,6 +97,22 @@ describe("buildGitScopeBranchTopology", () => {
         expect(result.byBranchName.get("old")?.historyIndex).toBeNull();
     });
 
+    it("uses the contextual current branch instead of stale project-wide flags", () => {
+        const result = buildGitScopeBranchTopology(
+            [
+                createBranch("stale-current", "shared", true),
+                createBranch("worktree-current", "shared"),
+            ],
+            [createCommit("shared")],
+            "worktree-current",
+        );
+
+        expect(result.orderedBranchNames).toEqual([
+            "worktree-current",
+            "stale-current",
+        ]);
+    });
+
     it("ignores remote refs in the local topology", () => {
         const remote = {
             ...createBranch("origin/main", "main"),
@@ -106,5 +126,40 @@ describe("buildGitScopeBranchTopology", () => {
 
         expect(result.orderedBranchNames).toEqual(["main"]);
         expect(result.byBranchName.has("origin/main")).toBe(false);
+    });
+});
+
+describe("buildGitScopeBranchTopologyRequestKey", () => {
+    it("changes only when the context or a local branch tip changes", () => {
+        const local = createBranch("main", "commit-main", true);
+        const remote = {
+            ...createBranch("origin/main", "remote-main"),
+            isRemote: true,
+            kind: "remote" as const,
+        };
+
+        const initial = buildGitScopeBranchTopologyRequestKey("project:main", [
+            local,
+            remote,
+        ]);
+
+        expect(
+            buildGitScopeBranchTopologyRequestKey("project:main", [
+                { ...remote, commitSha: "updated-remote" },
+                local,
+            ]),
+        ).toBe(initial);
+        expect(
+            buildGitScopeBranchTopologyRequestKey("project:main", [
+                { ...local, commitSha: "updated-local" },
+                remote,
+            ]),
+        ).not.toBe(initial);
+        expect(
+            buildGitScopeBranchTopologyRequestKey("project:worktree", [
+                local,
+                remote,
+            ]),
+        ).not.toBe(initial);
     });
 });

--- a/src/renderer/src/components/sidebar/sidebarGitBranchTopology.test.ts
+++ b/src/renderer/src/components/sidebar/sidebarGitBranchTopology.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+    GitBranchSummary,
+    GitHistoryCommitSummary,
+} from "@shared/ipc";
+
+import { buildGitScopeBranchTopology } from "./sidebarGitBranchTopology";
+
+function createBranch(
+    name: string,
+    commitSha: string,
+    isCurrent = false,
+): GitBranchSummary {
+    return {
+        aheadBy: 0,
+        behindBy: 0,
+        commitSha,
+        isCurrent,
+        isDetached: false,
+        isRemote: false,
+        kind: "branch",
+        name,
+        upstreamName: null,
+    };
+}
+
+function createCommit(sha: string): GitHistoryCommitSummary {
+    return {
+        authorEmail: "dev@example.com",
+        authorName: "Dev",
+        authoredAt: "2026-07-13T00:00:00.000Z",
+        body: "",
+        parentShas: [],
+        refs: [],
+        sha,
+        shortSha: sha.slice(0, 7),
+        subject: sha,
+    };
+}
+
+describe("buildGitScopeBranchTopology", () => {
+    it("orders local branches by their tips in date-ordered history", () => {
+        const result = buildGitScopeBranchTopology(
+            [
+                createBranch("release", "commit-release"),
+                createBranch("main", "commit-main", true),
+                createBranch("feature", "commit-feature"),
+            ],
+            [
+                createCommit("commit-feature"),
+                createCommit("commit-main"),
+                createCommit("commit-release"),
+            ],
+        );
+
+        expect(result.orderedBranchNames).toEqual([
+            "feature",
+            "main",
+            "release",
+        ]);
+        expect(result.byBranchName.get("feature")?.connected).toBe(true);
+        expect(result.byBranchName.get("feature")?.historyIndex).toBe(0);
+    });
+
+    it("keeps refs sharing a tip adjacent and prefers the current branch", () => {
+        const result = buildGitScopeBranchTopology(
+            [
+                createBranch("alias", "shared"),
+                createBranch("main", "shared", true),
+                createBranch("older", "older"),
+            ],
+            [createCommit("shared"), createCommit("older")],
+        );
+
+        expect(result.orderedBranchNames).toEqual(["main", "alias", "older"]);
+        expect(result.byBranchName.get("main")?.historyIndex).toBe(
+            result.byBranchName.get("alias")?.historyIndex,
+        );
+    });
+
+    it("places refs outside the loaded history after connected refs", () => {
+        const result = buildGitScopeBranchTopology(
+            [
+                createBranch("old", "missing"),
+                createBranch("main", "visible", true),
+            ],
+            [createCommit("visible")],
+        );
+
+        expect(result.orderedBranchNames).toEqual(["main", "old"]);
+        expect(result.byBranchName.get("old")?.connected).toBe(false);
+        expect(result.byBranchName.get("old")?.historyIndex).toBeNull();
+    });
+
+    it("ignores remote refs in the local topology", () => {
+        const remote = {
+            ...createBranch("origin/main", "main"),
+            isRemote: true,
+            kind: "remote" as const,
+        };
+        const result = buildGitScopeBranchTopology(
+            [remote, createBranch("main", "main", true)],
+            [createCommit("main")],
+        );
+
+        expect(result.orderedBranchNames).toEqual(["main"]);
+        expect(result.byBranchName.has("origin/main")).toBe(false);
+    });
+});

--- a/src/renderer/src/components/sidebar/sidebarGitBranchTopology.ts
+++ b/src/renderer/src/components/sidebar/sidebarGitBranchTopology.ts
@@ -1,0 +1,75 @@
+import type {
+    GitBranchSummary,
+    GitHistoryCommitSummary,
+} from "@shared/ipc";
+
+export interface GitScopeBranchTopology {
+    readonly branchName: string;
+    readonly connected: boolean;
+    readonly historyIndex: number | null;
+}
+
+export interface GitScopeBranchTopologyResult {
+    readonly byBranchName: ReadonlyMap<string, GitScopeBranchTopology>;
+    readonly orderedBranchNames: readonly string[];
+}
+
+/**
+ * Orders local branches by where their tip commit falls in `history` (most
+ * recent first), so the branch list reads like a commit timeline rather than
+ * an alphabetical list. Branches whose tip isn't in the loaded history window
+ * are marked `connected: false` and sorted after every connected branch.
+ */
+export function buildGitScopeBranchTopology(
+    branches: readonly GitBranchSummary[],
+    history: readonly GitHistoryCommitSummary[],
+): GitScopeBranchTopologyResult {
+    const localBranches = branches.filter((branch) => !branch.isRemote);
+    const historyIndexBySha = new Map(
+        history.map((commit, index) => [commit.sha, index]),
+    );
+
+    const orderedBranches = localBranches.toSorted((left, right) => {
+        const leftIndex = left.commitSha
+            ? (historyIndexBySha.get(left.commitSha) ?? null)
+            : null;
+        const rightIndex = right.commitSha
+            ? (historyIndexBySha.get(right.commitSha) ?? null)
+            : null;
+
+        if (leftIndex !== null && rightIndex !== null && leftIndex !== rightIndex) {
+            return leftIndex - rightIndex;
+        }
+        if (leftIndex !== null && rightIndex === null) {
+            return -1;
+        }
+        if (leftIndex === null && rightIndex !== null) {
+            return 1;
+        }
+        if (left.isCurrent !== right.isCurrent) {
+            return left.isCurrent ? -1 : 1;
+        }
+        return left.name.localeCompare(right.name);
+    });
+
+    const byBranchName = new Map<string, GitScopeBranchTopology>(
+        orderedBranches.map((branch) => {
+            const historyIndex = branch.commitSha
+                ? (historyIndexBySha.get(branch.commitSha) ?? null)
+                : null;
+            return [
+                branch.name,
+                {
+                    branchName: branch.name,
+                    connected: historyIndex !== null,
+                    historyIndex,
+                },
+            ];
+        }),
+    );
+
+    return {
+        byBranchName,
+        orderedBranchNames: orderedBranches.map((branch) => branch.name),
+    };
+}

--- a/src/renderer/src/components/sidebar/sidebarGitBranchTopology.ts
+++ b/src/renderer/src/components/sidebar/sidebarGitBranchTopology.ts
@@ -14,6 +14,22 @@ export interface GitScopeBranchTopologyResult {
     readonly orderedBranchNames: readonly string[];
 }
 
+export function buildGitScopeBranchTopologyRequestKey(
+    contextKey: string | null,
+    branches: readonly GitBranchSummary[],
+): string | null {
+    if (!contextKey) {
+        return null;
+    }
+
+    const localTips = branches
+        .filter((branch) => !branch.isRemote)
+        .map((branch) => `${branch.name}:${branch.commitSha ?? ""}`)
+        .toSorted();
+
+    return `${contextKey}:${localTips.join("|")}`;
+}
+
 /**
  * Orders local branches by where their tip commit falls in `history` (most
  * recent first), so the branch list reads like a commit timeline rather than
@@ -23,6 +39,9 @@ export interface GitScopeBranchTopologyResult {
 export function buildGitScopeBranchTopology(
     branches: readonly GitBranchSummary[],
     history: readonly GitHistoryCommitSummary[],
+    currentBranchName: string | null =
+        branches.find((branch) => !branch.isRemote && branch.isCurrent)?.name ??
+        null,
 ): GitScopeBranchTopologyResult {
     const localBranches = branches.filter((branch) => !branch.isRemote);
     const historyIndexBySha = new Map(
@@ -46,8 +65,10 @@ export function buildGitScopeBranchTopology(
         if (leftIndex === null && rightIndex !== null) {
             return 1;
         }
-        if (left.isCurrent !== right.isCurrent) {
-            return left.isCurrent ? -1 : 1;
+        const leftIsCurrent = left.name === currentBranchName;
+        const rightIsCurrent = right.name === currentBranchName;
+        if (leftIsCurrent !== rightIsCurrent) {
+            return leftIsCurrent ? -1 : 1;
         }
         return left.name.localeCompare(right.name);
     });

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2297,12 +2297,39 @@ button {
     content: "·";
 }
 
+/* Sized and boxed as its own hit target so the disclosure affordance reads
+   clearly at a glance instead of blending into the "· branch" label, without
+   growing the tab row (the pill is padding on the icon itself, not extra
+   height on the button). */
 .sidebar-git-scope-trigger--titlebar > svg {
-    width: 10px;
-    height: 10px;
+    box-sizing: content-box;
+    width: 12px;
+    height: 12px;
     flex: 0 0 auto;
-    margin-right: 1px;
-    color: var(--color-text-secondary);
+    margin-right: 2px;
+    padding: 3px;
+    border-radius: 5px;
+    color: color-mix(in srgb, var(--color-text-secondary) 70%, var(--color-text-primary));
+    background: transparent;
+    transition:
+        background-color 120ms ease,
+        color 120ms ease,
+        transform 75ms ease;
+}
+
+.sidebar-git-scope-trigger--titlebar:hover > svg,
+.sidebar-git-scope-trigger--titlebar:focus-visible > svg,
+.sidebar-git-scope-trigger--titlebar.sidebar-git-scope-trigger--open > svg {
+    color: var(--color-text-primary);
+    background: color-mix(in srgb, var(--color-text-primary) 12%, transparent);
+}
+
+/* Same light "press" feedback the other icon buttons in this menu use
+   (see .sidebar-git-scope-menu__new-branch-button:active), scoped to the
+   pill instead of the whole tab so the rest of the tab stays still. */
+.sidebar-git-scope-trigger--titlebar:active > svg {
+    background: color-mix(in srgb, var(--color-text-primary) 16%, transparent);
+    transform: translateY(1px) scale(0.92);
 }
 
 .sidebar-git-scope-menu {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2313,18 +2313,38 @@ button {
     min-height: 260px;
     z-index: 10010;
     overflow: hidden;
-    border: 1px solid var(--color-border);
+    border: 1px solid color-mix(in srgb, var(--color-border) 42%, transparent);
     border-radius: 12px;
-    background: color-mix(in srgb, var(--color-bg-secondary) 96%, black 4%);
+    background: color-mix(in srgb, var(--color-bg-elevated) 52%, transparent);
     box-shadow:
-        0 16px 40px rgba(0, 0, 0, 0.34),
-        inset 0 1px 0 color-mix(in srgb, white 6%, transparent);
-    backdrop-filter: blur(16px);
+        0 20px 48px rgba(0, 0, 0, 0.28),
+        inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
+    backdrop-filter: blur(28px) saturate(1.85);
+}
+
+/* Users who turn off window transparency get a fully opaque menu to match
+   the rest of the chrome (see .app-sidebar / .desktop-titlebar above). */
+:root[data-transparency-enabled="false"] .sidebar-git-scope-menu {
+    background: var(--color-bg-elevated);
+    backdrop-filter: none;
+}
+
+/* Every plain .ide-input inside this menu (the branch-form name field and
+   base select) gets the same glass treatment as the search field, instead of
+   the opaque box .ide-input draws by default elsewhere in the app. */
+.sidebar-git-scope-menu .ide-input {
+    border-color: color-mix(in srgb, var(--color-border) 42%, transparent);
+    background: color-mix(in srgb, var(--color-bg-tertiary) 30%, transparent);
+    padding: 0.4rem 0.6rem;
+}
+
+.sidebar-git-scope-menu .ide-input:focus {
+    background: color-mix(in srgb, var(--color-bg-tertiary) 46%, transparent);
+    border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-border));
 }
 
 .sidebar-git-scope-menu__header {
-    border-bottom: 1px solid var(--color-border);
-    background: color-mix(in srgb, var(--color-bg-elevated) 22%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--color-border) 38%, transparent);
 }
 
 .sidebar-git-scope-menu__title {
@@ -2347,12 +2367,12 @@ button {
 .sidebar-git-scope-menu__tabs {
     display: flex;
     gap: 3px;
-    margin: 0 12px 10px;
-    padding: 3px;
-    border-radius: 9px;
-    background: color-mix(in srgb, var(--color-bg-tertiary) 60%, transparent);
+    margin: 0 10px 8px;
+    padding: 2px;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--color-bg-tertiary) 32%, transparent);
     box-shadow: inset 0 0 0 1px
-        color-mix(in srgb, var(--color-border) 60%, transparent);
+        color-mix(in srgb, var(--color-border) 32%, transparent);
 }
 
 .sidebar-git-scope-menu__tab {
@@ -2383,25 +2403,43 @@ button {
 }
 
 .sidebar-git-scope-menu__tab--active {
-    background: var(--color-bg-elevated);
-    box-shadow:
-        0 1px 3px rgba(0, 0, 0, 0.1),
-        inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 24%, transparent);
+    background: color-mix(in srgb, var(--color-bg-elevated) 45%, transparent);
+    box-shadow: inset 0 0 0 1px
+        color-mix(in srgb, var(--color-accent) 22%, transparent);
     color: var(--color-text-primary);
 }
 
 .sidebar-git-scope-menu__search-row {
     display: flex;
     align-items: center;
-    gap: 8px;
-    margin-bottom: 10px;
-    padding: 0 12px;
+    gap: 6px;
+    margin-bottom: 8px;
+    padding: 0 10px;
 }
 
+/* The shell (not the bare <input>) owns the border/background here, so the
+   field reads as one compact glass control instead of the taller, opaque
+   box the shared .ide-input draws everywhere else in the app. */
 .sidebar-git-scope-menu__search {
     position: relative;
+    display: flex;
+    align-items: center;
     min-width: 0;
     flex: 1;
+    height: 27px;
+    border: 1px solid color-mix(in srgb, var(--color-border) 42%, transparent);
+    border-radius: 7px;
+    background: color-mix(in srgb, var(--color-bg-tertiary) 30%, transparent);
+    transition:
+        border-color 120ms ease,
+        background-color 120ms ease,
+        box-shadow 120ms ease;
+}
+
+.sidebar-git-scope-menu__search:focus-within {
+    border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-border));
+    background: color-mix(in srgb, var(--color-bg-tertiary) 46%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 12%, transparent);
 }
 
 .sidebar-git-scope-menu__search-icon {
@@ -2409,8 +2447,8 @@ button {
     left: 8px;
     top: 50%;
     transform: translateY(-50%);
-    width: 13px;
-    height: 13px;
+    width: 12px;
+    height: 12px;
     color: var(--color-text-secondary);
     pointer-events: none;
     opacity: 0.6;
@@ -2426,75 +2464,52 @@ button {
 }
 
 .sidebar-git-scope-menu__search .ide-input {
-    padding-left: 28px;
-    transition:
-        border-color 120ms ease,
-        background-color 120ms ease,
-        box-shadow 120ms ease;
+    height: 100%;
+    border: none;
+    border-radius: inherit;
+    background: transparent;
+    padding: 0 8px 0 25px;
 }
 
 .sidebar-git-scope-menu__search .ide-input:focus {
-    box-shadow: 0 0 0 3px
-        color-mix(in srgb, var(--color-accent) 16%, transparent);
+    background: transparent;
+    box-shadow: none;
 }
 
 .sidebar-git-scope-menu__new-branch-button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 6px;
-    height: 26px;
-    width: 32px;
-    min-height: 26px;
+    height: 27px;
+    width: 27px;
+    min-height: 27px;
     flex-shrink: 0;
-    max-width: 100%;
-    border: 1px solid
-        color-mix(in srgb, var(--color-accent) 34%, var(--color-border));
+    border: 1px solid color-mix(in srgb, var(--color-border) 42%, transparent);
     border-radius: 7px;
-    background: color-mix(
-        in srgb,
-        var(--color-accent) 11%,
-        var(--color-bg-elevated)
-    );
+    background: color-mix(in srgb, var(--color-bg-tertiary) 30%, transparent);
     padding: 0;
-    color: var(--color-text-primary);
-    font-size: 11px;
-    font-weight: 600;
-    line-height: normal;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+    color: var(--color-text-secondary);
     transition:
         background-color 120ms ease,
         border-color 120ms ease,
         color 120ms ease,
-        box-shadow 120ms ease,
         transform 75ms ease;
 }
 
 .sidebar-git-scope-menu__new-branch-button:hover:not(:disabled) {
-    border-color: color-mix(
-        in srgb,
-        var(--color-accent) 55%,
-        var(--color-border)
-    );
-    background: color-mix(
-        in srgb,
-        var(--color-accent) 17%,
-        var(--color-bg-elevated)
-    );
-    box-shadow: 0 2px 6px
-        color-mix(in srgb, var(--color-accent) 22%, transparent);
+    border-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-border));
+    background: color-mix(in srgb, var(--color-bg-tertiary) 48%, transparent);
+    color: var(--color-text-primary);
 }
 
 /* Depress into the surface while held down */
 .sidebar-git-scope-menu__new-branch-button:active:not(:disabled) {
     transform: translateY(1px) scale(0.99);
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.16);
 }
 
 .sidebar-git-scope-menu__new-branch-button:disabled {
     cursor: default;
-    opacity: 0.55;
-    box-shadow: none;
+    opacity: 0.5;
 }
 
 .sidebar-git-scope-menu__new-branch-button svg {
@@ -2508,8 +2523,8 @@ button {
     flex-direction: column;
     flex-shrink: 0;
     gap: 8px;
-    border-bottom: 1px solid var(--color-border);
-    background: color-mix(in srgb, var(--color-bg-elevated) 58%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--color-border) 38%, transparent);
+    background: color-mix(in srgb, var(--color-bg-elevated) 30%, transparent);
     padding: 10px 12px 12px;
 }
 
@@ -2605,37 +2620,24 @@ button {
 }
 
 .sidebar-git-scope-menu__branch-form-primary {
-    border: 1px solid
-        color-mix(in srgb, var(--color-accent) 48%, var(--color-border));
-    background: color-mix(
-        in srgb,
-        var(--color-accent) 18%,
-        var(--color-bg-elevated)
-    );
+    border: 1px solid color-mix(in srgb, var(--color-accent) 45%, transparent);
+    background: color-mix(in srgb, var(--color-accent) 16%, transparent);
     color: var(--color-text-primary);
 }
 
 .sidebar-git-scope-menu__branch-form-primary:hover:not(:disabled) {
-    border-color: color-mix(
-        in srgb,
-        var(--color-accent) 68%,
-        var(--color-border)
-    );
-    background: color-mix(
-        in srgb,
-        var(--color-accent) 25%,
-        var(--color-bg-elevated)
-    );
+    border-color: color-mix(in srgb, var(--color-accent) 65%, transparent);
+    background: color-mix(in srgb, var(--color-accent) 24%, transparent);
 }
 
 .sidebar-git-scope-menu__branch-form-secondary {
-    border: 1px solid var(--color-border);
-    background: color-mix(in srgb, var(--color-bg-tertiary) 55%, transparent);
+    border: 1px solid color-mix(in srgb, var(--color-border) 45%, transparent);
+    background: color-mix(in srgb, var(--color-bg-tertiary) 28%, transparent);
     color: var(--color-text-secondary);
 }
 
 .sidebar-git-scope-menu__branch-form-secondary:hover:not(:disabled) {
-    background: var(--color-bg-tertiary);
+    background: color-mix(in srgb, var(--color-bg-tertiary) 48%, transparent);
     color: var(--color-text-primary);
 }
 
@@ -2683,6 +2685,39 @@ button {
     font-size: 10px;
     color: var(--color-text-secondary);
     opacity: 0.7;
+}
+
+/* Connects consecutive local-branch rows with the same dashed rail used by
+   the chat activity tree (.activity-tree-branch), so the list reads as one
+   ordered commit timeline instead of a flat alphabetical list. The line sits
+   directly behind each row's leading bullet (see BranchTopologyBullet). */
+.sidebar-git-scope-menu__branch-node {
+    position: relative;
+}
+
+.sidebar-git-scope-menu__branch-node::before {
+    content: "";
+    position: absolute;
+    top: -3px;
+    bottom: -3px;
+    left: 15px;
+    width: 1px;
+    background: repeating-linear-gradient(
+        to bottom,
+        color-mix(in srgb, var(--color-text-secondary) 32%, transparent) 0 2px,
+        transparent 2px 5px
+    );
+    pointer-events: none;
+}
+
+.sidebar-git-scope-menu__branch-node[data-branch-node-position="first"]::before,
+.sidebar-git-scope-menu__branch-node[data-branch-node-position="only"]::before {
+    top: 50%;
+}
+
+.sidebar-git-scope-menu__branch-node[data-branch-node-position="last"]::before,
+.sidebar-git-scope-menu__branch-node[data-branch-node-position="only"]::before {
+    bottom: 50%;
 }
 
 .sidebar-git-scope-menu__list {
@@ -2733,14 +2768,9 @@ button {
     width: 100%;
     min-height: 36px;
     min-width: 0;
-    border: 1px solid
-        color-mix(in srgb, var(--color-accent) 24%, var(--color-border));
+    border: 1px solid color-mix(in srgb, var(--color-accent) 22%, transparent);
     border-radius: 7px;
-    background: color-mix(
-        in srgb,
-        var(--color-accent) 8%,
-        var(--color-bg-elevated)
-    );
+    background: color-mix(in srgb, var(--color-accent) 7%, transparent);
     margin-bottom: 6px;
     padding: 7px 9px;
     color: var(--color-text-primary);
@@ -2758,16 +2788,8 @@ button {
 
 .sidebar-git-scope-menu__create-query:hover:not(:disabled),
 .sidebar-git-scope-menu__create-query--selected {
-    border-color: color-mix(
-        in srgb,
-        var(--color-accent) 45%,
-        var(--color-border)
-    );
-    background: color-mix(
-        in srgb,
-        var(--color-accent) 14%,
-        var(--color-bg-elevated)
-    );
+    border-color: color-mix(in srgb, var(--color-accent) 42%, transparent);
+    background: color-mix(in srgb, var(--color-accent) 13%, transparent);
 }
 
 .sidebar-git-scope-menu__create-query:disabled {
@@ -2827,40 +2849,25 @@ button {
     gap: 7px;
     width: 100%;
     min-height: 30px;
-    border: 1px solid
-        color-mix(in srgb, var(--color-accent) 35%, var(--color-border));
+    border: 1px solid color-mix(in srgb, var(--color-accent) 32%, transparent);
     border-radius: 7px;
-    background: color-mix(
-        in srgb,
-        var(--color-accent) 14%,
-        var(--color-bg-elevated)
-    );
+    background: color-mix(in srgb, var(--color-accent) 12%, transparent);
     color: var(--color-text-primary);
     font-size: 11px;
     font-weight: 600;
     transition:
         border-color 120ms ease,
         background-color 120ms ease,
-        transform 75ms ease,
-        box-shadow 120ms ease;
+        transform 75ms ease;
 }
 
 .sidebar-git-scope-menu__init-button:active:not(:disabled) {
     transform: translateY(1px) scale(0.99);
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.14);
 }
 
 .sidebar-git-scope-menu__init-button:hover:not(:disabled) {
-    border-color: color-mix(
-        in srgb,
-        var(--color-accent) 60%,
-        var(--color-border)
-    );
-    background: color-mix(
-        in srgb,
-        var(--color-accent) 20%,
-        var(--color-bg-elevated)
-    );
+    border-color: color-mix(in srgb, var(--color-accent) 55%, transparent);
+    background: color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 
 .sidebar-git-scope-menu__init-button:disabled {
@@ -2874,7 +2881,7 @@ button {
 }
 
 .sidebar-git-scope-menu__status {
-    border-top: 1px solid var(--color-border);
+    border-top: 1px solid color-mix(in srgb, var(--color-border) 38%, transparent);
     padding: 8px 12px;
     color: var(--color-text-secondary);
     font-size: 11px;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2333,6 +2333,8 @@ button {
 }
 
 .sidebar-git-scope-menu {
+    --git-scope-menu-enter-y: -4px;
+    --git-scope-menu-exit-y: -2px;
     position: fixed;
     display: flex;
     flex-direction: column;
@@ -2347,6 +2349,47 @@ button {
         0 20px 48px rgba(0, 0, 0, 0.28),
         inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
     backdrop-filter: blur(28px) saturate(1.85);
+}
+
+.sidebar-git-scope-menu[data-placement="above"] {
+    --git-scope-menu-enter-y: 4px;
+    --git-scope-menu-exit-y: 2px;
+}
+
+@keyframes sidebar-git-scope-menu-in {
+    from {
+        opacity: 0;
+        transform: translate3d(0, var(--git-scope-menu-enter-y), 0);
+    }
+
+    to {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+@keyframes sidebar-git-scope-menu-out {
+    from {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+
+    to {
+        opacity: 0;
+        transform: translate3d(0, var(--git-scope-menu-exit-y), 0);
+    }
+}
+
+.sidebar-git-scope-menu[data-animation-state="opening"] {
+    animation: sidebar-git-scope-menu-in 110ms cubic-bezier(0.2, 0.8, 0.2, 1)
+        both;
+    will-change: opacity, transform;
+}
+
+.sidebar-git-scope-menu[data-animation-state="closing"] {
+    pointer-events: none;
+    animation: sidebar-git-scope-menu-out 80ms cubic-bezier(0.4, 0, 1, 1) both;
+    will-change: opacity, transform;
 }
 
 /* Users who turn off window transparency get a fully opaque menu to match
@@ -3220,6 +3263,11 @@ button {
 }
 
 @media (prefers-reduced-motion: reduce) {
+    .sidebar-git-scope-menu[data-animation-state="opening"],
+    .sidebar-git-scope-menu[data-animation-state="closing"] {
+        animation-duration: 1ms !important;
+    }
+
     [data-edge-peek-overlay] {
         animation-duration: 1ms !important;
     }


### PR DESCRIPTION
## Summary

Modernizes the sidebar branch and worktree picker so navigation better reflects the repository's actual state and is clearer visually.

- Orders local branches by commit topology and history, prioritizing the active branch in the current context.
- Progressively loads the history needed to connect branch tips, with a safe limit of 2,400 commits.
- Correctly distinguishes worktree contexts and detached HEAD.
- Adds a topology rail, open/close animations, and reduced-motion support.
- Refreshes the menu surface, search controls, tabs, and actions for a more compact interface.
- Adjusts sidebar row density.

## Validation

- `pnpm exec vitest run src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts src/renderer/src/components/sidebar/sidebarGitBranchTopology.test.ts`
- `pnpm run typecheck`

Result: 18 tests passed and typecheck completed without errors.