### PR TITLE
feat(workspace): restore layouts for closed contexts

### DIFF
--- a/src/main/native-backend/app-data.test.ts
+++ b/src/main/native-backend/app-data.test.ts
@@ -81,7 +81,7 @@ describe("createNativeAppDataClient", () => {
             activeContextKey: null,
             contexts: [],
             openContextKeys: [],
-            version: 2,
+            version: 3,
         });
         const firstWindowId = firstWindow.windowContext?.windowId;
         if (!firstWindowId) {
@@ -408,7 +408,7 @@ function workspaceNavigation(
             },
         ],
         openContextKeys: [key],
-        version: 2,
+        version: 3,
     };
 }
 

--- a/src/main/native-backend/app-data.test.ts
+++ b/src/main/native-backend/app-data.test.ts
@@ -50,10 +50,29 @@ describe("createNativeAppDataClient", () => {
         if (!firstWorkspaceId || !secondWorkspaceId) {
             throw new Error("Expected workspace ids for both windows.");
         }
-        await firstClient.workspace.saveSnapshot(
-            firstWorkspaceId,
-            workspaceNavigation("project-1", null, "pane-a"),
-        );
+        const firstSnapshot = workspaceNavigation("project-1", null, "pane-a");
+        await firstClient.workspace.saveSnapshot(firstWorkspaceId, {
+            ...firstSnapshot,
+            contexts: [
+                ...firstSnapshot.contexts,
+                {
+                    key: "project-1::worktree-closed",
+                    lastActivatedAt: "2026-01-02T00:00:00.000Z",
+                    projectId: "project-1",
+                    workspace: {
+                        activePaneId: "pane-cached",
+                        rootNode: {
+                            activeTabId: null,
+                            id: "pane-cached",
+                            tabIds: [],
+                            type: "pane",
+                        },
+                        tabs: [],
+                    },
+                    worktreeId: "worktree-closed",
+                },
+            ],
+        });
         await firstClient.workspace.saveSnapshot(
             secondWorkspaceId,
             workspaceNavigation("project-2", "worktree-2", "pane-b"),
@@ -69,6 +88,14 @@ describe("createNativeAppDataClient", () => {
 
         expect(firstRestore.revision).toBe(1);
         expect(firstRestore.snapshot.contexts[0]?.workspace.activePaneId).toBe("pane-a");
+        expect(firstRestore.snapshot.openContextKeys).toEqual([
+            "project-1::__primary__",
+        ]);
+        expect(
+            firstRestore.snapshot.contexts.find(
+                (context) => context.key === "project-1::worktree-closed",
+            )?.workspace.activePaneId,
+        ).toBe("pane-cached");
         expect(secondRestore.snapshot.contexts[0]).toMatchObject({
             projectId: "project-2",
             worktreeId: "worktree-2",
@@ -160,7 +187,7 @@ describe("createNativeAppDataClient", () => {
 
         const workspace = await client.workspace.loadSnapshot("workspace-1");
         expect(workspace.schemaVersion).toBe(1);
-        expect(workspace.snapshot.version).toBe(2);
+        expect(workspace.snapshot.version).toBe(3);
         const restoredLayout = workspace.snapshot.contexts[0]?.workspace;
         expect(restoredLayout?.activePaneId).toBe("pane-1");
         expect(restoredLayout?.tabs).toHaveLength(1);

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -339,7 +339,7 @@ describe("workspace file opening", () => {
         expect(persistedSnapshot).toMatchObject({
             activeContextKey: "project-1::__primary__",
             openContextKeys: ["project-1::__primary__"],
-            version: 2,
+            version: 3,
         });
         expect(persistedSnapshot?.contexts).toHaveLength(1);
         expect(persistedSnapshot?.contexts[0]?.workspace.tabs).toEqual([
@@ -368,7 +368,7 @@ describe("workspace file opening", () => {
         expect(snapshot).toMatchObject({
             activeContextKey: "project-1::__primary__",
             openContextKeys: ["project-1::__primary__"],
-            version: 2,
+            version: 3,
         });
         expect(snapshot?.contexts).toHaveLength(1);
         expect(snapshot?.contexts[0]).toMatchObject({

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -21,6 +21,7 @@ import {
     getPaneRuntimeId,
     getWorkspaceChatTabId,
     getWorkspaceTabRuntimeId,
+    pruneClosedWorkspaceContexts,
     resetWorkspacePersistenceForTests,
     useWorkspaceStore,
 } from "./workspace-store";
@@ -396,6 +397,68 @@ describe("workspace file opening", () => {
                 }),
             ],
         });
+    });
+
+    it("keeps open contexts while expiring the oldest closed layout", () => {
+        const workspace = createDefaultWorkspaceState();
+        const contextsByKey = Object.fromEntries(
+            Array.from({ length: 31 }, (_, index) => [
+                `closed-${index}`,
+                {
+                    key: `closed-${index}`,
+                    lastActivatedAt: `2026-01-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+                    projectId: `project-${index}`,
+                    workspace,
+                    worktreeId: null,
+                },
+            ]),
+        );
+        contextsByKey.open = {
+            key: "open",
+            lastActivatedAt: "2020-01-01T00:00:00.000Z",
+            projectId: "open-project",
+            workspace,
+            worktreeId: null,
+        };
+
+        const pruned = pruneClosedWorkspaceContexts(contextsByKey, ["open"]);
+
+        expect(pruned.open).toBeTruthy();
+        expect(pruned["closed-0"]).toBeUndefined();
+        expect(Object.keys(pruned)).toHaveLength(31);
+    });
+
+    it("removes cached layouts when a project is removed", async () => {
+        const workspace = createDefaultWorkspaceState();
+        const remainingContext = {
+            key: "project-2::__primary__",
+            lastActivatedAt: "2026-04-15T00:00:00.000Z",
+            projectId: "project-2",
+            workspace,
+            worktreeId: null,
+        };
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            contextsByKey: {
+                ...state.contextsByKey,
+                [remainingContext.key]: remainingContext,
+                "project-1::worktree-1": {
+                    key: "project-1::worktree-1",
+                    lastActivatedAt: "2026-04-16T00:00:00.000Z",
+                    projectId: "project-1",
+                    workspace,
+                    worktreeId: "worktree-1",
+                },
+            },
+            openContextKeys: ["project-1::__primary__", remainingContext.key],
+        }));
+
+        await useWorkspaceStore.getState().removeProjectTabs("project-1");
+
+        expect(useWorkspaceStore.getState().contextsByKey).toEqual({
+            [remainingContext.key]: remainingContext,
+        });
+        expect(useWorkspaceStore.getState().activeContextKey).toBe(remainingContext.key);
     });
 
     it("reorders workspace contexts without changing the active context", async () => {

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -274,7 +274,7 @@ describe("workspace file opening", () => {
         vi.unstubAllGlobals();
     });
 
-    it("keeps independent layouts for open project contexts", async () => {
+    it("restores a closed project context layout without reopening other contexts", async () => {
         const firstTab = createWorkspaceFileTab("file-project-1", "README.md");
         useWorkspaceStore.setState((state) => ({
             ...state,
@@ -341,10 +341,21 @@ describe("workspace file opening", () => {
             openContextKeys: ["project-1::__primary__"],
             version: 3,
         });
-        expect(persistedSnapshot?.contexts).toHaveLength(1);
-        expect(persistedSnapshot?.contexts[0]?.workspace.tabs).toEqual([
+        expect(persistedSnapshot?.contexts).toHaveLength(2);
+        expect(
+            persistedSnapshot?.contexts.find(
+                (context) => context.key === "project-1::__primary__",
+            )?.workspace.tabs,
+        ).toEqual([
             expect.objectContaining({ id: firstTab.id }),
         ]);
+
+        await useWorkspaceStore.getState().openContext("project-2");
+        expect(useWorkspaceStore.getState().openContextKeys).toEqual([
+            "project-1::__primary__",
+            "project-2::__primary__",
+        ]);
+        expect(useWorkspaceStore.getState().tabsById[secondTab.id]).toBeTruthy();
     });
 
     it("exports one context as a self-contained navigation snapshot", () => {

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -420,7 +420,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 },
             ],
             openContextKeys: [context.key],
-            version: 2,
+            version: 3,
         };
     },
 
@@ -3149,7 +3149,7 @@ function invalidateInactiveContextFileDocuments(
 function isWorkspaceNavigationSnapshot(
     snapshot: PersistedWorkspaceSnapshot,
 ): snapshot is WorkspaceNavigationSnapshot {
-    return "version" in snapshot && snapshot.version === 2;
+    return "version" in snapshot && snapshot.version === 3;
 }
 
 function resolveWorkspaceNavigationSnapshot(
@@ -3191,7 +3191,7 @@ function workspaceStoreToNavigationSnapshot(
                 : null,
         contexts,
         openContextKeys: contexts.map((context) => context.key),
-        version: 2,
+        version: 3,
     };
 }
 

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -501,7 +501,6 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         );
 
         const nextContextsByKey = { ...contextsByKey };
-        delete nextContextsByKey[contextKey];
         const closedIndex = state.openContextKeys.indexOf(contextKey);
         const openContextKeys = state.openContextKeys.filter(
             (key) => key !== contextKey,
@@ -1196,14 +1195,22 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             input.target,
         ),
 
-    openContext: async (projectId, worktreeId = null) => {
+    openContext: async (projectId, worktreeId = null, options = {}) => {
         const normalizedWorktreeId =
             worktreeId === `${projectId}:primary` ? null : worktreeId;
         const contextKey = getProjectContextKey(
             projectId,
             normalizedWorktreeId,
         );
-        if (get().contextsByKey[contextKey]) {
+        const currentState = get();
+        const existingContext = captureVisibleWorkspaceContext(currentState)[contextKey];
+        if (existingContext && !options.emptyLayout) {
+            if (!currentState.openContextKeys.includes(contextKey)) {
+                set((state) => ({
+                    contextsByKey: captureVisibleWorkspaceContext(state),
+                    openContextKeys: [...state.openContextKeys, contextKey],
+                }));
+            }
             await get().activateContext(contextKey);
             return;
         }
@@ -1215,12 +1222,44 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             workspace: createDefaultWorkspaceState(),
             worktreeId: normalizedWorktreeId,
         };
+
+        if (existingContext && currentState.activeContextKey === contextKey) {
+            await Promise.all(
+                Object.values(existingContext.workspace.tabsById).map(closeTabSideEffects),
+            );
+            const workspace = context.workspace;
+            const scopeEpoch = currentState.scopeEpoch + 1;
+            set((state) => ({
+                ...workspace,
+                activeContextKey: contextKey,
+                contextsByKey: {
+                    ...captureVisibleWorkspaceContext(state),
+                    [contextKey]: context,
+                },
+                deferredPaneIds: getDeferredWorkspacePaneIds(workspace),
+                error: null,
+                lastFocusedChatTabId: null,
+                lastFocusedRuntimeId: "codex",
+                openContextKeys: state.openContextKeys.includes(contextKey)
+                    ? state.openContextKeys
+                    : [...state.openContextKeys, contextKey],
+                recentActiveTabIds: [],
+                recentClosedTabs: [],
+                recentFocusedChatTabIds: [],
+                scopeEpoch,
+            }));
+            await persistWorkspaceState(get);
+            return;
+        }
+
         set((state) => ({
             contextsByKey: {
                 ...captureVisibleWorkspaceContext(state),
                 [contextKey]: context,
             },
-            openContextKeys: [...state.openContextKeys, contextKey],
+            openContextKeys: state.openContextKeys.includes(contextKey)
+                ? state.openContextKeys
+                : [...state.openContextKeys, contextKey],
         }));
         await get().activateContext(contextKey);
     },
@@ -3167,22 +3206,14 @@ function workspaceStoreToNavigationSnapshot(
     state: WorkspaceStore,
 ): WorkspaceNavigationSnapshot {
     const contextsByKey = captureVisibleWorkspaceContext(state);
-    const contexts = state.openContextKeys.flatMap((key) => {
-        const context = contextsByKey[key];
-        if (!context) {
-            return [];
-        }
-
-        return [
-            {
-                key: context.key,
-                lastActivatedAt: context.lastActivatedAt,
-                projectId: context.projectId,
-                workspace: workspaceStateToSnapshot(context.workspace),
-                worktreeId: context.worktreeId,
-            },
-        ];
-    });
+    const contexts = Object.values(contextsByKey).map((context) => ({
+        key: context.key,
+        lastActivatedAt: context.lastActivatedAt,
+        projectId: context.projectId,
+        workspace: workspaceStateToSnapshot(context.workspace),
+        worktreeId: context.worktreeId,
+    }));
+    const openContextKeys = state.openContextKeys.filter((key) => Boolean(contextsByKey[key]));
 
     return {
         activeContextKey:
@@ -3190,7 +3221,7 @@ function workspaceStoreToNavigationSnapshot(
                 ? state.activeContextKey
                 : null,
         contexts,
-        openContextKeys: contexts.map((context) => context.key),
+        openContextKeys,
         version: 3,
     };
 }

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -297,6 +297,7 @@ interface WorkspaceStore extends WorkspaceTreeState {
     ) => Promise<void>;
     reopenLastClosedTab: () => Promise<void>;
     removeProjectTabs: (projectId: string) => Promise<void>;
+    removeWorktreeTabs: (projectId: string, worktreeId: string | null) => Promise<void>;
     pinPaneTab: (paneId: string, tabId: string) => Promise<void>;
     reorderTab: (
         paneId: string,
@@ -500,11 +501,12 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             ),
         );
 
-        const nextContextsByKey = { ...contextsByKey };
-        const closedIndex = state.openContextKeys.indexOf(contextKey);
-        const openContextKeys = state.openContextKeys.filter(
-            (key) => key !== contextKey,
+        const nextContextsByKey = pruneClosedWorkspaceContexts(
+            contextsByKey,
+            state.openContextKeys.filter((key) => key !== contextKey),
         );
+        const closedIndex = state.openContextKeys.indexOf(contextKey);
+        const openContextKeys = state.openContextKeys.filter((key) => key !== contextKey);
 
         if (state.activeContextKey !== contextKey) {
             set({ contextsByKey: nextContextsByKey, openContextKeys });
@@ -1945,10 +1947,17 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     },
 
     removeProjectTabs: async (projectId) => {
-        const tabIdsToClose = Object.values(get().tabsById)
-            .filter((tab) => tab.projectId === projectId)
-            .map((tab) => tab.id);
-        await closeTabsWithSideEffects(get, set, tabIdsToClose);
+        await removeWorkspaceContexts(get, set, (context) => context.projectId === projectId);
+    },
+
+    removeWorktreeTabs: async (projectId, worktreeId) => {
+        await removeWorkspaceContexts(
+            get,
+            set,
+            (context) =>
+                context.projectId === projectId &&
+                normalizeWorktreeId(context.worktreeId) === normalizeWorktreeId(worktreeId),
+        );
     },
 
     pinPaneTab: async (paneId, tabId) => {
@@ -3121,6 +3130,89 @@ function captureVisibleWorkspaceContext(
             },
         },
     };
+}
+
+const MAX_CLOSED_WORKSPACE_CONTEXTS = 30;
+
+export function pruneClosedWorkspaceContexts(
+    contextsByKey: Record<string, RuntimeWorkspaceContext>,
+    openContextKeys: readonly string[],
+): Record<string, RuntimeWorkspaceContext> {
+    const openContextKeySet = new Set(openContextKeys);
+    const retainedClosedContextKeys = new Set(
+        Object.values(contextsByKey)
+            .filter((context) => !openContextKeySet.has(context.key))
+            .sort((left, right) =>
+                Date.parse(right.lastActivatedAt) - Date.parse(left.lastActivatedAt),
+            )
+            .slice(0, MAX_CLOSED_WORKSPACE_CONTEXTS)
+            .map((context) => context.key),
+    );
+
+    return Object.fromEntries(
+        Object.entries(contextsByKey).filter(
+            ([key]) => openContextKeySet.has(key) || retainedClosedContextKeys.has(key),
+        ),
+    );
+}
+
+async function removeWorkspaceContexts(
+    get: GetWorkspaceState,
+    set: WorkspaceSetState,
+    shouldRemove: (context: RuntimeWorkspaceContext) => boolean,
+): Promise<void> {
+    const state = get();
+    const capturedContexts = captureVisibleWorkspaceContext(state);
+    const removedContexts = Object.values(capturedContexts).filter(shouldRemove);
+    if (removedContexts.length === 0) {
+        return;
+    }
+
+    await Promise.all(
+        removedContexts.flatMap((context) =>
+            Object.values(context.workspace.tabsById).map(closeTabSideEffects),
+        ),
+    );
+
+    const contextsByKey = Object.fromEntries(
+        Object.entries(capturedContexts).filter(([, context]) => !shouldRemove(context)),
+    );
+    const openContextKeys = state.openContextKeys.filter((key) => Boolean(contextsByKey[key]));
+    const activeContextKey = state.activeContextKey && contextsByKey[state.activeContextKey]
+        ? state.activeContextKey
+        : (openContextKeys[0] ?? null);
+    const activeContext = activeContextKey ? contextsByKey[activeContextKey] : null;
+    const workspace = activeContext?.workspace ?? createDefaultWorkspaceState();
+    const scopeEpoch = state.scopeEpoch + 1;
+
+    set({
+        ...workspace,
+        activeContextKey,
+        contextsByKey,
+        deferredPaneIds: getDeferredWorkspacePaneIds(workspace),
+        error: null,
+        lastFocusedChatTabId: getPaneChatTabId(workspace, workspace.activePaneId),
+        lastFocusedRuntimeId: getPaneRuntimeId(workspace, workspace.activePaneId) ?? "codex",
+        openContextKeys,
+        recentActiveTabIds: recordRecentTabActivation(
+            [],
+            getPaneActiveTabId(workspace, workspace.activePaneId),
+        ),
+        recentClosedTabs: [],
+        recentFocusedChatTabIds: recordRecentChatFocus(
+            [],
+            getPaneChatTabId(workspace, workspace.activePaneId),
+        ),
+        scopeEpoch,
+    });
+
+    if (activeContextKey) {
+        void activateWorkspaceRuntimePanes(workspace, get, set, {
+            contextKey: activeContextKey,
+            scopeEpoch,
+        });
+    }
+    await persistWorkspaceState(get);
 }
 
 function invalidateInactiveContextFileDocuments(

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -372,6 +372,9 @@ export function SidebarGitScopePicker({
     const refreshGitProject = useGitStore((state) => state.refreshProject);
     const removeWorktree = useGitStore((state) => state.removeWorktree);
     const openContext = useWorkspaceStore((state) => state.openContext);
+    const removeWorktreeTabs = useWorkspaceStore(
+        (state) => state.removeWorktreeTabs,
+    );
 
     const worktrees = projectWorktrees ?? snapshot?.worktrees ?? EMPTY_WORKTREES;
     const activeWorktree =
@@ -1637,6 +1640,7 @@ export function SidebarGitScopePicker({
                     targetWorktree.rootPath,
                     worktreeId ?? snapshot?.currentWorktreeId ?? null,
                 );
+                await removeWorktreeTabs(projectId, targetWorktree.id);
                 await Promise.all([
                     refreshGitProject(
                         projectId,
@@ -1669,6 +1673,7 @@ export function SidebarGitScopePicker({
             refreshGitHistory,
             refreshGitProject,
             refreshProjectTree,
+            removeWorktreeTabs,
             removeWorktree,
             snapshot?.currentWorktreeId,
             worktreeId,

--- a/src/renderer/src/features/terminal/WorkspaceTerminalHost.test.ts
+++ b/src/renderer/src/features/terminal/WorkspaceTerminalHost.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { WorkspaceNode } from "@shared/ipc";
 
-import { getReadyActiveWorkspaceTabIds } from "./WorkspaceTerminalHost";
+import {
+    getOpenContextTerminalIds,
+    getReadyActiveWorkspaceTabIds,
+} from "./WorkspaceTerminalHost";
 
 describe("getReadyActiveWorkspaceTabIds", () => {
     it("excludes active tabs whose pane is still deferred", () => {
@@ -48,5 +51,37 @@ describe("getReadyActiveWorkspaceTabIds", () => {
                 "pane-focused",
             ),
         ).toEqual(new Set(["terminal-focused", "terminal-background"]));
+    });
+});
+
+describe("getOpenContextTerminalIds", () => {
+    it("does not retain terminals from cached closed contexts", () => {
+        const contextsByKey = {
+            active: {
+                workspace: {
+                    tabsById: {
+                        active: { kind: "terminal", terminalId: "terminal-active" },
+                    },
+                },
+            },
+            open: {
+                workspace: {
+                    tabsById: {
+                        open: { kind: "terminal", terminalId: "terminal-open" },
+                    },
+                },
+            },
+            closed: {
+                workspace: {
+                    tabsById: {
+                        closed: { kind: "terminal", terminalId: "terminal-closed" },
+                    },
+                },
+            },
+        };
+
+        expect(getOpenContextTerminalIds(contextsByKey, ["active", "open"], "active")).toEqual([
+            "terminal-open",
+        ]);
     });
 });

--- a/src/renderer/src/features/terminal/WorkspaceTerminalHost.tsx
+++ b/src/renderer/src/features/terminal/WorkspaceTerminalHost.tsx
@@ -32,12 +32,36 @@ export function getReadyActiveWorkspaceTabIds(
     );
 }
 
+export function getOpenContextTerminalIds(
+    contextsByKey: Readonly<Record<string, { readonly workspace: { readonly tabsById: Record<string, unknown> } }>>,
+    openContextKeys: readonly string[],
+    activeContextKey: string | null,
+): readonly string[] {
+    return openContextKeys.flatMap((contextKey) => {
+        if (contextKey === activeContextKey) {
+            return [];
+        }
+        const context = contextsByKey[contextKey];
+        if (!context) {
+            return [];
+        }
+        return Object.values(context.workspace.tabsById).flatMap((tab) =>
+            typeof tab === "object" && tab !== null &&
+            "kind" in tab && tab.kind === "terminal" &&
+            "terminalId" in tab && typeof tab.terminalId === "string"
+                ? [tab.terminalId]
+                : [],
+        );
+    });
+}
+
 export function WorkspaceTerminalHost() {
     const {
         activeContextKey,
         activePaneId,
         contextsByKey,
         deferredPaneIds,
+        openContextKeys,
         rootNode,
         tabsById,
     } = useWorkspaceStore(
@@ -46,6 +70,7 @@ export function WorkspaceTerminalHost() {
             activePaneId: state.activePaneId,
             contextsByKey: state.contextsByKey,
             deferredPaneIds: state.deferredPaneIds,
+            openContextKeys: state.openContextKeys,
             rootNode: state.rootNode,
             tabsById: state.tabsById,
         })),
@@ -68,22 +93,17 @@ export function WorkspaceTerminalHost() {
         return visibleTerminalTabs.filter((tab) => activeTabIds.has(tab.id));
     }, [activePaneId, deferredPaneIds, rootNode, visibleTerminalTabs]);
     const liveTerminalIds = useMemo(() => {
-        const inactiveTerminalIds = Object.values(contextsByKey)
-            .filter((context) => context.key !== activeContextKey)
-            .flatMap((context) =>
-                Object.values(context.workspace.tabsById)
-                    .filter(
-                        (tab): tab is RuntimeWorkspaceTerminalTab =>
-                            tab.kind === "terminal",
-                    )
-                    .map((tab) => tab.terminalId),
-            );
+        const inactiveTerminalIds = getOpenContextTerminalIds(
+            contextsByKey,
+            openContextKeys,
+            activeContextKey,
+        );
 
         return [
             ...visibleTerminalTabs.map((tab) => tab.terminalId),
             ...inactiveTerminalIds,
         ];
-    }, [activeContextKey, contextsByKey, visibleTerminalTabs]);
+    }, [activeContextKey, contextsByKey, openContextKeys, visibleTerminalTabs]);
     const ensureTerminal = useTerminalRuntimeStore(
         (state) => state.ensureTerminal,
     );

--- a/src/renderer/src/features/terminal/terminalRuntimeStore.test.ts
+++ b/src/renderer/src/features/terminal/terminalRuntimeStore.test.ts
@@ -123,6 +123,27 @@ describe("terminalRuntimeStore", () => {
         });
     });
 
+    it("creates a new session when a closed workspace terminal is reopened", async () => {
+        createTerminalSessionMock
+            .mockResolvedValueOnce(createSession("closed-session"))
+            .mockResolvedValueOnce(createSession("reopened-session"));
+
+        const tab = createTerminalTab();
+        useTerminalRuntimeStore.getState().ensureTerminal(tab);
+        await flushPromises();
+        await useTerminalRuntimeStore.getState().closeTerminal(tab.terminalId);
+
+        useTerminalRuntimeStore.getState().ensureTerminal(tab);
+        await flushPromises();
+
+        expect(closeTerminalSessionMock).toHaveBeenCalledWith("closed-session");
+        expect(createTerminalSessionMock).toHaveBeenCalledTimes(2);
+        expect(
+            useTerminalRuntimeStore.getState().runtimesById[tab.terminalId]
+                ?.sessionId,
+        ).toBe("reopened-session");
+    });
+
     it("passes the Claude Code no-flicker env flag for optimized terminals", async () => {
         useSettingsStore.setState({
             terminal: {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -2113,7 +2113,7 @@ export interface WorkspaceNavigationSnapshot {
     readonly activeContextKey: WorkspaceContextKey | null;
     readonly contexts: readonly PersistedWorkspaceContext[];
     readonly openContextKeys: readonly WorkspaceContextKey[];
-    readonly version: 2;
+    readonly version: 3;
 }
 
 export interface WindowWorkspaceRestoreRecord {

--- a/src/shared/workspace-restore.test.ts
+++ b/src/shared/workspace-restore.test.ts
@@ -67,6 +67,7 @@ describe("workspace restore normalization", () => {
         expect(result.snapshot.openContextKeys).toEqual([
             "project-1::__primary__",
         ]);
+        expect(result.snapshot.version).toBe(3);
         expect(result.snapshot.contexts[0]?.workspace).toMatchObject({
             activePaneId: "pane-root",
             rootNode: { activeTabId: null, pinnedTabIds: [], tabIds: [] },
@@ -81,12 +82,58 @@ describe("workspace restore normalization", () => {
                 activeContextKey: null,
                 contexts: [],
                 openContextKeys: [],
-                version: 2,
+                version: 3,
             },
             updatedAt: "2026-01-01T00:00:00.000Z",
         });
 
         expect(record.revision).toBe(4);
         expect(record.schemaVersion).toBe(1);
+    });
+
+    it("keeps closed v3 contexts out of the open context keys", () => {
+        const result = normalizeWorkspaceNavigationSnapshot({
+            activeContextKey: "project-1::__primary__",
+            contexts: [
+                {
+                    key: "project-1::__primary__",
+                    lastActivatedAt: "2026-01-02T00:00:00.000Z",
+                    projectId: "project-1",
+                    workspace: {
+                        activePaneId: "pane-root",
+                        rootNode: { activeTabId: null, id: "pane-root", tabIds: [], type: "pane" },
+                        tabs: [],
+                    },
+                    worktreeId: null,
+                },
+                {
+                    key: "project-2::__primary__",
+                    lastActivatedAt: "2026-01-01T00:00:00.000Z",
+                    projectId: "project-2",
+                    workspace: {
+                        activePaneId: "pane-root",
+                        rootNode: { activeTabId: null, id: "pane-root", tabIds: [], type: "pane" },
+                        tabs: [],
+                    },
+                    worktreeId: null,
+                },
+            ],
+            openContextKeys: ["project-1::__primary__", "missing", "project-1::__primary__"],
+            version: 3,
+        });
+
+        expect(result.snapshot.openContextKeys).toEqual(["project-1::__primary__"]);
+        expect(result.snapshot.activeContextKey).toBe("project-1::__primary__");
+    });
+
+    it("clears an active v3 context that is no longer open", () => {
+        const result = normalizeWorkspaceNavigationSnapshot({
+            activeContextKey: "project-2::__primary__",
+            contexts: [],
+            openContextKeys: [],
+            version: 3,
+        });
+
+        expect(result.snapshot.activeContextKey).toBeNull();
     });
 });

--- a/src/shared/workspace-restore.ts
+++ b/src/shared/workspace-restore.ts
@@ -36,7 +36,7 @@ export function normalizeWorkspaceNavigationSnapshot(
     value: unknown,
     fallbackScope: { readonly projectId?: string | null; readonly worktreeId?: string | null } = {},
 ): WorkspaceRestoreNormalizationResult {
-    if (!isRecord(value) || value.version !== 2) {
+    if (!isRecord(value) || (value.version !== 2 && value.version !== 3)) {
         const legacy = normalizeLayout(value);
         const projectId = fallbackScope.projectId ?? firstTabProjectId(legacy);
         if (!legacy || !projectId) {
@@ -54,7 +54,7 @@ export function normalizeWorkspaceNavigationSnapshot(
                 activeContextKey: key,
                 contexts: [{ key, lastActivatedAt: new Date().toISOString(), projectId, workspace: legacy, worktreeId }],
                 openContextKeys: [key],
-                version: 2,
+                version: 3,
             },
         };
     }
@@ -80,8 +80,10 @@ export function normalizeWorkspaceNavigationSnapshot(
     const openContextKeys = requestedKeys.filter(
         (key, index) => seen.has(key) && requestedKeys.indexOf(key) === index,
     );
-    for (const context of contexts) {
-        if (!openContextKeys.includes(context.key)) openContextKeys.push(context.key);
+    if (value.version === 2) {
+        for (const context of contexts) {
+            if (!openContextKeys.includes(context.key)) openContextKeys.push(context.key);
+        }
     }
     const requestedActive = typeof value.activeContextKey === "string" ? value.activeContextKey : null;
     const activeContextKey = requestedActive && openContextKeys.includes(requestedActive)
@@ -91,7 +93,7 @@ export function normalizeWorkspaceNavigationSnapshot(
     return {
         droppedContextCount: rawContexts.length - contexts.length,
         repaired,
-        snapshot: { activeContextKey, contexts, openContextKeys, version: 2 },
+        snapshot: { activeContextKey, contexts, openContextKeys, version: 3 },
     };
 }
 
@@ -235,7 +237,7 @@ function normalizePrimaryWorktree(projectId: string, worktreeId: string | null):
 }
 
 function emptyNavigation(): WorkspaceNavigationSnapshot {
-    return { activeContextKey: null, contexts: [], openContextKeys: [], version: 2 };
+    return { activeContextKey: null, contexts: [], openContextKeys: [], version: 3 };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary
- persist closed workspace layouts per window using navigation snapshot v3
- restore cached layouts without retaining terminal processes, recreating them when reopened
- prune stale cached contexts and purge layouts when projects or worktrees are removed

## Validation
- pnpm exec vitest run src/shared/workspace-restore.test.ts src/renderer/src/app/store/workspace-store.test.ts src/renderer/src/features/terminal/WorkspaceTerminalHost.test.ts src/renderer/src/features/terminal/terminalRuntimeStore.test.ts src/main/native-backend/app-data.test.ts
- pnpm run typecheck
- pnpm exec eslint (modified files)
- pnpm run native:persistence:check
- pnpm run native:protocol:check