### PR TITLE
build: use electron-builder's macOS signing keychain

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
             "entitlementsInherit": "resources/entitlements.mac.inherit.plist",
             "hardenedRuntime": true,
             "icon": "resources/icons/macos.icns",
+            "sign": "scripts/sign-macos-app.cjs",
             "x64ArchFiles": "{Contents/Resources/ai/**/*,Contents/Resources/native/**/*}",
             "target": [
                 {

--- a/scripts/sign-macos-app.cjs
+++ b/scripts/sign-macos-app.cjs
@@ -1,0 +1,29 @@
+const { execFileSync } = require("node:child_process");
+
+exports.default = function signMacApp(options) {
+    const entitlements = options.optionsForFile(options.app).entitlements;
+
+    if (!options.identity || !entitlements) {
+        throw new Error("macOS signing identity or entitlements are unavailable.");
+    }
+
+    const args = [
+        "--force",
+        "--deep",
+        "--sign",
+        options.identity,
+        "--timestamp",
+        "--options",
+        "runtime",
+        "--entitlements",
+        entitlements,
+    ];
+
+    if (options.keychain) {
+        args.push("--keychain", options.keychain);
+    }
+
+    args.push(options.app);
+
+    execFileSync("/usr/bin/codesign", args, { stdio: "inherit" });
+};


### PR DESCRIPTION
## Summary
- add a custom macOS signing hook for the packaged application
- use the signing identity and entitlements resolved by electron-builder
- pass electron-builder's temporary keychain to codesign when one is provided

## Validation
- node --check scripts/sign-macos-app.cjs
- git diff --check