### PR TITLE
Fix primary worktree scope equivalence

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2513,7 +2513,11 @@ export function App() {
                 (tab) =>
                     tab.kind === "chat" &&
                     tab.projectId === activeProjectId &&
-                    (tab.worktreeId ?? null) === worktreeId,
+                    areGitWorktreeIdsEquivalent(
+                        activeProjectId,
+                        tab.worktreeId ?? null,
+                        worktreeId,
+                    ),
             );
 
             const attachContext = (sessionId: string) => {
@@ -2561,7 +2565,11 @@ export function App() {
                 (tab) =>
                     tab.kind === "chat" &&
                     tab.projectId === activeProjectId &&
-                    (tab.worktreeId ?? null) === worktreeId &&
+                    areGitWorktreeIdsEquivalent(
+                        activeProjectId,
+                        tab.worktreeId ?? null,
+                        worktreeId,
+                    ) &&
                     !existingTabIds.has(tab.id),
             );
 

--- a/src/renderer/src/app/projects/file-tree-selection.test.ts
+++ b/src/renderer/src/app/projects/file-tree-selection.test.ts
@@ -65,6 +65,16 @@ describe("file tree selection", () => {
         ).toBeNull();
     });
 
+    it("recognizes the primary checkout when its workspace context uses null", () => {
+        expect(
+            resolveActiveFileTreePath({
+                activeProjectId: "project-1",
+                activeWorkspaceTab: createFileTab({ worktreeId: null }),
+                activeWorktreeId: "project-1:primary",
+            }),
+        ).toBe("docs/guide.md");
+    });
+
     it("uses the active file when there is no manual tree selection", () => {
         expect(
             reconcileFileTreeSelection({

--- a/src/renderer/src/app/projects/file-tree-selection.ts
+++ b/src/renderer/src/app/projects/file-tree-selection.ts
@@ -1,4 +1,5 @@
 import type { RuntimeWorkspaceTab } from "../workspace/tree";
+import { areGitWorktreeIdsEquivalent } from "../git/context-key";
 import {
     selectGitTreeRange,
     toggleGitTreePathSelection,
@@ -40,7 +41,11 @@ export function resolveActiveFileTreePath({
         activeWorkspaceTab?.kind !== "file" ||
         !activeProjectId ||
         activeWorkspaceTab.projectId !== activeProjectId ||
-        (activeWorkspaceTab.worktreeId ?? null) !== activeWorktreeId
+        !areGitWorktreeIdsEquivalent(
+            activeProjectId,
+            activeWorkspaceTab.worktreeId ?? null,
+            activeWorktreeId,
+        )
     ) {
         return null;
     }

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -3749,6 +3749,35 @@ describe("workspace runtime focus helpers", () => {
         ).toBe("chat-worktree");
     });
 
+    it("matches a primary workspace chat when the active scope is canonical", () => {
+        const state: WorkspaceTreeState = {
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: "chat-primary",
+                id: "pane-root",
+                tabIds: ["chat-primary"],
+                type: "pane",
+            },
+            tabsById: {
+                "chat-primary": createWorkspaceChatTab(
+                    "chat-primary",
+                    "session-primary",
+                    "codex",
+                ),
+            },
+        };
+
+        expect(
+            getBestMatchingChatTabId(state, {
+                currentPaneId: "pane-root",
+                lastFocusedChatTabId: "chat-primary",
+                projectId: "project-1",
+                recentFocusedChatTabIds: [],
+                worktreeId: "project-1:primary",
+            }),
+        ).toBe("chat-primary");
+    });
+
     it("tracks chat focus recency without overwriting it when a file tab is selected", async () => {
         useWorkspaceStore.setState((state) => ({
             ...state,

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -617,8 +617,11 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
 
             if (
                 tab.projectId === projectId &&
-                normalizeWorktreeId(tab.worktreeId) ===
-                    normalizeWorktreeId(worktreeId) &&
+                areWorkspaceWorktreeIdsEquivalent(
+                    projectId,
+                    tab.worktreeId ?? null,
+                    worktreeId,
+                ) &&
                 matchesRelativePath
             ) {
                 fileTabsToClose.push(tab);
@@ -647,8 +650,11 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 if (
                     tab.kind !== "file" ||
                     tab.projectId !== projectId ||
-                    normalizeWorktreeId(tab.worktreeId) !==
-                        normalizeWorktreeId(worktreeId)
+                    !areWorkspaceWorktreeIdsEquivalent(
+                        projectId,
+                        tab.worktreeId,
+                        worktreeId,
+                    )
                 ) {
                     return false;
                 }
@@ -1901,8 +1907,11 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             (tab): tab is RuntimeWorkspaceFileTab =>
                 tab.kind === "file" &&
                 tab.projectId === projectId &&
-                normalizeWorktreeId(tab.worktreeId) ===
-                    normalizeWorktreeId(worktreeId),
+                areWorkspaceWorktreeIdsEquivalent(
+                    projectId,
+                    tab.worktreeId ?? null,
+                    worktreeId,
+                ),
         );
 
         if (fileTabs.length === 0) {
@@ -1956,7 +1965,11 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             set,
             (context) =>
                 context.projectId === projectId &&
-                normalizeWorktreeId(context.worktreeId) === normalizeWorktreeId(worktreeId),
+                areGitWorktreeIdsEquivalent(
+                    projectId,
+                    context.worktreeId,
+                    worktreeId,
+                ),
         );
     },
 
@@ -2534,8 +2547,11 @@ export function getBestMatchingChatTabId(
         return (
             tab?.kind === "chat" &&
             tab.projectId === input.projectId &&
-            normalizeWorktreeId(tab.worktreeId) ===
-                normalizeWorktreeId(input.worktreeId)
+            areWorkspaceWorktreeIdsEquivalent(
+                input.projectId,
+                tab.worktreeId,
+                input.worktreeId,
+            )
         );
     };
 
@@ -3235,8 +3251,11 @@ function invalidateInactiveContextFileDocuments(
             if (
                 tab.kind !== "file" ||
                 tab.projectId !== projectId ||
-                normalizeWorktreeId(tab.worktreeId) !==
-                    normalizeWorktreeId(worktreeId) ||
+                !areWorkspaceWorktreeIdsEquivalent(
+                    projectId,
+                    tab.worktreeId ?? null,
+                    worktreeId,
+                ) ||
                 !isFileTabAffectedByProjectInvalidation(
                     tab.relativePath,
                     invalidatedRelativePaths,
@@ -3811,7 +3830,7 @@ function getOrCreateFileDocumentLoad(
 function getWorkspaceFileLoadKey(tab: RuntimeWorkspaceFileTab): string {
     return [
         tab.projectId,
-        normalizeWorktreeId(tab.worktreeId) ?? "__primary__",
+        getWorkspaceWorktreeScopeKey(tab.projectId, tab.worktreeId),
         tab.relativePath,
     ].join("\u0000");
 }
@@ -4088,8 +4107,11 @@ function findExistingFileTabs(
         (tab): tab is RuntimeWorkspaceFileTab =>
             tab.kind === "file" &&
             tab.projectId === projectId &&
-            normalizeWorktreeId(tab.worktreeId) ===
-                normalizeWorktreeId(worktreeId) &&
+            areGitWorktreeIdsEquivalent(
+                projectId,
+                tab.worktreeId ?? null,
+                worktreeId,
+            ) &&
             tab.relativePath === relativePath,
     );
 }
@@ -4128,8 +4150,11 @@ function findExistingGitTab(
             (tab): tab is RuntimeWorkspaceGitTab =>
                 tab.kind === "git" &&
                 tab.projectId === projectId &&
-                normalizeWorktreeId(tab.worktreeId) ===
-                    normalizeWorktreeId(worktreeId),
+                areGitWorktreeIdsEquivalent(
+                    projectId,
+                    tab.worktreeId ?? null,
+                    worktreeId,
+                ),
         ) ?? null
     );
 }
@@ -4144,8 +4169,11 @@ function findExistingChatHistoryTab(
             (tab): tab is RuntimeWorkspaceChatHistoryTab =>
                 tab.kind === "chat_history" &&
                 tab.projectId === projectId &&
-                normalizeWorktreeId(tab.worktreeId) ===
-                    normalizeWorktreeId(worktreeId),
+                areWorkspaceWorktreeIdsEquivalent(
+                    projectId,
+                    tab.worktreeId,
+                    worktreeId,
+                ),
         ) ?? null
     );
 }
@@ -4161,8 +4189,11 @@ function findExistingGitCommitTab(
             (tab): tab is RuntimeWorkspaceGitCommitTab =>
                 tab.kind === "git_commit" &&
                 tab.projectId === projectId &&
-                normalizeWorktreeId(tab.worktreeId) ===
-                    normalizeWorktreeId(worktreeId) &&
+                areWorkspaceWorktreeIdsEquivalent(
+                    projectId,
+                    tab.worktreeId,
+                    worktreeId,
+                ) &&
                 tab.commitSha === commitSha,
         ) ?? null
     );
@@ -4180,8 +4211,8 @@ function findExistingGitWorktreeDiffTab(
                 tab.projectId === projectId &&
                 areGitWorktreeIdsEquivalent(
                     projectId,
-                    normalizeWorktreeId(tab.worktreeId),
-                    normalizeWorktreeId(worktreeId),
+                    tab.worktreeId ?? null,
+                    worktreeId,
                 ),
         ) ?? null
     );
@@ -4206,8 +4237,11 @@ function findExistingGitHubTab(
                 tab.kind !== input.kind ||
                 !isGitHubTabKind(tab.kind) ||
                 tab.projectId !== input.projectId ||
-                normalizeWorktreeId(tab.worktreeId) !==
-                    normalizeWorktreeId(input.worktreeId) ||
+                !areWorkspaceWorktreeIdsEquivalent(
+                    input.projectId,
+                    tab.worktreeId ?? null,
+                    input.worktreeId,
+                ) ||
                 !matchesGitHubRepositoryRef(tab.ref, input.ref)
             ) {
                 return false;
@@ -4294,10 +4328,23 @@ function getComandoApi() {
     return comandoWindow.comando;
 }
 
-function normalizeWorktreeId(
+function areWorkspaceWorktreeIdsEquivalent(
+    projectId: string | null,
+    left: string | null | undefined,
+    right: string | null | undefined,
+): boolean {
+    return projectId
+        ? areGitWorktreeIdsEquivalent(projectId, left ?? null, right ?? null)
+        : (left ?? null) === (right ?? null);
+}
+
+function getWorkspaceWorktreeScopeKey(
+    projectId: string,
     worktreeId: string | null | undefined,
-): string | null {
-    return worktreeId ?? null;
+): string {
+    return areGitWorktreeIdsEquivalent(projectId, worktreeId ?? null, null)
+        ? "__primary__"
+        : (worktreeId ?? "__primary__");
 }
 
 function isFileTabAffectedByProjectInvalidation(

--- a/src/renderer/src/app/workspace/tree.test.ts
+++ b/src/renderer/src/app/workspace/tree.test.ts
@@ -1123,6 +1123,24 @@ describe("workspace tree helpers", () => {
         expect(Object.keys(closed.tabsById).sort()).toEqual(["tab-3"]);
     });
 
+    it("matches primary file tabs when an operation uses the canonical worktree id", () => {
+        const withReadme = attachTabToPane(
+            createDefaultWorkspaceState(),
+            "pane-root",
+            makeFileTab("tab-primary", "docs/readme.md"),
+        );
+
+        const closed = closeWorkspaceTabsForProjectPath(
+            withReadme,
+            "project-1",
+            "project-1:primary",
+            "docs/readme.md",
+            "file",
+        );
+
+        expect(closed.tabsById).toEqual({});
+    });
+
     it("renames every matching open tab when a directory moves", () => {
         const withReadme = attachTabToPane(
             createDefaultWorkspaceState(),

--- a/src/renderer/src/app/workspace/tree.ts
+++ b/src/renderer/src/app/workspace/tree.ts
@@ -22,6 +22,7 @@ import type {
     WorkspaceTerminalTab,
 } from "@shared/ipc";
 import { resolveEditorLanguage } from "@shared/editor-language";
+import { areGitWorktreeIdsEquivalent } from "../git/context-key";
 
 export type SplitDirection = "down" | "left" | "right" | "up";
 export type MoveDirection = "next" | "previous";
@@ -867,8 +868,11 @@ export function closeWorkspaceTabsForProjectPath(
             (tab): tab is RuntimeWorkspaceFileTab =>
                 tab.kind === "file" &&
                 tab.projectId === projectId &&
-                normalizeWorktreeId(tab.worktreeId) ===
-                    normalizeWorktreeId(worktreeId) &&
+                areGitWorktreeIdsEquivalent(
+                    projectId,
+                    tab.worktreeId ?? null,
+                    worktreeId,
+                ) &&
                 matchesProjectPath(tab.relativePath, relativePath, kind),
         )
         .map((tab) => tab.id);
@@ -892,8 +896,11 @@ export function renameWorkspaceTabsForProjectPath(
             if (
                 tab.kind !== "file" ||
                 tab.projectId !== projectId ||
-                normalizeWorktreeId(tab.worktreeId) !==
-                    normalizeWorktreeId(worktreeId) ||
+                !areGitWorktreeIdsEquivalent(
+                    projectId,
+                    tab.worktreeId ?? null,
+                    worktreeId,
+                ) ||
                 !matchesProjectPath(
                     tab.relativePath,
                     previousRelativePath,
@@ -1616,16 +1623,13 @@ function matchesSameWorkspaceFile(
 ): boolean {
     return (
         left.projectId === right.projectId &&
-        normalizeWorktreeId(left.worktreeId) ===
-            normalizeWorktreeId(right.worktreeId) &&
+        areGitWorktreeIdsEquivalent(
+            left.projectId,
+            left.worktreeId ?? null,
+            right.worktreeId ?? null,
+        ) &&
         left.relativePath === right.relativePath
     );
-}
-
-function normalizeWorktreeId(
-    worktreeId: string | null | undefined,
-): string | null {
-    return worktreeId ?? null;
 }
 
 function rebaseAbsolutePath(

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -21,6 +21,7 @@ import {
 } from "@shared/ai-runtimes";
 
 import { useAiStore } from "@renderer/app/store/ai-store";
+import { areGitWorktreeIdsEquivalent } from "@renderer/app/git/context-key";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
 import { collectPaneNodes } from "@renderer/app/workspace/tree";
 import {
@@ -188,6 +189,11 @@ export function SidebarAgentsPanel({
         () => getSidebarAgentsHistoryCacheKey(projectId, worktreeId),
         [projectId, worktreeId],
     );
+    const historyQueryWorktreeId =
+        projectId &&
+        areGitWorktreeIdsEquivalent(projectId, worktreeId ?? null, null)
+            ? null
+            : (worktreeId ?? null);
     const folderScopeKey = useMemo(
         () => getSidebarAgentsFolderStorageKey(projectId, worktreeId),
         [projectId, worktreeId],
@@ -280,7 +286,14 @@ export function SidebarAgentsPanel({
             terminalAgentSessions.filter(
                 (session) =>
                     session.projectId === projectId &&
-                    (session.worktreeId ?? null) === (worktreeId ?? null),
+                    (projectId
+                        ? areGitWorktreeIdsEquivalent(
+                              projectId,
+                              session.worktreeId ?? null,
+                              worktreeId ?? null,
+                          )
+                        : (session.worktreeId ?? null) ===
+                          (worktreeId ?? null)),
         ),
         [projectId, terminalAgentSessions, worktreeId],
     );
@@ -375,7 +388,7 @@ export function SidebarAgentsPanel({
             const nextSessions = await api.listAiSessionHistory({
                 limit: SIDEBAR_AGENTS_HISTORY_LIMIT,
                 projectId,
-                worktreeId: worktreeId ?? null,
+                worktreeId: historyQueryWorktreeId,
             });
             if (requestIdRef.current !== requestId) {
                 return;
@@ -397,7 +410,7 @@ export function SidebarAgentsPanel({
                 setIsLoading(false);
             }
         }
-    }, [historyScopeKey, projectId, worktreeId]);
+    }, [historyQueryWorktreeId, historyScopeKey, projectId, worktreeId]);
 
     const clearRefreshTimer = useCallback(() => {
         if (refreshTimerRef.current !== null) {

--- a/src/renderer/src/components/sidebar/sidebarAgentsHistory.test.ts
+++ b/src/renderer/src/components/sidebar/sidebarAgentsHistory.test.ts
@@ -79,6 +79,24 @@ function createSnapshot(
 }
 
 describe("applySessionUpdateToSidebarHistory", () => {
+    it("includes primary sessions stored with null in a canonical primary scope", () => {
+        const result = applySessionUpdateToSidebarHistory({
+            limit: SIDEBAR_AGENTS_HISTORY_LIMIT,
+            scope: {
+                projectId: "project-1",
+                worktreeId: "project-1:primary",
+            },
+            sessions: [],
+            update: {
+                kind: "snapshot",
+                snapshot: createSnapshot({ worktreeId: null }),
+            },
+        });
+
+        expect(result.sessions).toHaveLength(1);
+        expect(result.sessions[0]?.worktreeId).toBeNull();
+    });
+
     it("applies a patch locally for a known session without forcing reload", () => {
         const sessions = [
             createSummary({

--- a/src/renderer/src/components/sidebar/sidebarAgentsHistory.ts
+++ b/src/renderer/src/components/sidebar/sidebarAgentsHistory.ts
@@ -6,6 +6,7 @@ import type {
     AiSessionSnapshot,
     AiSessionUpdate,
 } from "@shared/ipc";
+import { areGitWorktreeIdsEquivalent } from "@renderer/app/git/context-key";
 
 export interface SidebarAgentsHistoryScope {
     readonly projectId: string | null;
@@ -348,7 +349,13 @@ function isHistorySummaryVisibleInScope(
 ): boolean {
     return (
         session.projectId === scope.projectId &&
-        (session.worktreeId ?? null) === scope.worktreeId
+        (scope.projectId
+            ? areGitWorktreeIdsEquivalent(
+                  scope.projectId,
+                  session.worktreeId ?? null,
+                  scope.worktreeId,
+              )
+            : (session.worktreeId ?? null) === scope.worktreeId)
     );
 }
 

--- a/src/renderer/src/components/sidebar/sidebarAgentsHistoryCache.test.ts
+++ b/src/renderer/src/components/sidebar/sidebarAgentsHistoryCache.test.ts
@@ -96,6 +96,21 @@ describe("sidebarAgentsHistoryCache", () => {
         expect(readSidebarAgentsHistoryCache("", "")?.sessions).toHaveLength(1);
     });
 
+    it("shares the primary checkout cache between null and canonical ids", () => {
+        const sessions = [createSummary({ worktreeId: null })];
+        writeSidebarAgentsHistoryCache("project-1", null, sessions, 100);
+
+        expect(
+            getSidebarAgentsHistoryCacheKey("project-1", null),
+        ).toBe(
+            getSidebarAgentsHistoryCacheKey("project-1", "project-1:primary"),
+        );
+        expect(
+            readSidebarAgentsHistoryCache("project-1", "project-1:primary")
+                ?.sessions,
+        ).toEqual(sessions);
+    });
+
     it("returns copied arrays so callers cannot mutate cached references", () => {
         const sessions = [createSummary({ sessionId: "session-a" })];
 

--- a/src/renderer/src/components/sidebar/sidebarAgentsHistoryCache.ts
+++ b/src/renderer/src/components/sidebar/sidebarAgentsHistoryCache.ts
@@ -1,4 +1,5 @@
 import type { AiHistorySessionSummary } from "@shared/ipc";
+import { getGitContextKey } from "@renderer/app/git/context-key";
 
 export interface SidebarAgentsHistoryCacheEntry {
     readonly loadedAt: number;
@@ -15,7 +16,9 @@ export function getSidebarAgentsHistoryCacheKey(
     projectId: string | null,
     worktreeId: string | null | undefined,
 ): string {
-    return JSON.stringify([projectId ?? "", worktreeId ?? ""]);
+    return projectId
+        ? getGitContextKey(projectId, worktreeId ?? null)
+        : JSON.stringify(["", worktreeId ?? ""]);
 }
 
 export function readSidebarAgentsHistoryCache(


### PR DESCRIPTION
## Summary
- treat `null` and the canonical primary worktree id as the same workspace tab scope
- reuse primary workspace chats when adding files from the tree
- keep the Agents sidebar history, live updates, and cache in the same primary scope

## Testing
- `pnpm exec vitest run src/renderer/src/app/projects/file-tree-selection.test.ts src/renderer/src/app/store/workspace-store.test.ts src/renderer/src/app/workspace/tree.test.ts`
- `pnpm exec vitest run src/renderer/src/components/sidebar/sidebarAgentsHistory.test.ts src/renderer/src/components/sidebar/sidebarAgentsHistoryCache.test.ts src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx`
- `pnpm exec eslint src/renderer/src/App.tsx src/renderer/src/app/store/workspace-store.ts src/renderer/src/app/workspace/tree.ts src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx src/renderer/src/components/sidebar/sidebarAgentsHistory.ts src/renderer/src/components/sidebar/sidebarAgentsHistoryCache.ts`
- `pnpm exec tsc --noEmit -p tsconfig.web.json`