### PR TITLE
Fix workspace panes not updating after settings changes

### DIFF
--- a/src/main/settings/window-zoom.test.ts
+++ b/src/main/settings/window-zoom.test.ts
@@ -23,8 +23,11 @@ vi.mock("../window", () => ({
 vi.mock("../windows/registry", () => ({
     windowRegistry: {
         forEachLiveWebContents: (
-            callback: (webContents: (typeof embeddedWebContents)[number]) => void,
+            callback: (webContents: (typeof liveWindows)[number]["webContents"]) => void,
         ) => {
+            for (const window of liveWindows) {
+                callback(window.webContents);
+            }
             for (const webContents of embeddedWebContents) {
                 callback(webContents);
             }

--- a/src/main/settings/window-zoom.test.ts
+++ b/src/main/settings/window-zoom.test.ts
@@ -6,6 +6,9 @@ import { DEFAULT_APP_TERMINAL_SETTINGS } from "@shared/terminal-settings";
 const liveWindows: Array<{
     readonly webContents: { readonly send: ReturnType<typeof vi.fn> };
 }> = [];
+const embeddedWebContents: Array<{
+    readonly send: ReturnType<typeof vi.fn>;
+}> = [];
 
 vi.mock("../window", () => ({
     forEachLiveWindow: (
@@ -17,9 +20,22 @@ vi.mock("../window", () => ({
     },
 }));
 
+vi.mock("../windows/registry", () => ({
+    windowRegistry: {
+        forEachLiveWebContents: (
+            callback: (webContents: (typeof embeddedWebContents)[number]) => void,
+        ) => {
+            for (const webContents of embeddedWebContents) {
+                callback(webContents);
+            }
+        },
+    },
+}));
+
 describe("broadcastSettingsUpdated", () => {
     beforeEach(() => {
         liveWindows.length = 0;
+        embeddedWebContents.length = 0;
     });
 
     it("sends appearance, editor, aiChat, and terminal settings", async () => {
@@ -99,6 +115,21 @@ describe("broadcastSettingsUpdated", () => {
                 vimModeEnabled: false,
             },
             terminal: DEFAULT_APP_TERMINAL_SETTINGS,
+        });
+    });
+
+    it("sends settings updates to embedded workspace renderers", async () => {
+        const { broadcastSettingsUpdated } = await import("./window-zoom");
+        const send = vi.fn();
+        embeddedWebContents.push({ send });
+
+        broadcastSettingsUpdated(null, null, null, null);
+
+        expect(send).toHaveBeenCalledWith(IPC_EVENTS.settingsUpdated, {
+            aiChat: null,
+            appearance: null,
+            editor: null,
+            terminal: null,
         });
     });
 });

--- a/src/main/settings/window-zoom.ts
+++ b/src/main/settings/window-zoom.ts
@@ -11,6 +11,7 @@ import {
 } from "@shared/ipc";
 
 import { applyWindowTransparencyToWindow, forEachLiveWindow } from "../window";
+import { windowRegistry } from "../windows/registry";
 
 export function applyAppZoomToWindow(
     window: BrowserWindow,
@@ -46,7 +47,7 @@ export function broadcastSettingsUpdated(
         terminal,
     };
 
-    forEachLiveWindow((window) => {
-        window.webContents.send(IPC_EVENTS.settingsUpdated, payload);
+    windowRegistry.forEachLiveWebContents((webContents) => {
+        webContents.send(IPC_EVENTS.settingsUpdated, payload);
     });
 }


### PR DESCRIPTION
## Summary

- broadcast application settings to every live renderer, including embedded workspace surfaces
- add a regression test covering embedded workspace renderers

## Validation

- `npm test -- --run src/main/settings/window-zoom.test.ts`
- `npm run typecheck`