### PR TITLE
feat(github): add label management for pull requests

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -52,6 +52,8 @@ import type {
     GitHubPublishReleaseInput,
     GitHubReleaseSummary,
     GitHubSetIssueStateInput,
+    GitHubSetIssueLabelsInput,
+    GitHubSetIssueLabelsResult,
     GitHubSetPullRequestDraftStateInput,
     GitHubUpdateCommentInput,
     GitHubUpdateIssueInput,
@@ -572,6 +574,24 @@ export class GitHubApiClient {
         }
 
         return updated;
+    }
+
+    async setIssueLabels(
+        input: GitHubSetIssueLabelsInput,
+    ): Promise<GitHubSetIssueLabelsResult> {
+        const response = await this.#requestJson<readonly RawGitHubLabel[]>(
+            input.repository.host,
+            repoPath(input.repository, `/issues/${input.number}/labels`),
+            {
+                body: { labels: input.labels },
+                method: "PUT",
+            },
+        );
+
+        return {
+            labels: response.data.map(mapLabel),
+            number: input.number,
+        };
     }
 
     async commentIssue(input: {

--- a/src/main/github/service.test.ts
+++ b/src/main/github/service.test.ts
@@ -428,6 +428,104 @@ describe("GitHubService", () => {
         });
     });
 
+    it("sets labels through the shared issue endpoint", async () => {
+        const fetchMock = vi.fn<GitHubFetch>().mockResolvedValue(
+            jsonResponse([
+                rawLabel(),
+                rawLabel({
+                    color: "0052cc",
+                    description: "User interface",
+                    id: 2,
+                    name: "area/ui",
+                }),
+            ]),
+        );
+        const service = createService(fetchMock);
+
+        const result = await service.setIssueLabels({
+            clientRequestId: "set-labels",
+            labels: ["bug", "area/ui"],
+            number: 5,
+            repository,
+        });
+
+        expect(result).toEqual({
+            labels: [
+                {
+                    color: "d73a4a",
+                    description: "Something is not working",
+                    id: 208045946,
+                    name: "bug",
+                },
+                {
+                    color: "0052cc",
+                    description: "User interface",
+                    id: 2,
+                    name: "area/ui",
+                },
+            ],
+            number: 5,
+        });
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                href: "https://api.github.com/repos/octocat/hello-world/issues/5/labels",
+            }),
+            expect.objectContaining({ method: "PUT" }),
+        );
+        const body = fetchMock.mock.calls[0]?.[1]?.body;
+        if (typeof body !== "string") {
+            throw new Error("Expected request body to be JSON.");
+        }
+        expect(JSON.parse(body)).toEqual({ labels: ["bug", "area/ui"] });
+    });
+
+    it("clears labels with an empty label set", async () => {
+        const fetchMock = vi.fn<GitHubFetch>().mockResolvedValue(jsonResponse([]));
+        const service = createService(fetchMock);
+
+        const result = await service.setIssueLabels({
+            labels: [],
+            number: 5,
+            repository,
+        });
+
+        expect(result).toEqual({ labels: [], number: 5 });
+        const body = fetchMock.mock.calls[0]?.[1]?.body;
+        if (typeof body !== "string") {
+            throw new Error("Expected request body to be JSON.");
+        }
+        expect(JSON.parse(body)).toEqual({ labels: [] });
+    });
+
+    it("deduplicates concurrent label assignments with the same request id", async () => {
+        const resolveFetchCalls: Array<(response: Response) => void> = [];
+        const fetchMock = vi.fn<GitHubFetch>().mockReturnValue(
+            new Promise<Response>((resolve) => {
+                resolveFetchCalls.push(resolve);
+            }),
+        );
+        const service = createService(fetchMock);
+        const input = {
+            clientRequestId: "same-label-save",
+            labels: ["bug"],
+            number: 5,
+            repository,
+        };
+
+        const first = service.setIssueLabels(input);
+        const second = service.setIssueLabels(input);
+        const resolveFetch = resolveFetchCalls[0];
+        if (!resolveFetch) {
+            throw new Error("Fetch resolver was not captured.");
+        }
+        resolveFetch(jsonResponse([rawLabel()]));
+
+        const [firstResult, secondResult] = await Promise.all([first, second]);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(firstResult).toEqual(secondResult);
+    });
+
     it("creates pull requests and comments on PR conversations", async () => {
         const fetchMock = vi
             .fn<GitHubFetch>()
@@ -824,12 +922,19 @@ function rawIssue(
     };
 }
 
-function rawLabel() {
+function rawLabel(
+    overrides: Partial<{
+        readonly color: string;
+        readonly description: string | null;
+        readonly id: number;
+        readonly name: string;
+    }> = {},
+) {
     return {
-        color: "d73a4a",
-        description: "Something is not working",
-        id: 208045946,
-        name: "bug",
+        color: overrides.color ?? "d73a4a",
+        description: overrides.description ?? "Something is not working",
+        id: overrides.id ?? 208045946,
+        name: overrides.name ?? "bug",
     };
 }
 

--- a/src/main/github/service.ts
+++ b/src/main/github/service.ts
@@ -43,6 +43,8 @@ import type {
     GitHubReleaseSummary,
     GitHubRequestPullRequestReviewInput,
     GitHubSaveTokenInput,
+    GitHubSetIssueLabelsInput,
+    GitHubSetIssueLabelsResult,
     GitHubSetIssueStateInput,
     GitHubSetPullRequestDraftStateInput,
     GitHubUpdateCommentInput,
@@ -79,6 +81,9 @@ export interface GitHubGateway {
     ): Promise<GitHubPullRequestDetail>;
     createIssue(input: GitHubCreateIssueInput): Promise<GitHubIssueDetail>;
     updateIssue(input: GitHubUpdateIssueInput): Promise<GitHubIssueDetail>;
+    setIssueLabels(
+        input: GitHubSetIssueLabelsInput,
+    ): Promise<GitHubSetIssueLabelsResult>;
     createPullRequest(
         input: GitHubCreatePullRequestInput,
     ): Promise<GitHubPullRequestDetail>;
@@ -221,6 +226,16 @@ export class GitHubService implements GitHubGateway {
     ): Promise<GitHubIssueDetail> {
         return await this.#dedupeMutation(input.clientRequestId, async () =>
             (await this.#createClient(input.repository.host)).updateIssue(input),
+        );
+    }
+
+    async setIssueLabels(
+        input: GitHubSetIssueLabelsInput,
+    ): Promise<GitHubSetIssueLabelsResult> {
+        return await this.#dedupeMutation(input.clientRequestId, async () =>
+            (await this.#createClient(input.repository.host)).setIssueLabels(
+                input,
+            ),
         );
     }
 

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -87,6 +87,8 @@ import {
     type GitHubReleaseSummary,
     type GitHubRequestPullRequestReviewInput,
     type GitHubSaveTokenInput,
+    type GitHubSetIssueLabelsInput,
+    type GitHubSetIssueLabelsResult,
     type GitHubSetIssueStateInput,
     type GitHubSetPullRequestDraftStateInput,
     type GitHubUpdateCommentInput,
@@ -289,6 +291,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.getGitHubIssue);
     ipcMain.removeHandler(IPC_CHANNELS.createGitHubIssue);
     ipcMain.removeHandler(IPC_CHANNELS.updateGitHubIssue);
+    ipcMain.removeHandler(IPC_CHANNELS.setGitHubIssueLabels);
     ipcMain.removeHandler(IPC_CHANNELS.commentGitHubIssue);
     ipcMain.removeHandler(IPC_CHANNELS.updateGitHubComment);
     ipcMain.removeHandler(IPC_CHANNELS.closeGitHubIssue);
@@ -1166,6 +1169,14 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             input: GitHubUpdateIssueInput,
         ): Promise<GitHubIssueDetail> =>
             options.githubService.updateIssue(input),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.setGitHubIssueLabels,
+        async (
+            _event,
+            input: GitHubSetIssueLabelsInput,
+        ): Promise<GitHubSetIssueLabelsResult> =>
+            options.githubService.setIssueLabels(input),
     );
     ipcMain.handle(
         IPC_CHANNELS.commentGitHubIssue,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -124,6 +124,8 @@ import {
     type GitHubReleaseSummary,
     type GitHubRequestPullRequestReviewInput,
     type GitHubSaveTokenInput,
+    type GitHubSetIssueLabelsInput,
+    type GitHubSetIssueLabelsResult,
     type GitHubSetIssueStateInput,
     type GitHubSetPullRequestDraftStateInput,
     type GitHubUpdateCommentInput,
@@ -1100,6 +1102,14 @@ const comandoApi: ComandoApi = {
         assertIpcObject<GitHubIssueDetail>(
             IPC_CHANNELS.updateGitHubIssue,
             await ipcRenderer.invoke(IPC_CHANNELS.updateGitHubIssue, input),
+        ),
+    setGitHubIssueLabels: async (input: GitHubSetIssueLabelsInput) =>
+        assertIpcObject<GitHubSetIssueLabelsResult>(
+            IPC_CHANNELS.setGitHubIssueLabels,
+            await ipcRenderer.invoke(
+                IPC_CHANNELS.setGitHubIssueLabels,
+                input,
+            ),
         ),
     commentGitHubIssue: async (input: GitHubCommentIssueInput) =>
         assertIpcObject<GitHubCommentSummary>(

--- a/src/renderer/src/app/store/github-store.test.ts
+++ b/src/renderer/src/app/store/github-store.test.ts
@@ -534,6 +534,57 @@ describe("github-store", () => {
         ).toEqual([updated]);
     });
 
+    it("assigns pull request labels through the shared issue endpoint", async () => {
+        const nextLabels = [
+            createLabel({ name: "bug" }),
+            createLabel({ id: 2, name: "area/ui" }),
+        ];
+        const pullRequest = createPullRequestDetail({
+            labels: [createLabel({ name: "needs-review" })],
+            number: 12,
+        });
+        const setGitHubIssueLabels = vi.fn<
+            (input: GitHubSetIssueLabelsInput) => Promise<GitHubSetIssueLabelsResult>
+        >().mockResolvedValue({ labels: nextLabels, number: 12 });
+        useGitHubStore.setState({
+            pullRequestDetailsByRepo: { [repoKey]: { 12: pullRequest } },
+            pullRequestsByRepo: { [repoKey]: [pullRequest] },
+            pullRequestsByRepoAndState: {
+                [repoKey]: { all: [pullRequest], open: [pullRequest] },
+            },
+        });
+        stubComando({ setGitHubIssueLabels });
+
+        await expect(
+            useGitHubStore
+                .getState()
+                .setPullRequestLabels(repository, 12, ["bug", "area/ui"]),
+        ).resolves.toEqual(nextLabels);
+
+        const input = setGitHubIssueLabels.mock.calls[0]?.[0];
+        expect(input).toMatchObject({
+            labels: ["bug", "area/ui"],
+            number: 12,
+            repository,
+        });
+        expect(input?.clientRequestId).toEqual(
+            expect.stringContaining(`${repoKey}:pr:12:labels:`),
+        );
+        const state = useGitHubStore.getState();
+        expect(state.pullRequestDetailsByRepo[repoKey]?.[12]?.labels).toEqual(
+            nextLabels,
+        );
+        expect(state.pullRequestsByRepo[repoKey]?.[0]?.labels).toEqual(
+            nextLabels,
+        );
+        expect(
+            state.pullRequestsByRepoAndState[repoKey]?.open?.[0]?.labels,
+        ).toEqual(nextLabels);
+        expect(
+            state.pullRequestsByRepoAndState[repoKey]?.all?.[0]?.labels,
+        ).toEqual(nextLabels);
+    });
+
     it("updates pull request caches from draft state mutations", async () => {
         const pullRequest = createPullRequestDetail({
             draft: false,

--- a/src/renderer/src/app/store/github-store.test.ts
+++ b/src/renderer/src/app/store/github-store.test.ts
@@ -13,6 +13,8 @@ import type {
     GitHubReleaseSummary,
     GitHubRequestPullRequestReviewInput,
     GitHubRepositoryRef,
+    GitHubSetIssueLabelsInput,
+    GitHubSetIssueLabelsResult,
     GitHubUpdateCommentInput,
     GitHubUpdateIssueInput,
     GitHubUpdatePullRequestInput,
@@ -343,6 +345,56 @@ describe("github-store", () => {
                 `${repoKey}:issue:9:update`
             ],
         ).toBe(false);
+    });
+
+    it("assigns issue labels through the canonical transport and patches caches", async () => {
+        const previousLabels = [createLabel({ name: "bug" })];
+        const nextLabels = [
+            createLabel({ name: "bug" }),
+            createLabel({ id: 2, name: "area/ui" }),
+        ];
+        const issue = createIssueDetail({
+            labels: previousLabels,
+            number: 9,
+        });
+        const setGitHubIssueLabels = vi.fn<
+            (input: GitHubSetIssueLabelsInput) => Promise<GitHubSetIssueLabelsResult>
+        >().mockResolvedValue({ labels: nextLabels, number: 9 });
+        useGitHubStore.setState({
+            issueDetailsByRepo: { [repoKey]: { 9: issue } },
+            issuesByRepo: { [repoKey]: [issue] },
+            issuesByRepoAndState: {
+                [repoKey]: { all: [issue], open: [issue] },
+            },
+        });
+        stubComando({ setGitHubIssueLabels });
+
+        await expect(
+            useGitHubStore
+                .getState()
+                .setIssueLabels(repository, 9, ["bug", "area/ui"]),
+        ).resolves.toEqual(nextLabels);
+
+        const input = setGitHubIssueLabels.mock.calls[0]?.[0];
+        expect(input).toMatchObject({
+            labels: ["bug", "area/ui"],
+            number: 9,
+            repository,
+        });
+        expect(input?.clientRequestId).toEqual(
+            expect.stringContaining(`${repoKey}:issue:9:labels:`),
+        );
+        const state = useGitHubStore.getState();
+        expect(state.issueDetailsByRepo[repoKey]?.[9]?.labels).toEqual(
+            nextLabels,
+        );
+        expect(state.issuesByRepo[repoKey]?.[0]?.labels).toEqual(nextLabels);
+        expect(state.issuesByRepoAndState[repoKey]?.open?.[0]?.labels).toEqual(
+            nextLabels,
+        );
+        expect(state.issuesByRepoAndState[repoKey]?.all?.[0]?.labels).toEqual(
+            nextLabels,
+        );
     });
 
     it("appends comments to cached issue details and summaries", async () => {
@@ -680,6 +732,38 @@ describe("github-store", () => {
         expect(useGitHubStore.getState().milestonesByRepo[repoKey]).toEqual([
             milestone,
         ]);
+    });
+
+    it("loads every page of repository labels", async () => {
+        const firstLabel = createLabel({ id: 1, name: "bug" });
+        const secondLabel = createLabel({ id: 2, name: "area/ui" });
+        const listGitHubLabels = vi
+            .fn()
+            .mockResolvedValueOnce({
+                labels: [firstLabel],
+                nextCursor: "2",
+                totalCount: null,
+            })
+            .mockResolvedValueOnce({
+                labels: [secondLabel],
+                nextCursor: null,
+                totalCount: null,
+            });
+        stubComando({ listGitHubLabels });
+
+        await expect(
+            useGitHubStore.getState().refreshLabels(repository),
+        ).resolves.toEqual([firstLabel, secondLabel]);
+
+        expect(listGitHubLabels).toHaveBeenNthCalledWith(1, {
+            limit: 100,
+            repository,
+        });
+        expect(listGitHubLabels).toHaveBeenNthCalledWith(2, {
+            cursor: "2",
+            limit: 100,
+            repository,
+        });
     });
 
     it("clears a repository cache without touching auth status", () => {

--- a/src/renderer/src/app/store/github-store.ts
+++ b/src/renderer/src/app/store/github-store.ts
@@ -174,6 +174,11 @@ export interface GitHubStoreState {
         number: number,
         input: GitHubUpdateIssueOptions,
     ) => Promise<GitHubIssueDetail>;
+    setIssueLabels: (
+        ref: GitHubRepositoryRef,
+        number: number,
+        labels: readonly string[],
+    ) => Promise<readonly GitHubLabelSummary[]>;
     createPullRequest: (
         ref: GitHubRepositoryRef,
         input: GitHubCreatePullRequestOptions,
@@ -490,6 +495,23 @@ export const useGitHubStore = create<GitHubStoreState>((set, get) => ({
                 });
                 setIssueDetail(set, ref, detail);
                 return detail;
+            },
+        ),
+
+    setIssueLabels: async (ref, number, labels) =>
+        dedupeMutation(
+            set,
+            getRepoKey(ref),
+            `issue:${number}:labels`,
+            async (clientRequestId) => {
+                const result = await getComandoApi().setGitHubIssueLabels({
+                    clientRequestId,
+                    labels,
+                    number,
+                    repository: ref,
+                });
+                setIssueLabelsInCache(set, ref, number, result.labels);
+                return result.labels;
             },
         ),
 
@@ -940,17 +962,26 @@ export const useGitHubStore = create<GitHubStoreState>((set, get) => ({
         }
 
         return await withLoading(set, `${repoKey}:labels`, async () => {
-            const result = await getComandoApi().listGitHubLabels({
-                limit: 100,
-                repository: ref,
-            });
+            const labels: GitHubLabelSummary[] = [];
+            let cursor: string | null = null;
+
+            do {
+                const result = await getComandoApi().listGitHubLabels({
+                    ...(cursor ? { cursor } : {}),
+                    limit: 100,
+                    repository: ref,
+                });
+                labels.push(...result.labels);
+                cursor = result.nextCursor;
+            } while (cursor);
+
             set((state) => ({
                 labelsByRepo: {
                     ...state.labelsByRepo,
-                    [repoKey]: result.labels,
+                    [repoKey]: labels,
                 },
             }));
-            return result.labels;
+            return labels;
         });
     },
 
@@ -1252,6 +1283,42 @@ function setIssueDetail(
             detail,
         ),
     }));
+}
+
+function setIssueLabelsInCache(
+    set: SetGitHubState,
+    ref: GitHubRepositoryRef,
+    number: number,
+    labels: readonly GitHubLabelSummary[],
+): void {
+    const repoKey = getRepoKey(ref);
+    set((state) => {
+        const detail = state.issueDetailsByRepo[repoKey]?.[number];
+        const issues = state.issuesByRepo[repoKey];
+
+        return {
+            issueDetailsByRepo: detail
+                ? {
+                      ...state.issueDetailsByRepo,
+                      [repoKey]: {
+                          ...(state.issueDetailsByRepo[repoKey] ?? {}),
+                          [number]: { ...detail, labels },
+                      },
+                  }
+                : state.issueDetailsByRepo,
+            issuesByRepo: issues
+                ? {
+                      ...state.issuesByRepo,
+                      [repoKey]: replaceLabelsByNumber(issues, number, labels),
+                  }
+                : state.issuesByRepo,
+            issuesByRepoAndState: updateIssueStateCaches(
+                state.issuesByRepoAndState,
+                repoKey,
+                (entries) => replaceLabelsByNumber(entries, number, labels),
+            ),
+        };
+    });
 }
 
 function appendIssueComment(
@@ -1599,6 +1666,26 @@ function upsertByNumber<T extends { readonly number: number }>(
 
     return entries.map((entry, index) =>
         index === existingIndex ? nextEntry : entry,
+    );
+}
+
+function replaceLabelsByNumber<
+    T extends {
+        readonly labels: readonly GitHubLabelSummary[];
+        readonly number: number;
+    },
+>(
+    entries: readonly T[],
+    number: number,
+    labels: readonly GitHubLabelSummary[],
+): readonly T[] {
+    const entryIndex = entries.findIndex((entry) => entry.number === number);
+    if (entryIndex < 0) {
+        return entries;
+    }
+
+    return entries.map((entry, index) =>
+        index === entryIndex ? { ...entry, labels } : entry,
     );
 }
 

--- a/src/renderer/src/app/store/github-store.ts
+++ b/src/renderer/src/app/store/github-store.ts
@@ -179,6 +179,11 @@ export interface GitHubStoreState {
         number: number,
         labels: readonly string[],
     ) => Promise<readonly GitHubLabelSummary[]>;
+    setPullRequestLabels: (
+        ref: GitHubRepositoryRef,
+        number: number,
+        labels: readonly string[],
+    ) => Promise<readonly GitHubLabelSummary[]>;
     createPullRequest: (
         ref: GitHubRepositoryRef,
         input: GitHubCreatePullRequestOptions,
@@ -511,6 +516,23 @@ export const useGitHubStore = create<GitHubStoreState>((set, get) => ({
                     repository: ref,
                 });
                 setIssueLabelsInCache(set, ref, number, result.labels);
+                return result.labels;
+            },
+        ),
+
+    setPullRequestLabels: async (ref, number, labels) =>
+        dedupeMutation(
+            set,
+            getRepoKey(ref),
+            `pr:${number}:labels`,
+            async (clientRequestId) => {
+                const result = await getComandoApi().setGitHubIssueLabels({
+                    clientRequestId,
+                    labels,
+                    number,
+                    repository: ref,
+                });
+                setPullRequestLabelsInCache(set, ref, number, result.labels);
                 return result.labels;
             },
         ),
@@ -1412,6 +1434,46 @@ function setPullRequestDetail(
             detail,
         ),
     }));
+}
+
+function setPullRequestLabelsInCache(
+    set: SetGitHubState,
+    ref: GitHubRepositoryRef,
+    number: number,
+    labels: readonly GitHubLabelSummary[],
+): void {
+    const repoKey = getRepoKey(ref);
+    set((state) => {
+        const detail = state.pullRequestDetailsByRepo[repoKey]?.[number];
+        const pullRequests = state.pullRequestsByRepo[repoKey];
+
+        return {
+            pullRequestDetailsByRepo: detail
+                ? {
+                      ...state.pullRequestDetailsByRepo,
+                      [repoKey]: {
+                          ...(state.pullRequestDetailsByRepo[repoKey] ?? {}),
+                          [number]: { ...detail, labels },
+                      },
+                  }
+                : state.pullRequestDetailsByRepo,
+            pullRequestsByRepo: pullRequests
+                ? {
+                      ...state.pullRequestsByRepo,
+                      [repoKey]: replaceLabelsByNumber(
+                          pullRequests,
+                          number,
+                          labels,
+                      ),
+                  }
+                : state.pullRequestsByRepo,
+            pullRequestsByRepoAndState: updatePullRequestStateCaches(
+                state.pullRequestsByRepoAndState,
+                repoKey,
+                (entries) => replaceLabelsByNumber(entries, number, labels),
+            ),
+        };
+    });
 }
 
 function appendPullRequestComment(

--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
@@ -2190,6 +2190,9 @@ function pullRequestMatchesSearch(
         pullRequest.head.ref.toLowerCase().includes(normalizedSearch) ||
         pullRequest.base.label.toLowerCase().includes(normalizedSearch) ||
         pullRequest.base.ref.toLowerCase().includes(normalizedSearch) ||
+        pullRequest.labels.some((label) =>
+            label.name.toLowerCase().includes(normalizedSearch),
+        ) ||
         (pullRequest.author?.login.toLowerCase().includes(normalizedSearch) ??
             false)
     );

--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
@@ -148,8 +148,8 @@ type SidebarGitHubContextMenuPayload = {
     readonly itemNumbers: readonly number[];
 };
 
-type SidebarIssueLabelPickerState = {
-    readonly issueNumber: number;
+type SidebarGitHubLabelPickerState = {
+    readonly itemNumber: number;
     readonly x: number;
     readonly y: number;
 };
@@ -316,6 +316,9 @@ export function SidebarGitHubPanel({
         (state) => state.refreshPullRequests,
     );
     const setIssueLabels = useGitHubStore((state) => state.setIssueLabels);
+    const setPullRequestLabels = useGitHubStore(
+        (state) => state.setPullRequestLabels,
+    );
     const mutatingKeys = useGitHubStore((state) => state.mutatingKeys);
     const openGitHubIssuesTab = useWorkspaceStore(
         (state) => state.openGitHubIssuesTab,
@@ -332,7 +335,7 @@ export function SidebarGitHubPanel({
     const [githubContextMenu, setGitHubContextMenu] =
         useState<ContextMenuState<SidebarGitHubContextMenuPayload> | null>(null);
     const [labelPicker, setLabelPicker] =
-        useState<SidebarIssueLabelPickerState | null>(null);
+        useState<SidebarGitHubLabelPickerState | null>(null);
     const [selectionAnchorNumber, setSelectionAnchorNumber] = useState<
         number | null
     >(null);
@@ -548,6 +551,14 @@ export function SidebarGitHubPanel({
         [currentBranch, pullRequests, repoRef],
     );
     const canWriteIssues = hasGitHubWritePermission(authStatus, "issues");
+    const canWritePullRequests = hasGitHubWritePermission(
+        authStatus,
+        "pull_requests",
+    );
+    const canEditLabels =
+        kind === "issues"
+            ? canWriteIssues
+            : canWritePullRequests || canWriteIssues;
     const visibleItemNumbers = useMemo(
         () =>
             kind === "issues"
@@ -627,24 +638,33 @@ export function SidebarGitHubPanel({
     );
     const contextItemCount =
         kind === "issues" ? contextIssues.length : contextPullRequests.length;
-    const activeLabelPickerIssue = labelPicker
-        ? (visibleIssues.find(
-              (issue) => issue.number === labelPicker.issueNumber,
-          ) ??
-          issues.find((issue) => issue.number === labelPicker.issueNumber) ??
-          null)
+    const activeLabelPickerItem = labelPicker
+        ? kind === "issues"
+            ? (visibleIssues.find(
+                  (issue) => issue.number === labelPicker.itemNumber,
+              ) ??
+              issues.find((issue) => issue.number === labelPicker.itemNumber) ??
+              null)
+            : (visiblePullRequests.find(
+                  (pullRequest) =>
+                      pullRequest.number === labelPicker.itemNumber,
+              ) ??
+              pullRequests.find(
+                  (pullRequest) =>
+                      pullRequest.number === labelPicker.itemNumber,
+              ) ??
+              null)
         : null;
-    const isUpdatingLabelPickerIssue =
-        repoKey && activeLabelPickerIssue
-            ? (mutatingKeys[
-                  `${repoKey}:issue:${activeLabelPickerIssue.number}:labels`
-              ] ?? false)
-            : false;
+    const labelPickerMutationKey =
+        repoKey && activeLabelPickerItem
+            ? `${repoKey}:${kind === "issues" ? "issue" : "pr"}:${activeLabelPickerItem.number}:labels`
+            : null;
+    const isUpdatingLabelPicker = labelPickerMutationKey
+        ? (mutatingKeys[labelPickerMutationKey] ?? false)
+        : false;
     const labelPickerMutationError = useGitHubStore((state) =>
-        repoKey && activeLabelPickerIssue
-            ? (state.errors[
-                  `${repoKey}:issue:${activeLabelPickerIssue.number}:labels`
-              ] ?? null)
+        labelPickerMutationKey
+            ? (state.errors[labelPickerMutationKey] ?? null)
             : null,
     );
     const openIssueTab = useCallback(
@@ -662,14 +682,17 @@ export function SidebarGitHubPanel({
         },
         [openGitHubIssueTab, projectId, repoRef, worktreeId],
     );
-    const openIssueLabelPicker = useCallback(
-        (issue: GitHubIssueSummary, position: { x: number; y: number }) => {
+    const openLabelPicker = useCallback(
+        (
+            item: GitHubIssueSummary | GitHubPullRequestSummary,
+            position: { x: number; y: number },
+        ) => {
             if (!repoRef) {
                 return;
             }
 
             setLabelPicker({
-                issueNumber: issue.number,
+                itemNumber: item.number,
                 x: position.x,
                 y: position.y,
             });
@@ -726,7 +749,7 @@ export function SidebarGitHubPanel({
     const contextMenuEntries: ContextMenuEntry[] =
         repoRef && githubContextMenu && contextMenuPosition && contextItemCount > 0
             ? buildSidebarGitHubContextMenuEntries({
-                  canWriteIssues,
+                  canEditLabels,
                   count: contextItemCount,
                   kind,
                   onAddToChat: () =>
@@ -734,12 +757,18 @@ export function SidebarGitHubPanel({
                   onAddToNewChat: () =>
                       addGitHubItemsToChat({ forceNewChat: true }),
                   onEditLabels:
-                      kind === "issues" && contextIssues.length === 1
-                          ? () =>
-                                openIssueLabelPicker(
-                                    contextIssues[0],
-                                    contextMenuPosition,
-                                )
+                      contextItemCount === 1
+                          ? kind === "issues"
+                              ? () =>
+                                    openLabelPicker(
+                                        contextIssues[0],
+                                        contextMenuPosition,
+                                    )
+                              : () =>
+                                    openLabelPicker(
+                                        contextPullRequests[0],
+                                        contextMenuPosition,
+                                    )
                           : null,
                   onOpen:
                       kind === "issues"
@@ -835,24 +864,39 @@ export function SidebarGitHubPanel({
             }),
         [selectedItemNumbers, visiblePullRequests, visibleItemNumbers],
     );
-    const handleSaveIssueLabels = useCallback(
+    const handleSaveLabels = useCallback(
         async (labelNames: readonly string[]) => {
-            if (!repoRef || !activeLabelPickerIssue || !canWriteIssues) {
+            if (!repoRef || !activeLabelPickerItem || !canEditLabels) {
                 return;
             }
 
             try {
-                await setIssueLabels(
-                    repoRef,
-                    activeLabelPickerIssue.number,
-                    labelNames,
-                );
+                if (kind === "issues") {
+                    await setIssueLabels(
+                        repoRef,
+                        activeLabelPickerItem.number,
+                        labelNames,
+                    );
+                } else {
+                    await setPullRequestLabels(
+                        repoRef,
+                        activeLabelPickerItem.number,
+                        labelNames,
+                    );
+                }
                 setLabelPicker(null);
             } catch {
                 // The store exposes the mutation error while the picker remains open.
             }
         },
-        [activeLabelPickerIssue, canWriteIssues, repoRef, setIssueLabels],
+        [
+            activeLabelPickerItem,
+            canEditLabels,
+            kind,
+            repoRef,
+            setIssueLabels,
+            setPullRequestLabels,
+        ],
     );
 
     const handleRefresh = useCallback(async () => {
@@ -1176,16 +1220,17 @@ export function SidebarGitHubPanel({
                     onClose={() => setGitHubContextMenu(null)}
                 />
             ) : null}
-            {activeLabelPickerIssue && labelPicker ? (
-                <SidebarGitHubLabelPicker
+            {activeLabelPickerItem && labelPicker ? (
+                <GitHubLabelPicker
                     anchor={{ x: labelPicker.x, y: labelPicker.y }}
                     error={labelPickerMutationError ?? labelsError}
                     isLoading={isLoadingLabels}
-                    isSaving={isUpdatingLabelPickerIssue}
-                    issue={activeLabelPickerIssue}
+                    isSaving={isUpdatingLabelPicker}
+                    item={activeLabelPickerItem}
+                    key={`${kind}:${activeLabelPickerItem.number}`}
                     labels={labels}
                     onClose={() => setLabelPicker(null)}
-                    onSave={(labelNames) => void handleSaveIssueLabels(labelNames)}
+                    onSave={(labelNames) => void handleSaveLabels(labelNames)}
                 />
             ) : null}
         </div>
@@ -1342,6 +1387,17 @@ function SidebarGitHubPullRequestRow({
                     #{pullRequest.number}
                 </span>
             </div>
+            {pullRequest.labels.length > 0 ? (
+                <div className="mt-1 flex min-w-0 flex-wrap gap-1">
+                    {pullRequest.labels.slice(0, 3).map((label) => (
+                        <GitHubLabelPill
+                            className="sidebar-github-label-pill"
+                            key={label.id}
+                            label={label}
+                        />
+                    ))}
+                </div>
+            ) : null}
             <div className="sidebar-github-branch mt-1 flex w-full min-w-0 items-center gap-1.5 font-mono text-text-secondary">
                 <span className="min-w-0 truncate">{pullRequest.head.label}</span>
                 <span aria-hidden="true" className="shrink-0">
@@ -1371,40 +1427,6 @@ function SidebarGitHubPullRequestRow({
                 ) : null}
             </div>
         </SidebarGitHubDraggableRow>
-    );
-}
-
-function SidebarGitHubLabelPicker({
-    anchor,
-    error,
-    issue,
-    isLoading,
-    isSaving,
-    labels,
-    onClose,
-    onSave,
-}: {
-    readonly anchor: { readonly x: number; readonly y: number };
-    readonly error: string | null;
-    readonly issue: GitHubIssueSummary;
-    readonly isLoading: boolean;
-    readonly isSaving: boolean;
-    readonly labels: readonly GitHubLabelSummary[];
-    readonly onClose: () => void;
-    readonly onSave: (labelNames: readonly string[]) => void;
-}) {
-    return (
-        <GitHubLabelPicker
-            anchor={anchor}
-            error={error}
-            isLoading={isLoading}
-            isSaving={isSaving}
-            item={issue}
-            key={issue.number}
-            labels={labels}
-            onClose={onClose}
-            onSave={onSave}
-        />
     );
 }
 
@@ -1971,7 +1993,7 @@ export function getSidebarGitHubAddToChatLabel({
 }
 
 function buildSidebarGitHubContextMenuEntries({
-    canWriteIssues,
+    canEditLabels,
     count,
     kind,
     onAddToChat,
@@ -1980,7 +2002,7 @@ function buildSidebarGitHubContextMenuEntries({
     onOpen,
     onOpenInGitHub,
 }: {
-    readonly canWriteIssues: boolean;
+    readonly canEditLabels: boolean;
     readonly count: number;
     readonly kind: SidebarGitHubPanelKind;
     readonly onAddToChat: () => void;
@@ -2019,13 +2041,13 @@ function buildSidebarGitHubContextMenuEntries({
         },
     ];
 
-    if (kind === "issues" && count === 1 && onEditLabels) {
+    if (count === 1 && onEditLabels) {
         entries.push(
             { type: "separator" },
             {
                 label: "Edit Labels...",
                 action: onEditLabels,
-                disabled: !canWriteIssues,
+                disabled: !canEditLabels,
             },
         );
     }

--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
@@ -1,7 +1,6 @@
 import {
     useCallback,
     useEffect,
-    useLayoutEffect,
     useMemo,
     useRef,
     useState,
@@ -43,7 +42,6 @@ import {
     getGitHubRepoKey,
     useGitHubStore,
 } from "@renderer/app/store/github-store";
-import { getViewportSafeMenuPosition } from "@renderer/app/utils/menu-position";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
 import {
     ContextMenu,
@@ -59,6 +57,7 @@ import {
     hasGitHubWritePermission,
     openGitHubWebUrl,
 } from "@renderer/components/workspace/GitHubWorkspacePrimitives";
+import { GitHubLabelPicker } from "@renderer/components/workspace/GitHubLabelPicker";
 
 import {
     emitSidebarGitHubDrag,
@@ -316,7 +315,7 @@ export function SidebarGitHubPanel({
     const refreshPullRequests = useGitHubStore(
         (state) => state.refreshPullRequests,
     );
-    const updateIssue = useGitHubStore((state) => state.updateIssue);
+    const setIssueLabels = useGitHubStore((state) => state.setIssueLabels);
     const mutatingKeys = useGitHubStore((state) => state.mutatingKeys);
     const openGitHubIssuesTab = useWorkspaceStore(
         (state) => state.openGitHubIssuesTab,
@@ -638,9 +637,16 @@ export function SidebarGitHubPanel({
     const isUpdatingLabelPickerIssue =
         repoKey && activeLabelPickerIssue
             ? (mutatingKeys[
-                  `${repoKey}:issue:${activeLabelPickerIssue.number}:update`
+                  `${repoKey}:issue:${activeLabelPickerIssue.number}:labels`
               ] ?? false)
             : false;
+    const labelPickerMutationError = useGitHubStore((state) =>
+        repoKey && activeLabelPickerIssue
+            ? (state.errors[
+                  `${repoKey}:issue:${activeLabelPickerIssue.number}:labels`
+              ] ?? null)
+            : null,
+    );
     const openIssueTab = useCallback(
         (issueNumber: number) => {
             if (!repoRef) {
@@ -835,12 +841,18 @@ export function SidebarGitHubPanel({
                 return;
             }
 
-            await updateIssue(repoRef, activeLabelPickerIssue.number, {
-                labels: labelNames,
-            });
-            setLabelPicker(null);
+            try {
+                await setIssueLabels(
+                    repoRef,
+                    activeLabelPickerIssue.number,
+                    labelNames,
+                );
+                setLabelPicker(null);
+            } catch {
+                // The store exposes the mutation error while the picker remains open.
+            }
         },
-        [activeLabelPickerIssue, canWriteIssues, repoRef, updateIssue],
+        [activeLabelPickerIssue, canWriteIssues, repoRef, setIssueLabels],
     );
 
     const handleRefresh = useCallback(async () => {
@@ -1167,10 +1179,10 @@ export function SidebarGitHubPanel({
             {activeLabelPickerIssue && labelPicker ? (
                 <SidebarGitHubLabelPicker
                     anchor={{ x: labelPicker.x, y: labelPicker.y }}
-                    error={labelsError}
-                    issue={activeLabelPickerIssue}
+                    error={labelPickerMutationError ?? labelsError}
                     isLoading={isLoadingLabels}
                     isSaving={isUpdatingLabelPickerIssue}
+                    issue={activeLabelPickerIssue}
                     labels={labels}
                     onClose={() => setLabelPicker(null)}
                     onSave={(labelNames) => void handleSaveIssueLabels(labelNames)}
@@ -1381,184 +1393,18 @@ function SidebarGitHubLabelPicker({
     readonly onClose: () => void;
     readonly onSave: (labelNames: readonly string[]) => void;
 }) {
-    const ref = useRef<HTMLDivElement | null>(null);
-    const [query, setQuery] = useState("");
-    const [position, setPosition] = useState(anchor);
-    const [selectedNames, setSelectedNames] = useState<ReadonlySet<string>>(
-        () => new Set(issue.labels.map((label) => label.name)),
-    );
-
-    useEffect(() => {
-        const handleMouseDown = (event: MouseEvent) => {
-            if (ref.current && !ref.current.contains(event.target as Node)) {
-                onClose();
-            }
-        };
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key === "Escape") {
-                onClose();
-            }
-        };
-
-        document.addEventListener("mousedown", handleMouseDown);
-        document.addEventListener("keydown", handleKeyDown);
-
-        return () => {
-            document.removeEventListener("mousedown", handleMouseDown);
-            document.removeEventListener("keydown", handleKeyDown);
-        };
-    }, [onClose]);
-
-    useEffect(() => {
-        setQuery("");
-        setSelectedNames(new Set(issue.labels.map((label) => label.name)));
-    }, [issue.number, issue.labels]);
-
-    const normalizedQuery = query.trim().toLowerCase();
-    const visibleLabels = labels.filter(
-        (label) =>
-            !normalizedQuery ||
-            label.name.toLowerCase().includes(normalizedQuery) ||
-            (label.description?.toLowerCase().includes(normalizedQuery) ??
-                false),
-    );
-    const labelNames = labels.map((label) => label.name);
-    const selectedLabels = labelNames.filter((name) => selectedNames.has(name));
-
-    useLayoutEffect(() => {
-        const element = ref.current;
-        if (!element) {
-            return;
-        }
-
-        const rect = element.getBoundingClientRect();
-        setPosition(
-            getViewportSafeMenuPosition(
-                anchor.x,
-                anchor.y,
-                rect.width,
-                rect.height,
-            ),
-        );
-    }, [
-        anchor.x,
-        anchor.y,
-        error,
-        isLoading,
-        labels.length,
-        visibleLabels.length,
-    ]);
-
-    const toggleLabel = (labelName: string) => {
-        setSelectedNames((current) => {
-            const next = new Set(current);
-            if (next.has(labelName)) {
-                next.delete(labelName);
-            } else {
-                next.add(labelName);
-            }
-            return next;
-        });
-    };
-
-    return createPortal(
-        <div
-            className="fixed w-[min(320px,calc(100vw-16px))] rounded-lg border border-border bg-bg-panel p-2 shadow-[0_18px_42px_rgba(0,0,0,0.34)]"
-            data-context-menu-root="true"
-            ref={ref}
-            style={{ left: position.x, top: position.y, zIndex: 10020 }}
-        >
-            <div className="flex min-w-0 items-start justify-between gap-3">
-                <div className="min-w-0">
-                    <div className="text-[12px] font-semibold text-text-primary">
-                        Edit Labels
-                    </div>
-                    <div className="mt-0.5 truncate text-[10px] text-text-secondary">
-                        #{issue.number} {issue.title}
-                    </div>
-                </div>
-                <button
-                    className="review-action-btn"
-                    onClick={onClose}
-                    type="button"
-                >
-                    Close
-                </button>
-            </div>
-            <input
-                className="mt-3 h-[24px] w-full rounded-md border border-border/70 bg-bg-primary px-2 font-mono text-[11px] text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
-                onChange={(event) => setQuery(event.currentTarget.value)}
-                placeholder="Search labels..."
-                value={query}
-            />
-            {error ? (
-                <div className="mt-2 rounded-md border border-[color-mix(in_srgb,var(--diff-remove)_35%,var(--color-border))] bg-[color-mix(in_srgb,var(--diff-remove)_8%,transparent)] px-2 py-1.5 text-[11px] text-text-primary">
-                    {error}
-                </div>
-            ) : null}
-            <div className="shell-scrollbar mt-2 max-h-64 space-y-1 overflow-y-auto pr-1">
-                {isLoading ? (
-                    <div className="px-1 py-2 text-[11px] text-text-secondary">
-                        Loading labels...
-                    </div>
-                ) : null}
-                {!isLoading && visibleLabels.length === 0 ? (
-                    <div className="px-1 py-2 text-[11px] text-text-secondary">
-                        No labels match this search.
-                    </div>
-                ) : null}
-                {visibleLabels.map((label) => (
-                    <label
-                        className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-[11px] text-text-primary hover:bg-bg-tertiary"
-                        key={label.id || label.name}
-                    >
-                        <input
-                            checked={selectedNames.has(label.name)}
-                            className="h-3.5 w-3.5 accent-[var(--color-accent)]"
-                            onChange={() => toggleLabel(label.name)}
-                            type="checkbox"
-                        />
-                        <span
-                            aria-hidden="true"
-                            className="h-2.5 w-2.5 shrink-0 rounded-full"
-                            style={{ backgroundColor: `#${label.color}` }}
-                        />
-                        <span className="min-w-0 flex-1 truncate">
-                            {label.name}
-                        </span>
-                    </label>
-                ))}
-            </div>
-            <div className="mt-3 flex items-center justify-between gap-2">
-                <button
-                    className="review-action-btn"
-                    disabled={isSaving || selectedNames.size === 0}
-                    onClick={() => setSelectedNames(new Set())}
-                    type="button"
-                >
-                    Clear
-                </button>
-                <div className="flex items-center gap-2">
-                    <button
-                        className="review-action-btn"
-                        disabled={isSaving}
-                        onClick={onClose}
-                        type="button"
-                    >
-                        Cancel
-                    </button>
-                    <button
-                        className="review-action-btn"
-                        disabled={isSaving || isLoading}
-                        onClick={() => onSave(selectedLabels)}
-                        type="button"
-                    >
-                        {isSaving ? "Saving..." : "Save"}
-                    </button>
-                </div>
-            </div>
-        </div>,
-        document.body,
+    return (
+        <GitHubLabelPicker
+            anchor={anchor}
+            error={error}
+            isLoading={isLoading}
+            isSaving={isSaving}
+            item={issue}
+            key={issue.number}
+            labels={labels}
+            onClose={onClose}
+            onSave={onSave}
+        />
     );
 }
 

--- a/src/renderer/src/components/workspace/GitHubLabelPicker.test.tsx
+++ b/src/renderer/src/components/workspace/GitHubLabelPicker.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { GitHubLabelSummary } from "@shared/ipc";
+
+import { GitHubLabelPicker } from "./GitHubLabelPicker";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+    if (root) {
+        act(() => root?.unmount());
+    }
+    root = null;
+    container?.remove();
+    container = null;
+});
+
+describe("GitHubLabelPicker", () => {
+    it("keeps an assigned label that is absent from the loaded catalog", () => {
+        const legacyLabel: GitHubLabelSummary = {
+            color: "d73a4a",
+            description: null,
+            id: 1,
+            name: "legacy",
+        };
+        const onSave = vi.fn();
+        container = document.createElement("div");
+        document.body.append(container);
+        root = createRoot(container);
+
+        act(() => {
+            root?.render(
+                createElement(GitHubLabelPicker, {
+                    anchor: { x: 10, y: 10 },
+                    error: null,
+                    isLoading: false,
+                    isSaving: false,
+                    item: {
+                        labels: [legacyLabel],
+                        number: 7,
+                        title: "Keep this label",
+                    },
+                    labels: [],
+                    onClose: () => undefined,
+                    onSave,
+                }),
+            );
+        });
+
+        const picker = document.querySelector("[data-context-menu-root='true']");
+        const saveButton = [...(picker?.querySelectorAll("button") ?? [])].find(
+            (button) => button.textContent === "Save",
+        );
+        expect(picker?.textContent).toContain("legacy");
+        expect(saveButton).toBeDefined();
+
+        act(() => saveButton?.click());
+
+        expect(onSave).toHaveBeenCalledWith(["legacy"]);
+    });
+});

--- a/src/renderer/src/components/workspace/GitHubLabelPicker.tsx
+++ b/src/renderer/src/components/workspace/GitHubLabelPicker.tsx
@@ -1,0 +1,212 @@
+import {
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+import type { GitHubLabelSummary } from "@shared/ipc";
+
+import { getViewportSafeMenuPosition } from "@renderer/app/utils/menu-position";
+
+type GitHubLabelPickerItem = {
+    readonly labels: readonly GitHubLabelSummary[];
+    readonly number: number;
+    readonly title: string;
+};
+
+export function GitHubLabelPicker({
+    anchor,
+    error,
+    isLoading,
+    isSaving,
+    item,
+    labels,
+    onClose,
+    onSave,
+}: {
+    readonly anchor: { readonly x: number; readonly y: number };
+    readonly error: string | null;
+    readonly isLoading: boolean;
+    readonly isSaving: boolean;
+    readonly item: GitHubLabelPickerItem;
+    readonly labels: readonly GitHubLabelSummary[];
+    readonly onClose: () => void;
+    readonly onSave: (labelNames: readonly string[]) => void;
+}) {
+    const ref = useRef<HTMLDivElement | null>(null);
+    const [query, setQuery] = useState("");
+    const [position, setPosition] = useState(anchor);
+    const [selectedNames, setSelectedNames] = useState<ReadonlySet<string>>(
+        () => new Set(item.labels.map((label) => label.name)),
+    );
+
+    useEffect(() => {
+        const handleMouseDown = (event: MouseEvent) => {
+            if (ref.current && !ref.current.contains(event.target as Node)) {
+                onClose();
+            }
+        };
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                onClose();
+            }
+        };
+
+        document.addEventListener("mousedown", handleMouseDown);
+        document.addEventListener("keydown", handleKeyDown);
+
+        return () => {
+            document.removeEventListener("mousedown", handleMouseDown);
+            document.removeEventListener("keydown", handleKeyDown);
+        };
+    }, [onClose]);
+
+    const labelOptions = useMemo(() => {
+        const knownNames = new Set(labels.map((label) => label.name));
+        return [
+            ...labels,
+            ...item.labels.filter((label) => !knownNames.has(label.name)),
+        ];
+    }, [item.labels, labels]);
+    const normalizedQuery = query.trim().toLowerCase();
+    const visibleLabels = labelOptions.filter(
+        (label) =>
+            !normalizedQuery ||
+            label.name.toLowerCase().includes(normalizedQuery) ||
+            (label.description?.toLowerCase().includes(normalizedQuery) ??
+                false),
+    );
+
+    useLayoutEffect(() => {
+        const element = ref.current;
+        if (!element) {
+            return;
+        }
+
+        const rect = element.getBoundingClientRect();
+        setPosition(
+            getViewportSafeMenuPosition(
+                anchor.x,
+                anchor.y,
+                rect.width,
+                rect.height,
+            ),
+        );
+    }, [anchor.x, anchor.y, error, isLoading, labelOptions.length, visibleLabels.length]);
+
+    const toggleLabel = (labelName: string) => {
+        setSelectedNames((current) => {
+            const next = new Set(current);
+            if (next.has(labelName)) {
+                next.delete(labelName);
+            } else {
+                next.add(labelName);
+            }
+            return next;
+        });
+    };
+
+    return createPortal(
+        <div
+            className="fixed w-[min(320px,calc(100vw-16px))] rounded-lg border border-border bg-bg-panel p-2 shadow-[0_18px_42px_rgba(0,0,0,0.34)]"
+            data-context-menu-root="true"
+            ref={ref}
+            style={{ left: position.x, top: position.y, zIndex: 10020 }}
+        >
+            <div className="flex min-w-0 items-start justify-between gap-3">
+                <div className="min-w-0">
+                    <div className="text-[12px] font-semibold text-text-primary">
+                        Edit Labels
+                    </div>
+                    <div className="mt-0.5 truncate text-[10px] text-text-secondary">
+                        #{item.number} {item.title}
+                    </div>
+                </div>
+                <button
+                    className="review-action-btn"
+                    onClick={onClose}
+                    type="button"
+                >
+                    Close
+                </button>
+            </div>
+            <input
+                autoFocus
+                className="mt-3 h-[24px] w-full rounded-md border border-border/70 bg-bg-primary px-2 font-mono text-[11px] text-text-primary outline-none placeholder:text-text-secondary/60 focus:border-[color-mix(in_srgb,var(--color-accent)_55%,var(--color-border))]"
+                onChange={(event) => setQuery(event.currentTarget.value)}
+                placeholder="Search labels..."
+                value={query}
+            />
+            {error ? (
+                <div className="mt-2 rounded-md border border-[color-mix(in_srgb,var(--diff-remove)_35%,var(--color-border))] bg-[color-mix(in_srgb,var(--diff-remove)_8%,transparent)] px-2 py-1.5 text-[11px] text-text-primary">
+                    {error}
+                </div>
+            ) : null}
+            <div className="shell-scrollbar mt-2 max-h-64 space-y-1 overflow-y-auto pr-1">
+                {isLoading ? (
+                    <div className="px-1 py-2 text-[11px] text-text-secondary">
+                        Loading labels...
+                    </div>
+                ) : null}
+                {!isLoading && visibleLabels.length === 0 ? (
+                    <div className="px-1 py-2 text-[11px] text-text-secondary">
+                        No labels match this search.
+                    </div>
+                ) : null}
+                {visibleLabels.map((label) => (
+                    <label
+                        className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-[11px] text-text-primary hover:bg-bg-tertiary"
+                        key={label.id || label.name}
+                    >
+                        <input
+                            checked={selectedNames.has(label.name)}
+                            className="h-3.5 w-3.5 accent-[var(--color-accent)]"
+                            onChange={() => toggleLabel(label.name)}
+                            type="checkbox"
+                        />
+                        <span
+                            aria-hidden="true"
+                            className="h-2.5 w-2.5 shrink-0 rounded-full"
+                            style={{ backgroundColor: `#${label.color}` }}
+                        />
+                        <span className="min-w-0 flex-1 truncate">
+                            {label.name}
+                        </span>
+                    </label>
+                ))}
+            </div>
+            <div className="mt-3 flex items-center justify-between gap-2">
+                <button
+                    className="review-action-btn"
+                    disabled={isSaving || selectedNames.size === 0}
+                    onClick={() => setSelectedNames(new Set())}
+                    type="button"
+                >
+                    Clear
+                </button>
+                <div className="flex items-center gap-2">
+                    <button
+                        className="review-action-btn"
+                        disabled={isSaving}
+                        onClick={onClose}
+                        type="button"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        className="review-action-btn"
+                        disabled={isSaving || isLoading}
+                        onClick={() => onSave([...selectedNames])}
+                        type="button"
+                    >
+                        {isSaving ? "Saving..." : "Save"}
+                    </button>
+                </div>
+            </div>
+        </div>,
+        document.body,
+    );
+}

--- a/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
@@ -1,4 +1,9 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+    useEffect,
+    useRef,
+    useState,
+    type ReactNode,
+} from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import type {
@@ -27,6 +32,7 @@ import {
     GitHubEmptyState,
     GitHubErrorState,
     GitHubInput,
+    GitHubLabelPill,
     GitHubMergeablePill,
     GitHubSection,
     GitHubSectionLabel,
@@ -37,6 +43,7 @@ import {
     openGitHubWebUrl,
 } from "./GitHubWorkspacePrimitives";
 import { GitHubActionsPanel } from "./GitHubActionsPanel";
+import { GitHubLabelPicker } from "./GitHubLabelPicker";
 import { MarkdownContent } from "./MarkdownContent";
 import { IdeActionButton } from "./ide-bar";
 
@@ -59,6 +66,11 @@ export function GitHubPullRequestTabView({
     const [isEditingDescription, setIsEditingDescription] = useState(false);
     const [titleDraft, setTitleDraft] = useState("");
     const [descriptionDraft, setDescriptionDraft] = useState("");
+    const [labelPickerAnchor, setLabelPickerAnchor] = useState<{
+        readonly x: number;
+        readonly y: number;
+    } | null>(null);
+    const labelPickerTriggerRef = useRef<HTMLSpanElement | null>(null);
 
     const detail = useGitHubStore(
         (state) =>
@@ -74,6 +86,9 @@ export function GitHubPullRequestTabView({
     const authStatus = useGitHubStore(
         (state) => state.authStatusByHost[repo.host] ?? null,
     );
+    const labels = useGitHubStore(
+        (state) => state.labelsByRepo[repoKey] ?? [],
+    );
     const commentMutatingKeys = useGitHubStore((state) => state.mutatingKeys);
     const commentErrors = useGitHubStore((state) => state.errors);
 
@@ -81,7 +96,7 @@ export function GitHubPullRequestTabView({
         ? getGitHubPullRequestChecksKey(repo, detail.head.sha)
         : null;
 
-    const { isLoading, isLoadingChecks } = useGitHubStore(
+    const { isLoading, isLoadingChecks, isLoadingLabels } = useGitHubStore(
         useShallow((state) => ({
             isLoading:
                 state.loadingKeys[
@@ -90,6 +105,7 @@ export function GitHubPullRequestTabView({
             isLoadingChecks: checksKey
                 ? (state.loadingKeys[checksKey] ?? false)
                 : false,
+            isLoadingLabels: state.loadingKeys[`${repoKey}:labels`] ?? false,
         })),
     );
 
@@ -99,6 +115,7 @@ export function GitHubPullRequestTabView({
         isConvertingDraft,
         isRequestingReview,
         isUpdatingPullRequest,
+        isUpdatingLabels,
     } = useGitHubStore(
         useShallow((state) => ({
             isCommenting:
@@ -121,6 +138,10 @@ export function GitHubPullRequestTabView({
                 state.mutatingKeys[
                     `${repoKey}:pr:${pullRequestNumber}:update`
                 ] ?? false,
+            isUpdatingLabels:
+                state.mutatingKeys[
+                    `${repoKey}:pr:${pullRequestNumber}:labels`
+                ] ?? false,
         })),
     );
 
@@ -132,6 +153,8 @@ export function GitHubPullRequestTabView({
         requestReviewError,
         checksError,
         updateError,
+        labelMutationError,
+        labelsError,
     } = useGitHubStore(
         useShallow((state) => ({
             checksError: checksKey ? (state.errors[checksKey] ?? null) : null,
@@ -157,6 +180,11 @@ export function GitHubPullRequestTabView({
                 state.errors[
                     `${repoKey}:pr:${pullRequestNumber}:update`
                 ] ?? null,
+            labelMutationError:
+                state.errors[
+                    `${repoKey}:pr:${pullRequestNumber}:labels`
+                ] ?? null,
+            labelsError: state.errors[`${repoKey}:labels`] ?? null,
         })),
     );
 
@@ -185,6 +213,10 @@ export function GitHubPullRequestTabView({
     const updatePullRequest = useGitHubStore(
         (state) => state.updatePullRequest,
     );
+    const refreshLabels = useGitHubStore((state) => state.refreshLabels);
+    const setPullRequestLabels = useGitHubStore(
+        (state) => state.setPullRequestLabels,
+    );
     const openGitCommitTab = useWorkspaceStore(
         (state) => state.openGitCommitTab,
     );
@@ -193,12 +225,16 @@ export function GitHubPullRequestTabView({
         authStatus,
         "pull_requests",
     );
+    const canEditLabels =
+        canWritePullRequests || hasGitHubWritePermission(authStatus, "issues");
     const canCommentPullRequests =
         hasGitHubWritePermission(authStatus, "issues") ||
         canWritePullRequests;
     const writePermissionLabel = getGitHubWritePermissionLabel("pull_requests");
     const commentPermissionLabel =
         "Your GitHub token cannot write PR conversation comments.";
+    const labelPermissionLabel =
+        "Your GitHub token cannot edit pull request labels.";
 
     useEffect(() => {
         let cancelled = false;
@@ -365,6 +401,33 @@ export function GitHubPullRequestTabView({
         setIsEditingDescription(false);
     };
 
+    const handleOpenLabelPicker = () => {
+        if (!detail || !canEditLabels) {
+            return;
+        }
+
+        const rect = labelPickerTriggerRef.current?.getBoundingClientRect();
+        if (!rect) {
+            return;
+        }
+
+        setLabelPickerAnchor({ x: rect.left, y: rect.bottom + 6 });
+        void refreshLabels(repo).catch(() => undefined);
+    };
+
+    const handleSaveLabels = async (labelNames: readonly string[]) => {
+        if (!detail || !canEditLabels) {
+            return;
+        }
+
+        try {
+            await setPullRequestLabels(repo, pullRequestNumber, labelNames);
+            setLabelPickerAnchor(null);
+        } catch {
+            // The store exposes the mutation error while the picker remains open.
+        }
+    };
+
     const stateTone = detail?.draft
         ? "draft"
         : detail?.mergedAt
@@ -498,6 +561,27 @@ export function GitHubPullRequestTabView({
                                 <span className="text-[11px] text-text-secondary">
                                     updated{" "}
                                     {formatGitHubDateTime(detail.updatedAt)}
+                                </span>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-1.5">
+                                {detail.labels.map((label) => (
+                                    <GitHubLabelPill
+                                        key={label.id}
+                                        label={label}
+                                    />
+                                ))}
+                                <span ref={labelPickerTriggerRef}>
+                                    <IdeActionButton
+                                        disabled={!canEditLabels}
+                                        onClick={handleOpenLabelPicker}
+                                        title={
+                                            canEditLabels
+                                                ? undefined
+                                                : labelPermissionLabel
+                                        }
+                                    >
+                                        Edit labels
+                                    </IdeActionButton>
                                 </span>
                             </div>
                             <div className="flex flex-wrap items-center gap-2 text-[11px]">
@@ -821,6 +905,19 @@ export function GitHubPullRequestTabView({
                     </>
                 ) : null}
             </div>
+            {detail && labelPickerAnchor ? (
+                <GitHubLabelPicker
+                    anchor={labelPickerAnchor}
+                    error={labelMutationError ?? labelsError}
+                    isLoading={isLoadingLabels}
+                    isSaving={isUpdatingLabels}
+                    item={detail}
+                    key={detail.number}
+                    labels={labels}
+                    onClose={() => setLabelPickerAnchor(null)}
+                    onSave={(labelNames) => void handleSaveLabels(labelNames)}
+                />
+            ) : null}
         </GitHubTabShell>
     );
 }

--- a/src/renderer/src/components/workspace/GitHubPullRequestsTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestsTabView.test.tsx
@@ -124,6 +124,7 @@ import {
     GITHUB_PULL_REQUESTS_VIRTUALIZATION_THRESHOLD,
     GitHubPullRequestsTabView,
     getVisiblePullRequestCheckTargets,
+    pullRequestMatchesSearch,
 } from "./GitHubPullRequestsTabView";
 
 class MemoryStorage implements Storage {
@@ -400,6 +401,16 @@ describe("GitHubPullRequestsTabView", () => {
         expect(markup).toContain("checks pending");
         expect(markup).toContain("checks...");
         expect(markup).toContain("checks unknown");
+    });
+
+    it("matches pull requests by their labels", () => {
+        const pullRequest = createPullRequestSummary(5);
+
+        expect(pullRequest.labels).toHaveLength(1);
+        expect(pullRequestMatchesSearch(pullRequest, "stack-5")).toBe(true);
+        expect(pullRequestMatchesSearch(pullRequest, "missing-label")).toBe(
+            false,
+        );
     });
 
     it("derives check targets from the virtual visible range", () => {

--- a/src/renderer/src/components/workspace/GitHubPullRequestsTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestsTabView.tsx
@@ -390,12 +390,7 @@ export function GitHubPullRequestsTabView({
                 return true;
             }
 
-            return (
-                pullRequest.title.toLowerCase().includes(normalizedQuery) ||
-                String(pullRequest.number).includes(normalizedQuery) ||
-                pullRequest.head.label.toLowerCase().includes(normalizedQuery) ||
-                pullRequest.base.label.toLowerCase().includes(normalizedQuery)
-            );
+            return pullRequestMatchesSearch(pullRequest, normalizedQuery);
         });
 
         return sortPullRequestsNewestFirst(filteredPullRequests);
@@ -1265,6 +1260,21 @@ function getPullRequestListState(
     filter: PullRequestFilter,
 ): "all" | "closed" | "open" {
     return filter === "draft" || filter === "branch" ? "all" : filter;
+}
+
+export function pullRequestMatchesSearch(
+    pullRequest: GitHubPullRequestSummary,
+    normalizedQuery: string,
+): boolean {
+    return (
+        pullRequest.title.toLowerCase().includes(normalizedQuery) ||
+        String(pullRequest.number).includes(normalizedQuery) ||
+        pullRequest.head.label.toLowerCase().includes(normalizedQuery) ||
+        pullRequest.base.label.toLowerCase().includes(normalizedQuery) ||
+        pullRequest.labels.some((label) =>
+            label.name.toLowerCase().includes(normalizedQuery),
+        )
+    );
 }
 
 function getContextKey(projectId: string, worktreeId: string | null): string {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -73,6 +73,7 @@ export const IPC_CHANNELS = {
     getGitHubIssue: "github:get-issue",
     createGitHubIssue: "github:create-issue",
     updateGitHubIssue: "github:update-issue",
+    setGitHubIssueLabels: "github:set-issue-labels",
     commentGitHubIssue: "github:comment-issue",
     updateGitHubComment: "github:update-comment",
     closeGitHubIssue: "github:close-issue",
@@ -1219,6 +1220,21 @@ export interface GitHubUpdateIssueInput
     readonly labels?: readonly string[] | null;
     readonly number: number;
     readonly title?: string | null;
+}
+
+/**
+ * Uses GitHub's issue-label endpoint, which also manages labels on pull requests.
+ */
+export interface GitHubSetIssueLabelsInput
+    extends GitHubRepositoryInput,
+        GitHubMutationInput {
+    readonly labels: readonly string[];
+    readonly number: number;
+}
+
+export interface GitHubSetIssueLabelsResult {
+    readonly labels: readonly GitHubLabelSummary[];
+    readonly number: number;
 }
 
 export interface GitHubCommentIssueInput
@@ -3027,6 +3043,9 @@ export interface ComandoApi {
     updateGitHubIssue: (
         input: GitHubUpdateIssueInput,
     ) => Promise<GitHubIssueDetail>;
+    setGitHubIssueLabels: (
+        input: GitHubSetIssueLabelsInput,
+    ) => Promise<GitHubSetIssueLabelsResult>;
     commentGitHubIssue: (
         input: GitHubCommentIssueInput,
     ) => Promise<GitHubCommentSummary>;


### PR DESCRIPTION
## Summary

- Add canonical GitHub label assignment transport shared by issues and pull requests.
- Reuse and harden the label picker, preserving labels absent from a loaded catalog.
- Support editing and displaying labels from the pull request sidebar and detail view.
- Include pull request labels in sidebar and table search results.
- Keep issue and pull request caches synchronized after label updates.

## Testing

- `pnpm run lint`
- `pnpm test`
- `pnpm run typecheck`
- `pnpm run build`