### PR TITLE
Fix workspace context menu layering

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -159,6 +159,8 @@ import {
     type WindowContextSnapshot,
     type WriteTerminalInput,
     type WorkspaceNavigationSnapshot,
+    type WorkspaceContextMenuAction,
+    type WorkspaceContextMenuInput,
     type WorkspaceSurfaceContextRequest,
     type WorkspaceSurfaceDragEvent,
 } from "@shared/ipc";
@@ -170,6 +172,7 @@ import {
     clipboard,
     dialog,
     ipcMain,
+    Menu,
     nativeTheme,
     shell,
     type MessageBoxOptions,
@@ -359,6 +362,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.requestWorkspaceSurfaceContext);
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceGitScopeMenu);
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceProjectMenu);
+    ipcMain.removeHandler(IPC_CHANNELS.showWorkspaceContextMenu);
     ipcMain.removeHandler(IPC_CHANNELS.setWorkspaceSurfaceContentInset);
     ipcMain.removeHandler(IPC_CHANNELS.setWorkspaceSurfaceContentLeftInset);
     ipcMain.removeHandler(IPC_CHANNELS.notifyFileBuffer);
@@ -2017,6 +2021,49 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         }
         workspaceSurfaceManager.requestActiveProjectMenu(context.windowId);
     });
+    ipcMain.handle(
+        IPC_CHANNELS.showWorkspaceContextMenu,
+        (event, input: WorkspaceContextMenuInput) => {
+            requireWindowContext(event.sender, "main");
+            const window = BrowserWindow.fromWebContents(event.sender);
+            if (!window || workspaceSurfaceManager.isSurface(event.sender)) {
+                return null;
+            }
+
+            return new Promise<WorkspaceContextMenuAction | null>((resolve) => {
+                let selected = false;
+                const select = (action: WorkspaceContextMenuAction) => {
+                    selected = true;
+                    resolve(action);
+                };
+                const menu = Menu.buildFromTemplate([
+                    {
+                        click: () => select("copy_full_path"),
+                        enabled: input.canCopyFullPath,
+                        label: "Copy Full Path",
+                    },
+                    { type: "separator" },
+                    {
+                        click: () => select("move_to_new_window"),
+                        label: "Move to New Window",
+                    },
+                    { type: "separator" },
+                    {
+                        click: () => select("close"),
+                        label: "Close",
+                    },
+                ]);
+                menu.popup({
+                    callback: () => {
+                        if (!selected) resolve(null);
+                    },
+                    window,
+                    x: Math.max(0, Math.round(input.x)),
+                    y: Math.max(0, Math.round(input.y)),
+                });
+            });
+        },
+    );
     ipcMain.handle(
         IPC_CHANNELS.setWorkspaceSurfaceContentInset,
         (event, height: number) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1067,6 +1067,8 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.openWorkspaceSurfaceGitScopeMenu, anchor),
     openWorkspaceSurfaceProjectMenu: () =>
         ipcRenderer.invoke(IPC_CHANNELS.openWorkspaceSurfaceProjectMenu),
+    showWorkspaceContextMenu: (input) =>
+        ipcRenderer.invoke(IPC_CHANNELS.showWorkspaceContextMenu, input),
     setWorkspaceSurfaceContentInset: (height: number) =>
         ipcRenderer.invoke(IPC_CHANNELS.setWorkspaceSurfaceContentInset, height),
     setWorkspaceSurfaceContentLeftInset: (width: number) =>

--- a/src/renderer/src/components/DesktopTopBar.context-menu.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.context-menu.test.tsx
@@ -87,23 +87,19 @@ function renderTopBar() {
     };
 }
 
-function getContextMenuButton(label: string): HTMLButtonElement {
-    const button = document.body.querySelector<HTMLButtonElement>(
-        `button[aria-label="${label}"]`,
-    );
-    if (!button) {
-        throw new Error(`Context menu action "${label}" was not rendered.`);
-    }
-    return button;
-}
-
 describe("DesktopTopBar context menu", () => {
     it("offers move and close actions for the context clicked with the secondary button", async () => {
         const writeText = vi.fn(() => Promise.resolve());
+        const showWorkspaceContextMenu = vi
+            .fn()
+            .mockResolvedValueOnce("copy_full_path")
+            .mockResolvedValueOnce("move_to_new_window")
+            .mockResolvedValueOnce("close");
         vi.stubGlobal("navigator", {
             ...navigator,
             clipboard: { writeText },
         });
+        vi.stubGlobal("comando", { showWorkspaceContextMenu });
         const { container, onCloseContext, onMoveContextToNewWindow } =
             renderTopBar();
         const tab = container.querySelector<HTMLElement>(
@@ -111,7 +107,7 @@ describe("DesktopTopBar context menu", () => {
         );
         expect(tab).toBeTruthy();
 
-        act(() => {
+        await act(async () => {
             tab?.dispatchEvent(
                 new MouseEvent("contextmenu", {
                     bubbles: true,
@@ -120,19 +116,17 @@ describe("DesktopTopBar context menu", () => {
                     clientY: 40,
                 }),
             );
+            await Promise.resolve();
         });
 
-        expect(getContextMenuButton("Copy Full Path")).toBeTruthy();
-        expect(getContextMenuButton("Move to New Window")).toBeTruthy();
-        expect(getContextMenuButton("Close")).toBeTruthy();
-
-        await act(async () => {
-            getContextMenuButton("Copy Full Path").click();
-            await Promise.resolve();
+        expect(showWorkspaceContextMenu).toHaveBeenLastCalledWith({
+            canCopyFullPath: true,
+            x: 120,
+            y: 40,
         });
         expect(writeText).toHaveBeenCalledWith("/projects/sandbox");
 
-        act(() => {
+        await act(async () => {
             tab?.dispatchEvent(
                 new MouseEvent("contextmenu", {
                     bubbles: true,
@@ -141,16 +135,27 @@ describe("DesktopTopBar context menu", () => {
                     clientY: 40,
                 }),
             );
-        });
-
-        await act(async () => {
-            getContextMenuButton("Move to New Window").click();
             await Promise.resolve();
         });
         expect(onMoveContextToNewWindow).toHaveBeenCalledWith(
             "project-2::__primary__",
         );
         expect(onCloseContext).not.toHaveBeenCalled();
+
+        await act(async () => {
+            tab?.dispatchEvent(
+                new MouseEvent("contextmenu", {
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: 120,
+                    clientY: 40,
+                }),
+            );
+            await Promise.resolve();
+        });
+        expect(onCloseContext).toHaveBeenCalledWith(
+            "project-2::__primary__",
+        );
     });
 
     it("opens a project from the portaled project menu", async () => {

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -11,10 +11,6 @@ import {
     type ProjectContextMenuProject,
 } from "./ProjectContextMenu";
 import {
-    ContextMenu,
-    type ContextMenuState,
-} from "./context-menu/ContextMenu";
-import {
     projectAvatarColor,
     projectAvatarInitial,
 } from "./projectAvatar";
@@ -80,8 +76,6 @@ export function DesktopTopBar({
     settingsLabel,
 }: DesktopTopBarProps) {
     const [menuOpen, setMenuOpen] = useState(false);
-    const [contextMenu, setContextMenu] =
-        useState<ContextMenuState<ProjectContextTabItem> | null>(null);
     const menuRootRef = useRef<HTMLDivElement | null>(null);
     const tabsRef = useRef<HTMLDivElement | null>(null);
     const contextTabDrag = useProjectContextTabDrag({
@@ -223,8 +217,10 @@ export function DesktopTopBar({
                             onContextMenu={(event) => {
                                 event.preventDefault();
                                 setMenuOpen(false);
-                                setContextMenu({
-                                    payload: context,
+                                void openWorkspaceContextMenu({
+                                    context,
+                                    onCloseContext,
+                                    onMoveContextToNewWindow,
                                     x: event.clientX,
                                     y: event.clientY,
                                 });
@@ -366,50 +362,36 @@ export function DesktopTopBar({
                     />
                 )}
             </div>
-            {contextMenu ? (
-                <ContextMenu
-                    entries={[
-                        {
-                            action: () => {
-                                const fullPath = contextMenu.payload.fullPath;
-                                if (!fullPath) {
-                                    return;
-                                }
-                                void (async () => {
-                                    try {
-                                        await navigator.clipboard.writeText(
-                                            fullPath,
-                                        );
-                                    } catch {
-                                        window.alert(
-                                            "Could not copy the project path.",
-                                        );
-                                    }
-                                })();
-                            },
-                            disabled: !contextMenu.payload.fullPath,
-                            label: "Copy Full Path",
-                        },
-                        { type: "separator" },
-                        {
-                            action: () =>
-                                onMoveContextToNewWindow(
-                                    contextMenu.payload.key,
-                                ),
-                            label: "Move to New Window",
-                        },
-                        { type: "separator" },
-                        {
-                            action: () =>
-                                onCloseContext(contextMenu.payload.key),
-                            danger: true,
-                            label: "Close",
-                        },
-                    ]}
-                    menu={contextMenu}
-                    onClose={() => setContextMenu(null)}
-                />
-            ) : null}
         </header>
     );
+}
+
+async function openWorkspaceContextMenu(input: {
+    readonly context: ProjectContextTabItem;
+    readonly onCloseContext: (contextKey: string) => void;
+    readonly onMoveContextToNewWindow: (contextKey: string) => void;
+    readonly x: number;
+    readonly y: number;
+}): Promise<void> {
+    // Native menus render above the workspace WebContentsView boundary.
+    const action = await window.comando?.showWorkspaceContextMenu({
+        canCopyFullPath: Boolean(input.context.fullPath),
+        x: input.x,
+        y: input.y,
+    });
+    if (action === "copy_full_path" && input.context.fullPath) {
+        try {
+            await navigator.clipboard.writeText(input.context.fullPath);
+        } catch {
+            window.alert("Could not copy the project path.");
+        }
+        return;
+    }
+    if (action === "move_to_new_window") {
+        input.onMoveContextToNewWindow(input.context.key);
+        return;
+    }
+    if (action === "close") {
+        input.onCloseContext(input.context.key);
+    }
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -135,6 +135,7 @@ export const IPC_CHANNELS = {
     requestWorkspaceSurfaceContext: "workspace:request-surface-context",
     openWorkspaceSurfaceGitScopeMenu: "workspace:open-surface-git-scope-menu",
     openWorkspaceSurfaceProjectMenu: "workspace:open-surface-project-menu",
+    showWorkspaceContextMenu: "workspace:show-context-menu",
     setWorkspaceSurfaceContentInset: "workspace:set-surface-content-inset",
     setWorkspaceSurfaceContentLeftInset: "workspace:set-surface-content-left-inset",
     notifyFileBuffer: "workspace:notify-file-buffer",
@@ -2171,6 +2172,17 @@ export interface WorkspaceSurfaceContextRequest {
     readonly worktreeId?: string | null;
 }
 
+export interface WorkspaceContextMenuInput {
+    readonly canCopyFullPath: boolean;
+    readonly x: number;
+    readonly y: number;
+}
+
+export type WorkspaceContextMenuAction =
+    | "copy_full_path"
+    | "move_to_new_window"
+    | "close";
+
 export interface WindowWorkspaceRestoreRecord {
     readonly revision: number;
     readonly schemaVersion: 1;
@@ -3023,6 +3035,9 @@ export interface ComandoApi {
         readonly x: number;
     }) => Promise<void>;
     openWorkspaceSurfaceProjectMenu: () => Promise<void>;
+    showWorkspaceContextMenu: (
+        input: WorkspaceContextMenuInput,
+    ) => Promise<WorkspaceContextMenuAction | null>;
     setWorkspaceSurfaceContentInset: (height: number) => Promise<void>;
     setWorkspaceSurfaceContentLeftInset: (width: number) => Promise<void>;
     setTrafficLightVisibility: (visible: boolean) => Promise<void>;


### PR DESCRIPTION
## Summary

- render the workspace tab context menu as a native Electron menu
- keep copy, move-to-window, and close actions in the renderer
- avoid the menu being covered by persistent workspace WebContentsView surfaces
- update DesktopTopBar context-menu coverage for all actions

## Validation

- `pnpm run typecheck`
- targeted ESLint for modified files
- `pnpm exec vitest run src/renderer/src/components/DesktopTopBar.context-menu.test.tsx`
- `git diff --check`