### PR TITLE
feat(git): add uncommitted changes shortcut

### DIFF
--- a/src/renderer/src/app/shortcuts/registry.test.ts
+++ b/src/renderer/src/app/shortcuts/registry.test.ts
@@ -3,12 +3,15 @@ import { describe, expect, it } from "vitest";
 import { shortcutDefinitions } from "./registry";
 
 describe("shortcutDefinitions", () => {
-    it("includes chat history and git history shortcuts for macOS and Windows", () => {
+    it("includes chat history and git shortcuts for macOS and Windows", () => {
         const chatHistoryShortcut = shortcutDefinitions.find(
             (shortcut) => shortcut.id === "open_chat_history",
         );
         const gitHistoryShortcut = shortcutDefinitions.find(
             (shortcut) => shortcut.id === "open_git_history",
+        );
+        const uncommittedChangesShortcut = shortcutDefinitions.find(
+            (shortcut) => shortcut.id === "open_uncommitted_changes",
         );
 
         expect(chatHistoryShortcut).toMatchObject({
@@ -28,6 +31,16 @@ describe("shortcutDefinitions", () => {
                 windows: "Ctrl+Shift+G",
             },
             label: "Open git history",
+            section: "Git",
+        });
+        expect(uncommittedChangesShortcut).toMatchObject({
+            description:
+                "Open the singleton uncommitted changes tab for the active project.",
+            keys: {
+                mac: "Cmd+Shift+M",
+                windows: "Ctrl+Shift+M",
+            },
+            label: "Open uncommitted changes",
             section: "Git",
         });
     });

--- a/src/renderer/src/app/shortcuts/registry.ts
+++ b/src/renderer/src/app/shortcuts/registry.ts
@@ -19,6 +19,7 @@ export interface ShortcutDefinition {
         | "open_current_project_in_new_window"
         | "open_file_picker"
         | "open_settings"
+        | "open_uncommitted_changes"
         | "previous_pane_tab"
         | "previous_workspace"
         | "reload_window"
@@ -253,6 +254,17 @@ export const shortcutDefinitions: readonly ShortcutDefinition[] = [
         keys: {
             mac: "Cmd+Shift+G",
             windows: "Ctrl+Shift+G",
+        },
+        section: "Git",
+    },
+    {
+        id: "open_uncommitted_changes",
+        label: "Open uncommitted changes",
+        description:
+            "Open the singleton uncommitted changes tab for the active project.",
+        keys: {
+            mac: "Cmd+Shift+M",
+            windows: "Ctrl+Shift+M",
         },
         section: "Git",
     },

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -1660,6 +1660,7 @@ function WorkspacePaneView({
         openChatImageTab,
         openFileTab,
         openGitTab,
+        openGitWorktreeDiffTab,
         openReviewTab,
         paneCount,
         recentActiveTabIds,
@@ -1699,6 +1700,7 @@ function WorkspacePaneView({
                         openChatImageTab: state.openChatImageTab,
                         openFileTab: state.openFileTab,
                         openGitTab: state.openGitTab,
+                        openGitWorktreeDiffTab: state.openGitWorktreeDiffTab,
                         openReviewTab: state.openReviewTab,
                         paneCount: getIndexedWorkspacePaneCount(state.rootNode),
                         recentActiveTabIds: state.recentActiveTabIds,
@@ -2442,6 +2444,7 @@ function WorkspacePaneView({
         handleCreateFile,
         openChatHistoryTab,
         openGitTab,
+        openGitWorktreeDiffTab,
         paneNodeId,
         selectAdjacentTab: handleSelectAdjacentTab,
     });
@@ -2454,6 +2457,7 @@ function WorkspacePaneView({
             handleCreateFile,
             openChatHistoryTab,
             openGitTab,
+            openGitWorktreeDiffTab,
             paneNodeId,
             selectAdjacentTab: handleSelectAdjacentTab,
         };
@@ -2465,6 +2469,7 @@ function WorkspacePaneView({
         handleCreateFile,
         openChatHistoryTab,
         openGitTab,
+        openGitWorktreeDiffTab,
         paneNodeId,
         handleSelectAdjacentTab,
     ]);
@@ -2568,6 +2573,20 @@ function WorkspacePaneView({
                 event.preventDefault();
                 event.stopPropagation();
                 void handlers.openGitTab(
+                    handlers.defaultProjectId,
+                    handlers.defaultWorktreeId ?? null,
+                );
+                return;
+            }
+
+            if (event.shiftKey && key === "m") {
+                if (!handlers.defaultProjectId) {
+                    return;
+                }
+
+                event.preventDefault();
+                event.stopPropagation();
+                void handlers.openGitWorktreeDiffTab(
                     handlers.defaultProjectId,
                     handlers.defaultWorktreeId ?? null,
                 );


### PR DESCRIPTION
## Summary
- add Cmd+Shift+M / Ctrl+Shift+M to open uncommitted changes
- expose the shortcut in Settings under Git
- cover the shortcut registry entry

## Validation
- pnpm exec vitest run src/renderer/src/app/shortcuts/registry.test.ts
- pnpm run typecheck
- pnpm run lint