### PR TITLE
feat(github): review complete pull request diffs

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -12,6 +12,56 @@ const repository = {
 };
 
 describe("GitHubApiClient", () => {
+    it("loads and maps every page of pull request files", async () => {
+        const fetchMock = vi
+            .fn<GitHubFetch>()
+            .mockResolvedValueOnce(
+                jsonResponse({
+                    ...rawPullRequest(),
+                    additions: 3,
+                    changed_files: 2,
+                    deletions: 1,
+                }),
+            )
+            .mockResolvedValueOnce(
+                jsonResponse(
+                    [
+                        {
+                            additions: 2,
+                            deletions: 1,
+                            filename: "src/a.ts",
+                            patch: "@@ -1 +1,2 @@\n-old\n+new\n+next",
+                            status: "modified",
+                        },
+                    ],
+                    {
+                        Link: '<https://api.github.com/repos/octocat/hello-world/pulls/7/files?page=2>; rel="next"',
+                    },
+                ),
+            )
+            .mockResolvedValueOnce(
+                jsonResponse([
+                    {
+                        additions: 1,
+                        filename: "src/new.ts",
+                        status: "added",
+                    },
+                ]),
+            );
+        const client = new GitHubApiClient({ fetch: fetchMock, token: "ghp_test" });
+
+        const result = await client.getPullRequestDiff({ number: 7, repository });
+
+        expect(result.fileListComplete).toBe(true);
+        expect(result.contentComplete).toBe(false);
+        expect(result.files[0]?.hunks[0]?.lines).toHaveLength(3);
+        expect(result.files[1]).toMatchObject({
+            contentState: "unavailable",
+            kind: "create",
+            statusLabel: "added",
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
     it("aborts pending REST requests after the request timeout", async () => {
         let requestSignal: AbortSignal | undefined;
         const fetchMock = vi.fn<GitHubFetch>((_, init) =>
@@ -169,9 +219,9 @@ function pendingAbortableBodyResponse(
     });
 }
 
-function jsonResponse(body: unknown): Response {
+function jsonResponse(body: unknown, headers?: HeadersInit): Response {
     return new Response(JSON.stringify(body), {
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", ...headers },
         status: 200,
     });
 }

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1841,12 +1841,16 @@ function mapPullRequestDiffFile(
                 : "update";
     const path = file.filename ?? `unknown-file-${index}`;
     const patch = file.patch?.trim() ?? "";
+    const hunks = patch
+        ? parseUnifiedDiffHunks(patch, `github-pr:${index}:${path}`)
+        : [];
+    const contentState = hunks.length > 0 ? "available" : "unavailable";
     return {
         additions: file.additions ?? null,
-        contentState: patch ? "available" : "unavailable",
+        contentState,
         deletions: file.deletions ?? null,
-        hunks: patch ? parseUnifiedDiffHunks(patch, `github-pr:${index}:${path}`) : [],
-        isText: Boolean(patch),
+        hunks,
+        isText: contentState === "available",
         kind,
         newText: null,
         oldText: null,

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -12,6 +12,7 @@ import type {
     GitHubErrorCode,
     GitHubGetIssueInput,
     GitHubGetPullRequestInput,
+    GitHubGetPullRequestDiffInput,
     GitHubIssueDetail,
     GitHubIssueState,
     GitHubIssueStateReason,
@@ -42,9 +43,11 @@ import type {
     GitHubNotificationsResult,
     GitHubPullRequestBranchRef,
     GitHubPullRequestDetail,
+    GitHubPullRequestDiffResult,
     GitHubPullRequestState,
     GitHubPullRequestSummary,
     GitHubRequestPullRequestReviewInput,
+    GitRevisionFileDiff,
     GitHubRepositoryRef,
     GitHubCreateReleaseInput,
     GitHubGeneratedReleaseNotes,
@@ -74,11 +77,15 @@ import type {
     GitHubWorkflowRunStatus,
     GitHubWorkflowRunSummary,
 } from "@shared/ipc";
+import { parseUnifiedDiffHunks } from "@shared/diff/unified-diff";
 
 // Skip per-commit stats enrichment for PRs above this size to avoid
 // flooding the GitHub API with N detail requests for very large PRs.
 const PR_COMMIT_STATS_LIMIT = 50;
 const GITHUB_REQUEST_TIMEOUT_MS = 15_000;
+const PULL_REQUEST_FILES_PAGE_SIZE = 100;
+const PULL_REQUEST_FILES_MAX_COUNT = 3_000;
+const PULL_REQUEST_PATCH_MAX_BYTES = 20 * 1024 * 1024;
 
 export type GitHubFetch = (
     input: string | URL,
@@ -233,6 +240,15 @@ interface RawGitHubPullRequest {
     readonly title?: string;
     readonly updated_at?: string;
     readonly user?: RawGitHubUser | null;
+}
+
+interface RawGitHubPullRequestFile {
+    readonly additions?: number;
+    readonly deletions?: number;
+    readonly filename?: string;
+    readonly patch?: string;
+    readonly previous_filename?: string;
+    readonly status?: string;
 }
 
 interface RawGitHubCommitStatus {
@@ -701,6 +717,71 @@ export class GitHubApiClient {
             comments,
             commits,
         );
+    }
+
+    async getPullRequestDiff(
+        input: GitHubGetPullRequestDiffInput,
+    ): Promise<GitHubPullRequestDiffResult> {
+        const pullRequest = await this.#requestJson<RawGitHubPullRequest>(
+            input.repository.host,
+            repoPath(input.repository, `/pulls/${input.number}`),
+        );
+        const files: RawGitHubPullRequestFile[] = [];
+        const seenCursors = new Set<string>();
+        let cursor: string | null = "1";
+        let patchBytes = 0;
+        let patchLimitReached = false;
+
+        while (cursor && files.length < PULL_REQUEST_FILES_MAX_COUNT) {
+            if (seenCursors.has(cursor)) break;
+            seenCursors.add(cursor);
+            const page = await this.#requestJson<readonly RawGitHubPullRequestFile[]>(
+                input.repository.host,
+                repoPath(input.repository, `/pulls/${input.number}/files`),
+                { query: { page: cursor, per_page: PULL_REQUEST_FILES_PAGE_SIZE } },
+            );
+            for (const file of page.data) {
+                if (files.length >= PULL_REQUEST_FILES_MAX_COUNT) break;
+                const patch = file.patch ?? "";
+                const canIncludePatch =
+                    !patchLimitReached &&
+                    patchBytes + Buffer.byteLength(patch, "utf8") <=
+                        PULL_REQUEST_PATCH_MAX_BYTES;
+                if (patch && !canIncludePatch) patchLimitReached = true;
+                if (canIncludePatch) patchBytes += Buffer.byteLength(patch, "utf8");
+                files.push(canIncludePatch ? file : { ...file, patch: undefined });
+            }
+            cursor = readNextPageCursor(page.headers);
+        }
+
+        const summary = mapPullRequestSummary(pullRequest.data, input.repository);
+        const totalFileCount = summary.changedFileCount ?? files.length;
+        const fileListComplete = files.length >= totalFileCount && !cursor;
+        const mappedFiles = files.map((file, index) => mapPullRequestDiffFile(file, index));
+        const unavailableCount = mappedFiles.filter(
+            (file) => file.contentState === "unavailable",
+        ).length;
+        const reasons: string[] = [];
+        if (!fileListComplete) {
+            reasons.push(`GitHub returned ${files.length} of ${totalFileCount} changed files.`);
+        }
+        if (patchLimitReached) reasons.push("Diff content exceeded the local size limit.");
+        if (unavailableCount > 0) {
+            reasons.push(`Diff content is unavailable for ${unavailableCount} files.`);
+        }
+
+        return {
+            additions: summary.additions ?? mappedFiles.reduce((sum, file) => sum + (file.additions ?? 0), 0),
+            baseSha: summary.base.sha,
+            contentComplete: !patchLimitReached && unavailableCount === 0,
+            deletions: summary.deletions ?? mappedFiles.reduce((sum, file) => sum + (file.deletions ?? 0), 0),
+            fileListComplete,
+            files: mappedFiles,
+            headSha: summary.head.sha,
+            incompleteReason: reasons.length > 0 ? reasons.join(" ") : null,
+            number: input.number,
+            totalFileCount,
+        };
     }
 
     async listPullRequestChecks(
@@ -1742,6 +1823,46 @@ function mapPullRequestDetail(
         comments,
         commits,
         mergeable: pullRequest.mergeable ?? null,
+    };
+}
+
+function mapPullRequestDiffFile(
+    file: RawGitHubPullRequestFile,
+    index: number,
+): GitRevisionFileDiff {
+    const status = file.status?.toLowerCase() ?? "modified";
+    const kind =
+        status === "added" || status === "copied"
+            ? "create"
+            : status === "removed"
+              ? "delete"
+              : status === "renamed"
+                ? "move"
+                : "update";
+    const path = file.filename ?? `unknown-file-${index}`;
+    const patch = file.patch?.trim() ?? "";
+    return {
+        additions: file.additions ?? null,
+        contentState: patch ? "available" : "unavailable",
+        deletions: file.deletions ?? null,
+        hunks: patch ? parseUnifiedDiffHunks(patch, `github-pr:${index}:${path}`) : [],
+        isText: Boolean(patch),
+        kind,
+        newText: null,
+        oldText: null,
+        path,
+        previousPath: file.previous_filename ?? null,
+        reversible: false,
+        statusLabel:
+            status === "copied"
+                ? "copied"
+                : kind === "create"
+                  ? "added"
+                  : kind === "delete"
+                    ? "deleted"
+                    : kind === "move"
+                      ? "renamed"
+                      : "modified",
     };
 }
 

--- a/src/main/github/service.ts
+++ b/src/main/github/service.ts
@@ -20,6 +20,7 @@ import type {
     GitHubCreatePullRequestInput,
     GitHubGetIssueInput,
     GitHubGetPullRequestInput,
+    GitHubGetPullRequestDiffInput,
     GitHubIssueDetail,
     GitHubListLabelsInput,
     GitHubListLabelsResult,
@@ -36,6 +37,7 @@ import type {
     GitHubPullRequestChecksInput,
     GitHubPullRequestChecksResult,
     GitHubPullRequestDetail,
+    GitHubPullRequestDiffResult,
     GitHubCreateReleaseInput,
     GitHubGeneratedReleaseNotes,
     GitHubGenerateReleaseNotesInput,
@@ -95,6 +97,9 @@ export interface GitHubGateway {
     getPullRequest(
         input: GitHubGetPullRequestInput,
     ): Promise<GitHubPullRequestDetail | null>;
+    getPullRequestDiff(
+        input: GitHubGetPullRequestDiffInput,
+    ): Promise<GitHubPullRequestDiffResult>;
     listIssues(input: GitHubListIssuesInput): Promise<GitHubListIssuesResult>;
     listLabels(input: GitHubListLabelsInput): Promise<GitHubListLabelsResult>;
     listPullRequests(
@@ -283,6 +288,14 @@ export class GitHubService implements GitHubGateway {
         return await (
             await this.#createClient(input.repository.host)
         ).getPullRequest(input);
+    }
+
+    async getPullRequestDiff(
+        input: GitHubGetPullRequestDiffInput,
+    ): Promise<GitHubPullRequestDiffResult> {
+        return await (
+            await this.#createClient(input.repository.host)
+        ).getPullRequestDiff(input);
     }
 
     async listPullRequestChecks(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -64,6 +64,7 @@ import {
     type GitHubCreatePullRequestInput,
     type GitHubGetIssueInput,
     type GitHubGetPullRequestInput,
+    type GitHubGetPullRequestDiffInput,
     type GitHubIssueDetail,
     type GitHubListLabelsInput,
     type GitHubListLabelsResult,
@@ -80,6 +81,7 @@ import {
     type GitHubPullRequestChecksInput,
     type GitHubPullRequestChecksResult,
     type GitHubPullRequestDetail,
+    type GitHubPullRequestDiffResult,
     type GitHubCreateReleaseInput,
     type GitHubGeneratedReleaseNotes,
     type GitHubGenerateReleaseNotesInput,
@@ -298,6 +300,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.reopenGitHubIssue);
     ipcMain.removeHandler(IPC_CHANNELS.listGitHubPullRequests);
     ipcMain.removeHandler(IPC_CHANNELS.getGitHubPullRequest);
+    ipcMain.removeHandler(IPC_CHANNELS.getGitHubPullRequestDiff);
     ipcMain.removeHandler(IPC_CHANNELS.listGitHubPullRequestChecks);
     ipcMain.removeHandler(IPC_CHANNELS.createGitHubPullRequest);
     ipcMain.removeHandler(IPC_CHANNELS.commentGitHubPullRequest);
@@ -1225,6 +1228,14 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             input: GitHubGetPullRequestInput,
         ): Promise<GitHubPullRequestDetail | null> =>
             options.githubService.getPullRequest(input),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.getGitHubPullRequestDiff,
+        async (
+            _event,
+            input: GitHubGetPullRequestDiffInput,
+        ): Promise<GitHubPullRequestDiffResult> =>
+            options.githubService.getPullRequestDiff(input),
     );
     ipcMain.handle(
         IPC_CHANNELS.listGitHubPullRequestChecks,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -101,6 +101,7 @@ import {
     type GitHubCreatePullRequestInput,
     type GitHubGetIssueInput,
     type GitHubGetPullRequestInput,
+    type GitHubGetPullRequestDiffInput,
     type GitHubIssueDetail,
     type GitHubListLabelsInput,
     type GitHubListLabelsResult,
@@ -117,6 +118,7 @@ import {
     type GitHubPullRequestChecksInput,
     type GitHubPullRequestChecksResult,
     type GitHubPullRequestDetail,
+    type GitHubPullRequestDiffResult,
     type GitHubCreateReleaseInput,
     type GitHubGeneratedReleaseNotes,
     type GitHubGenerateReleaseNotesInput,
@@ -1143,6 +1145,14 @@ const comandoApi: ComandoApi = {
         assertIpcObjectOrNull<GitHubPullRequestDetail>(
             IPC_CHANNELS.getGitHubPullRequest,
             await ipcRenderer.invoke(IPC_CHANNELS.getGitHubPullRequest, input),
+        ),
+    getGitHubPullRequestDiff: async (input: GitHubGetPullRequestDiffInput) =>
+        assertIpcObject<GitHubPullRequestDiffResult>(
+            IPC_CHANNELS.getGitHubPullRequestDiff,
+            await ipcRenderer.invoke(
+                IPC_CHANNELS.getGitHubPullRequestDiff,
+                input,
+            ),
         ),
     listGitHubPullRequestChecks: async (
         input: GitHubPullRequestChecksInput,

--- a/src/renderer/src/app/git/history-presentation.ts
+++ b/src/renderer/src/app/git/history-presentation.ts
@@ -1,6 +1,6 @@
 import type {
     GitCommitDetail,
-    GitCommitFileDiff,
+    GitRevisionFileDiff,
     GitHistoryCommitSummary,
 } from "@shared/ipc";
 
@@ -295,10 +295,12 @@ export function buildGitHistoryGraphRows(
 }
 
 export function convertCommitFilesToDiffFiles(
-    files: readonly GitCommitFileDiff[],
+    files: readonly GitRevisionFileDiff[],
 ): readonly GitDiffFile[] {
-    return files.map((file) => convertCommitFileToDiffFile(file));
+    return files.map((file) => convertRevisionFileToDiffFile(file));
 }
+
+export const convertRevisionFilesToDiffFiles = convertCommitFilesToDiffFiles;
 
 export function getTemporalGroupLabel(dateStr: string): string {
     const date = new Date(dateStr);
@@ -416,7 +418,7 @@ export function getRefPillStyle(kind: string): GitRefPillTone {
     }
 }
 
-function convertCommitFileToDiffFile(file: GitCommitFileDiff): GitDiffFile {
+function convertRevisionFileToDiffFile(file: GitRevisionFileDiff): GitDiffFile {
     return {
         hunks: file.hunks.map((hunk) => {
             let oldLine = hunk.oldStart;
@@ -469,6 +471,10 @@ function convertCommitFileToDiffFile(file: GitCommitFileDiff): GitDiffFile {
         previousPath: file.previousPath,
         reversible: file.reversible,
         statusLabel: file.statusLabel,
+        emptyState:
+            file.contentState === "unavailable"
+                ? "Diff content is unavailable from GitHub."
+                : undefined,
         summary: formatGitCountLabel(file.additions, file.deletions),
     };
 }

--- a/src/renderer/src/app/store/github-store.ts
+++ b/src/renderer/src/app/store/github-store.ts
@@ -105,7 +105,7 @@ export interface GitHubStoreState {
     >;
     readonly pullRequestDiffsByRepo: Record<
         string,
-        Record<number, GitHubPullRequestDiffResult | null>
+        Record<string, GitHubPullRequestDiffResult | null>
     >;
     readonly pullRequestsByRepo: Record<
         string,
@@ -631,7 +631,14 @@ export const useGitHubStore = create<GitHubStoreState>((set, get) => ({
 
     ensurePullRequestDiff: async (ref, number, options = {}) => {
         const repoKey = getRepoKey(ref);
-        const cached = get().pullRequestDiffsByRepo[repoKey]?.[number];
+        const detail = get().pullRequestDetailsByRepo[repoKey]?.[number];
+        const snapshotKey = getPullRequestDiffKey(
+            repoKey,
+            number,
+            detail?.base.sha ?? "",
+            detail?.head.sha ?? "",
+        );
+        const cached = get().pullRequestDiffsByRepo[repoKey]?.[snapshotKey];
         if (!options.force && cached !== undefined) return cached;
         return await withLoading(set, `${repoKey}:pr:${number}:diff`, async () => {
             const diff = await getComandoApi().getGitHubPullRequestDiff({
@@ -643,7 +650,12 @@ export const useGitHubStore = create<GitHubStoreState>((set, get) => ({
                     ...state.pullRequestDiffsByRepo,
                     [repoKey]: {
                         ...(state.pullRequestDiffsByRepo[repoKey] ?? {}),
-                        [number]: diff,
+                        [getPullRequestDiffKey(
+                            repoKey,
+                            number,
+                            diff.baseSha,
+                            diff.headSha,
+                        )]: diff,
                     },
                 },
             }));
@@ -1159,6 +1171,15 @@ export function getGitHubPullRequestChecksKey(
     headSha: string,
 ): string {
     return getPullRequestChecksKey(getRepoKey(ref), headSha);
+}
+
+export function getGitHubPullRequestDiffKey(
+    ref: GitHubRepositoryRef,
+    number: number,
+    baseSha: string,
+    headSha: string,
+): string {
+    return getPullRequestDiffKey(getRepoKey(ref), number, baseSha, headSha);
 }
 
 export function getGitHubWorkflowRunsKey(
@@ -1839,6 +1860,15 @@ function getRepoKey(ref: GitHubRepositoryRef): string {
 
 function getPullRequestChecksKey(repoKey: string, headSha: string): string {
     return `${repoKey}:pr-checks:${headSha}`;
+}
+
+function getPullRequestDiffKey(
+    repoKey: string,
+    number: number,
+    baseSha: string,
+    headSha: string,
+): string {
+    return `${repoKey}:pr:${number}:diff:${baseSha || "unknown"}:${headSha || "unknown"}`;
 }
 
 function getWorkflowRunsKey(repoKey: string, headSha: string): string {

--- a/src/renderer/src/app/store/github-store.ts
+++ b/src/renderer/src/app/store/github-store.ts
@@ -19,6 +19,7 @@ import type {
     GitHubReleaseSummary,
     GitHubPullRequestChecksResult,
     GitHubPullRequestDetail,
+    GitHubPullRequestDiffResult,
     GitHubPullRequestSummary,
     GitHubRequestPullRequestReviewInput,
     GitHubRepositoryRef,
@@ -101,6 +102,10 @@ export interface GitHubStoreState {
     readonly pullRequestChecksByRepo: Record<
         string,
         Record<string, GitHubPullRequestChecksResult | null>
+    >;
+    readonly pullRequestDiffsByRepo: Record<
+        string,
+        Record<number, GitHubPullRequestDiffResult | null>
     >;
     readonly pullRequestsByRepo: Record<
         string,
@@ -198,6 +203,11 @@ export interface GitHubStoreState {
         number: number,
         options?: { readonly force?: boolean },
     ) => Promise<GitHubPullRequestDetail | null>;
+    ensurePullRequestDiff: (
+        ref: GitHubRepositoryRef,
+        number: number,
+        options?: { readonly force?: boolean },
+    ) => Promise<GitHubPullRequestDiffResult | null>;
     markPullRequestReady: (
         ref: GitHubRepositoryRef,
         number: number,
@@ -325,6 +335,7 @@ export const useGitHubStore = create<GitHubStoreState>((set, get) => ({
     mutatingKeys: {},
     pullRequestDetailsByRepo: {},
     pullRequestChecksByRepo: {},
+    pullRequestDiffsByRepo: {},
     pullRequestListStateByRepo: {},
     pullRequestsByRepo: {},
     pullRequestsByRepoAndState: {},
@@ -361,6 +372,10 @@ export const useGitHubStore = create<GitHubStoreState>((set, get) => ({
             ),
             pullRequestChecksByRepo: omitKey(
                 state.pullRequestChecksByRepo,
+                repoKey,
+            ),
+            pullRequestDiffsByRepo: omitKey(
+                state.pullRequestDiffsByRepo,
                 repoKey,
             ),
             pullRequestListStateByRepo: omitKey(
@@ -611,6 +626,28 @@ export const useGitHubStore = create<GitHubStoreState>((set, get) => ({
                 upsertPullRequest(set, ref, detail);
             }
             return detail;
+        });
+    },
+
+    ensurePullRequestDiff: async (ref, number, options = {}) => {
+        const repoKey = getRepoKey(ref);
+        const cached = get().pullRequestDiffsByRepo[repoKey]?.[number];
+        if (!options.force && cached !== undefined) return cached;
+        return await withLoading(set, `${repoKey}:pr:${number}:diff`, async () => {
+            const diff = await getComandoApi().getGitHubPullRequestDiff({
+                number,
+                repository: ref,
+            });
+            set((state) => ({
+                pullRequestDiffsByRepo: {
+                    ...state.pullRequestDiffsByRepo,
+                    [repoKey]: {
+                        ...(state.pullRequestDiffsByRepo[repoKey] ?? {}),
+                        [number]: diff,
+                    },
+                },
+            }));
+            return diff;
         });
     },
 
@@ -1100,6 +1137,7 @@ export function resetGitHubStoreForTests(): void {
         mutatingKeys: {},
         pullRequestDetailsByRepo: {},
         pullRequestChecksByRepo: {},
+        pullRequestDiffsByRepo: {},
         pullRequestListStateByRepo: {},
         pullRequestsByRepo: {},
         pullRequestsByRepoAndState: {},

--- a/src/renderer/src/components/workspace/GitCommitTabView.tsx
+++ b/src/renderer/src/components/workspace/GitCommitTabView.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { buildGitRemoteCommitLink } from "@renderer/app/git/remote-link";
 import { getGitContextKey } from "@renderer/app/git/context-key";
 import { useResolvedEditorSettings } from "@renderer/app/hooks/use-resolved-editor-settings";
-import { buildEditorFontFamily } from "@renderer/app/settings/theme";
 import { openExternalUrl } from "@renderer/app/utils/external-url";
 import {
     convertCommitFilesToDiffFiles,
@@ -15,7 +14,6 @@ import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
 import type { RuntimeWorkspaceGitCommitTab } from "@renderer/app/workspace/tree";
 import {
     GitAuthorAvatar,
-    GitDiffsView,
     GitEmptyState,
 } from "@renderer/components/git";
 import { usePersistedWorkspaceScroll } from "@renderer/components/workspace/usePersistedWorkspaceScroll";
@@ -25,6 +23,7 @@ import {
     readPersistedGitCommitDiffCollapseState,
 } from "./gitCommitDiffCollapsePersistence";
 import { MarkdownContent } from "./MarkdownContent";
+import { GitRevisionDiffView } from "./GitRevisionDiffView";
 import { IdeActionButton } from "./ide-bar";
 
 const EMPTY_LOADING_SHAS: readonly string[] = [];
@@ -81,9 +80,7 @@ export function GitCommitTabView({
         snapshot?.remotes ?? [],
         tab.commitSha,
     );
-    const codeFontFamily = buildEditorFontFamily(editorSettings.fontFamily);
     const codeFontSize = editorSettings.fontSize;
-    const codeLineHeight = editorSettings.lineHeight;
     const authorFontSize = Math.max(13, Math.round(codeFontSize * 0.92));
     const metadataFontSize = Math.max(11, Math.round(codeFontSize * 0.82));
     const refFontSize = Math.max(10, Math.round(codeFontSize * 0.76));
@@ -94,10 +91,6 @@ export function GitCommitTabView({
 
     const diffFileIdsKey = useMemo(
         () => diffFiles.map((file) => file.id).join("|"),
-        [diffFiles],
-    );
-    const diffFileIdSet = useMemo(
-        () => new Set(diffFiles.map((file) => file.id)),
         [diffFiles],
     );
     const diffCollapseStorageKey = useMemo(
@@ -154,26 +147,6 @@ export function GitCommitTabView({
     const allCollapsed =
         diffFiles.length > 0 &&
         diffFiles.every((file) => collapsedFileIdSet.has(file.id));
-
-    const handleToggleFileCollapse = useCallback(
-        (fileId: string) => {
-            const visibleCollapsedFileIds = collapsedFileIds.filter((id) =>
-                diffFileIdSet.has(id),
-            );
-            const nextIds = collapsedFileIdSet.has(fileId)
-                ? visibleCollapsedFileIds.filter((id) => id !== fileId)
-                : [...visibleCollapsedFileIds, fileId];
-
-            setCollapsedFileIds(nextIds);
-            persistGitCommitDiffCollapseState(diffCollapseStorageKey, nextIds);
-        },
-        [
-            collapsedFileIds,
-            collapsedFileIdSet,
-            diffCollapseStorageKey,
-            diffFileIdSet,
-        ],
-    );
 
     const handleToggleAllFiles = useCallback(() => {
         const nextIds = allCollapsed ? [] : diffFiles.map((file) => file.id);
@@ -416,18 +389,13 @@ export function GitCommitTabView({
                 onScroll={handleCommitScroll}
                 ref={setCommitScrollContainer}
             >
-                <GitDiffsView
-                    codeFontFamily={codeFontFamily}
-                    codeFontSize={codeFontSize}
-                    codeLineHeight={codeLineHeight}
-                    collapsedFileIds={collapsedFileIds}
-                    displayMode="stack"
-                    files={diffFiles}
-                    lineWrapping={false}
-                    onToggleFileCollapse={handleToggleFileCollapse}
+                <GitRevisionDiffView
+                    additions={detail.insertions}
+                    collapseStorageKey={diffCollapseStorageKey}
+                    deletions={detail.deletions}
+                    files={detail.files}
                     scrollContainerRef={commitScrollContainerRef}
-                    showFileSelector={false}
-                    surfaceVariant="flat"
+                    totalFileCount={detail.changedFileCount}
                 />
             </section>
         </div>

--- a/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
@@ -539,7 +539,7 @@ export function GitHubPullRequestTabView({
                         {pullRequestDiff ? (
                             <>
                                 {detail ? (
-                                    <h1 className="pb-2 text-[20px] font-bold leading-7 text-text-primary">
+                                    <h1 className="github-document-title pb-2">
                                         {detail.title}
                                     </h1>
                                 ) : null}

--- a/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
@@ -43,6 +43,7 @@ import {
     hasGitHubWritePermission,
     openGitHubWebUrl,
 } from "./GitHubWorkspacePrimitives";
+import { GitRevisionDiffView } from "./GitRevisionDiffView";
 import { GitHubActionsPanel } from "./GitHubActionsPanel";
 import { GitHubLabelPicker } from "./GitHubLabelPicker";
 import { MarkdownContent } from "./MarkdownContent";
@@ -64,6 +65,7 @@ export function GitHubPullRequestTabView({
     const repoKey = getGitHubRepoKey(repo);
     const [commentDraft, setCommentDraft] = useState("");
     const [showAllCommits, setShowAllCommits] = useState(false);
+    const [showChanges, setShowChanges] = useState(false);
     const [isEditingDescription, setIsEditingDescription] = useState(false);
     const [titleDraft, setTitleDraft] = useState("");
     const [descriptionDraft, setDescriptionDraft] = useState("");
@@ -84,6 +86,10 @@ export function GitHubPullRequestTabView({
                 ? state.pullRequestChecksByRepo[repoKey]?.[detail.head.sha]
                 : undefined,
     );
+    const pullRequestDiff = useGitHubStore(
+        (state) =>
+            state.pullRequestDiffsByRepo[repoKey]?.[pullRequestNumber] ?? null,
+    );
     const authStatus = useGitHubStore(
         (state) => state.authStatusByHost[repo.host] ?? null,
     );
@@ -97,7 +103,7 @@ export function GitHubPullRequestTabView({
         ? getGitHubPullRequestChecksKey(repo, detail.head.sha)
         : null;
 
-    const { isLoading, isLoadingChecks, isLoadingLabels } = useGitHubStore(
+    const { isLoading, isLoadingChanges, isLoadingChecks, isLoadingLabels } = useGitHubStore(
         useShallow((state) => ({
             isLoading:
                 state.loadingKeys[
@@ -106,6 +112,8 @@ export function GitHubPullRequestTabView({
             isLoadingChecks: checksKey
                 ? (state.loadingKeys[checksKey] ?? false)
                 : false,
+            isLoadingChanges:
+                state.loadingKeys[`${repoKey}:pr:${pullRequestNumber}:diff`] ?? false,
             isLoadingLabels: state.loadingKeys[`${repoKey}:labels`] ?? false,
         })),
     );
@@ -156,6 +164,7 @@ export function GitHubPullRequestTabView({
         updateError,
         labelMutationError,
         labelsError,
+        changesError,
     } = useGitHubStore(
         useShallow((state) => ({
             checksError: checksKey ? (state.errors[checksKey] ?? null) : null,
@@ -186,6 +195,8 @@ export function GitHubPullRequestTabView({
                     `${repoKey}:pr:${pullRequestNumber}:labels`
                 ] ?? null,
             labelsError: state.errors[`${repoKey}:labels`] ?? null,
+            changesError:
+                state.errors[`${repoKey}:pr:${pullRequestNumber}:diff`] ?? null,
         })),
     );
 
@@ -194,6 +205,9 @@ export function GitHubPullRequestTabView({
     );
     const ensurePullRequestDetail = useGitHubStore(
         (state) => state.ensurePullRequestDetail,
+    );
+    const ensurePullRequestDiff = useGitHubStore(
+        (state) => state.ensurePullRequestDiff,
     );
     const refreshPullRequestChecks = useGitHubStore(
         (state) => state.refreshPullRequestChecks,
@@ -271,6 +285,18 @@ export function GitHubPullRequestTabView({
     ]);
 
     useEffect(() => {
+        if (!showChanges || pullRequestDiff || isLoadingChanges) return;
+        void ensurePullRequestDiff(repo, pullRequestNumber).catch(() => undefined);
+    }, [
+        ensurePullRequestDiff,
+        isLoadingChanges,
+        pullRequestDiff,
+        pullRequestNumber,
+        repo,
+        showChanges,
+    ]);
+
+    useEffect(() => {
         if (
             authStatus?.state !== "authenticated" ||
             !detail?.head.sha ||
@@ -318,6 +344,11 @@ export function GitHubPullRequestTabView({
                         force: true,
                     },
                 ).catch(() => undefined);
+            }
+            if (showChanges || pullRequestDiff) {
+                await ensurePullRequestDiff(repo, pullRequestNumber, {
+                    force: true,
+                }).catch(() => undefined);
             }
         }
     };
@@ -469,6 +500,13 @@ export function GitHubPullRequestTabView({
                 <GitHubTabHeader
                     actions={
                         <>
+                            <IdeActionButton
+                                onClick={() => setShowChanges((current) => !current)}
+                            >
+                                {showChanges
+                                    ? "Overview"
+                                    : `Changes ${detail?.changedFileCount ?? ""}`.trim()}
+                            </IdeActionButton>
                             <IdeActionButton
                                 onClick={() =>
                                     openGitHubWebUrl(
@@ -685,6 +723,50 @@ export function GitHubPullRequestTabView({
                                 </div>
                             ) : null}
                         </section>
+
+                        {showChanges ? (
+                            <GitHubSection
+                                title="Changes"
+                                tone="info"
+                            >
+                                {isLoadingChanges ? (
+                                    <div className="py-6 text-[12px] text-text-secondary">
+                                        Loading pull request changes...
+                                    </div>
+                                ) : changesError ? (
+                                    <div className="space-y-3 py-3">
+                                        <GitHubErrorState>
+                                            {changesError}
+                                        </GitHubErrorState>
+                                        <IdeActionButton
+                                            onClick={() =>
+                                                void ensurePullRequestDiff(
+                                                    repo,
+                                                    pullRequestNumber,
+                                                    { force: true },
+                                                )
+                                            }
+                                        >
+                                            Retry
+                                        </IdeActionButton>
+                                    </div>
+                                ) : pullRequestDiff ? (
+                                    <div className="-mx-5 flex min-h-[360px] flex-col">
+                                        {pullRequestDiff.incompleteReason ? (
+                                            <div className="px-5 py-2 text-[11px] text-[color:var(--diff-warn)]">
+                                                {pullRequestDiff.incompleteReason}
+                                            </div>
+                                        ) : null}
+                                        <GitRevisionDiffView
+                                            additions={pullRequestDiff.additions}
+                                            deletions={pullRequestDiff.deletions}
+                                            files={pullRequestDiff.files}
+                                            totalFileCount={pullRequestDiff.totalFileCount}
+                                        />
+                                    </div>
+                                ) : null}
+                            </GitHubSection>
+                        ) : null}
 
                         <GitHubSection
                             actions={

--- a/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
@@ -15,6 +15,7 @@ import type {
 import {
     EMPTY_GITHUB_LIST,
     getGitHubPullRequestChecksKey,
+    getGitHubPullRequestDiffKey,
     getGitHubRepoKey,
     useGitHubStore,
 } from "@renderer/app/store/github-store";
@@ -88,7 +89,16 @@ export function GitHubPullRequestTabView({
     );
     const pullRequestDiff = useGitHubStore(
         (state) =>
-            state.pullRequestDiffsByRepo[repoKey]?.[pullRequestNumber] ?? null,
+            detail
+                ? (state.pullRequestDiffsByRepo[repoKey]?.[
+                      getGitHubPullRequestDiffKey(
+                          repo,
+                          pullRequestNumber,
+                          detail.base.sha,
+                          detail.head.sha,
+                      )
+                  ] ?? null)
+                : null,
     );
     const authStatus = useGitHubStore(
         (state) => state.authStatusByHost[repo.host] ?? null,
@@ -493,6 +503,45 @@ export function GitHubPullRequestTabView({
         0,
         commits.length - COMMITS_PREVIEW_LIMIT,
     );
+
+    if (showChanges) {
+        return (
+            <GitHubTabShell
+                header={
+                    <GitHubTabHeader
+                        actions={
+                            <>
+                                <IdeActionButton onClick={() => setShowChanges(false)}>
+                                    Overview
+                                </IdeActionButton>
+                                <IdeActionButton onClick={() => void handleRefresh()}>
+                                    Refresh
+                                </IdeActionButton>
+                            </>
+                        }
+                        meta={detail ? <span className="min-w-0 flex-1 truncate text-[11px] font-medium text-text-primary">{detail.title}</span> : null}
+                        repo={repo}
+                        title={`PR #${pullRequestNumber}`}
+                    />
+                }
+                scrollScope={{
+                    entityId: `${repoKey}/pulls/${pullRequestNumber}:changes`,
+                    projectId,
+                    surface: "github_pull_request_changes",
+                    worktreeId: worktreeId ?? null,
+                }}
+            >
+                {({ scrollContainerRef }) => (
+                    <div className="github-document flex min-h-full flex-col">
+                        <GitHubAuthNotice authStatus={authStatus} />
+                        {isLoadingChanges ? <div className="py-6 text-[12px] text-text-secondary">Loading pull request changes...</div> : null}
+                        {changesError ? <div className="space-y-3 py-3"><GitHubErrorState>{changesError}</GitHubErrorState><IdeActionButton onClick={() => void ensurePullRequestDiff(repo, pullRequestNumber, { force: true })}>Retry</IdeActionButton></div> : null}
+                        {pullRequestDiff ? <><div className="py-2 text-[11px] text-text-secondary">{pullRequestDiff.incompleteReason ?? "Reviewing the net change in this pull request."}</div><GitRevisionDiffView additions={pullRequestDiff.additions} collapseStorageKey={`github-pr-diff:${repoKey}:${pullRequestDiff.number}:${pullRequestDiff.baseSha}:${pullRequestDiff.headSha}`} deletions={pullRequestDiff.deletions} files={pullRequestDiff.files} key={`${pullRequestDiff.baseSha}:${pullRequestDiff.headSha}`} scrollContainerRef={scrollContainerRef} totalFileCount={pullRequestDiff.totalFileCount} /></> : null}
+                    </div>
+                )}
+            </GitHubTabShell>
+        );
+    }
 
     return (
         <GitHubTabShell

--- a/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
@@ -536,7 +536,28 @@ export function GitHubPullRequestTabView({
                         <GitHubAuthNotice authStatus={authStatus} />
                         {isLoadingChanges ? <div className="py-6 text-[12px] text-text-secondary">Loading pull request changes...</div> : null}
                         {changesError ? <div className="space-y-3 py-3"><GitHubErrorState>{changesError}</GitHubErrorState><IdeActionButton onClick={() => void ensurePullRequestDiff(repo, pullRequestNumber, { force: true })}>Retry</IdeActionButton></div> : null}
-                        {pullRequestDiff ? <><div className="py-2 text-[11px] text-text-secondary">{pullRequestDiff.incompleteReason ?? "Reviewing the net change in this pull request."}</div><GitRevisionDiffView additions={pullRequestDiff.additions} collapseStorageKey={`github-pr-diff:${repoKey}:${pullRequestDiff.number}:${pullRequestDiff.baseSha}:${pullRequestDiff.headSha}`} deletions={pullRequestDiff.deletions} files={pullRequestDiff.files} key={`${pullRequestDiff.baseSha}:${pullRequestDiff.headSha}`} scrollContainerRef={scrollContainerRef} totalFileCount={pullRequestDiff.totalFileCount} /></> : null}
+                        {pullRequestDiff ? (
+                            <>
+                                {detail ? (
+                                    <h1 className="pb-2 text-[20px] font-bold leading-7 text-text-primary">
+                                        {detail.title}
+                                    </h1>
+                                ) : null}
+                                <div className="py-2 text-[11px] text-text-secondary">
+                                    {pullRequestDiff.incompleteReason ??
+                                        "Reviewing the net change in this pull request."}
+                                </div>
+                                <GitRevisionDiffView
+                                    additions={pullRequestDiff.additions}
+                                    collapseStorageKey={`github-pr-diff:${repoKey}:${pullRequestDiff.number}:${pullRequestDiff.baseSha}:${pullRequestDiff.headSha}`}
+                                    deletions={pullRequestDiff.deletions}
+                                    files={pullRequestDiff.files}
+                                    key={`${pullRequestDiff.baseSha}:${pullRequestDiff.headSha}`}
+                                    scrollContainerRef={scrollContainerRef}
+                                    totalFileCount={pullRequestDiff.totalFileCount}
+                                />
+                            </>
+                        ) : null}
                     </div>
                 )}
             </GitHubTabShell>

--- a/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
+++ b/src/renderer/src/components/workspace/GitHubPullRequestTabView.tsx
@@ -575,7 +575,7 @@ export function GitHubPullRequestTabView({
                             >
                                 {showChanges
                                     ? "Overview"
-                                    : `Changes ${detail?.changedFileCount ?? ""}`.trim()}
+                                    : "View Changes"}
                             </IdeActionButton>
                             <IdeActionButton
                                 onClick={() =>

--- a/src/renderer/src/components/workspace/GitRevisionDiffView.tsx
+++ b/src/renderer/src/components/workspace/GitRevisionDiffView.tsx
@@ -26,7 +26,7 @@ export function GitRevisionDiffView({
     readonly deletions: number;
     readonly files: readonly GitRevisionFileDiff[];
     readonly leadingContent?: ReactNode;
-    readonly scrollContainerRef: RefObject<HTMLElement | null>;
+    readonly scrollContainerRef?: RefObject<HTMLElement | null>;
     readonly totalFileCount: number;
 }) {
     const settings = useResolvedEditorSettings();

--- a/src/renderer/src/components/workspace/GitRevisionDiffView.tsx
+++ b/src/renderer/src/components/workspace/GitRevisionDiffView.tsx
@@ -1,0 +1,104 @@
+import {
+    useCallback,
+    useMemo,
+    useState,
+    type ReactNode,
+    type RefObject,
+} from "react";
+
+import type { GitRevisionFileDiff } from "@shared/ipc";
+import { convertRevisionFilesToDiffFiles } from "@renderer/app/git/history-presentation";
+import { useResolvedEditorSettings } from "@renderer/app/hooks/use-resolved-editor-settings";
+import { buildEditorFontFamily } from "@renderer/app/settings/theme";
+import { GitDiffsView } from "@renderer/components/git";
+
+import { IdeActionButton } from "./ide-bar";
+
+export function GitRevisionDiffView({
+    additions,
+    deletions,
+    files,
+    leadingContent,
+    scrollContainerRef,
+    totalFileCount,
+}: {
+    readonly additions: number;
+    readonly deletions: number;
+    readonly files: readonly GitRevisionFileDiff[];
+    readonly leadingContent?: ReactNode;
+    readonly scrollContainerRef: RefObject<HTMLElement | null>;
+    readonly totalFileCount: number;
+}) {
+    const settings = useResolvedEditorSettings();
+    const diffFiles = useMemo(
+        () => convertRevisionFilesToDiffFiles(files),
+        [files],
+    );
+    const [collapsedFileIds, setCollapsedFileIds] = useState<readonly string[]>(
+        [],
+    );
+    const collapsedFileIdSet = useMemo(
+        () => new Set(collapsedFileIds),
+        [collapsedFileIds],
+    );
+    const allCollapsed =
+        diffFiles.length > 0 &&
+        diffFiles.every((file) => collapsedFileIdSet.has(file.id));
+    const toggleFile = useCallback((fileId: string) => {
+        setCollapsedFileIds((current) =>
+            current.includes(fileId)
+                ? current.filter((id) => id !== fileId)
+                : [...current, fileId],
+        );
+    }, []);
+    const toggleAll = useCallback(() => {
+        setCollapsedFileIds(
+            allCollapsed ? [] : diffFiles.map((file) => file.id),
+        );
+    }, [allCollapsed, diffFiles]);
+
+    return (
+        <div className="flex min-h-0 flex-1 flex-col">
+            <div
+                className="flex flex-wrap items-center gap-3 border-y border-[color-mix(in_srgb,var(--color-border)_60%,transparent)] bg-bg-secondary px-5 py-1.5 font-mono text-[10.5px] text-text-secondary"
+            >
+                {leadingContent}
+                {diffFiles.length > 0 ? (
+                    <IdeActionButton
+                        onClick={toggleAll}
+                        title={allCollapsed ? "Expand all files" : "Collapse all files"}
+                    >
+                        {allCollapsed ? "expand all" : "collapse all"}
+                    </IdeActionButton>
+                ) : null}
+                <span className="ml-auto shrink-0">
+                    {totalFileCount} {totalFileCount === 1 ? "file" : "files"}
+                </span>
+                {additions > 0 ? (
+                    <span className="shrink-0" style={{ color: "var(--diff-add)" }}>
+                        +{additions}
+                    </span>
+                ) : null}
+                {deletions > 0 ? (
+                    <span className="shrink-0" style={{ color: "var(--diff-remove)" }}>
+                        -{deletions}
+                    </span>
+                ) : null}
+            </div>
+            <GitDiffsView
+                codeFontFamily={buildEditorFontFamily(settings.fontFamily)}
+                codeFontSize={settings.fontSize}
+                codeLineHeight={settings.lineHeight}
+                collapsedFileIds={collapsedFileIds}
+                displayMode="stack"
+                emptyState="This pull request has no file changes."
+                files={diffFiles}
+                lineWrapping={false}
+                onToggleFileCollapse={toggleFile}
+                scrollContainerRef={scrollContainerRef}
+                showFileSelector={false}
+                surfaceVariant="flat"
+            />
+        </div>
+    );
+}

--- a/src/renderer/src/components/workspace/GitRevisionDiffView.tsx
+++ b/src/renderer/src/components/workspace/GitRevisionDiffView.tsx
@@ -13,9 +13,14 @@ import { buildEditorFontFamily } from "@renderer/app/settings/theme";
 import { GitDiffsView } from "@renderer/components/git";
 
 import { IdeActionButton } from "./ide-bar";
+import {
+    persistGitCommitDiffCollapseState,
+    readPersistedGitCommitDiffCollapseState,
+} from "./gitCommitDiffCollapsePersistence";
 
 export function GitRevisionDiffView({
     additions,
+    collapseStorageKey,
     deletions,
     files,
     leadingContent,
@@ -23,6 +28,7 @@ export function GitRevisionDiffView({
     totalFileCount,
 }: {
     readonly additions: number;
+    readonly collapseStorageKey?: string;
     readonly deletions: number;
     readonly files: readonly GitRevisionFileDiff[];
     readonly leadingContent?: ReactNode;
@@ -35,7 +41,11 @@ export function GitRevisionDiffView({
         [files],
     );
     const [collapsedFileIds, setCollapsedFileIds] = useState<readonly string[]>(
-        [],
+        () =>
+            collapseStorageKey
+                ? (readPersistedGitCommitDiffCollapseState(collapseStorageKey)
+                      ?.collapsedFileIds ?? [])
+                : [],
     );
     const collapsedFileIdSet = useMemo(
         () => new Set(collapsedFileIds),
@@ -44,18 +54,26 @@ export function GitRevisionDiffView({
     const allCollapsed =
         diffFiles.length > 0 &&
         diffFiles.every((file) => collapsedFileIdSet.has(file.id));
+    const setAndPersistCollapsedFileIds = useCallback((next: readonly string[]) => {
+        setCollapsedFileIds(next);
+        if (collapseStorageKey) {
+            persistGitCommitDiffCollapseState(collapseStorageKey, next);
+        }
+    }, [collapseStorageKey]);
     const toggleFile = useCallback((fileId: string) => {
-        setCollapsedFileIds((current) =>
-            current.includes(fileId)
+        setCollapsedFileIds((current) => {
+            const next = current.includes(fileId)
                 ? current.filter((id) => id !== fileId)
-                : [...current, fileId],
-        );
-    }, []);
+                : [...current, fileId];
+            if (collapseStorageKey) {
+                persistGitCommitDiffCollapseState(collapseStorageKey, next);
+            }
+            return next;
+        });
+    }, [collapseStorageKey]);
     const toggleAll = useCallback(() => {
-        setCollapsedFileIds(
-            allCollapsed ? [] : diffFiles.map((file) => file.id),
-        );
-    }, [allCollapsed, diffFiles]);
+        setAndPersistCollapsedFileIds(allCollapsed ? [] : diffFiles.map((file) => file.id));
+    }, [allCollapsed, diffFiles, setAndPersistCollapsedFileIds]);
 
     return (
         <div className="flex min-h-0 flex-1 flex-col">

--- a/src/renderer/src/components/workspace/review/reviewDiff.ts
+++ b/src/renderer/src/components/workspace/review/reviewDiff.ts
@@ -1,4 +1,5 @@
 import type { AiDiffHunk, AiFileDiff, AiTrackedFile } from "@shared/ipc";
+import { parseUnifiedDiffHunks as parseSharedUnifiedDiffHunks } from "@shared/diff/unified-diff";
 
 export interface DiffLine {
     readonly type: "add" | "context" | "remove" | "separator";
@@ -45,9 +46,6 @@ export const DIFF_CONTEXT_LINES = 5;
 export const DIFF_PANEL_MAX_HEIGHT = 520;
 export const DIFF_ZOOM_MIN = 0.64;
 export const DIFF_ZOOM_MAX = 0.96;
-
-const UNIFIED_DIFF_HUNK_HEADER_REGEX =
-    /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
 
 interface DiffOp {
     readonly type: "add" | "context" | "remove";
@@ -511,73 +509,7 @@ export function computeApproximateDiffLines(
 }
 
 export function parseUnifiedDiffHunks(text: string): AiDiffHunk[] {
-    const hunks: AiDiffHunk[] = [];
-    let currentHunk: {
-        id: string;
-        lines: Array<{
-            id: string;
-            text: string;
-            type: "add" | "context" | "remove";
-        }>;
-        oldCount: number;
-        oldStart: number;
-        newCount: number;
-        newStart: number;
-    } | null = null;
-    let lineIndex = 0;
-
-    for (const rawLine of text.split("\n")) {
-        const headerMatch = UNIFIED_DIFF_HUNK_HEADER_REGEX.exec(rawLine);
-        if (headerMatch) {
-            currentHunk = {
-                id: `unified-hunk:${hunks.length}`,
-                oldStart: Number.parseInt(headerMatch[1] ?? "0", 10),
-                oldCount: Number.parseInt(headerMatch[2] ?? "1", 10),
-                newStart: Number.parseInt(headerMatch[3] ?? "0", 10),
-                newCount: Number.parseInt(headerMatch[4] ?? "1", 10),
-                lines: [],
-            };
-            hunks.push(currentHunk);
-            continue;
-        }
-
-        if (!currentHunk || rawLine === "\\ No newline at end of file") {
-            continue;
-        }
-
-        const marker = rawLine[0];
-        const textContent = rawLine.slice(1);
-        if (marker === " ") {
-            currentHunk.lines.push({
-                id: `unified-line:${lineIndex}`,
-                text: textContent,
-                type: "context",
-            });
-            lineIndex += 1;
-            continue;
-        }
-
-        if (marker === "-") {
-            currentHunk.lines.push({
-                id: `unified-line:${lineIndex}`,
-                text: textContent,
-                type: "remove",
-            });
-            lineIndex += 1;
-            continue;
-        }
-
-        if (marker === "+") {
-            currentHunk.lines.push({
-                id: `unified-line:${lineIndex}`,
-                text: textContent,
-                type: "add",
-            });
-            lineIndex += 1;
-        }
-    }
-
-    return hunks.filter((hunk) => hunk.lines.length > 0);
+    return parseSharedUnifiedDiffHunks(text) as AiDiffHunk[];
 }
 
 export function computeUnifiedDiffLines(text: string): readonly DiffLine[] {

--- a/src/shared/diff/unified-diff.ts
+++ b/src/shared/diff/unified-diff.ts
@@ -1,0 +1,58 @@
+export interface UnifiedDiffLine {
+    readonly id: string;
+    readonly text: string;
+    readonly type: "add" | "context" | "remove";
+}
+
+export interface UnifiedDiffHunk {
+    readonly id: string;
+    readonly lines: readonly UnifiedDiffLine[];
+    readonly newCount: number;
+    readonly newStart: number;
+    readonly oldCount: number;
+    readonly oldStart: number;
+}
+
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+export function parseUnifiedDiffHunks(
+    text: string,
+    namespace = "unified",
+): readonly UnifiedDiffHunk[] {
+    const hunks: Array<{
+        id: string;
+        lines: UnifiedDiffLine[];
+        newCount: number;
+        newStart: number;
+        oldCount: number;
+        oldStart: number;
+    }> = [];
+
+    for (const rawLine of text.replace(/\r\n/g, "\n").split("\n")) {
+        const header = HUNK_HEADER.exec(rawLine);
+        if (header) {
+            hunks.push({
+                id: `${namespace}:hunk:${hunks.length}`,
+                lines: [],
+                newCount: Number.parseInt(header[4] ?? "1", 10),
+                newStart: Number.parseInt(header[3] ?? "0", 10),
+                oldCount: Number.parseInt(header[2] ?? "1", 10),
+                oldStart: Number.parseInt(header[1] ?? "0", 10),
+            });
+            continue;
+        }
+        if (rawLine === "\\ No newline at end of file") continue;
+        const hunk = hunks[hunks.length - 1];
+        const marker = rawLine[0];
+        if (!hunk || (marker !== " " && marker !== "+" && marker !== "-")) {
+            continue;
+        }
+        hunk.lines.push({
+            id: `${namespace}:line:${hunks.length - 1}:${hunk.lines.length}`,
+            text: rawLine.slice(1),
+            type: marker === " " ? "context" : marker === "+" ? "add" : "remove",
+        });
+    }
+
+    return hunks;
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -80,6 +80,7 @@ export const IPC_CHANNELS = {
     reopenGitHubIssue: "github:reopen-issue",
     listGitHubPullRequests: "github:list-pull-requests",
     getGitHubPullRequest: "github:get-pull-request",
+    getGitHubPullRequestDiff: "github:get-pull-request-diff",
     listGitHubPullRequestChecks: "github:list-pull-request-checks",
     createGitHubPullRequest: "github:create-pull-request",
     updateGitHubPullRequest: "github:update-pull-request",
@@ -1314,6 +1315,19 @@ export interface GitHubPullRequestDetail extends GitHubPullRequestSummary {
     readonly mergeable: boolean | null;
 }
 
+export interface GitHubPullRequestDiffResult {
+    readonly additions: number;
+    readonly baseSha: string;
+    readonly contentComplete: boolean;
+    readonly deletions: number;
+    readonly fileListComplete: boolean;
+    readonly files: readonly GitRevisionFileDiff[];
+    readonly headSha: string;
+    readonly incompleteReason: string | null;
+    readonly number: number;
+    readonly totalFileCount: number;
+}
+
 export type GitHubPullRequestChecksState =
     | "failure"
     | "pending"
@@ -1379,6 +1393,11 @@ export interface GitHubListPullRequestsResult {
 }
 
 export interface GitHubGetPullRequestInput extends GitHubRepositoryInput {
+    readonly number: number;
+}
+
+export interface GitHubGetPullRequestDiffInput
+    extends GitHubRepositoryInput {
     readonly number: number;
 }
 
@@ -3068,6 +3087,9 @@ export interface ComandoApi {
     getGitHubPullRequest: (
         input: GitHubGetPullRequestInput,
     ) => Promise<GitHubPullRequestDetail | null>;
+    getGitHubPullRequestDiff: (
+        input: GitHubGetPullRequestDiffInput,
+    ) => Promise<GitHubPullRequestDiffResult>;
     listGitHubPullRequestChecks: (
         input: GitHubPullRequestChecksInput,
     ) => Promise<GitHubPullRequestChecksResult>;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -845,11 +845,15 @@ export interface GitFileDiff {
     readonly reversible: boolean;
 }
 
-export interface GitCommitFileDiff extends GitFileDiff {
+export interface GitRevisionFileDiff extends GitFileDiff {
     readonly additions: number | null;
+    /** Missing only when the value came from an older native backend. */
+    readonly contentState?: "available" | "unavailable";
     readonly deletions: number | null;
     readonly statusLabel: string | null;
 }
+
+export type GitCommitFileDiff = GitRevisionFileDiff;
 
 export interface GitRepositoryStatusSummary {
     readonly conflictedCount: number;


### PR DESCRIPTION
## Summary
- add a lazy Changes view for the net diff of a GitHub pull request
- load PR files through paginated GitHub API requests with snapshot-aware caching
- reuse the revision diff viewer with shared scrolling, virtualized files/lines, and persisted collapse state
- show incomplete/unavailable patch states clearly

## Validation
- pnpm run typecheck
- pnpm run lint
- pnpm run test
- pnpm run build:ci
- independent implementation audit approved