### PR TITLE
Add copy full path action to workspace tabs

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1490,6 +1490,7 @@ export function App() {
                 );
                 return [
                     {
+                        fullPath: worktree?.rootPath ?? project?.rootPath ?? null,
                         key: context.key,
                         projectId: context.projectId,
                         projectName: project?.name ?? "Missing project",

--- a/src/renderer/src/components/DesktopTopBar.context-menu.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.context-menu.test.tsx
@@ -12,6 +12,7 @@ const mountedRoots: Root[] = [];
 const mountedContainers: HTMLDivElement[] = [];
 
 afterEach(() => {
+    vi.unstubAllGlobals();
     for (const root of mountedRoots.splice(0)) {
         act(() => root.unmount());
     }
@@ -35,6 +36,7 @@ function renderTopBar() {
                 activeContextKey: "project-1::__primary__",
                 contexts: [
                     {
+                        fullPath: "/projects/comando",
                         key: "project-1::__primary__",
                         projectId: "project-1",
                         projectName: "Comando",
@@ -42,6 +44,7 @@ function renderTopBar() {
                         worktreeLabel: "main",
                     },
                     {
+                        fullPath: "/projects/sandbox",
                         key: "project-2::__primary__",
                         projectId: "project-2",
                         projectName: "Sandbox",
@@ -82,6 +85,11 @@ function getContextMenuButton(label: string): HTMLButtonElement {
 
 describe("DesktopTopBar context menu", () => {
     it("offers move and close actions for the context clicked with the secondary button", async () => {
+        const writeText = vi.fn(() => Promise.resolve());
+        vi.stubGlobal("navigator", {
+            ...navigator,
+            clipboard: { writeText },
+        });
         const { container, onCloseContext, onMoveContextToNewWindow } =
             renderTopBar();
         const tab = container.querySelector<HTMLElement>(
@@ -100,8 +108,26 @@ describe("DesktopTopBar context menu", () => {
             );
         });
 
+        expect(getContextMenuButton("Copy Full Path")).toBeTruthy();
         expect(getContextMenuButton("Move to New Window")).toBeTruthy();
         expect(getContextMenuButton("Close")).toBeTruthy();
+
+        await act(async () => {
+            getContextMenuButton("Copy Full Path").click();
+            await Promise.resolve();
+        });
+        expect(writeText).toHaveBeenCalledWith("/projects/sandbox");
+
+        act(() => {
+            tab?.dispatchEvent(
+                new MouseEvent("contextmenu", {
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: 120,
+                    clientY: 40,
+                }),
+            );
+        });
 
         await act(async () => {
             getContextMenuButton("Move to New Window").click();

--- a/src/renderer/src/components/DesktopTopBar.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.test.tsx
@@ -10,6 +10,7 @@ describe("DesktopTopBar", () => {
                 activeContextKey="project-1::__primary__"
                 contexts={[
                     {
+                        fullPath: "/projects/comando",
                         key: "project-1::__primary__",
                         projectId: "project-1",
                         projectName: "Comando",
@@ -17,6 +18,7 @@ describe("DesktopTopBar", () => {
                         worktreeLabel: "main",
                     },
                     {
+                        fullPath: "/projects/comando-navigation",
                         key: "project-1::worktree-1",
                         projectId: "project-1",
                         projectName: "Comando",

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -24,6 +24,7 @@ import { useProjectContextTabDrag } from "./useProjectContextTabDrag";
 export type { ProjectContextMenuProject } from "./ProjectContextMenu";
 
 export interface ProjectContextTabItem {
+    readonly fullPath: string | null;
     readonly key: string;
     readonly projectId: string;
     readonly projectName: string;
@@ -356,6 +357,28 @@ export function DesktopTopBar({
             {contextMenu ? (
                 <ContextMenu
                     entries={[
+                        {
+                            action: () => {
+                                const fullPath = contextMenu.payload.fullPath;
+                                if (!fullPath) {
+                                    return;
+                                }
+                                void (async () => {
+                                    try {
+                                        await navigator.clipboard.writeText(
+                                            fullPath,
+                                        );
+                                    } catch {
+                                        window.alert(
+                                            "Could not copy the project path.",
+                                        );
+                                    }
+                                })();
+                            },
+                            disabled: !contextMenu.payload.fullPath,
+                            label: "Copy Full Path",
+                        },
+                        { type: "separator" },
                         {
                             action: () =>
                                 onMoveContextToNewWindow(


### PR DESCRIPTION
## Summary

- add a Copy Full Path action to workspace-tab context menus
- resolve paths from the selected project or worktree
- disable the action when the workspace path is unavailable
- cover copying the path of the clicked workspace tab

## Validation

- `pnpm exec vitest run src/renderer/src/components/DesktopTopBar.test.tsx src/renderer/src/components/DesktopTopBar.context-menu.test.tsx`
- `pnpm exec eslint src/renderer/src/App.tsx src/renderer/src/components/DesktopTopBar.tsx src/renderer/src/components/DesktopTopBar.test.tsx src/renderer/src/components/DesktopTopBar.context-menu.test.tsx`
- `pnpm run typecheck`