### PR TITLE
Restore quick open in persistent workspace surfaces

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4765,6 +4765,21 @@ export function App() {
                         recentProjects={workspaceRecentProjects}
                     />
                 </main>
+                <QuickOpenFilePalette
+                    loading={isQuickOpenLoading}
+                    onChangeQuery={setQuickOpenQuery}
+                    onClose={closeQuickOpen}
+                    onHoverIndex={setQuickOpenSelectedIndex}
+                    onInputKeyDown={handleQuickOpenInputKeyDown}
+                    onSelect={(item) => {
+                        void handleQuickOpenSelect(item);
+                    }}
+                    open={isQuickOpenOpen}
+                    projectName={activeProject?.name ?? null}
+                    query={quickOpenQuery}
+                    results={quickOpenResults}
+                    selectedIndex={quickOpenSelectedIndex}
+                />
             </div>
         );
     }


### PR DESCRIPTION
## Summary

Restores `Cmd+T` / `Ctrl+T` quick open when focus is inside a persistent workspace surface.

## Changes

- Render `QuickOpenFilePalette` in the workspace surface renderer.
- Reuse the surface-local quick-open state and callbacks.
- Keep file selection targeted at the active pane of the visible workspace.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec vitest run src/renderer/src/app/projects/quick-open.test.ts`

Closes #140.