### PR TITLE
fix: refresh cached Git workspace tabs

### DIFF
--- a/crates/comando-fs/src/policy.rs
+++ b/crates/comando-fs/src/policy.rs
@@ -103,6 +103,7 @@ pub fn git_watch_invalidation_reason(relative_path: &str) -> Option<GitWatchInva
         _ if path == ".git/logs/head" || path.starts_with(".git/logs/refs/") => {
             Some(GitWatchInvalidationReason::Branch)
         }
+        _ if path.starts_with(".git/worktrees/") => Some(GitWatchInvalidationReason::Worktree),
         _ if path.starts_with(".git/rebase-merge/") || path.starts_with(".git/rebase-apply/") => {
             Some(GitWatchInvalidationReason::Status)
         }
@@ -151,6 +152,15 @@ mod tests {
 
         assert!(!should_ignore_watch_path(".git/HEAD"));
         assert!(!should_ignore_watch_path(".git/refs/heads/main"));
+    }
+
+    #[test]
+    fn keeps_linked_worktree_metadata_that_invalidates_the_inventory() {
+        assert_eq!(
+            git_watch_invalidation_reason(".git/worktrees/feature/gitdir"),
+            Some(GitWatchInvalidationReason::Worktree),
+        );
+        assert!(!should_ignore_watch_path(".git/worktrees/feature/gitdir"));
     }
 
     #[test]

--- a/crates/comando-fs/src/watcher.rs
+++ b/crates/comando-fs/src/watcher.rs
@@ -317,7 +317,13 @@ fn handle_notify_event(context: NotifyEventContext<'_>, event: Event) {
             }
         }
 
-        record_pending_invalidation(context.key, context.root, &relative_path, context.pending);
+        record_external_watch_path(
+            context.key,
+            context.root,
+            &relative_path,
+            context.pending,
+            context.pending_git_invalidations,
+        );
         context.fs_events.lock().expect("watch events lock").push((
             event_name.to_string(),
             NativeFsWatchEvent {
@@ -330,6 +336,22 @@ fn handle_notify_event(context: NotifyEventContext<'_>, event: Event) {
             },
         ));
     }
+}
+
+fn record_external_watch_path(
+    key: &str,
+    root: &ProjectRoot,
+    relative_path: &str,
+    pending: &Arc<Mutex<HashMap<String, PendingInvalidation>>>,
+    pending_git_invalidations: &Arc<Mutex<HashMap<String, PendingGitInvalidation>>>,
+) {
+    record_pending_invalidation(key, root, relative_path, pending);
+    record_pending_git_invalidation(
+        key,
+        root,
+        GitWatchInvalidationReason::Filesystem,
+        pending_git_invalidations,
+    );
 }
 
 fn record_pending_git_invalidation(
@@ -372,7 +394,7 @@ fn record_test_watch_path(
         return;
     }
 
-    record_pending_invalidation(key, root, relative_path, pending);
+    record_external_watch_path(key, root, relative_path, pending, pending_git_invalidations);
 }
 
 fn merge_git_invalidation_reason(
@@ -456,6 +478,7 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
+    use comando_types::ids::{ProjectId, WorktreeId};
     use tempfile::TempDir;
 
     use super::*;
@@ -491,6 +514,45 @@ mod tests {
     }
 
     #[test]
+    fn coalesces_external_worktree_changes_into_a_git_invalidation() {
+        let temp = TempDir::new().expect("temp");
+        let root = ProjectRoot {
+            project_id: ProjectId("project_1".to_string()),
+            worktree_id: Some(WorktreeId("worktree_2".to_string())),
+            root_path: temp.path().to_path_buf(),
+        };
+        let mut watchers = WatcherRegistry::new();
+
+        record_external_watch_path(
+            "project_1:worktree_2",
+            &root,
+            "src/a.ts",
+            &watchers.pending,
+            &watchers.pending_git_invalidations,
+        );
+        record_external_watch_path(
+            "project_1:worktree_2",
+            &root,
+            "src/b.ts",
+            &watchers.pending,
+            &watchers.pending_git_invalidations,
+        );
+        thread::sleep(Duration::from_millis(160));
+
+        let drain = watchers.drain(false);
+        assert_eq!(drain.git_invalidations.len(), 1);
+        assert_eq!(drain.git_invalidations[0].reason, "filesystem");
+        assert_eq!(
+            drain.git_invalidations[0]
+                .worktree_id
+                .as_ref()
+                .map(|worktree_id| worktree_id.0.as_str()),
+            Some("worktree_2"),
+        );
+        assert_eq!(drain.invalidations.len(), 1);
+    }
+
+    #[test]
     fn write_tracker_suppresses_own_writes() {
         let temp = TempDir::new().expect("temp");
         let path = temp.path().join("owned.txt");
@@ -507,6 +569,7 @@ mod tests {
 
         let drain = watchers.drain(true);
         assert!(drain.invalidations.is_empty());
+        assert!(drain.git_invalidations.is_empty());
     }
 
     #[test]

--- a/crates/comando-fs/src/watcher.rs
+++ b/crates/comando-fs/src/watcher.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -38,6 +38,7 @@ pub struct WatcherDrain {
 pub struct WatcherRegistry {
     watchers: HashMap<String, RecommendedWatcher>,
     roots: HashMap<String, ProjectRoot>,
+    git_metadata_routes: Arc<Mutex<Vec<GitMetadataRoute>>>,
     write_tracker: WriteTracker,
     pending: Arc<Mutex<HashMap<String, PendingInvalidation>>>,
     pending_git_invalidations: Arc<Mutex<HashMap<String, PendingGitInvalidation>>>,
@@ -61,11 +62,18 @@ struct PendingGitInvalidation {
     last_event_at: Instant,
 }
 
+#[derive(Debug, Clone)]
+struct GitMetadataRoute {
+    metadata_path: PathBuf,
+    root: ProjectRoot,
+}
+
 impl WatcherRegistry {
     pub fn new() -> Self {
         Self {
             watchers: HashMap::new(),
             roots: HashMap::new(),
+            git_metadata_routes: Arc::new(Mutex::new(Vec::new())),
             write_tracker: WriteTracker::new(),
             pending: Arc::new(Mutex::new(HashMap::new())),
             pending_git_invalidations: Arc::new(Mutex::new(HashMap::new())),
@@ -83,6 +91,22 @@ impl WatcherRegistry {
             .filter(|root| root.root_path.is_dir())
             .map(|root| (watch_key(&root), root))
             .collect::<HashMap<_, _>>();
+
+        let mut metadata_routes = desired
+            .values()
+            .filter_map(git_metadata_route_for_root)
+            .collect::<Vec<_>>();
+        metadata_routes.sort_by(|left, right| {
+            right
+                .metadata_path
+                .components()
+                .count()
+                .cmp(&left.metadata_path.components().count())
+        });
+        *self
+            .git_metadata_routes
+            .lock()
+            .expect("git metadata routes lock") = metadata_routes;
 
         let current_keys = self.watchers.keys().cloned().collect::<Vec<_>>();
         for key in current_keys {
@@ -109,6 +133,7 @@ impl WatcherRegistry {
         if self.watchers.contains_key(&key) {
             return Ok(());
         }
+        self.register_git_metadata_route(&root);
         self.start_root(key, root)
     }
 
@@ -116,6 +141,29 @@ impl WatcherRegistry {
         let key = watch_key(root);
         self.watchers.remove(&key);
         self.roots.remove(&key);
+        self.git_metadata_routes
+            .lock()
+            .expect("git metadata routes lock")
+            .retain(|route| watch_key(&route.root) != key);
+    }
+
+    fn register_git_metadata_route(&self, root: &ProjectRoot) {
+        let Some(route) = git_metadata_route_for_root(root) else {
+            return;
+        };
+        let mut routes = self
+            .git_metadata_routes
+            .lock()
+            .expect("git metadata routes lock");
+        routes.retain(|existing| watch_key(&existing.root) != watch_key(root));
+        routes.push(route);
+        routes.sort_by(|left, right| {
+            right
+                .metadata_path
+                .components()
+                .count()
+                .cmp(&left.metadata_path.components().count())
+        });
     }
 
     pub fn drain(&mut self, force: bool) -> WatcherDrain {
@@ -188,10 +236,10 @@ impl WatcherRegistry {
         let watch_root = root.root_path.clone();
         let pending = Arc::clone(&self.pending);
         let pending_git_invalidations = Arc::clone(&self.pending_git_invalidations);
+        let git_metadata_routes = Arc::clone(&self.git_metadata_routes);
         let fs_events = Arc::clone(&self.fs_events);
         let write_tracker = self.write_tracker.clone();
         let root_for_callback = root.clone();
-        let key_for_callback = key.clone();
 
         let mut watcher =
             notify::recommended_watcher(move |result: Result<Event, notify::Error>| {
@@ -201,18 +249,21 @@ impl WatcherRegistry {
 
                 handle_notify_event(
                     NotifyEventContext {
-                        key: &key_for_callback,
                         root: &root_for_callback,
                         watch_root: &watch_root,
                         write_tracker: &write_tracker,
                         pending: &pending,
                         pending_git_invalidations: &pending_git_invalidations,
+                        git_metadata_routes: &git_metadata_routes,
                         fs_events: &fs_events,
                     },
                     event,
                 );
             })?;
         watcher.watch(&root.root_path, RecursiveMode::Recursive)?;
+        if let Some(route) = git_metadata_route_for_root(&root) {
+            watcher.watch(&route.metadata_path, RecursiveMode::Recursive)?;
+        }
 
         self.roots.insert(key.clone(), root);
         self.watchers.insert(key, watcher);
@@ -249,12 +300,12 @@ impl Default for WatcherRegistry {
 }
 
 struct NotifyEventContext<'a> {
-    key: &'a str,
     root: &'a ProjectRoot,
     watch_root: &'a Path,
     write_tracker: &'a WriteTracker,
     pending: &'a Arc<Mutex<HashMap<String, PendingInvalidation>>>,
     pending_git_invalidations: &'a Arc<Mutex<HashMap<String, PendingGitInvalidation>>>,
+    git_metadata_routes: &'a Arc<Mutex<Vec<GitMetadataRoute>>>,
     fs_events: &'a Arc<Mutex<Vec<(String, NativeFsWatchEvent)>>>,
 }
 
@@ -273,17 +324,23 @@ fn handle_notify_event(context: NotifyEventContext<'_>, event: Event) {
             continue;
         }
 
-        let Some(relative_path) = normalize_watched_path(context.watch_root, &absolute_path) else {
+        let Some((event_root, relative_path)) = resolve_watched_event_path(
+            context.root,
+            context.watch_root,
+            &absolute_path,
+            context.git_metadata_routes,
+        ) else {
             continue;
         };
+        let event_key = watch_key(&event_root);
         if should_ignore_watch_path(&relative_path) {
             continue;
         }
 
         if let Some(reason) = git_watch_invalidation_reason(&relative_path) {
             record_pending_git_invalidation(
-                context.key,
-                context.root,
+                &event_key,
+                &event_root,
                 reason,
                 context.pending_git_invalidations,
             );
@@ -318,8 +375,8 @@ fn handle_notify_event(context: NotifyEventContext<'_>, event: Event) {
         }
 
         record_external_watch_path(
-            context.key,
-            context.root,
+            &event_key,
+            &event_root,
             &relative_path,
             context.pending,
             context.pending_git_invalidations,
@@ -327,8 +384,8 @@ fn handle_notify_event(context: NotifyEventContext<'_>, event: Event) {
         context.fs_events.lock().expect("watch events lock").push((
             event_name.to_string(),
             NativeFsWatchEvent {
-                project_id: context.root.project_id.clone(),
-                worktree_id: context.root.worktree_id.clone(),
+                project_id: event_root.project_id.clone(),
+                worktree_id: event_root.worktree_id.clone(),
                 relative_path: Some(RelativePath(relative_path)),
                 kind: event_kind.to_string(),
                 origin: NativeFsMutationOrigin::External,
@@ -336,6 +393,45 @@ fn handle_notify_event(context: NotifyEventContext<'_>, event: Event) {
             },
         ));
     }
+}
+
+fn git_metadata_route_for_root(root: &ProjectRoot) -> Option<GitMetadataRoute> {
+    let git_file = root.root_path.join(".git");
+    let git_dir = std::fs::read_to_string(&git_file).ok()?;
+    let metadata_path = git_dir.trim().strip_prefix("gitdir: ")?;
+    let metadata_path = PathBuf::from(metadata_path);
+    let metadata_path = if metadata_path.is_absolute() {
+        metadata_path
+    } else {
+        git_file.parent()?.join(metadata_path)
+    };
+
+    metadata_path.is_dir().then_some(GitMetadataRoute {
+        metadata_path,
+        root: root.clone(),
+    })
+}
+
+fn resolve_watched_event_path(
+    watched_root: &ProjectRoot,
+    watch_root: &Path,
+    absolute_path: &Path,
+    git_metadata_routes: &Arc<Mutex<Vec<GitMetadataRoute>>>,
+) -> Option<(ProjectRoot, String)> {
+    let metadata_routes = git_metadata_routes
+        .lock()
+        .expect("git metadata routes lock");
+    if let Some(route) = metadata_routes
+        .iter()
+        .find(|route| absolute_path.starts_with(&route.metadata_path))
+    {
+        let relative_path = normalize_watched_path(&route.metadata_path, absolute_path)?;
+        return Some((route.root.clone(), format!(".git/{relative_path}")));
+    }
+    drop(metadata_routes);
+
+    normalize_watched_path(watch_root, absolute_path)
+        .map(|relative_path| (watched_root.clone(), relative_path))
 }
 
 fn record_external_watch_path(
@@ -550,6 +646,191 @@ mod tests {
             Some("worktree_2"),
         );
         assert_eq!(drain.invalidations.len(), 1);
+    }
+
+    #[test]
+    fn routes_linked_worktree_metadata_to_its_owner() {
+        let temp = TempDir::new().expect("temp");
+        let primary_path = temp.path().join("repository");
+        let linked_path = temp.path().join("feature-worktree");
+        let metadata_path = primary_path.join(".git/worktrees/feature");
+        fs::create_dir_all(&metadata_path).expect("metadata directory");
+        fs::create_dir_all(&linked_path).expect("linked worktree directory");
+        fs::write(
+            linked_path.join(".git"),
+            format!("gitdir: {}\n", metadata_path.display()),
+        )
+        .expect("linked gitdir file");
+
+        let primary_root = ProjectRoot {
+            project_id: ProjectId("project_1".to_string()),
+            worktree_id: Some(WorktreeId("project_1:primary".to_string())),
+            root_path: primary_path,
+        };
+        let linked_root = ProjectRoot {
+            project_id: ProjectId("project_1".to_string()),
+            worktree_id: Some(WorktreeId("worktree_2".to_string())),
+            root_path: linked_path,
+        };
+        let route = git_metadata_route_for_root(&linked_root).expect("metadata route");
+        let routes = Arc::new(Mutex::new(vec![route]));
+
+        for (relative_path, expected_reason) in [
+            ("index", GitWatchInvalidationReason::Status),
+            ("HEAD", GitWatchInvalidationReason::Branch),
+            ("refs/heads/feature", GitWatchInvalidationReason::Branch),
+            ("rebase-merge/head-name", GitWatchInvalidationReason::Status),
+        ] {
+            let absolute_path = metadata_path.join(relative_path);
+            let (event_root, projected_path) = resolve_watched_event_path(
+                &primary_root,
+                &primary_root.root_path,
+                &absolute_path,
+                &routes,
+            )
+            .expect("routed metadata path");
+
+            assert_eq!(event_root.worktree_id, linked_root.worktree_id);
+            assert_eq!(
+                git_watch_invalidation_reason(&projected_path),
+                Some(expected_reason),
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_unmapped_worktree_metadata_on_the_primary_context() {
+        let temp = TempDir::new().expect("temp");
+        let primary_path = temp.path().join("repository");
+        let metadata_path = primary_path.join(".git/worktrees/new-worktree/gitdir");
+        fs::create_dir_all(metadata_path.parent().expect("metadata parent"))
+            .expect("metadata directory");
+        let primary_root = ProjectRoot {
+            project_id: ProjectId("project_1".to_string()),
+            worktree_id: Some(WorktreeId("project_1:primary".to_string())),
+            root_path: primary_path,
+        };
+        let routes = Arc::new(Mutex::new(Vec::new()));
+
+        let (event_root, relative_path) = resolve_watched_event_path(
+            &primary_root,
+            &primary_root.root_path,
+            &metadata_path,
+            &routes,
+        )
+        .expect("primary metadata path");
+
+        assert_eq!(event_root.worktree_id, primary_root.worktree_id);
+        assert_eq!(
+            git_watch_invalidation_reason(&relative_path),
+            Some(GitWatchInvalidationReason::Worktree),
+        );
+    }
+
+    #[test]
+    fn synchronizing_roots_updates_linked_metadata_routes() {
+        let temp = TempDir::new().expect("temp");
+        let primary_path = temp.path().join("repository");
+        let linked_path = temp.path().join("feature-worktree");
+        let metadata_path = primary_path.join(".git/worktrees/feature");
+        fs::create_dir_all(&metadata_path).expect("metadata directory");
+        fs::create_dir_all(&linked_path).expect("linked worktree directory");
+        fs::write(
+            linked_path.join(".git"),
+            format!("gitdir: {}\n", metadata_path.display()),
+        )
+        .expect("linked gitdir file");
+
+        let primary_root = ProjectRoot {
+            project_id: ProjectId("project_1".to_string()),
+            worktree_id: Some(WorktreeId("project_1:primary".to_string())),
+            root_path: primary_path,
+        };
+        let linked_root = ProjectRoot {
+            project_id: ProjectId("project_1".to_string()),
+            worktree_id: Some(WorktreeId("worktree_2".to_string())),
+            root_path: linked_path,
+        };
+        let mut watchers = WatcherRegistry::new();
+
+        watchers
+            .sync_roots(vec![primary_root.clone(), linked_root])
+            .expect("sync roots");
+        assert_eq!(
+            watchers
+                .git_metadata_routes
+                .lock()
+                .expect("metadata routes lock")
+                .len(),
+            1,
+        );
+
+        watchers
+            .sync_roots(vec![primary_root])
+            .expect("remove linked worktree root");
+        assert_eq!(watchers.roots.len(), 1);
+        assert!(!watchers.watchers.contains_key("project_1:worktree_2"));
+        assert!(
+            watchers
+                .git_metadata_routes
+                .lock()
+                .expect("metadata routes lock")
+                .is_empty(),
+        );
+    }
+
+    #[test]
+    fn routes_linked_worktree_metadata_events_with_the_linked_context() {
+        let temp = TempDir::new().expect("temp");
+        let primary_path = temp.path().join("repository");
+        let linked_path = temp.path().join("feature-worktree");
+        let metadata_path = primary_path.join(".git/worktrees/feature");
+        fs::create_dir_all(&metadata_path).expect("metadata directory");
+        fs::create_dir_all(&linked_path).expect("linked worktree directory");
+        fs::write(
+            linked_path.join(".git"),
+            format!("gitdir: {}\n", metadata_path.display()),
+        )
+        .expect("linked gitdir file");
+
+        let primary_root = ProjectRoot {
+            project_id: ProjectId("project_1".to_string()),
+            worktree_id: Some(WorktreeId("project_1:primary".to_string())),
+            root_path: primary_path,
+        };
+        let linked_root = ProjectRoot {
+            project_id: ProjectId("project_1".to_string()),
+            worktree_id: Some(WorktreeId("worktree_2".to_string())),
+            root_path: linked_path,
+        };
+        let mut watchers = WatcherRegistry::new();
+        let routes = Arc::new(Mutex::new(vec![
+            git_metadata_route_for_root(&linked_root).expect("metadata route"),
+        ]));
+        let write_tracker = watchers.write_tracker();
+        handle_notify_event(
+            NotifyEventContext {
+                root: &primary_root,
+                watch_root: &primary_root.root_path,
+                write_tracker: &write_tracker,
+                pending: &watchers.pending,
+                pending_git_invalidations: &watchers.pending_git_invalidations,
+                git_metadata_routes: &routes,
+                fs_events: &watchers.fs_events,
+            },
+            Event::new(EventKind::Modify(ModifyKind::Any)).add_path(metadata_path.join("index")),
+        );
+
+        let drain = watchers.drain(true);
+        assert_eq!(drain.git_invalidations.len(), 1);
+        assert_eq!(drain.git_invalidations[0].reason, "status");
+        assert_eq!(
+            drain.git_invalidations[0]
+                .worktree_id
+                .as_ref()
+                .map(|worktree_id| worktree_id.0.as_str()),
+            Some("worktree_2"),
+        );
     }
 
     #[test]

--- a/src/renderer/src/app/store/git-store.test.ts
+++ b/src/renderer/src/app/store/git-store.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type {
+    GitHistoryCommitSummary,
     GitRepositorySnapshot,
     GitWorktreeDiffResult,
 } from "@shared/ipc";
@@ -66,7 +67,104 @@ describe("git-store history", () => {
             worktreeId: "worktree-1",
         });
     });
+
+    it("keeps the newest history response when refreshes resolve out of order", async () => {
+        const first = createDeferred<{
+            readonly commits: readonly GitHistoryCommitSummary[];
+            readonly matchedCount: number;
+            readonly totalCount: number;
+        }>();
+        const second = createDeferred<{
+            readonly commits: readonly GitHistoryCommitSummary[];
+            readonly matchedCount: number;
+            readonly totalCount: number;
+        }>();
+        stubComando({
+            listGitHistory: vi
+                .fn()
+                .mockReturnValueOnce(first.promise)
+                .mockReturnValueOnce(second.promise),
+        });
+
+        const firstRefresh = useGitStore
+            .getState()
+            .refreshHistory("project-1", null);
+        const secondRefresh = useGitStore
+            .getState()
+            .refreshHistory("project-1", null);
+
+        second.resolve({
+            commits: [createCommit("newest")],
+            matchedCount: 1,
+            totalCount: 1,
+        });
+        await secondRefresh;
+        first.resolve({
+            commits: [createCommit("stale")],
+            matchedCount: 1,
+            totalCount: 1,
+        });
+        await firstRefresh;
+
+        expect(
+            useGitStore.getState().historyByContext["project-1::primary"],
+        ).toEqual([createCommit("newest")]);
+    });
+
+    it("keeps the newest worktree diff when refreshes resolve out of order", async () => {
+        const first = createDeferred<GitWorktreeDiffResult>();
+        const second = createDeferred<GitWorktreeDiffResult>();
+        stubComando({
+            listGitWorktreeDiff: vi
+                .fn()
+                .mockReturnValueOnce(first.promise)
+                .mockReturnValueOnce(second.promise),
+        });
+
+        const firstRefresh = useGitStore
+            .getState()
+            .refreshWorktreeDiff("project-1", null);
+        const secondRefresh = useGitStore
+            .getState()
+            .refreshWorktreeDiff("project-1", null);
+
+        second.resolve(createWorktreeDiff("newest"));
+        await secondRefresh;
+        first.resolve(createWorktreeDiff("stale"));
+        await firstRefresh;
+
+        expect(
+            useGitStore.getState().worktreeDiffsByContext[
+                "project-1::primary"
+            ],
+        ).toEqual(createWorktreeDiff("newest"));
+    });
 });
+
+function createCommit(subject: string): GitHistoryCommitSummary {
+    return {
+        authorEmail: "author@example.com",
+        authorName: "Author",
+        authoredAt: "2026-07-14T12:00:00.000Z",
+        body: "",
+        parentShas: [],
+        refs: [],
+        sha: `${subject}-sha`,
+        shortSha: subject,
+        subject,
+    };
+}
+
+function createDeferred<T>(): {
+    readonly promise: Promise<T>;
+    readonly resolve: (value: T) => void;
+} {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((resolvePromise) => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
 
 function createSnapshot(): GitRepositorySnapshot {
     return {
@@ -95,6 +193,15 @@ function createSnapshot(): GitRepositorySnapshot {
         syncStatus: "in_sync",
         updatedAt: "2026-07-14T12:00:00.000Z",
         worktrees: [],
+    };
+}
+
+function createWorktreeDiff(updatedAt: string): GitWorktreeDiffResult {
+    return {
+        projectId: "project-1",
+        sections: [],
+        updatedAt,
+        worktreeId: null,
     };
 }
 

--- a/src/renderer/src/app/store/git-store.test.ts
+++ b/src/renderer/src/app/store/git-store.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type {
+    GitRepositorySnapshot,
+    GitWorktreeDiffResult,
+} from "@shared/ipc";
+
 import { useGitStore } from "./git-store";
 
 describe("git-store history", () => {
@@ -26,7 +31,72 @@ describe("git-store history", () => {
             }),
         );
     });
+
+    it("refreshes a cached worktree diff after a Git snapshot refresh", async () => {
+        const listGitWorktreeDiff = vi.fn().mockResolvedValue({
+            projectId: "project-1",
+            sections: [],
+            updatedAt: "2026-07-14T12:00:00.000Z",
+            worktreeId: "worktree-1",
+        } satisfies GitWorktreeDiffResult);
+        stubComando({
+            getGitRepositorySnapshot: vi.fn().mockResolvedValue(
+                createSnapshot(),
+            ),
+            listGitWorktreeDiff,
+        });
+        useGitStore.setState({
+            worktreeDiffsByContext: {
+                "project-1::worktree-1": {
+                    projectId: "project-1",
+                    sections: [],
+                    updatedAt: "2026-07-14T11:00:00.000Z",
+                    worktreeId: "worktree-1",
+                },
+            },
+        });
+
+        await useGitStore
+            .getState()
+            .refreshProject("project-1", "worktree-1");
+        await Promise.resolve();
+
+        expect(listGitWorktreeDiff).toHaveBeenCalledWith({
+            projectId: "project-1",
+            worktreeId: "worktree-1",
+        });
+    });
 });
+
+function createSnapshot(): GitRepositorySnapshot {
+    return {
+        aheadBy: 0,
+        behindBy: 0,
+        branch: null,
+        branches: [],
+        canonicalRootPath: "/tmp/project",
+        changedPaths: ["src/file.ts"],
+        changes: [],
+        currentWorktreeId: "worktree-1",
+        defaultTreeViewMode: "tree",
+        headSha: null,
+        projectId: "project-1",
+        remotes: [],
+        repositoryState: "ready",
+        rootPath: "/tmp/project-worktree",
+        selectedRemoteName: null,
+        status: {
+            changedCount: 1,
+            conflictedCount: 0,
+            stagedCount: 0,
+            unstagedCount: 1,
+            untrackedCount: 0,
+        },
+        syncStatus: "in_sync",
+        updatedAt: "2026-07-14T12:00:00.000Z",
+        worktrees: [],
+    };
+}
 
 function stubComando(api: Record<string, unknown>): void {
     vi.stubGlobal("window", {

--- a/src/renderer/src/components/workspace/GitTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitTabView.test.tsx
@@ -1,4 +1,6 @@
-import { createElement, type ReactNode } from "react";
+/** @vitest-environment jsdom */
+import { act, createElement, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
@@ -34,6 +36,9 @@ const mockWorkspaceStoreState = vi.hoisted(() => ({
 }));
 const mockScrollToIndex = vi.hoisted(() => vi.fn());
 
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
 vi.mock("@renderer/app/store/git-store", () => ({
     useGitStore: (
         selector: (state: typeof mockGitStoreState.current) => unknown,
@@ -44,6 +49,13 @@ vi.mock("@renderer/app/store/workspace-store", () => ({
     useWorkspaceStore: (
         selector: (state: typeof mockWorkspaceStoreState.current) => unknown,
     ) => selector(mockWorkspaceStoreState.current),
+}));
+
+vi.mock("@renderer/components/workspace/usePersistedWorkspaceScroll", () => ({
+    usePersistedWorkspaceScroll: () => ({
+        handleScroll: vi.fn(),
+        scrollRef: vi.fn(),
+    }),
 }));
 
 vi.mock("@renderer/components/virtual/MeasuredVirtualList", () => ({
@@ -194,6 +206,25 @@ function createCommitDetail(
 }
 
 describe("GitTabView", () => {
+    it("revalidates cached history when the tab mounts", () => {
+        resetStoreState();
+        const container = document.createElement("div");
+        const root = createRoot(container);
+
+        act(() => {
+            root.render(createElement(GitTabView, { tab: TAB }));
+        });
+
+        expect(mockGitStoreState.current.refreshHistory).toHaveBeenCalledWith(
+            TAB.projectId,
+            TAB.worktreeId,
+        );
+
+        act(() => {
+            root.unmount();
+        });
+    });
+
     it("shows a load more button when the current page is full", () => {
         resetStoreState();
         mockGitStoreState.current.historyByContext = {

--- a/src/renderer/src/components/workspace/GitTabView.tsx
+++ b/src/renderer/src/components/workspace/GitTabView.tsx
@@ -46,6 +46,7 @@ import {
     type MeasuredVirtualRange,
 } from "@renderer/components/virtual/MeasuredVirtualList";
 import { usePersistedWorkspaceScroll } from "@renderer/components/workspace/usePersistedWorkspaceScroll";
+import { useGitWorkspaceTabRevalidation } from "@renderer/components/workspace/useGitWorkspaceTabRevalidation";
 
 import {
     IdeActionButton,
@@ -181,6 +182,12 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
         (state) => state.openGitCommitTab,
     );
     const openFileTab = useWorkspaceStore((state) => state.openFileTab);
+    useGitWorkspaceTabRevalidation({
+        isLoading: isHistoryLoading,
+        projectId,
+        revalidate: refreshHistory,
+        worktreeId,
+    });
     useEffect(() => {
         if (!projectId || snapshot) {
             return;
@@ -211,9 +218,7 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
 
         if (lastHistorySearchKeyRef.current === null) {
             lastHistorySearchKeyRef.current = searchKey;
-            if (!query && history.length > 0) {
-                return;
-            }
+            return;
         } else if (lastHistorySearchKeyRef.current === searchKey) {
             return;
         } else {
@@ -226,7 +231,6 @@ export function GitTabView({ tab }: { readonly tab: RuntimeWorkspaceGitTab }) {
             resetLimit: true,
         });
     }, [
-        history.length,
         isCaseSensitive,
         isHistoryLoading,
         projectId,

--- a/src/renderer/src/components/workspace/GitWorktreeDiffTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitWorktreeDiffTabView.test.tsx
@@ -1,4 +1,6 @@
-import { createElement } from "react";
+/** @vitest-environment jsdom */
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -37,6 +39,9 @@ const mockWorkspaceStoreState = vi.hoisted(() => ({
     },
 }));
 
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
 vi.mock("@renderer/app/hooks/use-resolved-editor-settings", () => ({
     useResolvedEditorSettings: () => ({
         autoSaveDelayMs: 1000,
@@ -66,6 +71,13 @@ vi.mock("@renderer/app/store/workspace-store", () => ({
     useWorkspaceStore: (
         selector: (state: typeof mockWorkspaceStoreState.current) => unknown,
     ) => selector(mockWorkspaceStoreState.current),
+}));
+
+vi.mock("@renderer/components/workspace/usePersistedWorkspaceScroll", () => ({
+    usePersistedWorkspaceScroll: () => ({
+        handleScroll: vi.fn(),
+        scrollRef: vi.fn(),
+    }),
 }));
 
 import { GitWorktreeDiffTabView } from "./GitWorktreeDiffTabView";
@@ -150,5 +162,22 @@ describe("GitWorktreeDiffTabView", () => {
         );
         expect(markup).toContain('class="min-h-0 flex-1 px-2 py-2"');
         expect(markup).toContain("worktree-file.ts");
+    });
+
+    it("revalidates a cached diff when the tab mounts", () => {
+        const container = document.createElement("div");
+        const root = createRoot(container);
+
+        act(() => {
+            root.render(createElement(GitWorktreeDiffTabView, { tab: TAB }));
+        });
+
+        expect(
+            mockGitStoreState.current.refreshWorktreeDiff,
+        ).toHaveBeenCalledWith(TAB.projectId, TAB.worktreeId);
+
+        act(() => {
+            root.unmount();
+        });
     });
 });

--- a/src/renderer/src/components/workspace/GitWorktreeDiffTabView.tsx
+++ b/src/renderer/src/components/workspace/GitWorktreeDiffTabView.tsx
@@ -15,6 +15,7 @@ import type { RuntimeWorkspaceGitWorktreeDiffTab } from "@renderer/app/workspace
 import type { GitWorktreeDiffFile, GitWorktreeDiffResult } from "@shared/ipc";
 import { GitDiffsView, GitEmptyState } from "@renderer/components/git";
 import { usePersistedWorkspaceScroll } from "@renderer/components/workspace/usePersistedWorkspaceScroll";
+import { useGitWorkspaceTabRevalidation } from "@renderer/components/workspace/useGitWorkspaceTabRevalidation";
 import { IdeActionButton } from "./ide-bar";
 
 const EMPTY_COLLAPSED_FILE_IDS: readonly string[] = [];
@@ -60,9 +61,6 @@ export function GitWorktreeDiffTabView({
             state.collapsedWorktreeDiffFileIds[contextKey] ??
             EMPTY_COLLAPSED_FILE_IDS,
     );
-    const ensureWorktreeDiff = useGitStore(
-        (state) => state.ensureWorktreeDiff,
-    );
     const refreshProject = useGitStore((state) => state.refreshProject);
     const refreshWorktreeDiff = useGitStore(
         (state) => state.refreshWorktreeDiff,
@@ -80,6 +78,12 @@ export function GitWorktreeDiffTabView({
     const unstagePaths = useGitStore((state) => state.unstagePaths);
     const discardPaths = useGitStore((state) => state.discardPaths);
     const openFileTab = useWorkspaceStore((state) => state.openFileTab);
+    useGitWorkspaceTabRevalidation({
+        isLoading,
+        projectId,
+        revalidate: refreshWorktreeDiff,
+        worktreeId,
+    });
 
     const codeFontFamily = buildEditorFontFamily(editorSettings.fontFamily);
     const codeFontSize = editorSettings.fontSize;
@@ -267,8 +271,7 @@ export function GitWorktreeDiffTabView({
             void refreshProject(projectId, worktreeId);
         }
 
-        void ensureWorktreeDiff(projectId, worktreeId);
-    }, [ensureWorktreeDiff, projectId, refreshProject, snapshot, worktreeId]);
+    }, [projectId, refreshProject, snapshot, worktreeId]);
 
     if (!result && !isLoading && error) {
         return (

--- a/src/renderer/src/components/workspace/useGitWorkspaceTabRevalidation.ts
+++ b/src/renderer/src/components/workspace/useGitWorkspaceTabRevalidation.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from "react";
+
+type GitWorkspaceTabRevalidationOptions = {
+    readonly isLoading: boolean;
+    readonly projectId: string | null;
+    readonly revalidate: (
+        projectId: string,
+        worktreeId: string | null,
+    ) => Promise<unknown>;
+    readonly worktreeId: string | null;
+};
+
+export function useGitWorkspaceTabRevalidation({
+    isLoading,
+    projectId,
+    revalidate,
+    worktreeId,
+}: GitWorkspaceTabRevalidationOptions): void {
+    const revalidatedContextRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!projectId) {
+            return;
+        }
+
+        const contextKey = `${projectId}::${worktreeId ?? "__primary__"}`;
+        if (revalidatedContextRef.current === contextKey) {
+            return;
+        }
+
+        revalidatedContextRef.current = contextKey;
+        if (!isLoading) {
+            void revalidate(projectId, worktreeId);
+        }
+    }, [isLoading, projectId, revalidate, worktreeId]);
+}


### PR DESCRIPTION
## Summary

- Emit coalesced Git invalidations for external filesystem changes.
- Revalidate cached Git History and Uncommitted Changes tabs on activation.
- Route linked-worktree Git metadata invalidations to their owning worktree and resync watched roots.

## Validation

- `pnpm exec vitest run src/renderer/src/app/store/git-store.test.ts src/renderer/src/components/workspace/GitTabView.test.tsx src/renderer/src/components/workspace/GitWorktreeDiffTabView.test.tsx`
- `cargo test -p comando-fs`
- `cargo clippy -p comando-fs -- -D warnings`
- `pnpm run typecheck`

Closes #119