### PR TITLE
Show agent activity states in the sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
@@ -363,7 +363,7 @@ describe("SidebarAgentsPanel history cache", () => {
         expect(markup).toContain('data-provider-icon="codex"');
     });
 
-    it("shows an activity dot only for working child agents", () => {
+    it("renders activity labels at the end of active child agent rows", () => {
         const sessions = [
             createSummary({
                 runtimeSessionId: "runtime-parent",
@@ -381,6 +381,24 @@ describe("SidebarAgentsPanel history cache", () => {
                 runtimeSessionId: "runtime-child-running",
                 sessionId: "child-running",
                 title: "Running Child",
+            }),
+            createSummary({
+                parentSessionId: "runtime-parent",
+                runtimeSessionId: "runtime-child-error",
+                sessionId: "child-error",
+                title: "Errored Child",
+            }),
+            createSummary({
+                parentSessionId: "runtime-parent",
+                runtimeSessionId: "runtime-child-permission",
+                sessionId: "child-permission",
+                title: "Permission Child",
+            }),
+            createSummary({
+                parentSessionId: "runtime-parent",
+                runtimeSessionId: "runtime-child-input",
+                sessionId: "child-input",
+                title: "Input Child",
             }),
         ];
         writeSidebarAgentsHistoryCache(
@@ -405,6 +423,33 @@ describe("SidebarAgentsPanel history cache", () => {
                 sessionId: "child-running",
                 status: "streaming",
                 title: "Running Child",
+            }),
+        );
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                parentSessionId: "runtime-parent",
+                runtimeSessionId: "runtime-child-error",
+                sessionId: "child-error",
+                status: "error",
+                title: "Errored Child",
+            }),
+        );
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                parentSessionId: "runtime-parent",
+                runtimeSessionId: "runtime-child-permission",
+                sessionId: "child-permission",
+                status: "waiting_permission",
+                title: "Permission Child",
+            }),
+        );
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                parentSessionId: "runtime-parent",
+                runtimeSessionId: "runtime-child-input",
+                sessionId: "child-input",
+                status: "waiting_user_input",
+                title: "Input Child",
             }),
         );
         Object.defineProperty(window, "comando", {
@@ -442,19 +487,60 @@ describe("SidebarAgentsPanel history cache", () => {
         const runningItem = items.find((item) =>
             item.textContent?.includes("Running Child"),
         );
+        const erroredItem = items.find((item) =>
+            item.textContent?.includes("Errored Child"),
+        );
+        const permissionItem = items.find((item) =>
+            item.textContent?.includes("Permission Child"),
+        );
+        const inputItem = items.find((item) =>
+            item.textContent?.includes("Input Child"),
+        );
 
         expect(
-            container.querySelectorAll(".sidebar-agents-activity-dot"),
-        ).toHaveLength(1);
+            container.querySelectorAll(".sidebar-agents-activity-label"),
+        ).toHaveLength(4);
         expect(
-            finishedItem?.querySelector(".sidebar-agents-activity-dot"),
+            container.querySelector(".sidebar-agents-activity-dot"),
         ).toBeNull();
         expect(
-            runningItem?.querySelector(".sidebar-agents-activity-dot"),
-        ).not.toBeNull();
+            finishedItem?.querySelector(".sidebar-agents-activity-label"),
+        ).toBeNull();
+        expect(
+            runningItem?.querySelector(".sidebar-agents-activity-label")
+                ?.textContent,
+        ).toBe("Working…");
         expect(
             runningItem?.querySelector(
-                ".sidebar-agents-provider-slot .sidebar-agents-activity-dot",
+                ".sidebar-agents-provider-slot .sidebar-agents-activity-label",
+            ),
+        ).toBeNull();
+        expect(
+            erroredItem?.querySelector(".sidebar-agents-activity-label")
+                ?.textContent,
+        ).toBe("Error");
+        expect(
+            permissionItem?.querySelector(".sidebar-agents-activity-label")
+                ?.textContent,
+        ).toBe("Waiting permission…");
+        expect(
+            inputItem?.querySelector(".sidebar-agents-activity-label")
+                ?.textContent,
+        ).toBe("Waiting input…");
+        expect(
+            runningItem?.querySelector(".sidebar-agents-main-line")
+                ?.lastElementChild?.classList.contains(
+                    "sidebar-agents-activity-label",
+                ),
+        ).toBe(true);
+        expect(
+            runningItem?.querySelector(
+                ".sidebar-agents-compact-relative-time",
+            ),
+        ).toBeNull();
+        expect(
+            finishedItem?.querySelector(
+                ".sidebar-agents-compact-relative-time",
             ),
         ).not.toBeNull();
     });

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -118,6 +118,11 @@ type SidebarAgentDragPreview = {
     readonly y: number;
 };
 
+type SidebarAgentActivity = {
+    readonly indicator: NonNullable<WorkspaceChatTabActivityIndicator>;
+    readonly label: string;
+} | null;
+
 type SidebarAgentDragCoordinates = {
     readonly clientX: number;
     readonly clientY: number;
@@ -1777,7 +1782,8 @@ function SidebarAgentsItem({
     const isPinned = isSessionPinned(session);
     const isTerminalAgent = isClaudeCodeSidebarSession(session);
     const canOpenInPane = !isTerminalAgent;
-    const activity = useAgentActivityIndicator(session.sessionId);
+    const activityState = useAgentActivityIndicator(session.sessionId);
+    const activity = activityState?.indicator ?? null;
     const indentStyle =
         depth > 0
             ? { paddingLeft: `${8 + Math.min(depth, 4) * 14}px` }
@@ -2055,7 +2061,7 @@ function SidebarAgentsItem({
                         <ChevronIcon collapsed={isCollapsed} />
                     </button>
                 ) : null}
-                <span className="sidebar-agents-provider-slot relative flex shrink-0 items-center justify-center text-text-secondary">
+                <span className="sidebar-agents-provider-slot flex shrink-0 items-center justify-center text-text-secondary">
                     <ProviderIcon
                         className="sidebar-agents-provider-icon block"
                         opacity={0.68}
@@ -2066,7 +2072,6 @@ function SidebarAgentsItem({
                         }
                         size={13}
                     />
-                    <SidebarAgentActivityDot indicator={activity} />
                 </span>
                 {isRenaming ? (
                     <input
@@ -2122,7 +2127,12 @@ function SidebarAgentsItem({
                         <PinIcon active={isPinned} />
                     </button>
                 )}
-                {isRenaming ? null : (
+                {activityState ? (
+                    <SidebarAgentActivityLabel
+                        indicator={activityState.indicator}
+                        label={activityState.label}
+                    />
+                ) : isRenaming ? null : (
                     <span className="sidebar-agents-compact-relative-time shrink-0 text-[10px] text-text-secondary">
                         {formatHistoryRelativeDateCompact(session.updatedAt)}
                     </span>
@@ -2236,7 +2246,7 @@ function getSidebarAgentInternalDropTargetAtPoint(
 
 function useAgentActivityIndicator(
     sessionId: string,
-): WorkspaceChatTabActivityIndicator {
+): SidebarAgentActivity {
     const localError = useAiStore(
         (state) => state.sessions[sessionId]?.localError ?? null,
     );
@@ -2244,36 +2254,43 @@ function useAgentActivityIndicator(
         (state) => state.sessions[sessionId]?.snapshot?.status ?? null,
     );
     return useMemo(
-        () =>
-            resolveWorkspaceChatTabActivityIndicator({
+        () => {
+            const indicator = resolveWorkspaceChatTabActivityIndicator({
                 localError,
                 snapshot: status ? { status } : null,
-            }),
+            });
+            if (!indicator) {
+                return null;
+            }
+
+            const label =
+                indicator.tone === "danger"
+                    ? "Error"
+                    : status === "waiting_permission"
+                      ? "Waiting permission…"
+                      : status === "waiting_user_input"
+                        ? "Waiting input…"
+                        : "Working…";
+            return { indicator, label };
+        },
         [localError, status],
     );
 }
 
-function SidebarAgentActivityDot({
+function SidebarAgentActivityLabel({
     indicator,
+    label,
 }: {
-    readonly indicator: WorkspaceChatTabActivityIndicator;
+    readonly indicator: NonNullable<WorkspaceChatTabActivityIndicator>;
+    readonly label: string;
 }) {
-    if (!indicator) {
-        return null;
-    }
-
     return (
         <span
-            aria-hidden="true"
-            className={[
-                "sidebar-agents-activity-dot shrink-0 text-[9px] leading-none",
-                indicator.tone === "danger"
-                    ? "text-rose-500"
-                    : "text-(--diff-warn)",
-            ].join(" ")}
+            className="sidebar-agents-activity-label shrink-0"
+            data-tone={indicator.tone}
             title={indicator.title}
         >
-            ●
+            {label}
         </span>
     );
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2062,20 +2062,22 @@ button {
     -webkit-user-select: text;
 }
 
-.sidebar-agents-activity-dot {
-    font-size: calc(9px * var(--sidebar-list-scale, 1));
+.sidebar-agents-activity-label {
+    color: var(--color-text-secondary);
+    font-size: calc(10px * var(--sidebar-list-scale, 1));
+    line-height: calc(16px * var(--sidebar-list-scale, 1));
+    opacity: 0.8;
 }
 
-.sidebar-agents-provider-slot .sidebar-agents-activity-dot {
-    position: absolute;
-    right: -2px;
-    bottom: -1px;
-    font-size: calc(6px * var(--sidebar-list-scale, 1));
-    filter: drop-shadow(0 0 1px var(--color-bg-panel));
+.sidebar-agents-activity-label[data-tone="working"] {
+    color: var(--diff-warn, #d97706);
+}
+
+.sidebar-agents-activity-label[data-tone="danger"] {
+    color: var(--diff-remove, #f43f5e);
 }
 
 .sidebar-agents-pin-button {
-    order: 1;
     width: calc(20px * var(--sidebar-list-scale, 1));
     height: calc(20px * var(--sidebar-list-scale, 1));
     opacity: 0;


### PR DESCRIPTION
## Summary

- replace sidebar agent activity dots with clear status labels
- show working, permission, input, and error states inline
- add coverage for active agent status labels

## Validation

- `npx vitest run src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx`