### PR TITLE
Group thinking inside the chat activity rail

### DIFF
--- a/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatHistoryTabView.tsx
@@ -1989,6 +1989,9 @@ function HistoryTimelineRow({
         return (
             <ToolActivitySegment
                 canRenderFileReference={handlers.canRenderFileReference}
+                chatFontFamily={handlers.chatFontFamily}
+                chatFontSize={handlers.chatFontSize}
+                highlightQuery={handlers.highlightQuery}
                 onOpenFile={handlers.onOpenFile}
                 onOpenFileReference={handlers.onOpenResolvedFileReference}
                 onOpenSession={handlers.onOpenSession}

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -3106,10 +3106,14 @@ const ChatTimelineRowView = memo(function ChatTimelineRowView({
             <div className="min-w-0 w-full">
                 <ToolActivitySegment
                     canRenderFileReference={canRenderFileReference}
+                    chatFontFamily={chatFontFamily}
+                    chatFontSize={chatFontSize}
                     isCurrentTurnTail={isCurrentTurnTail}
+                    onAddFileReferenceToChat={onAddFileReferenceToChat}
                     onOpenFile={onOpenFile}
                     onOpenFileReference={onOpenResolvedFileReference}
                     onOpenSession={onOpenSession}
+                    onRevealFileReference={onRevealFileReference}
                     projectId={projectId}
                     resolveFileReference={resolveFileReference}
                     segment={row}

--- a/src/renderer/src/components/workspace/chat/ChatMessageRow.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatMessageRow.tsx
@@ -920,18 +920,7 @@ function UserInputRequestMessage({
     );
 }
 
-function ThinkingMessage({
-    canRenderFileReference,
-    chatFontFamily,
-    chatFontSize,
-    content,
-    highlightQuery,
-    inProgress,
-    onAddFileReferenceToChat,
-    onOpenFile,
-    onRevealFileReference,
-    resolveFileReference,
-}: {
+export interface ThinkingMessageProps {
     readonly canRenderFileReference?: (
         rawReference: string,
         reference: ResolvedProjectFileReference,
@@ -951,7 +940,20 @@ function ThinkingMessage({
     readonly resolveFileReference: (
         reference: string,
     ) => ResolvedProjectFileReference | null;
-}) {
+}
+
+export function ThinkingMessage({
+    canRenderFileReference,
+    chatFontFamily,
+    chatFontSize,
+    content,
+    highlightQuery,
+    inProgress,
+    onAddFileReferenceToChat,
+    onOpenFile,
+    onRevealFileReference,
+    resolveFileReference,
+}: ThinkingMessageProps) {
     const [expanded, setExpanded] = useState(false);
     return (
         <div className="min-w-0 max-w-full">

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -175,18 +175,20 @@ function createSegmentRow(entryCount = 1): ChatTimelineRow {
     );
     const firstActivity = activities[0];
     const latestActivity = activities.at(-1)!;
+    const entries = activities.map((activity) => ({
+        policy: "groupable" as const,
+        reviewEntry: {
+            activity,
+            hasPendingTrackedFiles: false,
+            pendingTrackedFiles: [],
+            trackedFiles: [],
+        },
+    }));
 
     return {
-        entries: activities.map((activity) => ({
-            policy: "groupable",
-            reviewEntry: {
-                activity,
-                hasPendingTrackedFiles: false,
-                pendingTrackedFiles: [],
-                trackedFiles: [],
-            },
-        })),
+        entries,
         id: "activity-segment:session-1:read-1",
+        items: entries.map((entry) => ({ entry, kind: "tool" })),
         kind: "activity-segment",
         summary: {
             actionCount: entryCount,

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
@@ -215,6 +215,34 @@ describe("ToolActivitySegment", () => {
         expect(container.textContent).toContain("Thinking");
     });
 
+    it("forwards the transcript search query to thinking content", () => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        mountedRoots.push(root);
+        act(() => {
+            root.render(
+                <ToolActivitySegment
+                    {...DEFAULT_PROPS}
+                    highlightQuery="activity"
+                    segment={createThinkingSegment()}
+                />,
+            );
+        });
+        act(() => {
+            container
+                .querySelector("button")
+                ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+        act(() => {
+            container
+                .querySelectorAll("button")[1]
+                ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+
+        expect(container.querySelector("mark")?.textContent).toBe("activity");
+    });
+
     it("keeps a single action compact while naming it in the summary", () => {
         const segment = createSegment(
             [

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
@@ -4,7 +4,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { AiToolActivity } from "@shared/ipc";
+import type { AiMessage, AiToolActivity } from "@shared/ipc";
 import {
     resetSettingsStoreForTests,
     useSettingsStore,
@@ -105,6 +105,7 @@ function createSegment(
     return {
         entries,
         id: `activity-segment:session-1:${first.id}`,
+        items: entries.map((entry) => ({ entry, kind: "tool" as const })),
         kind: "activity-segment",
         summary: {
             actionCount: entries.length,
@@ -138,9 +139,45 @@ function createEntry(
     };
 }
 
+function createThinkingSegment(
+    status: AiMessage["status"] = "completed",
+): ChatTimelineActivitySegmentRow {
+    const message: AiMessage = {
+        attachments: [],
+        content: "Inspect the activity model before changing it.",
+        createdAt: "2026-07-10T00:00:01.000Z",
+        id: "thinking-1",
+        kind: "thinking",
+        status,
+    };
+    return {
+        entries: [],
+        id: "activity-segment:thinking:thinking-1",
+        items: [{ kind: "thinking", message }],
+        kind: "activity-segment",
+        summary: {
+            actionCount: 0,
+            changeCount: 0,
+            changedFileCount: 0,
+            commandCount: 0,
+            failureCount: 0,
+            fileCount: 0,
+            hiddenActivityCount: 0,
+            isInProgress: status === "streaming",
+            latestActivityId: message.id,
+            latestTitle: status === "streaming" ? "Thinking..." : "Thinking",
+            searchCount: 0,
+            startedAt: message.createdAt,
+            updatedAt: message.createdAt,
+        },
+    };
+}
+
 const DEFAULT_PROPS = {
     onOpenFile: async () => {},
+    onOpenFileReference: () => {},
     projectId: "project-1",
+    resolveFileReference: () => null,
     worktreeId: null,
 };
 
@@ -161,6 +198,23 @@ function renderInteractive(segment: ChatTimelineActivitySegmentRow) {
 }
 
 describe("ToolActivitySegment", () => {
+    it("renders thinking-only work as an expandable activity rail", () => {
+        const container = renderInteractive(createThinkingSegment());
+        expect(container.textContent).toContain("Thought");
+        expect(container.querySelector("[data-thinking-message-id]")).toBeNull();
+
+        const railButton = container.querySelector("button");
+        act(() => {
+            railButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+        expect(
+            container
+                .querySelector("[data-thinking-message-id]")
+                ?.getAttribute("data-thinking-message-id"),
+        ).toBe("thinking-1");
+        expect(container.textContent).toContain("Thinking");
+    });
+
     it("keeps a single action compact while naming it in the summary", () => {
         const segment = createSegment(
             [
@@ -288,7 +342,7 @@ describe("ToolActivitySegment", () => {
             container
                 .querySelector('[role="region"]')
                 ?.getAttribute("aria-label"),
-        ).toBe("Full tool activity");
+        ).toBe("Full activity");
     });
 
     it("keeps a large safe burst DOM-bounded while collapsed", () => {
@@ -328,7 +382,7 @@ describe("ToolActivitySegment", () => {
             container
                 .querySelector('[role="region"]')
                 ?.getAttribute("aria-label"),
-        ).toBe("Full tool activity");
+        ).toBe("Full activity");
     });
 
     it("uses the AI setting as the initial state without overriding manual changes", () => {

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
@@ -12,6 +12,10 @@ import {
     ToolActivityItem,
     type ToolActivityItemProps,
 } from "./ToolActivityItem";
+import {
+    ThinkingMessage,
+    type ThinkingMessageProps,
+} from "./ChatMessageRow";
 import { usePersistentToolExpansion } from "./toolExpansionStore";
 
 type ToolActivitySegmentProps = Pick<
@@ -27,7 +31,13 @@ type ToolActivitySegmentProps = Pick<
     /** True only while this segment is the trailing activity of an active turn. */
     readonly isCurrentTurnTail?: boolean;
     readonly segment: ChatTimelineActivitySegmentRow;
-};
+} & Pick<
+        ThinkingMessageProps,
+        | "chatFontFamily"
+        | "chatFontSize"
+        | "onAddFileReferenceToChat"
+        | "onRevealFileReference"
+    >;
 
 function pluralize(count: number, singular: string, plural = `${singular}s`) {
     return `${count} ${count === 1 ? singular : plural}`;
@@ -38,6 +48,9 @@ function getSegmentHeadline(
     isCurrentTurnTail: boolean,
 ): string {
     const { summary } = segment;
+    if (summary.actionCount === 0) {
+        return isCurrentTurnTail ? "Thinking..." : "Thought";
+    }
     const details = [
         pluralize(summary.actionCount, "action"),
         summary.changedFileCount > 0
@@ -79,7 +92,13 @@ function getSegmentHeadline(
 function getLatestActivityLabel(
     segment: ChatTimelineActivitySegmentRow,
 ): string {
-    const latestActivity = segment.entries.at(-1)?.reviewEntry.activity;
+    const latestItem = segment.items.at(-1);
+    if (latestItem?.kind === "thinking") {
+        return latestItem.message.status === "streaming"
+            ? "Thinking..."
+            : "Thinking";
+    }
+    const latestActivity = latestItem?.entry.reviewEntry.activity;
     if (!latestActivity) {
         return segment.summary.latestTitle;
     }
@@ -114,9 +133,13 @@ function Chevron({ expanded }: { readonly expanded: boolean }) {
 
 export const ToolActivitySegment = memo(function ToolActivitySegment({
     canRenderFileReference,
+    chatFontFamily,
+    chatFontSize,
+    onAddFileReferenceToChat,
     onOpenFile,
     onOpenFileReference,
     onOpenSession,
+    onRevealFileReference,
     projectId,
     resolveFileReference,
     isCurrentTurnTail = false,
@@ -131,7 +154,7 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
         `${segment.id}:full-activity:${defaultExpansion}`,
         defaultExpanded,
     );
-    const canExpand = segment.entries.length > 0;
+    const canExpand = segment.items.length > 0;
     const contentId = `${segment.id}:activity`;
     const headline = getSegmentHeadline(segment, isCurrentTurnTail);
     const isWorkedSegment = headline.startsWith("Worked ·");
@@ -141,7 +164,11 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
         [segment.entries],
     );
     const hasChanges = segment.summary.changeCount > 0;
-    const visibleEntries = expanded ? segment.entries : [];
+    const visibleItems = expanded ? segment.items : [];
+    const openThinkingFileReference =
+        onOpenFileReference ?? (() => undefined);
+    const resolveThinkingFileReference =
+        resolveFileReference ?? (() => null);
     const activityState = isCurrentTurnTail
         ? "In progress"
         : "Completed";
@@ -249,9 +276,9 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                 </div>
             )}
 
-            {visibleEntries.length > 0 ? (
+            {visibleItems.length > 0 ? (
                 <div
-                    aria-label="Full tool activity"
+                    aria-label="Full activity"
                     className="pt-1"
                     id={contentId}
                     role="region"
@@ -260,16 +287,29 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                         className="activity-tree flex min-w-0 flex-col gap-1.5"
                         role="list"
                     >
-                        {visibleEntries.map(({ policy, reviewEntry }) => {
-                            const atomicRowId = `tool:${reviewEntry.activity.sessionId}:${reviewEntry.activity.id}`;
+                        {visibleItems.map((item) => {
+                            const atomicRowId =
+                                item.kind === "thinking"
+                                    ? `thinking:${item.message.id}`
+                                    : `tool:${item.entry.reviewEntry.activity.sessionId}:${item.entry.reviewEntry.activity.id}`;
                             return (
                                 <div
                                     className="activity-tree-branch min-w-0 pl-10"
                                     data-activity-rail-decoration="branch"
                                     data-activity-rail-indent="child"
-                                    data-tool-activity-id={reviewEntry.activity.id}
+                                    data-thinking-message-id={
+                                        item.kind === "thinking"
+                                            ? item.message.id
+                                            : undefined
+                                    }
+                                    data-tool-activity-id={
+                                        item.kind === "tool"
+                                            ? item.entry.reviewEntry.activity.id
+                                            : undefined
+                                    }
                                     data-tool-activity-visibility={
-                                        policy === "groupable"
+                                        item.kind === "tool" &&
+                                        item.entry.policy === "groupable"
                                             ? "expanded-only"
                                             : "always"
                                     }
@@ -277,23 +317,47 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                                     role="listitem"
                                 >
                                     <div className="min-w-0 py-0.5">
-                                        <ToolActivityItem
-                                            activity={reviewEntry.activity}
-                                            canRenderFileReference={canRenderFileReference}
-                                            compactTerminal
-                                            onOpenFile={onOpenFile}
-                                            onOpenFileReference={onOpenFileReference}
-                                            onOpenSession={onOpenSession}
-                                            projectId={projectId}
-                                            resolveFileReference={resolveFileReference}
-                                            surface={
-                                                policy === "standalone-change"
-                                                    ? "card"
-                                                    : "rail-row"
-                                            }
-                                            trackedFiles={reviewEntry.trackedFiles}
-                                            worktreeId={worktreeId}
-                                        />
+                                        {item.kind === "thinking" ? (
+                                            <ThinkingMessage
+                                                canRenderFileReference={canRenderFileReference}
+                                                chatFontFamily={chatFontFamily}
+                                                chatFontSize={chatFontSize}
+                                                content={item.message.content}
+                                                inProgress={
+                                                    item.message.status ===
+                                                    "streaming"
+                                                }
+                                                onAddFileReferenceToChat={onAddFileReferenceToChat}
+                                                onOpenFile={openThinkingFileReference}
+                                                onRevealFileReference={onRevealFileReference}
+                                                resolveFileReference={resolveThinkingFileReference}
+                                            />
+                                        ) : (
+                                            <ToolActivityItem
+                                                activity={
+                                                    item.entry.reviewEntry
+                                                        .activity
+                                                }
+                                                canRenderFileReference={canRenderFileReference}
+                                                compactTerminal
+                                                onOpenFile={onOpenFile}
+                                                onOpenFileReference={onOpenFileReference}
+                                                onOpenSession={onOpenSession}
+                                                projectId={projectId}
+                                                resolveFileReference={resolveFileReference}
+                                                surface={
+                                                    item.entry.policy ===
+                                                    "standalone-change"
+                                                        ? "card"
+                                                        : "rail-row"
+                                                }
+                                                trackedFiles={
+                                                    item.entry.reviewEntry
+                                                        .trackedFiles
+                                                }
+                                                worktreeId={worktreeId}
+                                            />
+                                        )}
                                     </div>
                                 </div>
                             );

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
@@ -35,6 +35,7 @@ type ToolActivitySegmentProps = Pick<
         ThinkingMessageProps,
         | "chatFontFamily"
         | "chatFontSize"
+        | "highlightQuery"
         | "onAddFileReferenceToChat"
         | "onRevealFileReference"
     >;
@@ -135,6 +136,7 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
     canRenderFileReference,
     chatFontFamily,
     chatFontSize,
+    highlightQuery,
     onAddFileReferenceToChat,
     onOpenFile,
     onOpenFileReference,
@@ -323,6 +325,7 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                                                 chatFontFamily={chatFontFamily}
                                                 chatFontSize={chatFontSize}
                                                 content={item.message.content}
+                                                highlightQuery={highlightQuery}
                                                 inProgress={
                                                     item.message.status ===
                                                     "streaming"

--- a/src/renderer/src/components/workspace/chat/chatTimelineModel.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineModel.test.ts
@@ -663,6 +663,104 @@ describe("chatTimelineModel", () => {
 });
 
 describe("chatTimelineModel activity segments", () => {
+    it("keeps thinking and surrounding tools in one chronological segment", () => {
+        const model = reconcileChatTimelineModel(null, {
+            messages: [
+                createMessage({
+                    content: "I should inspect the implementation.",
+                    createdAt: "2026-04-14T00:00:02.000Z",
+                    id: "thinking-1",
+                    kind: "thinking",
+                }),
+            ],
+            status: "idle",
+            toolActivity: [
+                createReadActivity("read-1", "2026-04-14T00:00:01.000Z"),
+                createReadActivity("read-2", "2026-04-14T00:00:03.000Z"),
+            ],
+            trackedFiles: [],
+        });
+
+        expect(model.orderedRows).toHaveLength(1);
+        const segment = model.orderedRows[0];
+        expect(segment?.kind).toBe("activity-segment");
+        if (segment?.kind !== "activity-segment") {
+            throw new Error("Expected an activity segment row.");
+        }
+        expect(segment.items.map((item) => item.kind)).toEqual([
+            "tool",
+            "thinking",
+            "tool",
+        ]);
+        expect(segment.entries).toHaveLength(2);
+        expect(segment.summary.actionCount).toBe(2);
+    });
+
+    it("keeps a thinking-first segment stable when the first tool arrives", () => {
+        const thinking = createMessage({
+            content: "Inspecting the project.",
+            createdAt: "2026-04-14T00:00:01.000Z",
+            id: "thinking-1",
+            kind: "thinking",
+            status: "streaming",
+        });
+        const initialModel = reconcileChatTimelineModel(null, {
+            messages: [thinking],
+            status: "streaming",
+            toolActivity: [],
+            trackedFiles: [],
+        });
+        const nextModel = reconcileChatTimelineModel(initialModel, {
+            messages: [{ ...thinking, status: "completed" }],
+            status: "streaming",
+            toolActivity: [
+                createReadActivity("read-1", "2026-04-14T00:00:02.000Z"),
+            ],
+            trackedFiles: [],
+        });
+
+        expect(initialModel.orderedRowIds).toEqual([
+            "activity-segment:thinking:thinking-1",
+        ]);
+        expect(nextModel.orderedRowIds).toEqual(initialModel.orderedRowIds);
+        expect(nextModel.liveTailRowId).toBe(
+            "activity-segment:thinking:thinking-1",
+        );
+        const segment = nextModel.orderedRows[0];
+        expect(segment?.kind).toBe("activity-segment");
+        if (segment?.kind === "activity-segment") {
+            expect(segment.items.map((item) => item.kind)).toEqual([
+                "thinking",
+                "tool",
+            ]);
+            expect(segment.summary.actionCount).toBe(1);
+        }
+    });
+
+    it("still uses assistant messages as activity boundaries", () => {
+        const model = reconcileChatTimelineModel(null, {
+            messages: [
+                createMessage({
+                    content: "I will inspect the next file.",
+                    createdAt: "2026-04-14T00:00:02.000Z",
+                    id: "assistant-1",
+                }),
+            ],
+            status: "idle",
+            toolActivity: [
+                createReadActivity("read-1", "2026-04-14T00:00:01.000Z"),
+                createReadActivity("read-2", "2026-04-14T00:00:03.000Z"),
+            ],
+            trackedFiles: [],
+        });
+
+        expect(model.orderedRowIds).toEqual([
+            "activity-segment:session-1:read-1",
+            "message:assistant-1",
+            "activity-segment:session-1:read-2",
+        ]);
+    });
+
     it("compacts a burst of fifty observations into one presentation row", () => {
         const activities = Array.from({ length: 50 }, (_, index) =>
             createReadActivity(

--- a/src/renderer/src/components/workspace/chat/chatTimelineModel.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineModel.ts
@@ -43,6 +43,16 @@ export interface ToolActivitySegmentEntry {
     readonly reviewEntry: ToolActivityReviewEntry;
 }
 
+export type ActivitySegmentItem =
+    | {
+          readonly entry: ToolActivitySegmentEntry;
+          readonly kind: "tool";
+      }
+    | {
+          readonly kind: "thinking";
+          readonly message: AiSessionSnapshot["messages"][number];
+      };
+
 export interface ToolActivitySegmentSummary {
     readonly actionCount: number;
     readonly changeCount: number;
@@ -62,6 +72,7 @@ export interface ToolActivitySegmentSummary {
 export interface ChatTimelineActivitySegmentRow {
     readonly entries: readonly ToolActivitySegmentEntry[];
     readonly id: string;
+    readonly items: readonly ActivitySegmentItem[];
     readonly kind: "activity-segment";
     readonly summary: ToolActivitySegmentSummary;
 }
@@ -512,12 +523,35 @@ function addPath(paths: string[], path: string | null | undefined): void {
 }
 
 function buildToolActivitySegmentSummary(
-    entries: readonly ToolActivitySegmentEntry[],
+    items: readonly ActivitySegmentItem[],
 ): ToolActivitySegmentSummary {
-    const latestEntry = entries.at(-1);
-    if (!latestEntry) {
+    const latestItem = items.at(-1);
+    if (!latestItem) {
         throw new Error("Tool activity segments require at least one entry.");
     }
+
+    const entries = items.flatMap((item) =>
+        item.kind === "tool" ? [item.entry] : [],
+    );
+    const latestTitle =
+        latestItem.kind === "thinking"
+            ? latestItem.message.status === "streaming"
+                ? "Thinking..."
+                : "Thinking"
+            : latestItem.entry.reviewEntry.activity.title;
+    const latestActivityId =
+        latestItem.kind === "thinking"
+            ? latestItem.message.id
+            : latestItem.entry.reviewEntry.activity.id;
+    const firstItem = items[0] ?? latestItem;
+    const firstCreatedAt =
+        firstItem.kind === "thinking"
+            ? firstItem.message.createdAt
+            : firstItem.entry.reviewEntry.activity.createdAt;
+    const latestUpdatedAt =
+        latestItem.kind === "thinking"
+            ? latestItem.message.createdAt
+            : latestItem.entry.reviewEntry.activity.updatedAt;
 
     const fileTargets: string[] = [];
     const changedFileTargets: string[] = [];
@@ -525,9 +559,7 @@ function buildToolActivitySegmentSummary(
     let commandCount = 0;
     let failureCount = 0;
     let searchCount = 0;
-    let updatedAt =
-        entries[0]?.reviewEntry.activity.updatedAt ??
-        latestEntry.reviewEntry.activity.updatedAt;
+    let updatedAt = latestUpdatedAt;
 
     for (const entry of entries) {
         const { activity, trackedFiles } = entry.reviewEntry;
@@ -581,17 +613,16 @@ function buildToolActivitySegmentSummary(
         failureCount,
         fileCount: fileTargets.length,
         hiddenActivityCount: entries.length,
-        isInProgress: entries.some(
-            (entry) =>
-                entry.reviewEntry.activity.status === "pending" ||
-                entry.reviewEntry.activity.status === "in_progress",
+        isInProgress: items.some((item) =>
+            item.kind === "thinking"
+                ? item.message.status === "streaming"
+                : item.entry.reviewEntry.activity.status === "pending" ||
+                  item.entry.reviewEntry.activity.status === "in_progress",
         ),
-        latestActivityId: latestEntry.reviewEntry.activity.id,
-        latestTitle: latestEntry.reviewEntry.activity.title,
+        latestActivityId,
+        latestTitle,
         searchCount,
-        startedAt:
-            entries[0]?.reviewEntry.activity.createdAt ??
-            latestEntry.reviewEntry.activity.createdAt,
+        startedAt: firstCreatedAt,
         updatedAt,
     };
 }
@@ -620,19 +651,39 @@ function areToolActivitySegmentSummariesEquivalent(
 function reuseToolActivitySegmentRow(
     previousRowById: ReadonlyMap<string, ChatTimelinePresentationRow> | null,
     id: string,
-    entries: readonly ToolActivitySegmentEntry[],
+    items: readonly ActivitySegmentItem[],
 ): ChatTimelineActivitySegmentRow {
-    const summary = buildToolActivitySegmentSummary(entries);
+    const entries = items.flatMap((item) =>
+        item.kind === "tool" ? [item.entry] : [],
+    );
+    const summary = buildToolActivitySegmentSummary(items);
     const previousRow = previousRowById?.get(id);
 
     if (
         previousRow?.kind === "activity-segment" &&
-        previousRow.entries.length === entries.length &&
-        previousRow.entries.every(
-            (entry, index) =>
-                entry.policy === entries[index]?.policy &&
-                entry.reviewEntry === entries[index]?.reviewEntry,
-        ) &&
+        previousRow.items.length === items.length &&
+        previousRow.items.every((item, index) => {
+            const nextItem = items[index];
+            if (!nextItem || item.kind !== nextItem.kind) {
+                return false;
+            }
+            return item.kind === "thinking"
+                ? item.message ===
+                      (nextItem as Extract<
+                          ActivitySegmentItem,
+                          { readonly kind: "thinking" }
+                      >).message
+                : item.entry.policy ===
+                      (nextItem as Extract<
+                          ActivitySegmentItem,
+                          { readonly kind: "tool" }
+                      >).entry.policy &&
+                      item.entry.reviewEntry ===
+                          (nextItem as Extract<
+                              ActivitySegmentItem,
+                              { readonly kind: "tool" }
+                          >).entry.reviewEntry;
+        }) &&
         areToolActivitySegmentSummariesEquivalent(previousRow.summary, summary)
     ) {
         return previousRow;
@@ -641,6 +692,7 @@ function reuseToolActivitySegmentRow(
     return {
         entries,
         id,
+        items,
         kind: "activity-segment",
         summary,
     };
@@ -652,27 +704,35 @@ export function buildChatTimelinePresentationRows(
     previousRowById: ReadonlyMap<string, ChatTimelinePresentationRow> | null = null,
 ): ChatTimelinePresentationRow[] {
     const presentationRows: ChatTimelinePresentationRow[] = [];
-    let segmentEntries: ToolActivitySegmentEntry[] = [];
+    let segmentItems: ActivitySegmentItem[] = [];
     let segmentSessionId: string | null = null;
 
     const flushSegment = () => {
-        const firstEntry = segmentEntries[0];
-        if (!firstEntry || segmentSessionId === null) {
-            segmentEntries = [];
+        const firstItem = segmentItems[0];
+        if (!firstItem) {
+            segmentItems = [];
             segmentSessionId = null;
             return;
         }
 
-        const id = `activity-segment:${segmentSessionId}:${firstEntry.reviewEntry.activity.id}`;
+        const firstItemKey =
+            firstItem.kind === "thinking"
+                ? `thinking:${firstItem.message.id}`
+                : `${firstItem.entry.reviewEntry.activity.sessionId}:${firstItem.entry.reviewEntry.activity.id}`;
+        const id = `activity-segment:${firstItemKey}`;
         presentationRows.push(
-            reuseToolActivitySegmentRow(previousRowById, id, segmentEntries),
+            reuseToolActivitySegmentRow(previousRowById, id, segmentItems),
         );
-        segmentEntries = [];
+        segmentItems = [];
         segmentSessionId = null;
     };
 
     for (const row of atomicRows) {
         if (row.kind === "message") {
+            if (row.message.kind === "thinking") {
+                segmentItems.push({ kind: "thinking", message: row.message });
+                continue;
+            }
             flushSegment();
             presentationRows.push(row);
             continue;
@@ -696,7 +756,8 @@ export function buildChatTimelinePresentationRows(
             flushSegment();
         }
         segmentSessionId = sessionId;
-        segmentEntries.push({ policy, reviewEntry: row.reviewEntry });
+        const entry = { policy, reviewEntry: row.reviewEntry };
+        segmentItems.push({ entry, kind: "tool" });
     }
 
     flushSegment();
@@ -723,13 +784,15 @@ export function findPresentationRowContaining(
         }
         if (
             row.kind === "activity-segment" &&
-            atomicRow.kind === "tool" &&
-            row.entries.some(
-                (entry) =>
-                    entry.reviewEntry.activity.sessionId ===
-                        atomicRow.reviewEntry.activity.sessionId &&
-                    entry.reviewEntry.activity.id ===
-                        atomicRow.reviewEntry.activity.id,
+            row.items.some((item) =>
+                atomicRow.kind === "tool" && item.kind === "tool"
+                    ? item.entry.reviewEntry.activity.sessionId ===
+                          atomicRow.reviewEntry.activity.sessionId &&
+                      item.entry.reviewEntry.activity.id ===
+                          atomicRow.reviewEntry.activity.id
+                    : atomicRow.kind === "message" && item.kind === "thinking"
+                      ? item.message.id === atomicRow.message.id
+                      : false,
             )
         ) {
             return row;

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -546,7 +546,7 @@ describe("chatTimelineVirtualization", () => {
         ).not.toBe(base);
     });
 
-    it("keys tool rows independent of width but messages by width bucket", () => {
+    it("keys tool rows independent of width but messages and thinking rails by width bucket", () => {
         const baseContext = {
             chatFontFamily: "Inter",
             chatFontSize: 13,
@@ -554,9 +554,26 @@ describe("chatTimelineVirtualization", () => {
         };
         const toolRow = createToolRow();
         const messageRow = createMessageRow({ content: "hello" });
+        const thinkingModel = reconcileChatTimelineModel(null, {
+            messages: [
+                createMessage({
+                    content: "A long thought that can reflow when expanded.",
+                    id: "thinking-1",
+                    kind: "thinking",
+                }),
+            ],
+            status: "idle",
+            toolActivity: [],
+            trackedFiles: [],
+        });
+        const thinkingRail = thinkingModel.orderedRows[0];
+        if (!thinkingRail) {
+            throw new Error("Expected a thinking activity rail.");
+        }
 
         expect(isWidthSensitiveChatTimelineRow(toolRow)).toBe(false);
         expect(isWidthSensitiveChatTimelineRow(messageRow)).toBe(true);
+        expect(isWidthSensitiveChatTimelineRow(thinkingRail)).toBe(true);
 
         // A tool card lays out at a width-invariant height, so crossing a width
         // bucket must NOT churn its measurement key — that is what kept the whole
@@ -568,6 +585,17 @@ describe("chatTimelineVirtualization", () => {
             }),
         ).toBe(
             getChatTimelineRowMeasurementKey(toolRow, {
+                ...baseContext,
+                width: 960,
+            }),
+        );
+        expect(
+            getChatTimelineRowMeasurementKey(thinkingRail, {
+                ...baseContext,
+                width: 640,
+            }),
+        ).not.toBe(
+            getChatTimelineRowMeasurementKey(thinkingRail, {
                 ...baseContext,
                 width: 960,
             }),

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.ts
@@ -84,14 +84,14 @@ function getChatTimelineRowLayoutBase(
     ].join(":");
 }
 
-// Only message rows reflow their height with the available width; tool cards
-// lay out at width-invariant heights (fixed-height summaries, internally
-// scrolled diffs). So only messages fold the width bucket into their
-// measurement key — tool rows keep a stable key across a resize and never have
-// their measurement invalidated, which is what let the scroll settle during a
-// drag instead of collapsing the whole cache to rough estimates.
+// Message rows and activity rails containing expandable thinking can reflow
+// with the available width. Tool-only rails remain width-invariant.
 export function isWidthSensitiveChatTimelineRow(row: ChatTimelineRow): boolean {
-    return row.kind === "message";
+    return (
+        row.kind === "message" ||
+        (row.kind === "activity-segment" &&
+            row.items.some((item) => item.kind === "thinking"))
+    );
 }
 
 export function getChatTimelineRowMeasurementKey(
@@ -231,12 +231,12 @@ export function estimateChatTimelineRowHeight(
             return Math.ceil(CHAT_ACTIVITY_RAIL_HEADER_HEIGHT_PX + gapPx);
         }
 
-        const activityHeight = row.entries.reduce(
-            (height, _entry, index) =>
+        const activityHeight = row.items.reduce(
+            (height, item, index) =>
                 height +
-                // Every entry is now a collapsed rail row. Change previews are
-                // mounted only after the row's own disclosure is opened.
-                CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX +
+                (item.kind === "thinking"
+                    ? Math.ceil(28 * getFontScale(context.chatFontSize))
+                    : CHAT_ACTIVITY_RAIL_DENSE_ROW_HEIGHT_PX) +
                 CHAT_ACTIVITY_RAIL_ENTRY_PADDING_Y_PX +
                 (index > 0 ? CHAT_ACTIVITY_RAIL_ENTRY_GAP_PX : 0),
             0,


### PR DESCRIPTION
## Summary

- group thinking messages and tool activity into one chronological activity rail
- render thinking as expandable rail nodes without counting it as a tool action
- preserve stable live-tail identity when a turn begins with thinking
- keep assistant messages as segment boundaries
- update virtualized row measurement for rails with expandable thinking

## Validation

- pnpm run typecheck
- ESLint on all changed files
- pnpm test -- --run (238 files, 2168 passed, 1 skipped)
- git diff --check