### PR TITLE
Fix sidebar context menus across workspace surfaces

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -164,6 +164,7 @@ import {
     type WorkspaceContextMenuInput,
     type WorkspaceSurfaceContextRequest,
     type WorkspaceSurfaceDragEvent,
+    type WorkspaceSurfaceGitHubItemOpenRequest,
 } from "@shared/ipc";
 import { normalizePathKey as normalizeSharedPathKey } from "@shared/path-identity";
 import { normalizeWorkspaceNavigationSnapshot } from "@shared/workspace-restore";
@@ -360,6 +361,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.activateWorkspaceSurface);
     ipcMain.removeHandler(IPC_CHANNELS.captureWorkspaceSurfaceContext);
     ipcMain.removeHandler(IPC_CHANNELS.dispatchWorkspaceSurfaceDrag);
+    ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceGitHubItem);
     ipcMain.removeHandler(IPC_CHANNELS.notifyWorkspaceSurfaceFocused);
     ipcMain.removeHandler(IPC_CHANNELS.requestWorkspaceSurfaceContext);
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceGitScopeMenu);
@@ -1935,6 +1937,22 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             );
         },
     );
+    ipcMain.handle(
+        IPC_CHANNELS.openWorkspaceSurfaceGitHubItem,
+        (event, input: WorkspaceSurfaceGitHubItemOpenRequest) => {
+            const context = requireWindowContext(event.sender, "main");
+            if (workspaceSurfaceManager.isSurface(event.sender)) {
+                return;
+            }
+            if (!isWorkspaceSurfaceGitHubItemOpenRequest(input)) {
+                throw new Error("A valid GitHub item is required.");
+            }
+            workspaceSurfaceManager.requestActiveGitHubItemOpen(
+                context.windowId,
+                input,
+            );
+        },
+    );
     ipcMain.handle(IPC_CHANNELS.notifyWorkspaceSurfaceFocused, (event) => {
         const surfaceContext = workspaceSurfaceManager.getSurfaceContext(
             event.sender,
@@ -2440,6 +2458,32 @@ function showNativeContextMenu(
             y: Number.isFinite(input.y) ? Math.max(0, Math.round(input.y)) : 0,
         });
     });
+}
+
+function isWorkspaceSurfaceGitHubItemOpenRequest(
+    input: unknown,
+): input is WorkspaceSurfaceGitHubItemOpenRequest {
+    if (!input || typeof input !== "object") {
+        return false;
+    }
+    const candidate = input as Record<string, unknown>;
+    const ref = candidate.ref;
+    return (
+        (candidate.itemKind === "issue" ||
+            candidate.itemKind === "pull_request") &&
+        typeof candidate.itemNumber === "number" &&
+        Number.isSafeInteger(candidate.itemNumber) &&
+        candidate.itemNumber > 0 &&
+        (candidate.projectId === null ||
+            typeof candidate.projectId === "string") &&
+        (candidate.worktreeId === null ||
+            typeof candidate.worktreeId === "string") &&
+        Boolean(ref) &&
+        typeof ref === "object" &&
+        typeof (ref as Record<string, unknown>).host === "string" &&
+        typeof (ref as Record<string, unknown>).owner === "string" &&
+        typeof (ref as Record<string, unknown>).repo === "string"
+    );
 }
 
 function normalizeNativeContextMenuEntries(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -35,7 +35,7 @@ import {
     type CreateTerminalSessionInput,
     type DeleteProjectEntryInput,
     type FileBufferNotificationInput,
-    type FileTreeContextMenuInput,
+    type NativeContextMenuInput,
     type EnqueueAiPromptInput,
     type GitBranchListInput,
     type GitBranchSummary as SharedGitBranchSummary,
@@ -365,7 +365,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceGitScopeMenu);
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceProjectMenu);
     ipcMain.removeHandler(IPC_CHANNELS.showWorkspaceContextMenu);
-    ipcMain.removeHandler(IPC_CHANNELS.showFileTreeContextMenu);
+    ipcMain.removeHandler(IPC_CHANNELS.showNativeContextMenu);
     ipcMain.removeHandler(IPC_CHANNELS.setWorkspaceSurfaceContentInset);
     ipcMain.removeHandler(IPC_CHANNELS.setWorkspaceSurfaceContentLeftInset);
     ipcMain.removeHandler(IPC_CHANNELS.notifyFileBuffer);
@@ -2068,15 +2068,15 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         },
     );
     ipcMain.handle(
-        IPC_CHANNELS.showFileTreeContextMenu,
-        (event, input: FileTreeContextMenuInput) => {
+        IPC_CHANNELS.showNativeContextMenu,
+        (event, input: NativeContextMenuInput) => {
             requireWindowContext(event.sender, "main");
             const window = BrowserWindow.fromWebContents(event.sender);
             if (!window || workspaceSurfaceManager.isSurface(event.sender)) {
                 return null;
             }
 
-            return showFileTreeContextMenu(window, input);
+            return showNativeContextMenu(window, input);
         },
     );
     ipcMain.handle(
@@ -2412,9 +2412,9 @@ async function resolveGeneratedImageIpcPath(imagePath: string): Promise<string> 
     return resolvedPath;
 }
 
-function showFileTreeContextMenu(
+function showNativeContextMenu(
     window: BrowserWindow,
-    input: FileTreeContextMenuInput,
+    input: NativeContextMenuInput,
 ): Promise<string | null> {
     return new Promise((resolve) => {
         let selected = false;
@@ -2422,7 +2422,7 @@ function showFileTreeContextMenu(
             selected = true;
             resolve(id);
         };
-        const template = normalizeFileTreeContextMenuEntries(
+        const template = normalizeNativeContextMenuEntries(
             input?.entries,
             select,
         );
@@ -2442,7 +2442,7 @@ function showFileTreeContextMenu(
     });
 }
 
-function normalizeFileTreeContextMenuEntries(
+function normalizeNativeContextMenuEntries(
     entries: unknown,
     select: (id: string) => void,
     depth = 0,
@@ -2478,7 +2478,7 @@ function normalizeFileTreeContextMenuEntries(
 
         let submenu: MenuItemConstructorOptions[] | undefined;
         if (entry.children !== undefined) {
-            const normalizedChildren = normalizeFileTreeContextMenuEntries(
+            const normalizedChildren = normalizeNativeContextMenuEntries(
                 entry.children,
                 select,
                 depth + 1,

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -35,6 +35,7 @@ import {
     type CreateTerminalSessionInput,
     type DeleteProjectEntryInput,
     type FileBufferNotificationInput,
+    type FileTreeContextMenuInput,
     type EnqueueAiPromptInput,
     type GitBranchListInput,
     type GitBranchSummary as SharedGitBranchSummary,
@@ -176,6 +177,7 @@ import {
     nativeTheme,
     shell,
     type MessageBoxOptions,
+    type MenuItemConstructorOptions,
     type OpenDialogOptions,
 } from "electron";
 
@@ -363,6 +365,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceGitScopeMenu);
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceProjectMenu);
     ipcMain.removeHandler(IPC_CHANNELS.showWorkspaceContextMenu);
+    ipcMain.removeHandler(IPC_CHANNELS.showFileTreeContextMenu);
     ipcMain.removeHandler(IPC_CHANNELS.setWorkspaceSurfaceContentInset);
     ipcMain.removeHandler(IPC_CHANNELS.setWorkspaceSurfaceContentLeftInset);
     ipcMain.removeHandler(IPC_CHANNELS.notifyFileBuffer);
@@ -2065,6 +2068,18 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
         },
     );
     ipcMain.handle(
+        IPC_CHANNELS.showFileTreeContextMenu,
+        (event, input: FileTreeContextMenuInput) => {
+            requireWindowContext(event.sender, "main");
+            const window = BrowserWindow.fromWebContents(event.sender);
+            if (!window || workspaceSurfaceManager.isSurface(event.sender)) {
+                return null;
+            }
+
+            return showFileTreeContextMenu(window, input);
+        },
+    );
+    ipcMain.handle(
         IPC_CHANNELS.setWorkspaceSurfaceContentInset,
         (event, height: number) => {
             const context = requireWindowContext(event.sender, "main");
@@ -2395,6 +2410,92 @@ async function resolveGeneratedImageIpcPath(imagePath: string): Promise<string> 
     }
 
     return resolvedPath;
+}
+
+function showFileTreeContextMenu(
+    window: BrowserWindow,
+    input: FileTreeContextMenuInput,
+): Promise<string | null> {
+    return new Promise((resolve) => {
+        let selected = false;
+        const select = (id: string) => {
+            selected = true;
+            resolve(id);
+        };
+        const template = normalizeFileTreeContextMenuEntries(
+            input?.entries,
+            select,
+        );
+        if (!template || template.length === 0) {
+            resolve(null);
+            return;
+        }
+
+        Menu.buildFromTemplate(template).popup({
+            callback: () => {
+                if (!selected) resolve(null);
+            },
+            window,
+            x: Number.isFinite(input.x) ? Math.max(0, Math.round(input.x)) : 0,
+            y: Number.isFinite(input.y) ? Math.max(0, Math.round(input.y)) : 0,
+        });
+    });
+}
+
+function normalizeFileTreeContextMenuEntries(
+    entries: unknown,
+    select: (id: string) => void,
+    depth = 0,
+): MenuItemConstructorOptions[] | null {
+    if (!Array.isArray(entries) || entries.length > 100 || depth > 4) {
+        return null;
+    }
+
+    const template: MenuItemConstructorOptions[] = [];
+    for (const rawEntry of entries as unknown[]) {
+        if (!rawEntry || typeof rawEntry !== "object") {
+            return null;
+        }
+        const entry = rawEntry as Record<string, unknown>;
+        if (entry.type === "separator") {
+            template.push({ type: "separator" });
+            continue;
+        }
+        const id = entry.id;
+        const label = entry.label;
+        const enabled = entry.enabled;
+        if (
+            typeof id !== "string" ||
+            id.length === 0 ||
+            id.length > 128 ||
+            typeof label !== "string" ||
+            label.length === 0 ||
+            label.length > 512 ||
+            typeof enabled !== "boolean"
+        ) {
+            return null;
+        }
+
+        let submenu: MenuItemConstructorOptions[] | undefined;
+        if (entry.children !== undefined) {
+            const normalizedChildren = normalizeFileTreeContextMenuEntries(
+                entry.children,
+                select,
+                depth + 1,
+            );
+            if (!normalizedChildren) {
+                return null;
+            }
+            submenu = normalizedChildren;
+        }
+        template.push({
+            click: submenu ? undefined : () => select(id),
+            enabled,
+            label,
+            submenu,
+        });
+    }
+    return template;
 }
 
 function broadcastProjectSettingsUpdated(

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -11,6 +11,7 @@ import type {
     WindowContextSnapshot,
     WorkspaceNavigationSnapshot,
     WorkspaceSurfaceDragEvent,
+    WorkspaceSurfaceGitHubItemOpenRequest,
 } from "@shared/ipc";
 
 import {
@@ -180,6 +181,21 @@ class WorkspaceSurfaceManager {
 
         surface.webContents.send(
             IPC_EVENTS.workspaceSurfaceProjectMenuRequested,
+        );
+    }
+
+    requestActiveGitHubItemOpen(
+        hostWindowId: string,
+        input: WorkspaceSurfaceGitHubItemOpenRequest,
+    ): void {
+        const surface = this.#getActiveSurface(hostWindowId);
+        if (!surface || surface.webContents.isDestroyed()) {
+            return;
+        }
+
+        surface.webContents.send(
+            IPC_EVENTS.workspaceSurfaceGitHubItemOpenRequested,
+            input,
         );
     }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1069,8 +1069,8 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.openWorkspaceSurfaceProjectMenu),
     showWorkspaceContextMenu: (input) =>
         ipcRenderer.invoke(IPC_CHANNELS.showWorkspaceContextMenu, input),
-    showFileTreeContextMenu: (input) =>
-        ipcRenderer.invoke(IPC_CHANNELS.showFileTreeContextMenu, input),
+    showNativeContextMenu: (input) =>
+        ipcRenderer.invoke(IPC_CHANNELS.showNativeContextMenu, input),
     setWorkspaceSurfaceContentInset: (height: number) =>
         ipcRenderer.invoke(IPC_CHANNELS.setWorkspaceSurfaceContentInset, height),
     setWorkspaceSurfaceContentLeftInset: (width: number) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1069,6 +1069,8 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.openWorkspaceSurfaceProjectMenu),
     showWorkspaceContextMenu: (input) =>
         ipcRenderer.invoke(IPC_CHANNELS.showWorkspaceContextMenu, input),
+    showFileTreeContextMenu: (input) =>
+        ipcRenderer.invoke(IPC_CHANNELS.showFileTreeContextMenu, input),
     setWorkspaceSurfaceContentInset: (height: number) =>
         ipcRenderer.invoke(IPC_CHANNELS.setWorkspaceSurfaceContentInset, height),
     setWorkspaceSurfaceContentLeftInset: (width: number) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -179,6 +179,7 @@ import {
     type PersistedWorkspaceSnapshot,
     type WorkspaceNavigationSnapshot,
     type WorkspaceSurfaceDragEvent,
+    type WorkspaceSurfaceGitHubItemOpenRequest,
     type WorkspaceSurfaceContextRequest,
 } from "@shared/ipc";
 
@@ -902,6 +903,22 @@ const comandoApi: ComandoApi = {
             ipcRenderer.removeListener(IPC_EVENTS.workspaceSurfaceDrag, handleEvent);
         };
     },
+    onWorkspaceSurfaceGitHubItemOpenRequested: (listener) => {
+        const handleEvent = (
+            _event: Electron.IpcRendererEvent,
+            input: WorkspaceSurfaceGitHubItemOpenRequest,
+        ) => listener(input);
+        ipcRenderer.on(
+            IPC_EVENTS.workspaceSurfaceGitHubItemOpenRequested,
+            handleEvent,
+        );
+        return () => {
+            ipcRenderer.removeListener(
+                IPC_EVENTS.workspaceSurfaceGitHubItemOpenRequested,
+                handleEvent,
+            );
+        };
+    },
     onWorkspaceSurfaceSnapshotUpdated: (listener) => {
         const handleEvent = (
             _event: Electron.IpcRendererEvent,
@@ -1059,6 +1076,8 @@ const comandoApi: ComandoApi = {
         ),
     dispatchWorkspaceSurfaceDrag: (event) =>
         ipcRenderer.invoke(IPC_CHANNELS.dispatchWorkspaceSurfaceDrag, event),
+    openWorkspaceSurfaceGitHubItem: (input) =>
+        ipcRenderer.invoke(IPC_CHANNELS.openWorkspaceSurfaceGitHubItem, input),
     notifyWorkspaceSurfaceFocused: () =>
         ipcRenderer.invoke(IPC_CHANNELS.notifyWorkspaceSurfaceFocused),
     requestWorkspaceSurfaceContext: (input) =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -14,7 +14,6 @@ import { createPortal } from "react-dom";
 import type {
     AppUpdateState,
     ComandoApi,
-    FileTreeContextMenuEntry,
     GitRepositorySnapshot,
     GitWorktreeSummary,
     PersistenceSnapshot,
@@ -108,6 +107,7 @@ import {
     type ContextMenuEntry,
     type ContextMenuState,
 } from "./components/context-menu/ContextMenu";
+import { requestNativeContextMenuAction } from "./components/context-menu/nativeContextMenu";
 import {
     SidebarAgentsPanel,
     SidebarGitHubPanel,
@@ -188,38 +188,6 @@ type FileTreeContextMenuPayload =
           readonly node: GitTreeNode;
           readonly transientSelectionPath: string | null;
       };
-
-function serializeFileTreeContextMenuEntries(
-    entries: readonly ContextMenuEntry[],
-): {
-    readonly actions: ReadonlyMap<string, () => void>;
-    readonly entries: readonly FileTreeContextMenuEntry[];
-} {
-    const actions = new Map<string, () => void>();
-    let nextId = 0;
-
-    const serialize = (
-        sourceEntries: readonly ContextMenuEntry[],
-    ): readonly FileTreeContextMenuEntry[] =>
-        sourceEntries.map((entry) => {
-            if (entry.type === "separator") {
-                return { type: "separator" };
-            }
-
-            const id = `file-tree-menu-${nextId++}`;
-            if (entry.action) {
-                actions.set(id, entry.action);
-            }
-            return {
-                id,
-                label: entry.label,
-                enabled: !entry.disabled,
-                children: entry.children ? serialize(entry.children) : undefined,
-            };
-        });
-
-    return { actions, entries: serialize(entries) };
-}
 
 type FileTreeInlineEditorState = {
     readonly draftName: string;
@@ -3521,24 +3489,15 @@ export function App() {
             menu: ContextMenuState<FileTreeContextMenuPayload>,
             entries: readonly ContextMenuEntry[],
         ) => {
-            const serialized = serializeFileTreeContextMenuEntries(entries);
-            let selectedId: string | null = null;
+            let action: (() => void) | null = null;
             try {
-                selectedId =
-                    (await getComandoApi()?.showFileTreeContextMenu({
-                        entries: serialized.entries,
-                        x: menu.x,
-                        y: menu.y,
-                    })) ?? null;
+                action = await requestNativeContextMenuAction(entries, menu);
             } catch {
                 // Treat native menu failures like a dismissed menu.
             } finally {
                 closeFileTreeContextMenu();
             }
 
-            const action = selectedId
-                ? serialized.actions.get(selectedId)
-                : undefined;
             if (action) queueMicrotask(action);
         },
     );

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -21,6 +21,7 @@ import type {
     ProjectTreeNode,
     SettingsWindowCategory,
     SettingsSnapshot,
+    WorkspaceSurfaceGitHubItemOpenRequest,
 } from "@shared/ipc";
 import { resolveEditorLanguage } from "@shared/editor-language";
 import { isActiveAiRuntimeId } from "@shared/ai-runtimes";
@@ -805,6 +806,32 @@ export function App() {
         }
         return getComandoApi()?.onWorkspaceSurfaceSnapshotRequested(() =>
             useWorkspaceStore.getState().getNavigationSnapshot(),
+        );
+    }, []);
+
+    useEffect(() => {
+        if (!isWorkspaceSurfaceRenderer) {
+            return;
+        }
+        return getComandoApi()?.onWorkspaceSurfaceGitHubItemOpenRequested(
+            (input) => {
+                const workspaceState = useWorkspaceStore.getState();
+                if (input.itemKind === "issue") {
+                    void workspaceState.openGitHubIssueTab({
+                        issueNumber: input.itemNumber,
+                        projectId: input.projectId,
+                        ref: input.ref,
+                        worktreeId: input.worktreeId,
+                    });
+                    return;
+                }
+                void workspaceState.openGitHubPullRequestTab({
+                    projectId: input.projectId,
+                    pullRequestNumber: input.itemNumber,
+                    ref: input.ref,
+                    worktreeId: input.worktreeId,
+                });
+            },
         );
     }, []);
 
@@ -2785,6 +2812,13 @@ export function App() {
         [createChatTab, lastFocusedRuntimeId, setDraftComposerParts],
     );
 
+    const handleOpenSidebarGitHubItem = useCallback(
+        (input: WorkspaceSurfaceGitHubItemOpenRequest) => {
+            void getComandoApi()?.openWorkspaceSurfaceGitHubItem(input);
+        },
+        [],
+    );
+
     const sidebarFileNodes = useMemo(
         () =>
             buildGitTreeNodesFromProjectTree(
@@ -4329,6 +4363,7 @@ export function App() {
                             void handleAddGitHubItemsToChat(request)
                         }
                         onOpenSettings={openSettingsWindow}
+                        onOpenItem={handleOpenSidebarGitHubItem}
                         projectId={activeProjectId}
                         selectionResetSignal={gitHubSidebarSelectionResetSignal}
                         worktreeId={activeWorktreeId}
@@ -4341,6 +4376,7 @@ export function App() {
                             void handleAddGitHubItemsToChat(request)
                         }
                         onOpenSettings={openSettingsWindow}
+                        onOpenItem={handleOpenSidebarGitHubItem}
                         projectId={activeProjectId}
                         selectionResetSignal={gitHubSidebarSelectionResetSignal}
                         worktreeId={activeWorktreeId}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -14,6 +14,7 @@ import { createPortal } from "react-dom";
 import type {
     AppUpdateState,
     ComandoApi,
+    FileTreeContextMenuEntry,
     GitRepositorySnapshot,
     GitWorktreeSummary,
     PersistenceSnapshot,
@@ -187,6 +188,38 @@ type FileTreeContextMenuPayload =
           readonly node: GitTreeNode;
           readonly transientSelectionPath: string | null;
       };
+
+function serializeFileTreeContextMenuEntries(
+    entries: readonly ContextMenuEntry[],
+): {
+    readonly actions: ReadonlyMap<string, () => void>;
+    readonly entries: readonly FileTreeContextMenuEntry[];
+} {
+    const actions = new Map<string, () => void>();
+    let nextId = 0;
+
+    const serialize = (
+        sourceEntries: readonly ContextMenuEntry[],
+    ): readonly FileTreeContextMenuEntry[] =>
+        sourceEntries.map((entry) => {
+            if (entry.type === "separator") {
+                return { type: "separator" };
+            }
+
+            const id = `file-tree-menu-${nextId++}`;
+            if (entry.action) {
+                actions.set(id, entry.action);
+            }
+            return {
+                id,
+                label: entry.label,
+                enabled: !entry.disabled,
+                children: entry.children ? serialize(entry.children) : undefined,
+            };
+        });
+
+    return { actions, entries: serialize(entries) };
+}
 
 type FileTreeInlineEditorState = {
     readonly draftName: string;
@@ -528,6 +561,8 @@ export function App() {
     const [dragState, setDragState] = useState<DragState>(null);
     const [fileTreeContextMenu, setFileTreeContextMenu] =
         useState<ContextMenuState<FileTreeContextMenuPayload> | null>(null);
+    const activeNativeFileTreeMenuRef =
+        useRef<ContextMenuState<FileTreeContextMenuPayload> | null>(null);
     const [isFileTreeSearchOpen, setIsFileTreeSearchOpen] = useState(false);
     const [projectRootExpandedByContext, setProjectRootExpandedByContext] =
         useState<Record<string, boolean>>({});
@@ -3480,6 +3515,52 @@ export function App() {
         openFileTreeMovePicker,
         refreshProjectTree,
     ]);
+
+    const openNativeFileTreeContextMenu = useEffectEvent(
+        async (
+            menu: ContextMenuState<FileTreeContextMenuPayload>,
+            entries: readonly ContextMenuEntry[],
+        ) => {
+            const serialized = serializeFileTreeContextMenuEntries(entries);
+            let selectedId: string | null = null;
+            try {
+                selectedId =
+                    (await getComandoApi()?.showFileTreeContextMenu({
+                        entries: serialized.entries,
+                        x: menu.x,
+                        y: menu.y,
+                    })) ?? null;
+            } catch {
+                // Treat native menu failures like a dismissed menu.
+            } finally {
+                closeFileTreeContextMenu();
+            }
+
+            const action = selectedId
+                ? serialized.actions.get(selectedId)
+                : undefined;
+            if (action) queueMicrotask(action);
+        },
+    );
+
+    useEffect(() => {
+        if (!isWorkspaceHostRenderer || !fileTreeContextMenu) {
+            activeNativeFileTreeMenuRef.current = null;
+            return;
+        }
+        if (
+            fileTreeContextMenuEntries.length === 0 ||
+            activeNativeFileTreeMenuRef.current === fileTreeContextMenu
+        ) {
+            return;
+        }
+
+        activeNativeFileTreeMenuRef.current = fileTreeContextMenu;
+        void openNativeFileTreeContextMenu(
+            fileTreeContextMenu,
+            fileTreeContextMenuEntries,
+        );
+    }, [fileTreeContextMenu, fileTreeContextMenuEntries]);
 
     const { stickyFolders, stickyFolderPaths } = useStickyFolders({
         scrollContainer: fileTreeScrollElement,

--- a/src/renderer/src/components/context-menu/nativeContextMenu.test.ts
+++ b/src/renderer/src/components/context-menu/nativeContextMenu.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { requestNativeContextMenuAction } from "./nativeContextMenu";
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("requestNativeContextMenuAction", () => {
+    it("returns the renderer action selected by the native menu", async () => {
+        const firstAction = vi.fn();
+        const secondAction = vi.fn();
+        const showNativeContextMenu = vi
+            .fn()
+            .mockResolvedValue("native-menu-1");
+        vi.stubGlobal("comando", { showNativeContextMenu });
+
+        const action = await requestNativeContextMenuAction(
+            [
+                { action: firstAction, label: "First" },
+                { type: "separator" },
+                { action: secondAction, disabled: true, label: "Second" },
+            ],
+            { x: 20, y: 30 },
+        );
+
+        expect(showNativeContextMenu).toHaveBeenCalledWith({
+            entries: [
+                {
+                    children: undefined,
+                    enabled: true,
+                    id: "native-menu-0",
+                    label: "First",
+                },
+                { type: "separator" },
+                {
+                    children: undefined,
+                    enabled: false,
+                    id: "native-menu-1",
+                    label: "Second",
+                },
+            ],
+            x: 20,
+            y: 30,
+        });
+        expect(action).toBe(secondAction);
+    });
+});

--- a/src/renderer/src/components/context-menu/nativeContextMenu.ts
+++ b/src/renderer/src/components/context-menu/nativeContextMenu.ts
@@ -1,0 +1,48 @@
+import type { NativeContextMenuEntry } from "@shared/ipc";
+
+import type { ContextMenuEntry } from "./ContextMenu";
+
+export async function requestNativeContextMenuAction(
+    entries: readonly ContextMenuEntry[],
+    position: { readonly x: number; readonly y: number },
+): Promise<(() => void) | null> {
+    const serialized = serializeNativeContextMenuEntries(entries);
+    const selectedId =
+        (await window.comando?.showNativeContextMenu({
+            entries: serialized.entries,
+            x: position.x,
+            y: position.y,
+        })) ?? null;
+
+    return selectedId ? (serialized.actions.get(selectedId) ?? null) : null;
+}
+
+function serializeNativeContextMenuEntries(
+    entries: readonly ContextMenuEntry[],
+): {
+    readonly actions: ReadonlyMap<string, () => void>;
+    readonly entries: readonly NativeContextMenuEntry[];
+} {
+    const actions = new Map<string, () => void>();
+    let nextId = 0;
+
+    const serialize = (
+        sourceEntries: readonly ContextMenuEntry[],
+    ): readonly NativeContextMenuEntry[] =>
+        sourceEntries.map((entry) => {
+            if (entry.type === "separator") {
+                return { type: "separator" };
+            }
+
+            const id = `native-menu-${nextId++}`;
+            if (entry.action) actions.set(id, entry.action);
+            return {
+                id,
+                label: entry.label,
+                enabled: !entry.disabled,
+                children: entry.children ? serialize(entry.children) : undefined,
+            };
+        });
+
+    return { actions, entries: serialize(entries) };
+}

--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
@@ -1,6 +1,7 @@
 import {
     useCallback,
     useEffect,
+    useEffectEvent,
     useMemo,
     useRef,
     useState,
@@ -43,11 +44,12 @@ import {
     useGitHubStore,
 } from "@renderer/app/store/github-store";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
+import { useShellStore } from "@renderer/app/store/shell-store";
 import {
-    ContextMenu,
     type ContextMenuEntry,
     type ContextMenuState,
 } from "@renderer/components/context-menu/ContextMenu";
+import { requestNativeContextMenuAction } from "@renderer/components/context-menu/nativeContextMenu";
 import {
     formatGitHubRelativeTime,
     GitHubEmptyState,
@@ -332,8 +334,11 @@ export function SidebarGitHubPanel({
     const openGitHubPullRequestTab = useWorkspaceStore(
         (state) => state.openGitHubPullRequestTab,
     );
+    const sidebarWidth = useShellStore((state) => state.leftWidth);
     const [githubContextMenu, setGitHubContextMenu] =
         useState<ContextMenuState<SidebarGitHubContextMenuPayload> | null>(null);
+    const activeNativeContextMenuRef =
+        useRef<ContextMenuState<SidebarGitHubContextMenuPayload> | null>(null);
     const [labelPicker, setLabelPicker] =
         useState<SidebarGitHubLabelPickerState | null>(null);
     const [selectionAnchorNumber, setSelectionAnchorNumber] = useState<
@@ -789,6 +794,41 @@ export function SidebarGitHubPanel({
                       ),
               })
             : [];
+    const openNativeContextMenu = useEffectEvent(
+        async (menu: ContextMenuState<SidebarGitHubContextMenuPayload>) => {
+            if (contextMenuEntries.length === 0) {
+                setGitHubContextMenu(null);
+                return;
+            }
+            let action: (() => void) | null = null;
+            try {
+                action = await requestNativeContextMenuAction(
+                    contextMenuEntries,
+                    menu,
+                );
+            } catch {
+                // Treat native menu failures like a dismissed menu.
+            } finally {
+                setGitHubContextMenu(null);
+            }
+            if (action) queueMicrotask(action);
+        },
+    );
+
+    useEffect(() => {
+        if (!githubContextMenu) {
+            activeNativeContextMenuRef.current = null;
+            return;
+        }
+        if (
+            activeNativeContextMenuRef.current === githubContextMenu
+        ) {
+            return;
+        }
+
+        activeNativeContextMenuRef.current = githubContextMenu;
+        void openNativeContextMenu(githubContextMenu);
+    }, [githubContextMenu]);
     const handleItemClickSelection = useCallback(
         (
             event: ReactMouseEvent<HTMLElement>,
@@ -1212,14 +1252,6 @@ export function SidebarGitHubPanel({
                     </ul>
                 ) : null}
             </div>
-            {githubContextMenu && contextMenuEntries.length > 0 ? (
-                <ContextMenu
-                    entries={contextMenuEntries}
-                    menu={githubContextMenu}
-                    minWidth={230}
-                    onClose={() => setGitHubContextMenu(null)}
-                />
-            ) : null}
             {activeLabelPickerItem && labelPicker ? (
                 <GitHubLabelPicker
                     anchor={{ x: labelPicker.x, y: labelPicker.y }}
@@ -1231,6 +1263,7 @@ export function SidebarGitHubPanel({
                     labels={labels}
                     onClose={() => setLabelPicker(null)}
                     onSave={(labelNames) => void handleSaveLabels(labelNames)}
+                    rightBoundary={sidebarWidth}
                 />
             ) : null}
         </div>

--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
@@ -18,6 +18,7 @@ import type {
     GitHubPullRequestSummary,
     GitHubRepositoryRef,
     GitRepositorySnapshot,
+    WorkspaceSurfaceGitHubItemOpenRequest,
 } from "@shared/ipc";
 
 import {
@@ -200,6 +201,7 @@ export function SidebarGitHubPanel({
     filter,
     kind,
     onAddToChat,
+    onOpenItem,
     onOpenSettings,
     projectId,
     selectionResetSignal = 0,
@@ -208,6 +210,9 @@ export function SidebarGitHubPanel({
     readonly filter?: string;
     readonly kind: SidebarGitHubPanelKind;
     readonly onAddToChat?: (request: SidebarGitHubAddToChatRequest) => void;
+    readonly onOpenItem?: (
+        request: WorkspaceSurfaceGitHubItemOpenRequest,
+    ) => void;
     readonly onOpenSettings: () => void;
     readonly projectId: string | null;
     readonly selectionResetSignal?: number;
@@ -678,6 +683,17 @@ export function SidebarGitHubPanel({
                 return;
             }
 
+            const input = {
+                itemKind: "issue" as const,
+                itemNumber: issueNumber,
+                projectId,
+                ref: repoRef,
+                worktreeId,
+            };
+            if (onOpenItem) {
+                onOpenItem(input);
+                return;
+            }
             void openGitHubIssueTab({
                 issueNumber,
                 projectId,
@@ -685,7 +701,32 @@ export function SidebarGitHubPanel({
                 worktreeId,
             });
         },
-        [openGitHubIssueTab, projectId, repoRef, worktreeId],
+        [onOpenItem, openGitHubIssueTab, projectId, repoRef, worktreeId],
+    );
+    const openPullRequestTab = useCallback(
+        (pullRequestNumber: number) => {
+            if (!repoRef) {
+                return;
+            }
+            const input = {
+                itemKind: "pull_request" as const,
+                itemNumber: pullRequestNumber,
+                projectId,
+                ref: repoRef,
+                worktreeId,
+            };
+            if (onOpenItem) {
+                onOpenItem(input);
+                return;
+            }
+            void openGitHubPullRequestTab({
+                projectId,
+                pullRequestNumber,
+                ref: repoRef,
+                worktreeId,
+            });
+        },
+        [onOpenItem, openGitHubPullRequestTab, projectId, repoRef, worktreeId],
     );
     const openLabelPicker = useCallback(
         (
@@ -779,13 +820,9 @@ export function SidebarGitHubPanel({
                       kind === "issues"
                           ? () => openIssueTab(contextIssues[0].number)
                           : () =>
-                                void openGitHubPullRequestTab({
-                                    projectId,
-                                    pullRequestNumber:
-                                        contextPullRequests[0].number,
-                                    ref: repoRef,
-                                    worktreeId,
-                                }),
+                                openPullRequestTab(
+                                    contextPullRequests[0].number,
+                                ),
                   onOpenInGitHub: () =>
                       openGitHubWebUrl(
                           kind === "issues"
@@ -1216,13 +1253,7 @@ export function SidebarGitHubPanel({
                                         )
                                     }
                                     onOpen={() =>
-                                        void openGitHubPullRequestTab({
-                                            projectId,
-                                            pullRequestNumber:
-                                                pullRequest.number,
-                                            ref: activeRepoRef,
-                                            worktreeId,
-                                        })
+                                        openPullRequestTab(pullRequest.number)
                                     }
                                     onPointerDown={handleItemPointerDown}
                                     onRowClick={(event) =>
@@ -1230,13 +1261,9 @@ export function SidebarGitHubPanel({
                                             event,
                                             pullRequest.number,
                                             () =>
-                                                void openGitHubPullRequestTab({
-                                                    projectId,
-                                                    pullRequestNumber:
-                                                        pullRequest.number,
-                                                    ref: activeRepoRef,
-                                                    worktreeId,
-                                                }),
+                                                openPullRequestTab(
+                                                    pullRequest.number,
+                                                ),
                                         )
                                     }
                                     pullRequest={pullRequest}

--- a/src/renderer/src/components/workspace/GitHubLabelPicker.test.tsx
+++ b/src/renderer/src/components/workspace/GitHubLabelPicker.test.tsx
@@ -18,6 +18,7 @@ afterEach(() => {
     root = null;
     container?.remove();
     container = null;
+    vi.restoreAllMocks();
 });
 
 describe("GitHubLabelPicker", () => {
@@ -62,5 +63,43 @@ describe("GitHubLabelPicker", () => {
         act(() => saveButton?.click());
 
         expect(onSave).toHaveBeenCalledWith(["legacy"]);
+    });
+
+    it("keeps the sidebar picker inside its right boundary", () => {
+        vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+            bottom: 210,
+            height: 200,
+            left: 300,
+            right: 620,
+            top: 10,
+            width: 320,
+            x: 300,
+            y: 10,
+            toJSON: () => undefined,
+        });
+        container = document.createElement("div");
+        document.body.append(container);
+        root = createRoot(container);
+
+        act(() => {
+            root?.render(
+                createElement(GitHubLabelPicker, {
+                    anchor: { x: 300, y: 10 },
+                    error: null,
+                    isLoading: false,
+                    isSaving: false,
+                    item: { labels: [], number: 7, title: "Bounded picker" },
+                    labels: [],
+                    onClose: () => undefined,
+                    onSave: () => undefined,
+                    rightBoundary: 340,
+                }),
+            );
+        });
+
+        const picker = document.querySelector<HTMLElement>(
+            "[data-context-menu-root='true']",
+        );
+        expect(picker?.style.left).toBe("12px");
     });
 });

--- a/src/renderer/src/components/workspace/GitHubLabelPicker.tsx
+++ b/src/renderer/src/components/workspace/GitHubLabelPicker.tsx
@@ -26,6 +26,7 @@ export function GitHubLabelPicker({
     labels,
     onClose,
     onSave,
+    rightBoundary,
 }: {
     readonly anchor: { readonly x: number; readonly y: number };
     readonly error: string | null;
@@ -35,6 +36,7 @@ export function GitHubLabelPicker({
     readonly labels: readonly GitHubLabelSummary[];
     readonly onClose: () => void;
     readonly onSave: (labelNames: readonly string[]) => void;
+    readonly rightBoundary?: number;
 }) {
     const ref = useRef<HTMLDivElement | null>(null);
     const [query, setQuery] = useState("");
@@ -87,15 +89,31 @@ export function GitHubLabelPicker({
         }
 
         const rect = element.getBoundingClientRect();
-        setPosition(
-            getViewportSafeMenuPosition(
-                anchor.x,
-                anchor.y,
-                rect.width,
-                rect.height,
-            ),
+        const safePosition = getViewportSafeMenuPosition(
+            anchor.x,
+            anchor.y,
+            rect.width,
+            rect.height,
         );
-    }, [anchor.x, anchor.y, error, isLoading, labelOptions.length, visibleLabels.length]);
+        setPosition({
+            ...safePosition,
+            x:
+                rightBoundary === undefined
+                    ? safePosition.x
+                    : Math.min(
+                          safePosition.x,
+                          Math.max(8, rightBoundary - rect.width - 8),
+                      ),
+        });
+    }, [
+        anchor.x,
+        anchor.y,
+        error,
+        isLoading,
+        labelOptions.length,
+        rightBoundary,
+        visibleLabels.length,
+    ]);
 
     const toggleLabel = (labelName: string) => {
         setSelectedNames((current) => {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -131,6 +131,7 @@ export const IPC_CHANNELS = {
     activateWorkspaceSurface: "workspace:activate-surface",
     captureWorkspaceSurfaceContext: "workspace:capture-surface-context",
     dispatchWorkspaceSurfaceDrag: "workspace:dispatch-surface-drag",
+    openWorkspaceSurfaceGitHubItem: "workspace:open-surface-github-item",
     notifyWorkspaceSurfaceFocused: "workspace:notify-surface-focused",
     requestWorkspaceSurfaceContext: "workspace:request-surface-context",
     openWorkspaceSurfaceGitScopeMenu: "workspace:open-surface-git-scope-menu",
@@ -203,6 +204,8 @@ export const IPC_EVENTS = {
     workspaceSurfaceFocused: "workspace:surface-focused",
     workspaceSurfaceContextRequested: "workspace:surface-context-requested",
     workspaceSurfaceDrag: "workspace:surface-drag",
+    workspaceSurfaceGitHubItemOpenRequested:
+        "workspace:surface-github-item-open-requested",
     workspaceSurfaceGitScopeMenuRequested:
         "workspace:surface-git-scope-menu-requested",
     workspaceSurfaceProjectMenuRequested: "workspace:surface-project-menu-requested",
@@ -2173,6 +2176,14 @@ export interface WorkspaceSurfaceContextRequest {
     readonly worktreeId?: string | null;
 }
 
+export interface WorkspaceSurfaceGitHubItemOpenRequest {
+    readonly itemKind: "issue" | "pull_request";
+    readonly itemNumber: number;
+    readonly projectId: string | null;
+    readonly ref: GitHubRepositoryRef;
+    readonly worktreeId: string | null;
+}
+
 export interface WorkspaceContextMenuInput {
     readonly canCopyFullPath: boolean;
     readonly x: number;
@@ -3300,6 +3311,9 @@ export interface ComandoApi {
     dispatchWorkspaceSurfaceDrag: (
         event: WorkspaceSurfaceDragEvent,
     ) => Promise<void>;
+    openWorkspaceSurfaceGitHubItem: (
+        input: WorkspaceSurfaceGitHubItemOpenRequest,
+    ) => Promise<void>;
     notifyWorkspaceSurfaceFocused: () => Promise<void>;
     onWorkspaceSurfaceSnapshotRequested: (
         listener: () => WorkspaceNavigationSnapshot,
@@ -3440,6 +3454,9 @@ export interface ComandoApi {
     ) => () => void;
     onWorkspaceSurfaceDrag: (
         listener: (event: WorkspaceSurfaceDragEvent) => void,
+    ) => () => void;
+    onWorkspaceSurfaceGitHubItemOpenRequested: (
+        listener: (input: WorkspaceSurfaceGitHubItemOpenRequest) => void,
     ) => () => void;
     onWorkspaceSurfaceGitScopeMenuRequested: (
         listener: (anchor: { readonly width: number; readonly x: number }) => void,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -136,7 +136,7 @@ export const IPC_CHANNELS = {
     openWorkspaceSurfaceGitScopeMenu: "workspace:open-surface-git-scope-menu",
     openWorkspaceSurfaceProjectMenu: "workspace:open-surface-project-menu",
     showWorkspaceContextMenu: "workspace:show-context-menu",
-    showFileTreeContextMenu: "projects:show-file-tree-context-menu",
+    showNativeContextMenu: "app:show-native-context-menu",
     setWorkspaceSurfaceContentInset: "workspace:set-surface-content-inset",
     setWorkspaceSurfaceContentLeftInset: "workspace:set-surface-content-left-inset",
     notifyFileBuffer: "workspace:notify-file-buffer",
@@ -2184,7 +2184,7 @@ export type WorkspaceContextMenuAction =
     | "move_to_new_window"
     | "close";
 
-export type FileTreeContextMenuEntry =
+export type NativeContextMenuEntry =
     | {
           readonly type: "separator";
       }
@@ -2192,11 +2192,11 @@ export type FileTreeContextMenuEntry =
           readonly id: string;
           readonly label: string;
           readonly enabled: boolean;
-          readonly children?: readonly FileTreeContextMenuEntry[];
+          readonly children?: readonly NativeContextMenuEntry[];
       };
 
-export interface FileTreeContextMenuInput {
-    readonly entries: readonly FileTreeContextMenuEntry[];
+export interface NativeContextMenuInput {
+    readonly entries: readonly NativeContextMenuEntry[];
     readonly x: number;
     readonly y: number;
 }
@@ -3056,8 +3056,8 @@ export interface ComandoApi {
     showWorkspaceContextMenu: (
         input: WorkspaceContextMenuInput,
     ) => Promise<WorkspaceContextMenuAction | null>;
-    showFileTreeContextMenu: (
-        input: FileTreeContextMenuInput,
+    showNativeContextMenu: (
+        input: NativeContextMenuInput,
     ) => Promise<string | null>;
     setWorkspaceSurfaceContentInset: (height: number) => Promise<void>;
     setWorkspaceSurfaceContentLeftInset: (width: number) => Promise<void>;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -136,6 +136,7 @@ export const IPC_CHANNELS = {
     openWorkspaceSurfaceGitScopeMenu: "workspace:open-surface-git-scope-menu",
     openWorkspaceSurfaceProjectMenu: "workspace:open-surface-project-menu",
     showWorkspaceContextMenu: "workspace:show-context-menu",
+    showFileTreeContextMenu: "projects:show-file-tree-context-menu",
     setWorkspaceSurfaceContentInset: "workspace:set-surface-content-inset",
     setWorkspaceSurfaceContentLeftInset: "workspace:set-surface-content-left-inset",
     notifyFileBuffer: "workspace:notify-file-buffer",
@@ -2183,6 +2184,23 @@ export type WorkspaceContextMenuAction =
     | "move_to_new_window"
     | "close";
 
+export type FileTreeContextMenuEntry =
+    | {
+          readonly type: "separator";
+      }
+    | {
+          readonly id: string;
+          readonly label: string;
+          readonly enabled: boolean;
+          readonly children?: readonly FileTreeContextMenuEntry[];
+      };
+
+export interface FileTreeContextMenuInput {
+    readonly entries: readonly FileTreeContextMenuEntry[];
+    readonly x: number;
+    readonly y: number;
+}
+
 export interface WindowWorkspaceRestoreRecord {
     readonly revision: number;
     readonly schemaVersion: 1;
@@ -3038,6 +3056,9 @@ export interface ComandoApi {
     showWorkspaceContextMenu: (
         input: WorkspaceContextMenuInput,
     ) => Promise<WorkspaceContextMenuAction | null>;
+    showFileTreeContextMenu: (
+        input: FileTreeContextMenuInput,
+    ) => Promise<string | null>;
     setWorkspaceSurfaceContentInset: (height: number) => Promise<void>;
     setWorkspaceSurfaceContentLeftInset: (width: number) => Promise<void>;
     setTrafficLightVisibility: (visible: boolean) => Promise<void>;


### PR DESCRIPTION
## Summary

- show file tree and GitHub sidebar context menus with native Electron menus above workspace surfaces
- keep the interactive GitHub label picker custom and constrained to the sidebar
- route Issue and pull request opens from the host sidebar to the active workspace surface

## Validation

- `pnpm run typecheck`
- targeted ESLint checks
- 33 related renderer tests
- `git diff --check`