### PR TITLE
Fix reopen closed tab shortcut routing for workspace surfaces

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -414,7 +414,19 @@ if (!hasSingleInstanceLock) {
                 },
                 reopenLastClosedTab: () => {
                     const focusedWindow = windowRegistry.getFocusedMainWindow();
-                    focusedWindow?.webContents.send(
+                    if (!focusedWindow) {
+                        return;
+                    }
+
+                    const context =
+                        windowRegistry.getContextByBrowserWindow(focusedWindow);
+                    const targetContents =
+                        context?.windowKind === "main"
+                            ? (workspaceSurfaceManager.getActiveWebContents(
+                                  context.windowId,
+                              ) ?? focusedWindow.webContents)
+                            : focusedWindow.webContents;
+                    targetContents.send(
                         IPC_EVENTS.workspaceReopenLastClosedTab,
                     );
                 },


### PR DESCRIPTION
## Summary

Routes the native `Cmd+Shift+T` / `Ctrl+Shift+T` action to the active workspace surface instead of always targeting the host renderer.

## Changes

- Resolve the focused main window context.
- Send `workspace:reopen-last-closed-tab` to the active surface for that host window.
- Preserve the host renderer as a fallback when no active surface exists.

The tab restoration store logic remains unchanged, so the most recently closed tab is restored in its original pane and position within the visible workspace.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec vitest run src/renderer/src/app/store/workspace-store.test.ts`

Closes #138.