### PR TITLE
Fix stale worktree inventory in workspace switcher

### DIFF
--- a/crates/comando-fs/src/policy.rs
+++ b/crates/comando-fs/src/policy.rs
@@ -103,6 +103,7 @@ pub fn git_watch_invalidation_reason(relative_path: &str) -> Option<GitWatchInva
         _ if path == ".git/logs/head" || path.starts_with(".git/logs/refs/") => {
             Some(GitWatchInvalidationReason::Branch)
         }
+        _ if path.starts_with(".git/worktrees/") => Some(GitWatchInvalidationReason::Worktree),
         _ if path.starts_with(".git/rebase-merge/") || path.starts_with(".git/rebase-apply/") => {
             Some(GitWatchInvalidationReason::Status)
         }
@@ -151,6 +152,15 @@ mod tests {
 
         assert!(!should_ignore_watch_path(".git/HEAD"));
         assert!(!should_ignore_watch_path(".git/refs/heads/main"));
+    }
+
+    #[test]
+    fn keeps_linked_worktree_metadata_that_invalidates_the_inventory() {
+        assert_eq!(
+            git_watch_invalidation_reason(".git/worktrees/feature/gitdir"),
+            Some(GitWatchInvalidationReason::Worktree),
+        );
+        assert!(!should_ignore_watch_path(".git/worktrees/feature/gitdir"));
     }
 
     #[test]

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -165,22 +165,6 @@ const ROOT_NODE_KEY = "__root__";
 const PROJECT_SEARCH_FOLLOWUP_DEBOUNCE_MS = 50;
 const WORKSPACE_RECENT_PROJECTS_LIMIT = 6;
 
-function collectProjectWorktrees(
-    snapshots: Readonly<Record<string, GitRepositorySnapshot | null>>,
-    projectId: string,
-): readonly GitWorktreeSummary[] {
-    const worktreesById = new Map<string, GitWorktreeSummary>();
-    for (const snapshot of Object.values(snapshots)) {
-        if (snapshot?.projectId !== projectId) {
-            continue;
-        }
-        for (const worktree of snapshot.worktrees) {
-            worktreesById.set(worktree.id, worktree);
-        }
-    }
-    return [...worktreesById.values()];
-}
-
 function getWorktreeDisplayLabel(worktree: GitWorktreeSummary): string {
     if (worktree.branchName) {
         return worktree.branchName;
@@ -324,6 +308,9 @@ export function App() {
     const refreshGitProject = useGitStore((state) => state.refreshProject);
     const ingestGitSnapshot = useGitStore((state) => state.ingestSnapshot);
     const gitSnapshots = useGitStore((state) => state.snapshots);
+    const gitWorktreesByProject = useGitStore(
+        (state) => state.worktreesByProject,
+    );
     const setActiveWorktree = useGitStore((state) => state.setActiveWorktree);
     const selectGitBranch = useGitStore((state) => state.selectBranch);
 
@@ -1492,10 +1479,8 @@ export function App() {
                     return [];
                 }
 
-                const worktrees = collectProjectWorktrees(
-                    gitSnapshots,
-                    context.projectId,
-                );
+                const worktrees =
+                    gitWorktreesByProject[context.projectId] ?? [];
                 const worktree = worktrees.find((entry) =>
                     areGitWorktreeIdsEquivalent(
                         context.projectId,
@@ -1518,7 +1503,7 @@ export function App() {
                 ];
             }),
         [
-            gitSnapshots,
+            gitWorktreesByProject,
             openWorkspaceContextKeys,
             projects,
             workspaceContextsByKey,
@@ -1562,7 +1547,7 @@ export function App() {
                         null,
                     ),
             );
-            const worktrees = collectProjectWorktrees(gitSnapshots, project.id)
+            const worktrees = (gitWorktreesByProject[project.id] ?? [])
                 .filter((worktree) => !worktree.isPrimary)
                 .map((worktree) => ({
                     id: worktree.id,
@@ -1601,7 +1586,7 @@ export function App() {
         });
     }, [
         activeWorkspaceContext,
-        gitSnapshots,
+        gitWorktreesByProject,
         openWorkspaceContextKeys,
         projects,
         workspaceContextsByKey,

--- a/src/renderer/src/app/store/git-store.test.ts
+++ b/src/renderer/src/app/store/git-store.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { GitRepositorySnapshot, GitWorktreeSummary } from "@shared/ipc";
+
 import { useGitStore } from "./git-store";
 
 describe("git-store history", () => {
@@ -26,7 +28,99 @@ describe("git-store history", () => {
             }),
         );
     });
+
+    it("keeps the newest project worktree inventory across cached contexts", () => {
+        useGitStore.getState().ingestSnapshot(
+            createSnapshot({
+                currentWorktreeId: "worktree-1",
+                updatedAt: "2026-07-14T12:01:00.000Z",
+                worktrees: [
+                    createWorktree("project-1:primary", "main", true),
+                    createWorktree("worktree-1", "feature/current"),
+                ],
+            }),
+        );
+        useGitStore.getState().ingestSnapshot(
+            createSnapshot({
+                currentWorktreeId: "worktree-2",
+                updatedAt: "2026-07-14T12:02:00.000Z",
+                worktrees: [
+                    createWorktree("project-1:primary", "main", true),
+                    createWorktree("worktree-2", "feature/new"),
+                ],
+            }),
+        );
+        useGitStore.getState().ingestSnapshot(
+            createSnapshot({
+                currentWorktreeId: "worktree-1",
+                updatedAt: "2026-07-14T12:01:00.000Z",
+                worktrees: [
+                    createWorktree("project-1:primary", "main", true),
+                    createWorktree("worktree-1", "feature/stale"),
+                ],
+            }),
+        );
+
+        expect(useGitStore.getState().worktreesByProject["project-1"])
+            .toEqual([
+                createWorktree("project-1:primary", "main", true),
+                createWorktree("worktree-2", "feature/new"),
+            ]);
+    });
 });
+
+function createSnapshot(
+    overrides: Partial<GitRepositorySnapshot> = {},
+): GitRepositorySnapshot {
+    return {
+        aheadBy: 0,
+        behindBy: 0,
+        branch: null,
+        branches: [],
+        canonicalRootPath: "/tmp/project",
+        changedPaths: [],
+        changes: [],
+        currentWorktreeId: null,
+        defaultTreeViewMode: "tree",
+        headSha: null,
+        projectId: "project-1",
+        remotes: [],
+        repositoryState: "ready",
+        rootPath: "/tmp/project",
+        selectedRemoteName: null,
+        status: {
+            changedCount: 0,
+            conflictedCount: 0,
+            stagedCount: 0,
+            unstagedCount: 0,
+            untrackedCount: 0,
+        },
+        syncStatus: "in_sync",
+        updatedAt: "2026-07-14T12:00:00.000Z",
+        worktrees: [],
+        ...overrides,
+    };
+}
+
+function createWorktree(
+    id: string,
+    branchName: string,
+    isPrimary = false,
+): GitWorktreeSummary {
+    return {
+        branchName,
+        commitSha: null,
+        id,
+        isBare: false,
+        isCurrent: false,
+        isLocked: false,
+        isPrimary,
+        lockedReason: null,
+        projectId: "project-1",
+        rootPath: `/tmp/${id}`,
+        updatedAt: "2026-07-14T12:00:00.000Z",
+    };
+}
 
 function stubComando(api: Record<string, unknown>): void {
     vi.stubGlobal("window", {
@@ -66,6 +160,8 @@ function resetGitStoreForTests(): void {
         selectedDiffPaths: {},
         selectedWorktreeDiffFileIds: {},
         snapshots: {},
+        worktreeInventoryUpdatedAtByProject: {},
+        worktreesByProject: {},
         worktreeDiffRequestKeysByContext: {},
         worktreeDiffsByContext: {},
         collapsedWorktreeDiffFileIds: {},

--- a/src/renderer/src/app/store/git-store.test.ts
+++ b/src/renderer/src/app/store/git-store.test.ts
@@ -29,11 +29,11 @@ describe("git-store history", () => {
         );
     });
 
-    it("keeps the newest project worktree inventory across cached contexts", () => {
+    it("keeps the newest submillisecond worktree inventory across cached contexts", () => {
         useGitStore.getState().ingestSnapshot(
             createSnapshot({
                 currentWorktreeId: "worktree-1",
-                updatedAt: "2026-07-14T12:01:00.000Z",
+                updatedAt: "2026-07-14T12:01:00.123456700Z",
                 worktrees: [
                     createWorktree("project-1:primary", "main", true),
                     createWorktree("worktree-1", "feature/current"),
@@ -43,7 +43,7 @@ describe("git-store history", () => {
         useGitStore.getState().ingestSnapshot(
             createSnapshot({
                 currentWorktreeId: "worktree-2",
-                updatedAt: "2026-07-14T12:02:00.000Z",
+                updatedAt: "2026-07-14T12:01:00.123789900Z",
                 worktrees: [
                     createWorktree("project-1:primary", "main", true),
                     createWorktree("worktree-2", "feature/new"),
@@ -53,7 +53,7 @@ describe("git-store history", () => {
         useGitStore.getState().ingestSnapshot(
             createSnapshot({
                 currentWorktreeId: "worktree-1",
-                updatedAt: "2026-07-14T12:01:00.000Z",
+                updatedAt: "2026-07-14T12:01:00.123456700Z",
                 worktrees: [
                     createWorktree("project-1:primary", "main", true),
                     createWorktree("worktree-1", "feature/stale"),

--- a/src/renderer/src/app/store/git-store.ts
+++ b/src/renderer/src/app/store/git-store.ts
@@ -1395,7 +1395,56 @@ function isSnapshotNewerThanWorktreeInventory(
         return true;
     }
 
-    return Date.parse(snapshot.updatedAt) > Date.parse(currentUpdatedAt);
+    const snapshotTimestamp = rfc3339TimestampToNanoseconds(snapshot.updatedAt);
+    const currentTimestamp = rfc3339TimestampToNanoseconds(currentUpdatedAt);
+    if (snapshotTimestamp === null || currentTimestamp === null) {
+        return snapshot.updatedAt > currentUpdatedAt;
+    }
+
+    return snapshotTimestamp > currentTimestamp;
+}
+
+function rfc3339TimestampToNanoseconds(timestamp: string): bigint | null {
+    const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/.exec(
+        timestamp,
+    );
+    if (!match) {
+        return null;
+    }
+
+    const [
+        ,
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        fraction = "",
+        timezone,
+    ] = match;
+    const timezoneOffsetMinutes =
+        timezone === "Z"
+            ? 0
+            : (Number(timezone.slice(1, 3)) * 60 +
+                  Number(timezone.slice(4, 6))) *
+              (timezone.startsWith("+") ? 1 : -1);
+    const milliseconds =
+        Date.UTC(
+            Number(year),
+            Number(month) - 1,
+            Number(day),
+            Number(hour),
+            Number(minute),
+            Number(second),
+        ) -
+        timezoneOffsetMinutes * 60_000;
+    if (!Number.isFinite(milliseconds)) {
+        return null;
+    }
+
+    const nanoseconds = BigInt(`${fraction}000000000`.slice(0, 9));
+    return BigInt(milliseconds) * 1_000_000n + nanoseconds;
 }
 
 function clearCleanWorktreeDiffState(

--- a/src/renderer/src/app/store/git-store.ts
+++ b/src/renderer/src/app/store/git-store.ts
@@ -100,6 +100,11 @@ interface GitStoreState {
     readonly selectedDiffPaths: Record<string, string | null>;
     readonly selectedWorktreeDiffFileIds: Record<string, string | null>;
     readonly snapshots: Record<string, GitRepositorySnapshot | null>;
+    readonly worktreeInventoryUpdatedAtByProject: Record<string, string>;
+    readonly worktreesByProject: Record<
+        string,
+        readonly GitWorktreeSummary[]
+    >;
     readonly worktreeDiffRequestKeysByContext: Record<string, string>;
     readonly worktreeDiffsByContext: Record<
         string,
@@ -301,6 +306,8 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
     selectedDiffPaths: {},
     selectedWorktreeDiffFileIds: {},
     snapshots: {},
+    worktreeInventoryUpdatedAtByProject: {},
+    worktreesByProject: {},
     worktreeDiffRequestKeysByContext: {},
     worktreeDiffsByContext: {},
     collapsedWorktreeDiffFileIds: {},
@@ -523,6 +530,10 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
             const nextSelectedBranchesByContext = {
                 ...state.selectedBranchNamesByContext,
             };
+            const nextWorktreeInventoryUpdatedAtByProject = {
+                ...state.worktreeInventoryUpdatedAtByProject,
+            };
+            const nextWorktreesByProject = { ...state.worktreesByProject };
 
             for (const [projectId, snapshot] of snapshots) {
                 const snapshotWorktreeId =
@@ -551,6 +562,17 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
                     snapshot?.branch?.name ?? null;
                 nextSelectedBranchesByContext[contextKey] =
                     snapshot?.branch?.name ?? null;
+                if (
+                    snapshot &&
+                    isSnapshotNewerThanWorktreeInventory(
+                        snapshot,
+                        nextWorktreeInventoryUpdatedAtByProject[projectId],
+                    )
+                ) {
+                    nextWorktreeInventoryUpdatedAtByProject[projectId] =
+                        snapshot.updatedAt;
+                    nextWorktreesByProject[projectId] = snapshot.worktrees;
+                }
             }
 
             return {
@@ -562,6 +584,9 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
                 selectedBranchNames: nextSelectedBranches,
                 selectedBranchNamesByContext: nextSelectedBranchesByContext,
                 snapshots: nextSnapshots,
+                worktreeInventoryUpdatedAtByProject:
+                    nextWorktreeInventoryUpdatedAtByProject,
+                worktreesByProject: nextWorktreesByProject,
             };
         });
 
@@ -1274,71 +1299,103 @@ function applySnapshotState(
     const contextKey = getContextKey(projectId, snapshot.currentWorktreeId);
     const hasWorktreeChanges = snapshot.changedPaths.length > 0;
 
-    set((state) => ({
-        activeWorktreeIds: {
-            ...state.activeWorktreeIds,
-            [projectId]: resolveSnapshotWorktreeId(
+    set((state) => {
+        const shouldUpdateWorktreeInventory =
+            isSnapshotNewerThanWorktreeInventory(
                 snapshot,
-                state.activeWorktreeIds[projectId] ?? null,
-            ),
-        },
-        branchesByProject: {
-            ...state.branchesByProject,
-            [projectId]: snapshot.branches,
-        },
-        errors: {
-            ...state.errors,
-            [contextKey]: null,
-        },
-        expandedChangeGroups: {
-            ...state.expandedChangeGroups,
-            [contextKey]:
-                state.expandedChangeGroups[contextKey] ?? DEFAULT_CHANGE_GROUPS,
-        },
-        expandedProjects: {
-            ...state.expandedProjects,
-            [projectId]: state.expandedProjects[projectId] ?? true,
-        },
-        expandedBranchSections: {
-            ...state.expandedBranchSections,
-            [projectId]: state.expandedBranchSections[projectId] ?? true,
-        },
-        expandedWorktreeSections: {
-            ...state.expandedWorktreeSections,
-            [projectId]: state.expandedWorktreeSections[projectId] ?? true,
-        },
-        loadingContexts: {
-            ...state.loadingContexts,
-            [contextKey]: false,
-        },
-        panelTabs: {
-            ...state.panelTabs,
-            [contextKey]: state.panelTabs[contextKey] ?? "changes",
-        },
-        selectedBranchNames: {
-            ...state.selectedBranchNames,
-            [projectId]: snapshot.branch?.name ?? null,
-        },
-        selectedBranchNamesByContext: {
-            ...state.selectedBranchNamesByContext,
-            [contextKey]: snapshot.branch?.name ?? null,
-        },
-        selectedDiffPaths: {
-            ...state.selectedDiffPaths,
-            [contextKey]: snapshot.changedPaths.includes(
-                state.selectedDiffPaths[contextKey] ?? "",
-            )
-                ? (state.selectedDiffPaths[contextKey] ?? null)
-                : (snapshot.changedPaths[0] ?? null),
-        },
-        snapshots: {
-            ...state.snapshots,
-            [contextKey]: snapshot,
-        },
-        ...(hasWorktreeChanges
-            ? {}
-            : clearCleanWorktreeDiffState(state, contextKey)),
-    }));
+                state.worktreeInventoryUpdatedAtByProject[projectId],
+            );
+
+        return {
+            activeWorktreeIds: {
+                ...state.activeWorktreeIds,
+                [projectId]: resolveSnapshotWorktreeId(
+                    snapshot,
+                    state.activeWorktreeIds[projectId] ?? null,
+                ),
+            },
+            branchesByProject: {
+                ...state.branchesByProject,
+                [projectId]: snapshot.branches,
+            },
+            errors: {
+                ...state.errors,
+                [contextKey]: null,
+            },
+            expandedChangeGroups: {
+                ...state.expandedChangeGroups,
+                [contextKey]:
+                    state.expandedChangeGroups[contextKey] ??
+                    DEFAULT_CHANGE_GROUPS,
+            },
+            expandedProjects: {
+                ...state.expandedProjects,
+                [projectId]: state.expandedProjects[projectId] ?? true,
+            },
+            expandedBranchSections: {
+                ...state.expandedBranchSections,
+                [projectId]: state.expandedBranchSections[projectId] ?? true,
+            },
+            expandedWorktreeSections: {
+                ...state.expandedWorktreeSections,
+                [projectId]: state.expandedWorktreeSections[projectId] ?? true,
+            },
+            loadingContexts: {
+                ...state.loadingContexts,
+                [contextKey]: false,
+            },
+            panelTabs: {
+                ...state.panelTabs,
+                [contextKey]: state.panelTabs[contextKey] ?? "changes",
+            },
+            selectedBranchNames: {
+                ...state.selectedBranchNames,
+                [projectId]: snapshot.branch?.name ?? null,
+            },
+            selectedBranchNamesByContext: {
+                ...state.selectedBranchNamesByContext,
+                [contextKey]: snapshot.branch?.name ?? null,
+            },
+            selectedDiffPaths: {
+                ...state.selectedDiffPaths,
+                [contextKey]: snapshot.changedPaths.includes(
+                    state.selectedDiffPaths[contextKey] ?? "",
+                )
+                    ? (state.selectedDiffPaths[contextKey] ?? null)
+                    : (snapshot.changedPaths[0] ?? null),
+            },
+            snapshots: {
+                ...state.snapshots,
+                [contextKey]: snapshot,
+            },
+            ...(shouldUpdateWorktreeInventory
+                ? {
+                      worktreeInventoryUpdatedAtByProject: {
+                          ...state.worktreeInventoryUpdatedAtByProject,
+                          [projectId]: snapshot.updatedAt,
+                      },
+                      worktreesByProject: {
+                          ...state.worktreesByProject,
+                          [projectId]: snapshot.worktrees,
+                      },
+                  }
+                : {}),
+            ...(hasWorktreeChanges
+                ? {}
+                : clearCleanWorktreeDiffState(state, contextKey)),
+        };
+    });
+}
+
+function isSnapshotNewerThanWorktreeInventory(
+    snapshot: GitRepositorySnapshot,
+    currentUpdatedAt: string | undefined,
+): boolean {
+    if (!currentUpdatedAt) {
+        return true;
+    }
+
+    return Date.parse(snapshot.updatedAt) > Date.parse(currentUpdatedAt);
 }
 
 function clearCleanWorktreeDiffState(

--- a/src/renderer/src/components/ProjectContextMenu.tsx
+++ b/src/renderer/src/components/ProjectContextMenu.tsx
@@ -61,8 +61,11 @@ export function ProjectContextMenu({
     const [worktreeSubmitting, setWorktreeSubmitting] = useState(false);
     const normalizedQuery = query.trim().toLowerCase();
     const searchRef = useRef<HTMLInputElement | null>(null);
+    const hasRevalidatedInventoryRef = useRef(false);
     const projectSummaries = useProjectsStore((state) => state.projects);
     const gitSnapshots = useGitStore((state) => state.snapshots);
+    const refreshGitProject = useGitStore((state) => state.refreshProject);
+    const worktreesByProject = useGitStore((state) => state.worktreesByProject);
     const createWorktree = useGitStore((state) => state.createWorktree);
     const openContext = useWorkspaceStore((state) => state.openContext);
     const filteredProjects = useMemo(
@@ -111,6 +114,18 @@ export function ProjectContextMenu({
     useEffect(() => {
         searchRef.current?.focus();
     }, []);
+
+    useEffect(() => {
+        if (hasRevalidatedInventoryRef.current) {
+            return;
+        }
+
+        hasRevalidatedInventoryRef.current = true;
+        // Keep the visible inventory responsive while refreshing stale Git state.
+        for (const project of projects) {
+            void refreshGitProject(project.id);
+        }
+    }, [projects, refreshGitProject]);
 
     useEffect(() => {
         setSelectedIndex((currentIndex) =>
@@ -205,6 +220,9 @@ export function ProjectContextMenu({
     const worktreeSnapshot = worktreeProject
         ? findProjectSnapshot(gitSnapshots, worktreeProject.id)
         : null;
+    const worktreeInventory = worktreeProject
+        ? worktreesByProject[worktreeProject.id]
+        : undefined;
     const worktreeBaseBranch = resolveWorktreeBaseBranch(worktreeSnapshot);
 
     const handleCreateWorktree = async () => {
@@ -226,7 +244,7 @@ export function ProjectContextMenu({
                 path: buildSuggestedWorktreePath(
                     worktreeProjectSummary.rootPath,
                     branchName,
-                    worktreeSnapshot.worktrees,
+                    worktreeInventory ?? worktreeSnapshot.worktrees,
                 ),
                 projectId: worktreeProject.id,
                 startPoint: worktreeBaseBranch,

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -348,6 +348,9 @@ export function SidebarGitScopePicker({
             ? (state.branchesByProject[projectId] ?? EMPTY_BRANCHES)
             : EMPTY_BRANCHES,
     );
+    const projectWorktrees = useGitStore((state) =>
+        projectId ? state.worktreesByProject[projectId] : undefined,
+    );
     const gitContextKey = projectId
         ? getGitContextKey(projectId, worktreeId)
         : null;
@@ -370,15 +373,16 @@ export function SidebarGitScopePicker({
     const removeWorktree = useGitStore((state) => state.removeWorktree);
     const openContext = useWorkspaceStore((state) => state.openContext);
 
+    const worktrees = projectWorktrees ?? snapshot?.worktrees ?? EMPTY_WORKTREES;
     const activeWorktree =
-        snapshot?.worktrees.find(
+        worktrees.find(
             (entry) =>
                 projectId
                     ? isGitScopeWorktreeActive(projectId, worktreeId, entry)
                     : entry.id === worktreeId,
         ) ??
-        snapshot?.worktrees.find((entry) => entry.isCurrent) ??
-        snapshot?.worktrees.find((entry) => entry.isPrimary) ??
+        worktrees.find((entry) => entry.isCurrent) ??
+        worktrees.find((entry) => entry.isPrimary) ??
         null;
     const canInitializeGit = snapshot?.repositoryState === "not_repo";
     const contextualActiveBranchName =
@@ -390,7 +394,6 @@ export function SidebarGitScopePicker({
     const activeRootPath =
         activeWorktree?.rootPath ?? snapshot?.rootPath ?? null;
     const availableBranches = branches.length;
-    const worktrees = snapshot?.worktrees ?? EMPTY_WORKTREES;
     const availableWorktrees = worktrees.length;
     const deferredQuery = useDeferredValue(query);
     const topologyRequestKey = useMemo(

--- a/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@shared/ipc";
 
 import {
+    EMPTY_GITHUB_LIST,
     getGitHubPullRequestChecksKey,
     getGitHubRepoKey,
     useGitHubStore,
@@ -87,7 +88,7 @@ export function GitHubPullRequestTabView({
         (state) => state.authStatusByHost[repo.host] ?? null,
     );
     const labels = useGitHubStore(
-        (state) => state.labelsByRepo[repoKey] ?? [],
+        (state) => state.labelsByRepo[repoKey] ?? EMPTY_GITHUB_LIST,
     );
     const commentMutatingKeys = useGitHubStore((state) => state.mutatingKeys);
     const commentErrors = useGitHubStore((state) => state.errors);


### PR DESCRIPTION
## Summary

- keep one authoritative worktree inventory per project and reject stale snapshots
- render workspace tabs and Git scope pickers from that inventory
- revalidate project Git state when opening the switcher
- invalidate the inventory for `.git/worktrees/**` changes

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec vitest run src/renderer/src/app/store/git-store.test.ts src/renderer/src/components/ProjectContextMenu.test.tsx src/renderer/src/components/sidebar/SidebarGitScopePicker.test.ts`
- `cargo test -p comando-fs policy::tests`

Closes #118.