### PR TITLE
Fix sidebar shortcut routing

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -430,6 +430,16 @@ if (!hasSingleInstanceLock) {
                         IPC_EVENTS.workspaceReopenLastClosedTab,
                     );
                 },
+                toggleSidebar: () => {
+                    const focusedWindow = windowRegistry.getFocusedMainWindow();
+                    if (!focusedWindow) {
+                        return;
+                    }
+
+                    focusedWindow.webContents.send(
+                        IPC_EVENTS.sidebarToggleRequested,
+                    );
+                },
                 openSettingsWindow: (projectId) =>
                     openSettingsWindow(
                         { projectId },

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -15,6 +15,7 @@ interface InstallApplicationMenuOptions {
         projectId?: string | null,
     ) => Promise<void> | void;
     readonly reopenLastClosedTab: () => void;
+    readonly toggleSidebar: () => void;
     readonly openSettingsWindow: (
         projectId: string | null,
     ) => Promise<void> | void;
@@ -129,6 +130,9 @@ function buildMenuTemplate(
             { type: "separator" },
             {
                 accelerator: "CmdOrCtrl+B",
+                click: () => {
+                    options.toggleSidebar();
+                },
                 label: "Toggle Sidebar",
             },
             { type: "separator" },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -809,6 +809,20 @@ const comandoApi: ComandoApi = {
             );
         };
     },
+    onSidebarToggleRequested: (listener) => {
+        const handleEvent = () => {
+            listener();
+        };
+
+        ipcRenderer.on(IPC_EVENTS.sidebarToggleRequested, handleEvent);
+
+        return () => {
+            ipcRenderer.removeListener(
+                IPC_EVENTS.sidebarToggleRequested,
+                handleEvent,
+            );
+        };
+    },
     onWorkspaceCloseActiveTab: (listener) => {
         const handleEvent = () => {
             listener();

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1166,6 +1166,17 @@ export function App() {
             return;
         }
 
+        return comandoApi.onSidebarToggleRequested(() => {
+            toggleLeftCollapsed();
+        });
+    }, [toggleLeftCollapsed]);
+
+    useEffect(() => {
+        const comandoApi = getComandoApi();
+        if (!comandoApi) {
+            return;
+        }
+
         const unsubscribe = comandoApi.onWorkspaceCloseActiveTab(() => {
             requestCloseActiveWorkspaceTab();
         });

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -192,6 +192,7 @@ export const IPC_EVENTS = {
     themeUpdated: "app:theme-updated",
     settingsUpdated: "settings:updated",
     projectSettingsUpdated: "settings:project-updated",
+    sidebarToggleRequested: "shell:sidebar-toggle-requested",
     workspaceCloseActiveTab: "workspace:close-active-tab",
     workspaceReopenLastClosedTab: "workspace:reopen-last-closed-tab",
     workspaceFlushRequested: "workspace:flush-requested",
@@ -3405,6 +3406,7 @@ export interface ComandoApi {
     onProjectSettingsUpdated: (
         listener: (payload: ProjectSettingsUpdatedEvent) => void,
     ) => () => void;
+    onSidebarToggleRequested: (listener: () => void) => () => void;
     onWorkspaceCloseActiveTab: (listener: () => void) => () => void;
     onWorkspaceReopenLastClosedTab: (listener: () => void) => () => void;
     onWorkspaceFlushRequested: (


### PR DESCRIPTION
## Summary
- connect the native Cmd/Ctrl+B menu accelerator to a real action
- route sidebar toggle requests to the focused workspace host renderer
- toggle the host-owned sidebar state regardless of the active embedded surface focus

## Validation
- `pnpm run typecheck`
- `pnpm exec eslint src/main/index.ts src/main/menu.ts src/preload/index.ts src/renderer/src/App.tsx src/shared/ipc.ts`
- `pnpm exec vitest run src/renderer/src/app/store/shell-store.test.ts`
- `git diff --check`