### PR TITLE
Refine chat content layout

### DIFF
--- a/src/renderer/src/components/workspace/chat/chatContentLayout.ts
+++ b/src/renderer/src/components/workspace/chat/chatContentLayout.ts
@@ -1,1 +1,1 @@
-export const CHAT_CONTENT_MAX_WIDTH_PX = 740;
+export const CHAT_CONTENT_MAX_WIDTH_PX = 600;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1131,6 +1131,12 @@ body {
     background: color-mix(in srgb, var(--color-bg-tertiary) 68%, transparent);
 }
 
+/* Keep chat code fences readable without letting short snippets span the pane. */
+.chat-assistant-content > .markdown-code-frame {
+    inline-size: min(100%, 68ch);
+    margin-inline: auto;
+}
+
 .markdown-code-header {
     display: flex;
     min-height: 2.45em;


### PR DESCRIPTION
## Summary

- Align the chat content width with the 600px layout used in NeverWrite.
- Center assistant code fences and limit them to a readable 68ch measure.
- Preserve full-width fences in narrow chat panes and leave Markdown file previews unchanged.

## Testing

- `pnpm exec vitest run src/renderer/src/components/workspace/MarkdownContent.test.ts`