### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.2.0] - 2026-07-15
+
+### Added
+
+- Persistent project and worktree context tabs, including restored layouts for closed contexts, draggable titlebar tabs, and a shortcut for copying a context's full path.
+- Agent folders and live activity labels in the sidebar.
+- Markdown file previews with syntax-highlighted code blocks.
+- GitHub pull request label management and full-diff review support.
+- A shortcut for opening uncommitted changes directly from the Git workspace.
+
+### Changed
+
+- Reworked workspace surface persistence and resource management for faster context switching and better performance in long-running chats.
+- Modernized project tabs, Git branch navigation, the chat layout, activity rails, mentions, and the composer action button.
+- Centralized AI session orchestration and improved retained-chat reopening, prompt preparation, subagent lifecycle handling, and timeline state restoration.
+- Improved pull request and issue readability across the GitHub workspace.
+- Updated the bundled Claude ACP runtime to 0.59.0 and hardened AI runtime packaging and verification.
+- Updated GitHub Actions workflows to the Node.js 24 runtime and improved application signing and release packaging.
+
+### Fixed
+
+- Preserved chat history, virtual timeline geometry, tool activity anchors, and expanded activity state while navigating between contexts.
+- Restored Git status in the project file tree and refreshed stale worktree inventories in the workspace switcher.
+- Stabilized agent control and selector changes in newly created or retained chats.
+- Corrected primary worktree scope equivalence and prompt title hydration before the first user message.
+
 ## [0.1.0] - 2026-07-04
 
 Public launch. For full changelog, please check git history.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "comando-ai"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agent-client-protocol",
  "comando-diff",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "comando-diff"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "imara-diff",
  "serde",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "comando-fs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "comando-types",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "comando-git"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "comando-types",
  "serde_json",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "comando-index"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "comando-fs",
  "comando-types",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "comando-native-backend"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "comando-ai",
  "comando-diff",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "comando-persistence"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "comando-types",
  "rusqlite",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "comando-projects"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "comando-persistence",
  "comando-types",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "comando-settings"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "comando-types",
  "keyring",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "comando-terminal"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "comando-types",
  "portable-pty",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "comando-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [workspace.dependencies]

--- a/apps/native-backend/tests/jsonl_contract.rs
+++ b/apps/native-backend/tests/jsonl_contract.rs
@@ -114,7 +114,7 @@ fn reports_capabilities() {
     assert_eq!(response["id"], "caps");
     assert_eq!(response["ok"], true);
     assert_eq!(response["result"]["protocolVersion"], 1);
-    assert_eq!(response["result"]["backendVersion"], "0.1.0");
+    assert_eq!(response["result"]["backendVersion"], "0.2.0");
     assert_eq!(response["result"]["rustVersion"], "1.96");
     assert_eq!(
         response["result"]["capabilities"]["features"],

--- a/fixtures/native-backend/protocol/capabilities.v1.json
+++ b/fixtures/native-backend/protocol/capabilities.v1.json
@@ -1,6 +1,6 @@
 {
   "backendName": "comando-native-backend",
-  "backendVersion": "0.1.0",
+  "backendVersion": "0.2.0",
   "rustVersion": "1.96",
   "protocolVersion": 1,
   "minimumClientProtocolVersion": 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "comando",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "private": true,
     "description": "Workspace local-first para programar con IA.",
     "author": "José Gurruchaga",


### PR DESCRIPTION
## Summary

- add the 0.2.0 changelog entry dated July 15, 2026
- align Electron and Rust workspace metadata with version 0.2.0
- update native backend capability contracts and fixtures for the new version

## Validation

- pnpm install --frozen-lockfile
- pnpm run typecheck
- pnpm run lint
- pnpm run test
- pnpm run build:ci
- pnpm run native:check
- pnpm exec vitest run scripts/*.test.mjs
- release notes extraction and release body generation for v0.2.0