### PR TITLE
fix(ai): reopen retained chats before dispatching the first prompt

### DIFF
--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -280,6 +280,266 @@ describe("AiService prepareSession", () => {
         });
     });
 
+    it("reopens a session frozen by retention and dispatches its first queued prompt", async () => {
+        const persistedSnapshot = createSnapshot({
+            runtimeSessionId: "runtime-session-retained",
+            sessionId: "session-retained",
+            title: "Retained chat",
+        });
+        let service: InstanceType<typeof AiService>;
+        let releaseClose: (() => void) | null = null;
+        const closeSession = vi.fn<NativeAiGateway["closeSession"]>(() =>
+            new Promise<void>((resolve) => {
+                releaseClose = resolve;
+            }),
+        );
+        const prepareSession = vi
+            .fn<NativeAiGateway["prepareSession"]>()
+            .mockImplementation(({ launch }) =>
+                Promise.resolve({
+                    ...launch.persistedSnapshot,
+                    runtimeSessionId: `runtime-${prepareSession.mock.calls.length}`,
+                    status:
+                        prepareSession.mock.calls.length === 1
+                            ? "idle"
+                            : "streaming",
+                }),
+            );
+        const sendPrompt = vi.fn<NativeAiGateway["sendPrompt"]>(
+            ({ input }) =>
+                Promise.resolve({
+                    sessionId: input.sessionId,
+                    stopReason: "accepted",
+                }),
+        );
+        service = createPrepareService({
+            aiSessionRetention: {
+                idleTtlMs: -1,
+                maxHotSessionsPerWindow: 0,
+            },
+            nativeAi: createNativeAi({
+                closeSession,
+                loadSessionSnapshot: vi.fn(() =>
+                    Promise.resolve(persistedSnapshot),
+                ),
+                prepareSession,
+                sendPrompt,
+            }),
+        });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-retained",
+                title: "Retained chat",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+        await vi.waitFor(() => expect(closeSession).toHaveBeenCalledTimes(1));
+
+        // Retention's close event used to terminalize this existing queue.
+        service.getPromptQueue("session-retained", "window-1");
+        service.handleNativeSessionEvent("window-1", {
+            closedAt: "2026-07-13T00:00:01.000Z",
+            kind: "session-closed",
+            origin: "live",
+            parentSessionId: null,
+            runtimeId: "codex",
+            runtimeSessionId: "runtime-1",
+            sessionId: "session-retained",
+            updatedAt: "2026-07-13T00:00:01.000Z",
+        });
+        releaseClose?.();
+
+        service.enqueuePrompt(
+            {
+                attachments: [],
+                composerParts: [{ text: "Continue.", type: "text" }],
+                fileContextsSnapshot: [],
+                messageId: "message-retained-1",
+                projectId: null,
+                prompt: "Continue.",
+                runtimeId: "codex",
+                sessionId: "session-retained",
+                title: "Retained chat",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+
+        await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalledTimes(1));
+        expect(prepareSession).toHaveBeenCalledTimes(2);
+        expect(sendPrompt).toHaveBeenCalledWith(
+            expect.objectContaining({
+                input: expect.objectContaining({
+                    messageId: "message-retained-1",
+                    sessionId: "session-retained",
+                }),
+            }),
+        );
+    });
+
+    it("ignores a retained runtime close event that arrives after reopening", async () => {
+        const persistedSnapshot = createSnapshot({
+            runtimeSessionId: "runtime-session-retained",
+            sessionId: "session-retained-late-close",
+            title: "Retained chat",
+        });
+        const closeSession = vi.fn<NativeAiGateway["closeSession"]>(() =>
+            Promise.resolve(),
+        );
+        const prepareSession = vi
+            .fn<NativeAiGateway["prepareSession"]>()
+            .mockImplementation(({ launch }) =>
+                Promise.resolve({
+                    ...launch.persistedSnapshot,
+                    runtimeSessionId: `runtime-${prepareSession.mock.calls.length}`,
+                    status:
+                        prepareSession.mock.calls.length === 1
+                            ? "idle"
+                            : "streaming",
+                }),
+            );
+        const sendPrompt = vi.fn<NativeAiGateway["sendPrompt"]>(({ input }) =>
+            Promise.resolve({
+                sessionId: input.sessionId,
+                stopReason: "accepted",
+            }),
+        );
+        const service = createPrepareService({
+            aiSessionRetention: {
+                idleTtlMs: -1,
+                maxHotSessionsPerWindow: 0,
+            },
+            nativeAi: createNativeAi({
+                closeSession,
+                loadSessionSnapshot: vi.fn(() =>
+                    Promise.resolve(persistedSnapshot),
+                ),
+                prepareSession,
+                sendPrompt,
+            }),
+        });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-retained-late-close",
+                title: "Retained chat",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+        await vi.waitFor(() => expect(closeSession).toHaveBeenCalledTimes(1));
+
+        service.enqueuePrompt(
+            {
+                attachments: [],
+                composerParts: [{ text: "Continue.", type: "text" }],
+                fileContextsSnapshot: [],
+                messageId: "message-retained-late-close-1",
+                projectId: null,
+                prompt: "Continue.",
+                runtimeId: "codex",
+                sessionId: "session-retained-late-close",
+                title: "Retained chat",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+        await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalledTimes(1));
+
+        service.handleNativeSessionEvent("window-1", {
+            closedAt: "2026-07-13T00:00:01.000Z",
+            kind: "session-closed",
+            origin: "live",
+            parentSessionId: null,
+            runtimeId: "codex",
+            runtimeSessionId: "runtime-1",
+            sessionId: "session-retained-late-close",
+            updatedAt: "2026-07-13T00:00:01.000Z",
+        });
+
+        expect(
+            service.getPromptQueue("session-retained-late-close", "window-1"),
+        ).toMatchObject({
+            activeItem: {
+                messageId: "message-retained-late-close-1",
+                status: "running",
+            },
+            items: [],
+            paused: false,
+        });
+    });
+
+    it("reprepares and retries a prompt once when the runtime evicts its session", async () => {
+        const snapshot = createSnapshot({
+            runtimeSessionId: "runtime-session-1",
+            sessionId: "session-retry",
+            title: "Retry chat",
+        });
+        const prepareSession = vi
+            .fn<NativeAiGateway["prepareSession"]>()
+            .mockResolvedValueOnce(snapshot)
+            .mockResolvedValueOnce({
+                ...snapshot,
+                runtimeSessionId: "runtime-session-2",
+            });
+        const sendPrompt = vi
+            .fn<NativeAiGateway["sendPrompt"]>()
+            .mockRejectedValueOnce(
+                new NativeBackendError({
+                    code: "ai_session_not_found",
+                    details: null,
+                    message: "The AI session was not found.",
+                    retryable: false,
+                }),
+            )
+            .mockResolvedValueOnce({
+                sessionId: "session-retry",
+                stopReason: "accepted",
+            });
+        const service = createPrepareService({
+            nativeAi: createNativeAi({ prepareSession, sendPrompt }),
+        });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-retry",
+                title: "Retry chat",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+        await service.sendPrompt(
+            {
+                attachments: [],
+                composerParts: [{ text: "Retry this.", type: "text" }],
+                messageId: "message-retry-1",
+                projectId: null,
+                prompt: "Retry this.",
+                runtimeId: "codex",
+                sessionId: "session-retry",
+                title: "Retry chat",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+
+        expect(prepareSession).toHaveBeenCalledTimes(2);
+        expect(sendPrompt).toHaveBeenCalledTimes(2);
+        expect(
+            sendPrompt.mock.calls.map(
+                ([request]) => request.input.messageId,
+            ),
+        ).toEqual(["message-retry-1", "message-retry-1"]);
+    });
+
     it("hydrates newly prepared native sessions with persisted ACP catalog controls", async () => {
         const nativeSnapshot: AiSessionSnapshot = {
             availableCommands: [],
@@ -2253,6 +2513,9 @@ function createReasoningConfig(value: string): AiSessionConfigOption {
 
 function createPrepareService(
     options: {
+        readonly aiSessionRetention?: ConstructorParameters<
+            typeof AiService
+        >[0]["aiSessionRetention"];
         readonly nativeAi?: NativeAiGateway;
         readonly onSessionSnapshot?: (
             ownerWindowId: string,
@@ -2264,6 +2527,7 @@ function createPrepareService(
     } = {},
 ): InstanceType<typeof AiService> {
     return new AiService({
+        aiSessionRetention: options.aiSessionRetention,
         nativeAi: options.nativeAi ?? createNativeAi(),
         onRuntimeStatus: vi.fn(),
         onSessionSnapshot: options.onSessionSnapshot ?? vi.fn(),

--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -2395,6 +2395,7 @@ function createNativeAi(
 ): NativeAiGateway {
     return {
         cancelSession: vi.fn(),
+        captureReviewBaseline: vi.fn(),
         close: vi.fn(),
         closeOwnedByWindow: vi.fn(),
         closeSession: vi.fn(),

--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -286,8 +286,7 @@ describe("AiService prepareSession", () => {
             sessionId: "session-retained",
             title: "Retained chat",
         });
-        let service: InstanceType<typeof AiService>;
-        let releaseClose: (() => void) | null = null;
+        let releaseClose!: () => void;
         const closeSession = vi.fn<NativeAiGateway["closeSession"]>(() =>
             new Promise<void>((resolve) => {
                 releaseClose = resolve;
@@ -312,7 +311,7 @@ describe("AiService prepareSession", () => {
                     stopReason: "accepted",
                 }),
         );
-        service = createPrepareService({
+        const service = createPrepareService({
             aiSessionRetention: {
                 idleTtlMs: -1,
                 maxHotSessionsPerWindow: 0,
@@ -351,7 +350,7 @@ describe("AiService prepareSession", () => {
             sessionId: "session-retained",
             updatedAt: "2026-07-13T00:00:01.000Z",
         });
-        releaseClose?.();
+        releaseClose();
 
         service.enqueuePrompt(
             {
@@ -371,14 +370,10 @@ describe("AiService prepareSession", () => {
 
         await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalledTimes(1));
         expect(prepareSession).toHaveBeenCalledTimes(2);
-        expect(sendPrompt).toHaveBeenCalledWith(
-            expect.objectContaining({
-                input: expect.objectContaining({
-                    messageId: "message-retained-1",
-                    sessionId: "session-retained",
-                }),
-            }),
-        );
+        expect(sendPrompt.mock.calls[0]?.[0].input).toMatchObject({
+            messageId: "message-retained-1",
+            sessionId: "session-retained",
+        });
     });
 
     it("ignores a retained runtime close event that arrives after reopening", async () => {

--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -535,6 +535,92 @@ describe("AiService prepareSession", () => {
         ).toEqual(["message-retry-1", "message-retry-1"]);
     });
 
+    it("reprepares the root before retrying an evicted subagent prompt", async () => {
+        const parentSnapshot = createSnapshot({
+            runtimeSessionId: "runtime-parent-1",
+            sessionId: "session-parent",
+            title: "Parent chat",
+        });
+        const childSnapshot = createSnapshot({
+            parentSessionId: "session-parent",
+            runtimeSessionId: "runtime-child-1",
+            sessionId: "session-child",
+            title: "Child chat",
+        });
+        const loadSessionSnapshot = vi.fn<NativeAiGateway["loadSessionSnapshot"]>(
+            (sessionId) =>
+                Promise.resolve(
+                    sessionId === "session-child"
+                        ? childSnapshot
+                        : parentSnapshot,
+                ),
+        );
+        const prepareSession = vi
+            .fn<NativeAiGateway["prepareSession"]>()
+            .mockResolvedValueOnce(parentSnapshot)
+            .mockResolvedValueOnce({
+                ...parentSnapshot,
+                runtimeSessionId: "runtime-parent-2",
+            });
+        const sendPrompt = vi
+            .fn<NativeAiGateway["sendPrompt"]>()
+            .mockRejectedValueOnce(
+                new NativeBackendError({
+                    code: "ai_session_not_found",
+                    details: null,
+                    message: "The AI session was not found.",
+                    retryable: false,
+                }),
+            )
+            .mockResolvedValueOnce({
+                sessionId: "session-child",
+                stopReason: "accepted",
+            });
+        const service = createPrepareService({
+            nativeAi: createNativeAi({
+                loadSessionSnapshot,
+                prepareSession,
+                sendPrompt,
+            }),
+        });
+
+        await service.prepareSession(
+            {
+                projectId: null,
+                runtimeId: "codex",
+                sessionId: "session-child",
+                title: "Child chat",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+        await service.sendPrompt(
+            {
+                attachments: [],
+                composerParts: [{ text: "Continue.", type: "text" }],
+                messageId: "message-child-retry-1",
+                projectId: null,
+                prompt: "Continue.",
+                runtimeId: "codex",
+                sessionId: "session-child",
+                title: "Child chat",
+                worktreeId: null,
+            },
+            "window-1",
+        );
+
+        expect(prepareSession).toHaveBeenCalledTimes(2);
+        expect(
+            prepareSession.mock.calls.map(
+                ([request]) => request.input.sessionId,
+            ),
+        ).toEqual(["session-parent", "session-parent"]);
+        expect(sendPrompt).toHaveBeenCalledTimes(2);
+        expect(
+            sendPrompt.mock.calls[1]?.[0].launch.persistedSnapshot.sessionId,
+        ).toBe("session-child");
+    });
+
     it("hydrates newly prepared native sessions with persisted ACP catalog controls", async () => {
         const nativeSnapshot: AiSessionSnapshot = {
             availableCommands: [],

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -1530,9 +1530,14 @@ export class AiService {
                         // and retry this exact prompt without duplicating it.
                         debugBenignError("ai.service.recoverPrompt", error);
                         await this.#recoverMissingLiveSession(input.sessionId);
+                        const recoveredLaunch =
+                            await this.#buildNativeSessionLaunchInput(
+                                input,
+                                ownerWindowId,
+                            );
                         promptResult = await nativeAi.sendPrompt({
                             input,
-                            launch,
+                            launch: recoveredLaunch,
                         });
                     }
                     if (promptResult.stopReason === "accepted") {
@@ -1766,7 +1771,11 @@ export class AiService {
         }
 
         this.#cancelCapturedRuntimeDefaults(sessionId);
+        const rootSnapshot = await this.#resolveNativeRootSessionSnapshot(
+            snapshot,
+        );
         this.#nativeSessionIds.delete(sessionId);
+        this.#nativeSessionIds.delete(rootSnapshot.sessionId);
         await this.prepareSession(
             {
                 projectId: snapshot.projectId,
@@ -3883,29 +3892,11 @@ export class AiService {
         readonly input: SessionDescriptor;
         readonly launch: AiSessionLaunchInput;
     }> {
-        let rootSnapshot = launch.persistedSnapshot;
-        if (!rootSnapshot.parentSessionId) {
+        const rootSnapshot = await this.#resolveNativeRootSessionSnapshot(
+            launch.persistedSnapshot,
+        );
+        if (rootSnapshot.sessionId === launch.persistedSnapshot.sessionId) {
             return { input, launch };
-        }
-
-        const visitedSessionIds = new Set([rootSnapshot.sessionId]);
-        while (rootSnapshot.parentSessionId) {
-            const parentSessionId = rootSnapshot.parentSessionId;
-            if (visitedSessionIds.has(parentSessionId)) {
-                throw new Error(
-                    "The subagent hierarchy contains a parent cycle.",
-                );
-            }
-            visitedSessionIds.add(parentSessionId);
-            const parentSnapshot =
-                this.#liveSnapshots.get(parentSessionId) ??
-                (await this.#loadPersistedSessionSnapshot(parentSessionId));
-            if (!parentSnapshot) {
-                throw new Error(
-                    "An ancestor session could not be loaded for this subagent.",
-                );
-            }
-            rootSnapshot = parentSnapshot;
         }
 
         const rootInput: SessionDescriptor = {
@@ -3925,6 +3916,32 @@ export class AiService {
                 rootSnapshot,
             ),
         };
+    }
+
+    async #resolveNativeRootSessionSnapshot(
+        snapshot: AiSessionSnapshot,
+    ): Promise<AiSessionSnapshot> {
+        let rootSnapshot = snapshot;
+        const visitedSessionIds = new Set([snapshot.sessionId]);
+        while (rootSnapshot.parentSessionId) {
+            const parentSessionId = rootSnapshot.parentSessionId;
+            if (visitedSessionIds.has(parentSessionId)) {
+                throw new Error(
+                    "The subagent hierarchy contains a parent cycle.",
+                );
+            }
+            visitedSessionIds.add(parentSessionId);
+            const parentSnapshot =
+                this.#liveSnapshots.get(parentSessionId) ??
+                (await this.#loadPersistedSessionSnapshot(parentSessionId));
+            if (!parentSnapshot) {
+                throw new Error(
+                    "An ancestor session could not be loaded for this subagent.",
+                );
+            }
+            rootSnapshot = parentSnapshot;
+        }
+        return rootSnapshot;
     }
 
     #adoptNativeSubagentSnapshot(

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -2728,11 +2728,7 @@ export class AiService {
             return false;
         }
 
-        if (
-            matchesRetainedRuntime &&
-            expectedRuntimeSessionIds &&
-            event.runtimeSessionId !== null
-        ) {
+        if (matchesRetainedRuntime) {
             this.#forgetRetentionCloseRuntimeSession(
                 event.sessionId,
                 event.runtimeSessionId,

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -227,6 +227,7 @@ const DEFAULT_AI_SESSION_RETENTION_CONFIG: AiSessionRetentionConfig = {
     maxHotSessionsPerWindow: 6,
 };
 const RECENT_NATIVE_REVIEW_CONTEXT_TTL_MS = 60_000;
+const RETENTION_CLOSE_EVENT_GRACE_MS = 60_000;
 
 function isResyncEligibleAiSessionStatus(
     status: AiSessionSnapshot["status"],
@@ -275,6 +276,15 @@ interface AiSessionRetentionSkippedRecord {
     readonly sessionId: string;
     readonly skippedAtMs: number;
     readonly skippedReason: AiSessionFreezeSkippedReason;
+}
+
+interface AiSessionRetentionCandidate {
+    readonly reason: AiSessionFreezeReason;
+    readonly sessionId: string;
+    readonly touch: {
+        readonly lastUsedAtMs: number;
+        readonly order: number;
+    };
 }
 
 interface AiSchedulerTask<T> {
@@ -439,6 +449,14 @@ interface PendingNativeCatalogPatch {
 export class AiService {
     readonly #deletedSessionIds = new Set<string>();
     readonly #freezingSessionIds = new Set<string>();
+    readonly #frozenSessionIds = new Set<string>();
+    readonly #retentionCloseEventSessionIds = new Set<string>();
+    readonly #retentionCloseRuntimeSessionIds = new Map<string, Set<string>>();
+    readonly #retentionCloseRuntimeSessionTimers = new Map<
+        string,
+        ReturnType<typeof setTimeout>
+    >();
+    readonly #retentionFreezePromises = new Map<string, Promise<void>>();
     readonly #lastRetentionCloseRecords: AiSessionRetentionCloseRecord[] = [];
     readonly #lastRetentionSkippedRecords: AiSessionRetentionSkippedRecord[] = [];
     readonly #liveSessionContexts = new Map<string, LiveSessionContext>();
@@ -545,6 +563,9 @@ export class AiService {
         this.#liveSessionContexts.clear();
         this.#liveSnapshots.clear();
         this.#liveSessionTouches.clear();
+        for (const sessionId of this.#retentionCloseRuntimeSessionIds.keys()) {
+            this.#forgetRetentionCloseRuntimeSessions(sessionId);
+        }
     }
 
     getSchedulerDiagnostics(): AiSchedulerDiagnostics {
@@ -679,6 +700,14 @@ export class AiService {
         event: AiSessionDomainEvent,
     ): void {
         if (this.#deletedSessionIds.has(event.sessionId)) {
+            return;
+        }
+
+        // The runtime can deliver its close event after a retained session has
+        // already been prepared again. Consume the close for the specific old
+        // runtime session before it reaches snapshots, the renderer, or the
+        // prompt queue.
+        if (this.#consumeRetentionCloseEvent(event)) {
             return;
         }
 
@@ -1319,6 +1348,10 @@ export class AiService {
         input: EnqueueAiPromptInput,
         ownerWindowId: string,
     ): AiPromptQueueSnapshot {
+        // Count the user's action before the asynchronous queue dispatcher
+        // starts. This prevents a stale retention candidate from closing the
+        // session just as a new prompt is being queued.
+        this.#touchLiveSession(input.sessionId);
         return this.#promptQueue.enqueue(input, ownerWindowId);
     }
 
@@ -1381,6 +1414,7 @@ export class AiService {
         ownerWindowId: string,
     ): Promise<AiPromptResult> {
         await this.#waitForReviewMutations(input.sessionId);
+        await this.#waitForRetentionFreeze(input.sessionId);
         const launch = await this.#buildNativeSessionLaunchInput(
             input,
             ownerWindowId,
@@ -1480,10 +1514,27 @@ export class AiService {
                                 input.messageId,
                             );
                     }
-                    const promptResult = await nativeAi.sendPrompt({
-                        input,
-                        launch,
-                    });
+                    let promptResult: AiPromptResult;
+                    try {
+                        promptResult = await nativeAi.sendPrompt({
+                            input,
+                            launch,
+                        });
+                    } catch (error) {
+                        if (!isNativeAiSessionNotFoundError(error)) {
+                            throw error;
+                        }
+
+                        // A runtime can evict an otherwise live session. The
+                        // not-found response is definitive, so recreate once
+                        // and retry this exact prompt without duplicating it.
+                        debugBenignError("ai.service.recoverPrompt", error);
+                        await this.#recoverMissingLiveSession(input.sessionId);
+                        promptResult = await nativeAi.sendPrompt({
+                            input,
+                            launch,
+                        });
+                    }
                     if (promptResult.stopReason === "accepted") {
                         const terminalStatusAlreadySeen =
                             this.#markNativeReviewPromptAccepted(
@@ -1840,8 +1891,14 @@ export class AiService {
     }
 
     async deleteSession(sessionId: string): Promise<void> {
+        this.#frozenSessionIds.delete(sessionId);
+        this.#retentionCloseEventSessionIds.delete(sessionId);
+        this.#forgetRetentionCloseRuntimeSessions(sessionId);
         const subtreeSessionIds = await this.#collectSessionSubtreeIds(sessionId);
         for (const subtreeSessionId of subtreeSessionIds) {
+            this.#frozenSessionIds.delete(subtreeSessionId);
+            this.#retentionCloseEventSessionIds.delete(subtreeSessionId);
+            this.#forgetRetentionCloseRuntimeSessions(subtreeSessionId);
             this.#deletedSessionIds.add(subtreeSessionId);
         }
         try {
@@ -2526,23 +2583,21 @@ export class AiService {
     async #runSessionRetentionSweep(): Promise<void> {
         const candidates = this.#selectRetentionCandidates();
         for (const candidate of candidates) {
-            await this.#freezeSessionForRetention(
-                candidate.sessionId,
-                candidate.reason,
-            );
+            await this.#freezeSessionForRetention(candidate);
         }
     }
 
-    #selectRetentionCandidates(): readonly {
-        readonly reason: AiSessionFreezeReason;
-        readonly sessionId: string;
-    }[] {
-        const candidates = new Map<string, AiSessionFreezeReason>();
+    #selectRetentionCandidates(): readonly AiSessionRetentionCandidate[] {
+        const candidates = new Map<string, AiSessionRetentionCandidate>();
         const now = Date.now();
         if (this.#retentionConfig.idleTtlMs >= 0) {
             for (const [sessionId, touch] of this.#liveSessionTouches) {
                 if (now - touch.lastUsedAtMs >= this.#retentionConfig.idleTtlMs) {
-                    candidates.set(sessionId, "ttl");
+                    candidates.set(sessionId, {
+                        reason: "ttl",
+                        sessionId,
+                        touch,
+                    });
                 }
             }
         }
@@ -2567,22 +2622,25 @@ export class AiService {
                 index < ordered.length;
                 index += 1
             ) {
-                if (!candidates.has(ordered[index].sessionId)) {
-                    candidates.set(ordered[index].sessionId, "budget");
+                const session = ordered[index];
+                const touch = this.#liveSessionTouches.get(session.sessionId);
+                if (!candidates.has(session.sessionId) && touch) {
+                    candidates.set(session.sessionId, {
+                        reason: "budget",
+                        sessionId: session.sessionId,
+                        touch,
+                    });
                 }
             }
         }
 
-        return [...candidates.entries()].map(([sessionId, reason]) => ({
-            reason,
-            sessionId,
-        }));
+        return [...candidates.values()];
     }
 
     async #freezeSessionForRetention(
-        sessionId: string,
-        reason: AiSessionFreezeReason,
+        candidate: AiSessionRetentionCandidate,
     ): Promise<void> {
+        const { reason, sessionId, touch: selectedTouch } = candidate;
         if (
             this.#freezingSessionIds.has(sessionId) ||
             !this.#liveSessionContexts.has(sessionId)
@@ -2590,7 +2648,17 @@ export class AiService {
             return;
         }
 
+        const currentTouch = this.#liveSessionTouches.get(sessionId);
+        if (
+            !currentTouch ||
+            currentTouch.lastUsedAtMs !== selectedTouch.lastUsedAtMs ||
+            currentTouch.order !== selectedTouch.order
+        ) {
+            return;
+        }
+
         const snapshot = this.#liveSnapshots.get(sessionId) ?? null;
+        const retentionRuntimeSessionId = snapshot?.runtimeSessionId ?? null;
         const localSkippedReason = snapshot
             ? getRetentionSkippedReasonFromSnapshot(snapshot)
             : null;
@@ -2599,15 +2667,132 @@ export class AiService {
             return;
         }
 
+        let resolveFreeze: () => void = () => undefined;
+        const freezeComplete = new Promise<void>((resolve) => {
+            resolveFreeze = resolve;
+        });
         this.#freezingSessionIds.add(sessionId);
+        this.#frozenSessionIds.add(sessionId);
+        if (retentionRuntimeSessionId) {
+            this.#rememberRetentionCloseRuntimeSession(
+                sessionId,
+                retentionRuntimeSessionId,
+            );
+        }
+        this.#retentionFreezePromises.set(sessionId, freezeComplete);
         try {
             await this.closeSession(sessionId);
             this.#recordRetentionClose(sessionId, reason);
         } catch (error) {
+            this.#frozenSessionIds.delete(sessionId);
+            if (retentionRuntimeSessionId) {
+                this.#forgetRetentionCloseRuntimeSession(
+                    sessionId,
+                    retentionRuntimeSessionId,
+                );
+            }
             this.#deferSessionRetentionRetry(sessionId);
             debugBenignError("ai.service.freezeNativeSession", error);
         } finally {
             this.#freezingSessionIds.delete(sessionId);
+            if (this.#retentionCloseEventSessionIds.delete(sessionId)) {
+                this.#frozenSessionIds.delete(sessionId);
+            }
+            if (this.#retentionFreezePromises.get(sessionId) === freezeComplete) {
+                this.#retentionFreezePromises.delete(sessionId);
+            }
+            resolveFreeze();
+        }
+    }
+
+    async #waitForRetentionFreeze(sessionId: string): Promise<void> {
+        await this.#retentionFreezePromises.get(sessionId);
+    }
+
+    #consumeRetentionCloseEvent(event: AiSessionDomainEvent): boolean {
+        if (event.kind !== "session-closed") {
+            return false;
+        }
+
+        const expectedRuntimeSessionIds =
+            this.#retentionCloseRuntimeSessionIds.get(event.sessionId) ?? null;
+        const matchesRetainedRuntime =
+            expectedRuntimeSessionIds !== null &&
+            event.runtimeSessionId !== null &&
+            expectedRuntimeSessionIds.has(event.runtimeSessionId);
+        const closingWithoutRuntimeIdentity =
+            event.runtimeSessionId === null &&
+            (this.#freezingSessionIds.has(event.sessionId) ||
+                this.#frozenSessionIds.has(event.sessionId));
+        if (!matchesRetainedRuntime && !closingWithoutRuntimeIdentity) {
+            return false;
+        }
+
+        if (
+            matchesRetainedRuntime &&
+            expectedRuntimeSessionIds &&
+            event.runtimeSessionId !== null
+        ) {
+            this.#forgetRetentionCloseRuntimeSession(
+                event.sessionId,
+                event.runtimeSessionId,
+            );
+        } else if (closingWithoutRuntimeIdentity) {
+            this.#forgetRetentionCloseRuntimeSessions(event.sessionId);
+        }
+        if (this.#freezingSessionIds.has(event.sessionId)) {
+            this.#retentionCloseEventSessionIds.add(event.sessionId);
+        } else {
+            this.#frozenSessionIds.delete(event.sessionId);
+        }
+        return true;
+    }
+
+    #rememberRetentionCloseRuntimeSession(
+        sessionId: string,
+        runtimeSessionId: string,
+    ): void {
+        const runtimeSessionIds =
+            this.#retentionCloseRuntimeSessionIds.get(sessionId) ??
+            new Set<string>();
+        runtimeSessionIds.add(runtimeSessionId);
+        this.#retentionCloseRuntimeSessionIds.set(sessionId, runtimeSessionIds);
+
+        const previousTimer =
+            this.#retentionCloseRuntimeSessionTimers.get(sessionId);
+        if (previousTimer) {
+            clearTimeout(previousTimer);
+        }
+        const timer = setTimeout(() => {
+            this.#retentionCloseRuntimeSessionTimers.delete(sessionId);
+            this.#retentionCloseRuntimeSessionIds.delete(sessionId);
+        }, RETENTION_CLOSE_EVENT_GRACE_MS);
+        unrefTimer(timer);
+        this.#retentionCloseRuntimeSessionTimers.set(sessionId, timer);
+    }
+
+    #forgetRetentionCloseRuntimeSessions(sessionId: string): void {
+        this.#retentionCloseRuntimeSessionIds.delete(sessionId);
+        const timer = this.#retentionCloseRuntimeSessionTimers.get(sessionId);
+        if (timer) {
+            clearTimeout(timer);
+            this.#retentionCloseRuntimeSessionTimers.delete(sessionId);
+        }
+    }
+
+    #forgetRetentionCloseRuntimeSession(
+        sessionId: string,
+        runtimeSessionId: string,
+    ): void {
+        const runtimeSessionIds =
+            this.#retentionCloseRuntimeSessionIds.get(sessionId);
+        if (!runtimeSessionIds) {
+            return;
+        }
+
+        runtimeSessionIds.delete(runtimeSessionId);
+        if (runtimeSessionIds.size === 0) {
+            this.#forgetRetentionCloseRuntimeSessions(sessionId);
         }
     }
 
@@ -2769,6 +2954,7 @@ export class AiService {
             this.#persistence.saveSessionSnapshot(cachedSnapshot);
         }
         this.#promptQueue.handleSessionSnapshot(cachedSnapshot);
+        this.#frozenSessionIds.delete(cachedSnapshot.sessionId);
         return cachedSnapshot;
     }
 

--- a/src/main/native-backend/ai.test.ts
+++ b/src/main/native-backend/ai.test.ts
@@ -240,6 +240,68 @@ describe("NativeAiGateway", () => {
         );
     });
 
+    it("ignores a stale close without forgetting the reopened session owner", async () => {
+        const client = createClient();
+        const onSessionEvent = vi.fn<NativeAiGatewayOptions["onSessionEvent"]>();
+        const gateway = createGateway(client, { onSessionEvent });
+        const launch = createLaunch();
+
+        await gateway.prepareSession({
+            input: createPrepareInput(),
+            launch,
+        });
+        client.request.mockResolvedValueOnce({
+            projectId: "project-1",
+            runtimeId: "opencode",
+            runtimeSessionId: "runtime-session-2",
+            sessionId: "session-1",
+            status: "streaming",
+            title: "Native session",
+            updatedAt: "2026-06-20T00:00:02.000Z",
+            worktreeId: "worktree-1",
+        });
+        await gateway.prepareSession({
+            input: createPrepareInput(),
+            launch,
+        });
+        onSessionEvent.mockClear();
+
+        client.emit({
+            eventName: "ai://session-closed",
+            payload: {
+                runtimeId: "opencode",
+                runtimeSessionId: "runtime-session-1",
+                sessionId: "session-1",
+                updatedAt: "2026-06-20T00:00:03.000Z",
+            },
+            type: "event",
+        });
+        client.emit({
+            eventName: "ai://message-delta",
+            payload: {
+                content: "Still streaming",
+                delta: "Still streaming",
+                messageId: "assistant-1",
+                messageKind: "assistant",
+                runtimeId: "opencode",
+                runtimeSessionId: "runtime-session-2",
+                sessionId: "session-1",
+                updatedAt: "2026-06-20T00:00:04.000Z",
+            },
+            type: "event",
+        });
+
+        expect(onSessionEvent).toHaveBeenCalledTimes(1);
+        expect(onSessionEvent).toHaveBeenCalledWith(
+            "window-1",
+            expect.objectContaining({
+                content: "Still streaming",
+                kind: "message-delta",
+                runtimeSessionId: "runtime-session-2",
+            }),
+        );
+    });
+
     it("projects native catalog updates through the owning window", async () => {
         const client = createClient();
         const onSessionCatalogPatch = vi.fn();

--- a/src/main/native-backend/ai.ts
+++ b/src/main/native-backend/ai.ts
@@ -727,6 +727,12 @@ export class NativeAiGateway implements NativeAiGatewayContract {
                 return;
             }
 
+            // A close from an older runtime generation must not tear down the
+            // ownership and routing state of a session that was reopened.
+            if (this.#isStaleSessionCloseEvent(converted)) {
+                return;
+            }
+
             this.#rememberRuntimeSession(converted);
             if (converted.kind === "subagent-created") {
                 this.#sessionOwners.set(converted.childSessionId, ownerWindowId);
@@ -811,10 +817,12 @@ export class NativeAiGateway implements NativeAiGatewayContract {
         launch: NativeAiPrepareSessionRpcInput["launch"],
     ): void {
         this.#rememberOwnerIdentity(sessionId, launch);
-        this.#runtimeSessionIds.set(
-            sessionId,
-            launch.persistedSnapshot.runtimeSessionId ?? null,
-        );
+        if (!this.#runtimeSessionIds.has(sessionId)) {
+            this.#runtimeSessionIds.set(
+                sessionId,
+                launch.persistedSnapshot.runtimeSessionId ?? null,
+            );
+        }
     }
 
     #rememberOwnerIdentity(
@@ -924,6 +932,21 @@ export class NativeAiGateway implements NativeAiGatewayContract {
             ...event,
             parentSessionId,
         };
+    }
+
+    #isStaleSessionCloseEvent(event: AiSessionDomainEvent): boolean {
+        if (event.kind !== "session-closed" || !event.runtimeSessionId) {
+            return false;
+        }
+
+        const currentRuntimeSessionId = this.#runtimeSessionIds.get(
+            event.sessionId,
+        );
+        return (
+            currentRuntimeSessionId !== undefined &&
+            currentRuntimeSessionId !== null &&
+            currentRuntimeSessionId !== event.runtimeSessionId
+        );
     }
 
     #restoreOwner(sessionId: string, previousOwner: string | undefined): void {


### PR DESCRIPTION
## Summary

- Treat retention-driven runtime closes as temporary freezes instead of terminal chat closures.
- Preserve queued prompts while a retained session is reopening, then prepare and dispatch the original prompt.
- Ignore delayed close events that belong to the old retained runtime session.
- Revalidate retention candidates after new activity is queued to avoid closing a reactivated session.
- Recover once from `ai_session_not_found` during prompt dispatch without changing the message ID.

## Tests

- Retained session reopens and dispatches its first queued prompt.
- A delayed close event from the retired runtime does not terminalize the reopened queue.
- A prompt retries exactly once after runtime session eviction, preserving the original message ID.

Not run locally: dependencies are not installed in this worktree (`node_modules` is missing).