### PR TITLE
Route sidebar actions to active workspace surfaces

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -163,6 +163,7 @@ import {
     type WorkspaceContextMenuAction,
     type WorkspaceContextMenuInput,
     type WorkspaceSurfaceActionRequest,
+    type WorkspaceSurfaceActionCompletion,
     type WorkspaceSurfaceContextRequest,
     type WorkspaceSurfaceDragEvent,
 } from "@shared/ipc";
@@ -229,6 +230,7 @@ import { windowRegistry } from "@main/windows/registry";
 import { workspaceSurfaceManager } from "@main/workspace/surface-manager";
 import {
     isWorkspaceSurfaceActionRequest,
+    isWorkspaceSurfaceActionCompletion,
     isWorkspaceSurfaceFileRevealRequest,
 } from "@main/workspace/surface-actions";
 
@@ -1962,6 +1964,24 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.handle(IPC_CHANNELS.notifyWorkspaceSurfaceReady, (event) => {
         workspaceSurfaceManager.notifySurfaceReady(event.sender);
     });
+    ipcMain.handle(
+        IPC_CHANNELS.claimWorkspaceSurfaceAction,
+        (event, actionId: string) =>
+            typeof actionId === "string" &&
+            workspaceSurfaceManager.claimSurfaceAction(event.sender, actionId),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.completeWorkspaceSurfaceAction,
+        (event, completion: WorkspaceSurfaceActionCompletion) => {
+            if (!isWorkspaceSurfaceActionCompletion(completion)) {
+                return;
+            }
+            workspaceSurfaceManager.completeSurfaceAction(
+                event.sender,
+                completion,
+            );
+        },
+    );
     ipcMain.handle(
         IPC_CHANNELS.revealWorkspaceSurfaceFileInHostTree,
         (event, input) => {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -227,7 +227,10 @@ import {
 import type { WorkspaceGateway } from "@main/workspace/service";
 import { windowRegistry } from "@main/windows/registry";
 import { workspaceSurfaceManager } from "@main/workspace/surface-manager";
-import { isWorkspaceSurfaceActionRequest } from "@main/workspace/surface-actions";
+import {
+    isWorkspaceSurfaceActionRequest,
+    isWorkspaceSurfaceFileRevealRequest,
+} from "@main/workspace/surface-actions";
 
 interface RegisterIpcHandlersOptions {
     readonly aiService: AiService;
@@ -1950,6 +1953,18 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             }
             return workspaceSurfaceManager.dispatchActiveSurfaceAction(
                 context.windowId,
+                input,
+            );
+        },
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.revealWorkspaceSurfaceFileInHostTree,
+        (event, input) => {
+            if (!isWorkspaceSurfaceFileRevealRequest(input)) {
+                throw new Error("A valid workspace surface file reveal is required.");
+            }
+            return workspaceSurfaceManager.revealSurfaceFileInHostTree(
+                event.sender,
                 input,
             );
         },

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -165,7 +165,6 @@ import {
     type WorkspaceSurfaceActionRequest,
     type WorkspaceSurfaceContextRequest,
     type WorkspaceSurfaceDragEvent,
-    type WorkspaceSurfaceGitHubItemOpenRequest,
 } from "@shared/ipc";
 import { normalizePathKey as normalizeSharedPathKey } from "@shared/path-identity";
 import { normalizeWorkspaceNavigationSnapshot } from "@shared/workspace-restore";
@@ -364,7 +363,6 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.captureWorkspaceSurfaceContext);
     ipcMain.removeHandler(IPC_CHANNELS.dispatchWorkspaceSurfaceDrag);
     ipcMain.removeHandler(IPC_CHANNELS.dispatchWorkspaceSurfaceAction);
-    ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceGitHubItem);
     ipcMain.removeHandler(IPC_CHANNELS.notifyWorkspaceSurfaceFocused);
     ipcMain.removeHandler(IPC_CHANNELS.requestWorkspaceSurfaceContext);
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceGitScopeMenu);
@@ -1956,22 +1954,6 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             );
         },
     );
-    ipcMain.handle(
-        IPC_CHANNELS.openWorkspaceSurfaceGitHubItem,
-        (event, input: WorkspaceSurfaceGitHubItemOpenRequest) => {
-            const context = requireWindowContext(event.sender, "main");
-            if (workspaceSurfaceManager.isSurface(event.sender)) {
-                return;
-            }
-            if (!isWorkspaceSurfaceGitHubItemOpenRequest(input)) {
-                throw new Error("A valid GitHub item is required.");
-            }
-            workspaceSurfaceManager.requestActiveGitHubItemOpen(
-                context.windowId,
-                input,
-            );
-        },
-    );
     ipcMain.handle(IPC_CHANNELS.notifyWorkspaceSurfaceFocused, (event) => {
         const surfaceContext = workspaceSurfaceManager.getSurfaceContext(
             event.sender,
@@ -2477,32 +2459,6 @@ function showNativeContextMenu(
             y: Number.isFinite(input.y) ? Math.max(0, Math.round(input.y)) : 0,
         });
     });
-}
-
-function isWorkspaceSurfaceGitHubItemOpenRequest(
-    input: unknown,
-): input is WorkspaceSurfaceGitHubItemOpenRequest {
-    if (!input || typeof input !== "object") {
-        return false;
-    }
-    const candidate = input as Record<string, unknown>;
-    const ref = candidate.ref;
-    return (
-        (candidate.itemKind === "issue" ||
-            candidate.itemKind === "pull_request") &&
-        typeof candidate.itemNumber === "number" &&
-        Number.isSafeInteger(candidate.itemNumber) &&
-        candidate.itemNumber > 0 &&
-        (candidate.projectId === null ||
-            typeof candidate.projectId === "string") &&
-        (candidate.worktreeId === null ||
-            typeof candidate.worktreeId === "string") &&
-        Boolean(ref) &&
-        typeof ref === "object" &&
-        typeof (ref as Record<string, unknown>).host === "string" &&
-        typeof (ref as Record<string, unknown>).owner === "string" &&
-        typeof (ref as Record<string, unknown>).repo === "string"
-    );
 }
 
 function normalizeNativeContextMenuEntries(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -162,6 +162,7 @@ import {
     type WorkspaceNavigationSnapshot,
     type WorkspaceContextMenuAction,
     type WorkspaceContextMenuInput,
+    type WorkspaceSurfaceActionRequest,
     type WorkspaceSurfaceContextRequest,
     type WorkspaceSurfaceDragEvent,
     type WorkspaceSurfaceGitHubItemOpenRequest,
@@ -227,6 +228,7 @@ import {
 import type { WorkspaceGateway } from "@main/workspace/service";
 import { windowRegistry } from "@main/windows/registry";
 import { workspaceSurfaceManager } from "@main/workspace/surface-manager";
+import { isWorkspaceSurfaceActionRequest } from "@main/workspace/surface-actions";
 
 interface RegisterIpcHandlersOptions {
     readonly aiService: AiService;
@@ -361,6 +363,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.activateWorkspaceSurface);
     ipcMain.removeHandler(IPC_CHANNELS.captureWorkspaceSurfaceContext);
     ipcMain.removeHandler(IPC_CHANNELS.dispatchWorkspaceSurfaceDrag);
+    ipcMain.removeHandler(IPC_CHANNELS.dispatchWorkspaceSurfaceAction);
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceGitHubItem);
     ipcMain.removeHandler(IPC_CHANNELS.notifyWorkspaceSurfaceFocused);
     ipcMain.removeHandler(IPC_CHANNELS.requestWorkspaceSurfaceContext);
@@ -1934,6 +1937,22 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             workspaceSurfaceManager.dispatchActiveSurfaceDrag(
                 context.windowId,
                 payload as WorkspaceSurfaceDragEvent,
+            );
+        },
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.dispatchWorkspaceSurfaceAction,
+        (event, input: WorkspaceSurfaceActionRequest) => {
+            const context = requireWindowContext(event.sender, "main");
+            if (
+                workspaceSurfaceManager.isSurface(event.sender) ||
+                !isWorkspaceSurfaceActionRequest(input)
+            ) {
+                throw new Error("A valid workspace surface action is required.");
+            }
+            return workspaceSurfaceManager.dispatchActiveSurfaceAction(
+                context.windowId,
+                input,
             );
         },
     );

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -366,6 +366,8 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.captureWorkspaceSurfaceContext);
     ipcMain.removeHandler(IPC_CHANNELS.dispatchWorkspaceSurfaceDrag);
     ipcMain.removeHandler(IPC_CHANNELS.dispatchWorkspaceSurfaceAction);
+    ipcMain.removeHandler(IPC_CHANNELS.notifyWorkspaceSurfaceReady);
+    ipcMain.removeHandler(IPC_CHANNELS.revealWorkspaceSurfaceFileInHostTree);
     ipcMain.removeHandler(IPC_CHANNELS.notifyWorkspaceSurfaceFocused);
     ipcMain.removeHandler(IPC_CHANNELS.requestWorkspaceSurfaceContext);
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceGitScopeMenu);
@@ -1957,6 +1959,9 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             );
         },
     );
+    ipcMain.handle(IPC_CHANNELS.notifyWorkspaceSurfaceReady, (event) => {
+        workspaceSurfaceManager.notifySurfaceReady(event.sender);
+    });
     ipcMain.handle(
         IPC_CHANNELS.revealWorkspaceSurfaceFileInHostTree,
         (event, input) => {

--- a/src/main/workspace/surface-actions.test.ts
+++ b/src/main/workspace/surface-actions.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from "vitest";
 import type {
     PersistedWorkspaceContext,
     WorkspaceSurfaceActionRequest,
+    WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
 import {
     doesWorkspaceSurfaceActionMatchContext,
+    isWorkspaceSurfaceFileRevealRequest,
     isWorkspaceSurfaceActionRequest,
 } from "./surface-actions";
 
@@ -122,6 +124,24 @@ describe("workspace surface actions", () => {
                 })),
                 kind: "add-github-items-to-chat",
                 ref,
+            }),
+        ).toBe(false);
+    });
+
+    it("accepts only a bounded, scoped surface file reveal", () => {
+        const request: WorkspaceSurfaceFileRevealRequest = {
+            ...context,
+            relativePath: "src/index.ts",
+        };
+        expect(isWorkspaceSurfaceFileRevealRequest(request)).toBe(true);
+        expect(
+            isWorkspaceSurfaceFileRevealRequest({ ...request, relativePath: "" }),
+        ).toBe(false);
+        expect(
+            isWorkspaceSurfaceFileRevealRequest({
+                projectId: context.projectId,
+                relativePath: request.relativePath,
+                worktreeId: null,
             }),
         ).toBe(false);
     });

--- a/src/main/workspace/surface-actions.test.ts
+++ b/src/main/workspace/surface-actions.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+    PersistedWorkspaceContext,
+    WorkspaceSurfaceActionRequest,
+} from "@shared/ipc";
+import {
+    doesWorkspaceSurfaceActionMatchContext,
+    isWorkspaceSurfaceActionRequest,
+} from "./surface-actions";
+
+const context = {
+    contextKey: "project-1::__primary__",
+    projectId: "project-1",
+    worktreeId: null,
+} as const;
+
+const ref = {
+    host: "github.com",
+    owner: "openai",
+    repo: "codex",
+} as const;
+
+describe("workspace surface actions", () => {
+    it("accepts every supported discriminant", () => {
+        const requests: WorkspaceSurfaceActionRequest[] = [
+            {
+                ...context,
+                kind: "file",
+                origin: "tree",
+                relativePath: "src/index.ts",
+            },
+            { ...context, kind: "git-history" },
+            { ...context, kind: "git-worktree-diff" },
+            {
+                ...context,
+                kind: "chat-session",
+                runtimeId: "codex",
+                sessionId: "session-1",
+                sessionProjectId: "project-1",
+                sessionWorktreeId: null,
+                title: "Session",
+            },
+            { ...context, kind: "chat-history" },
+            { ...context, kind: "new-chat", runtimeId: "claude" },
+            { ...context, kind: "focus-terminal", terminalId: "terminal-1" },
+            { ...context, kind: "new-claude-terminal" },
+            {
+                ...context,
+                kind: "github-list",
+                listKind: "issues",
+                ref,
+            },
+            {
+                ...context,
+                itemKind: "pull_request",
+                itemNumber: 42,
+                kind: "github-item",
+                ref,
+            },
+            {
+                ...context,
+                files: [{ name: "index.ts", relativePath: "src/index.ts" }],
+                forceNewChat: false,
+                kind: "add-files-to-chat",
+            },
+            {
+                ...context,
+                forceNewChat: true,
+                itemKind: "issue",
+                items: [
+                    {
+                        number: 42,
+                        title: "Fix routing",
+                        url: "https://github.com/openai/codex/issues/42",
+                    },
+                ],
+                kind: "add-github-items-to-chat",
+                ref,
+            },
+        ];
+
+        for (const request of requests) {
+            expect(isWorkspaceSurfaceActionRequest(request)).toBe(true);
+        }
+    });
+
+    it("rejects malformed and unbounded payloads", () => {
+        expect(isWorkspaceSurfaceActionRequest(null)).toBe(false);
+        expect(
+            isWorkspaceSurfaceActionRequest({
+                ...context,
+                kind: "file",
+                origin: "tree",
+                relativePath: "",
+            }),
+        ).toBe(false);
+        expect(
+            isWorkspaceSurfaceActionRequest({
+                ...context,
+                kind: "new-chat",
+                runtimeId: "unknown",
+            }),
+        ).toBe(false);
+        expect(
+            isWorkspaceSurfaceActionRequest({
+                ...context,
+                files: [],
+                forceNewChat: false,
+                kind: "add-files-to-chat",
+            }),
+        ).toBe(false);
+        expect(
+            isWorkspaceSurfaceActionRequest({
+                ...context,
+                forceNewChat: false,
+                itemKind: "issue",
+                items: Array.from({ length: 101 }, (_, index) => ({
+                    number: index + 1,
+                    title: `Issue ${index + 1}`,
+                    url: `https://github.com/openai/codex/issues/${index + 1}`,
+                })),
+                kind: "add-github-items-to-chat",
+                ref,
+            }),
+        ).toBe(false);
+    });
+
+    it("matches only the requested project context", () => {
+        const persistedContext: PersistedWorkspaceContext = {
+            key: context.contextKey,
+            lastActivatedAt: "2026-07-19T00:00:00.000Z",
+            projectId: context.projectId,
+            workspace: {
+                activePaneId: "pane-1",
+                rootNode: {
+                    activeTabId: null,
+                    id: "pane-1",
+                    tabIds: [],
+                    type: "pane",
+                },
+                tabs: [],
+            },
+            worktreeId: null,
+        };
+        const request: WorkspaceSurfaceActionRequest = {
+            ...context,
+            kind: "chat-history",
+        };
+
+        expect(
+            doesWorkspaceSurfaceActionMatchContext(request, persistedContext),
+        ).toBe(true);
+        expect(
+            doesWorkspaceSurfaceActionMatchContext(
+                { ...request, worktreeId: "project-1:primary" },
+                persistedContext,
+            ),
+        ).toBe(true);
+        expect(
+            doesWorkspaceSurfaceActionMatchContext(
+                { ...request, contextKey: "project-2::__primary__" },
+                persistedContext,
+            ),
+        ).toBe(false);
+        expect(
+            doesWorkspaceSurfaceActionMatchContext(
+                { ...request, projectId: "project-2" },
+                persistedContext,
+            ),
+        ).toBe(false);
+        expect(
+            doesWorkspaceSurfaceActionMatchContext(
+                { ...request, worktreeId: "worktree-2" },
+                persistedContext,
+            ),
+        ).toBe(false);
+    });
+});

--- a/src/main/workspace/surface-actions.ts
+++ b/src/main/workspace/surface-actions.ts
@@ -1,0 +1,165 @@
+import { isKnownAiRuntimeId } from "@shared/ai-runtimes";
+import type {
+    GitHubRepositoryRef,
+    PersistedWorkspaceContext,
+    WorkspaceSurfaceActionRequest,
+} from "@shared/ipc";
+
+const MAX_ACTION_ITEMS = 100;
+const MAX_SHORT_TEXT_LENGTH = 1_000;
+const MAX_PATH_OR_URL_LENGTH = 16_384;
+
+export function isWorkspaceSurfaceActionRequest(
+    input: unknown,
+): input is WorkspaceSurfaceActionRequest {
+    if (!isRecord(input) || !hasValidContext(input)) {
+        return false;
+    }
+
+    switch (input.kind) {
+        case "file":
+            return (
+                (input.origin === "tree" ||
+                    input.origin === "git" ||
+                    input.origin === "quick-create") &&
+                isNonEmptyString(input.relativePath, MAX_PATH_OR_URL_LENGTH)
+            );
+        case "git-history":
+        case "git-worktree-diff":
+        case "chat-history":
+        case "new-claude-terminal":
+            return true;
+        case "chat-session":
+            return (
+                isKnownAiRuntimeId(input.runtimeId) &&
+                isNonEmptyString(input.sessionId, MAX_SHORT_TEXT_LENGTH) &&
+                isNullableString(input.sessionProjectId, MAX_SHORT_TEXT_LENGTH) &&
+                isNullableString(
+                    input.sessionWorktreeId,
+                    MAX_SHORT_TEXT_LENGTH,
+                ) &&
+                isNonEmptyString(input.title, MAX_SHORT_TEXT_LENGTH)
+            );
+        case "new-chat":
+            return isKnownAiRuntimeId(input.runtimeId);
+        case "focus-terminal":
+            return isNonEmptyString(input.terminalId, MAX_SHORT_TEXT_LENGTH);
+        case "github-list":
+            return (
+                (input.listKind === "issues" ||
+                    input.listKind === "pull_requests") &&
+                isGitHubRepositoryRef(input.ref)
+            );
+        case "github-item":
+            return (
+                (input.itemKind === "issue" ||
+                    input.itemKind === "pull_request") &&
+                isPositiveSafeInteger(input.itemNumber) &&
+                isGitHubRepositoryRef(input.ref)
+            );
+        case "add-files-to-chat":
+            return (
+                typeof input.forceNewChat === "boolean" &&
+                isBoundedNonEmptyArray(input.files) &&
+                input.files.every(
+                    (file) =>
+                        isRecord(file) &&
+                        isNonEmptyString(file.name, MAX_SHORT_TEXT_LENGTH) &&
+                        isNonEmptyString(
+                            file.relativePath,
+                            MAX_PATH_OR_URL_LENGTH,
+                        ),
+                )
+            );
+        case "add-github-items-to-chat":
+            return (
+                typeof input.forceNewChat === "boolean" &&
+                (input.itemKind === "issue" ||
+                    input.itemKind === "pull_request") &&
+                isGitHubRepositoryRef(input.ref) &&
+                isBoundedNonEmptyArray(input.items) &&
+                input.items.every(
+                    (item) =>
+                        isRecord(item) &&
+                        isPositiveSafeInteger(item.number) &&
+                        isNonEmptyString(item.title, MAX_SHORT_TEXT_LENGTH) &&
+                        isNonEmptyString(item.url, MAX_PATH_OR_URL_LENGTH),
+                )
+            );
+        default:
+            return false;
+    }
+}
+
+export function doesWorkspaceSurfaceActionMatchContext(
+    request: WorkspaceSurfaceActionRequest,
+    context: PersistedWorkspaceContext,
+): boolean {
+    return (
+        request.contextKey === context.key &&
+        request.projectId === context.projectId &&
+        normalizeWorktreeId(request.projectId, request.worktreeId) ===
+            normalizeWorktreeId(context.projectId, context.worktreeId)
+    );
+}
+
+function hasValidContext(input: Record<string, unknown>): boolean {
+    return (
+        isNonEmptyString(input.contextKey, MAX_SHORT_TEXT_LENGTH) &&
+        isNonEmptyString(input.projectId, MAX_SHORT_TEXT_LENGTH) &&
+        isNullableString(input.worktreeId, MAX_SHORT_TEXT_LENGTH)
+    );
+}
+
+function isGitHubRepositoryRef(input: unknown): input is GitHubRepositoryRef {
+    return (
+        isRecord(input) &&
+        isNonEmptyString(input.host, MAX_SHORT_TEXT_LENGTH) &&
+        isNonEmptyString(input.owner, MAX_SHORT_TEXT_LENGTH) &&
+        isNonEmptyString(input.repo, MAX_SHORT_TEXT_LENGTH)
+    );
+}
+
+function isBoundedNonEmptyArray(input: unknown): input is readonly unknown[] {
+    return (
+        Array.isArray(input) &&
+        input.length > 0 &&
+        input.length <= MAX_ACTION_ITEMS
+    );
+}
+
+function isNonEmptyString(input: unknown, maxLength: number): input is string {
+    return (
+        typeof input === "string" &&
+        input.length > 0 &&
+        input.length <= maxLength
+    );
+}
+
+function isNullableString(
+    input: unknown,
+    maxLength: number,
+): input is string | null {
+    return input === null || isNonEmptyString(input, maxLength);
+}
+
+function isPositiveSafeInteger(input: unknown): input is number {
+    return (
+        typeof input === "number" &&
+        Number.isSafeInteger(input) &&
+        input > 0
+    );
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+    return Boolean(input) && typeof input === "object";
+}
+
+function normalizeWorktreeId(
+    projectId: string,
+    worktreeId: string | null,
+): string {
+    return worktreeId === null || worktreeId === `${projectId}:primary`
+        ? "__primary__"
+        : worktreeId;
+}

--- a/src/main/workspace/surface-actions.ts
+++ b/src/main/workspace/surface-actions.ts
@@ -3,6 +3,8 @@ import type {
     GitHubRepositoryRef,
     PersistedWorkspaceContext,
     WorkspaceSurfaceActionRequest,
+    WorkspaceSurfaceActionContext,
+    WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
 
 const MAX_ACTION_ITEMS = 100;
@@ -91,8 +93,25 @@ export function isWorkspaceSurfaceActionRequest(
     }
 }
 
+export function isWorkspaceSurfaceFileRevealRequest(
+    input: unknown,
+): input is WorkspaceSurfaceFileRevealRequest {
+    return (
+        isRecord(input) &&
+        hasValidContext(input) &&
+        isNonEmptyString(input.relativePath, MAX_PATH_OR_URL_LENGTH)
+    );
+}
+
 export function doesWorkspaceSurfaceActionMatchContext(
     request: WorkspaceSurfaceActionRequest,
+    context: PersistedWorkspaceContext,
+): boolean {
+    return doesWorkspaceSurfaceContextMatchContext(request, context);
+}
+
+export function doesWorkspaceSurfaceContextMatchContext(
+    request: WorkspaceSurfaceActionContext,
     context: PersistedWorkspaceContext,
 ): boolean {
     return (

--- a/src/main/workspace/surface-actions.ts
+++ b/src/main/workspace/surface-actions.ts
@@ -4,6 +4,7 @@ import type {
     PersistedWorkspaceContext,
     WorkspaceSurfaceActionRequest,
     WorkspaceSurfaceActionContext,
+    WorkspaceSurfaceActionCompletion,
     WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
 
@@ -100,6 +101,18 @@ export function isWorkspaceSurfaceFileRevealRequest(
         isRecord(input) &&
         hasValidContext(input) &&
         isNonEmptyString(input.relativePath, MAX_PATH_OR_URL_LENGTH)
+    );
+}
+
+export function isWorkspaceSurfaceActionCompletion(
+    input: unknown,
+): input is WorkspaceSurfaceActionCompletion {
+    return (
+        isRecord(input) &&
+        isNonEmptyString(input.actionId, MAX_SHORT_TEXT_LENGTH) &&
+        (input.status === "completed" || input.status === "failed") &&
+        (input.error === undefined ||
+            isNonEmptyString(input.error, MAX_SHORT_TEXT_LENGTH))
     );
 }
 

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -96,6 +96,9 @@ describe("WorkspaceSurfaceManager action routing", () => {
         expect(manager.dispatchActiveSurfaceAction("host-1", actionA)).toEqual({
             delivered: true,
         });
+        expect(surfaceA.webContents.send).not.toHaveBeenCalled();
+
+        manager.notifySurfaceReady(asWebContents(surfaceA.webContents));
         expect(surfaceA.webContents.send).toHaveBeenCalledWith(
             IPC_EVENTS.workspaceSurfaceActionRequested,
             actionA,
@@ -111,6 +114,7 @@ describe("WorkspaceSurfaceManager action routing", () => {
         expect(surfaceB.webContents.send).not.toHaveBeenCalled();
 
         const actionB = createFileAction("project-b::__primary__", "project-b");
+        manager.notifySurfaceReady(asWebContents(surfaceB.webContents));
         expect(manager.dispatchActiveSurfaceAction("host-1", actionB)).toEqual({
             delivered: true,
         });

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { BrowserWindow } from "electron";
+import type { BrowserWindow, WebContents } from "electron";
 import { IPC_EVENTS } from "@shared/ipc";
 import type {
     WindowContextSnapshot,
     WorkspaceNavigationSnapshot,
     WorkspaceSurfaceActionRequest,
+    WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
 
 const electronMocks = vi.hoisted(() => {
@@ -133,15 +134,66 @@ describe("WorkspaceSurfaceManager action routing", () => {
         });
         expect(surfaceB.webContents.send).toHaveBeenCalledTimes(1);
     });
+
+    it("reveals a surface file only through its active host context", () => {
+        const manager = new WorkspaceSurfaceManager();
+        const host = createHostWindow();
+        manager.syncHost(host.window, createHostContext(), createSnapshot());
+        const [surfaceA, surfaceB] = electronMocks.views;
+        const requestA = createFileRevealRequest(
+            "project-a::__primary__",
+            "project-a",
+        );
+
+        expect(
+            manager.revealSurfaceFileInHostTree(
+                asWebContents(surfaceA.webContents),
+                requestA,
+            ),
+        ).toEqual({ delivered: true });
+        expect(host.send).toHaveBeenCalledWith(
+            IPC_EVENTS.workspaceSurfaceFileRevealRequested,
+            requestA,
+        );
+
+        manager.activate("host-1", "project-b::__primary__");
+        expect(
+            manager.revealSurfaceFileInHostTree(
+                asWebContents(surfaceA.webContents),
+                requestA,
+            ),
+        ).toEqual({ delivered: false, reason: "inactive-context" });
+        expect(
+            manager.revealSurfaceFileInHostTree(
+                asWebContents(surfaceB.webContents),
+                {
+                    ...requestA,
+                    contextKey: "project-b::__primary__",
+                    projectId: "project-a",
+                },
+            ),
+        ).toEqual({ delivered: false, reason: "invalid-context" });
+        expect(
+            manager.revealSurfaceFileInHostTree(
+                asWebContents(surfaceB.webContents),
+                createFileRevealRequest(
+                    "project-b::__primary__",
+                    "project-b",
+                ),
+            ),
+        ).toEqual({ delivered: true });
+    });
 });
 
 function createHostWindow(): {
+    readonly send: ReturnType<typeof vi.fn>;
     readonly window: BrowserWindow;
 } {
+    const send = vi.fn();
     const webContents = {
         getZoomFactor: () => 1,
         isDestroyed: () => false,
-        send: vi.fn(),
+        send,
     };
     const window = {
         contentView: {
@@ -153,7 +205,7 @@ function createHostWindow(): {
         on: vi.fn(),
         webContents,
     } as unknown as BrowserWindow;
-    return { window };
+    return { send, window };
 }
 
 function createHostContext(): WindowContextSnapshot {
@@ -213,4 +265,20 @@ function createFileAction(
         relativePath: "README.md",
         worktreeId: null,
     };
+}
+
+function createFileRevealRequest(
+    contextKey: string,
+    projectId: string,
+): WorkspaceSurfaceFileRevealRequest {
+    return {
+        contextKey,
+        projectId,
+        relativePath: "README.md",
+        worktreeId: null,
+    };
+}
+
+function asWebContents(value: unknown): WebContents {
+    return value as WebContents;
 }

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -93,17 +93,42 @@ describe("WorkspaceSurfaceManager action routing", () => {
         expect(surfaceB).toBeDefined();
 
         const actionA = createFileAction("project-a::__primary__", "project-a");
-        expect(manager.dispatchActiveSurfaceAction("host-1", actionA)).toEqual({
+        const queuedActionA = manager.dispatchActiveSurfaceAction(
+            "host-1",
+            actionA,
+        );
+        expect(queuedActionA).toMatchObject({
             delivered: true,
+            state: "queued",
         });
+        if (!queuedActionA.delivered) {
+            throw new Error("Expected the action to queue.");
+        }
         expect(surfaceA.webContents.send).not.toHaveBeenCalled();
 
         manager.notifySurfaceReady(asWebContents(surfaceA.webContents));
         expect(surfaceA.webContents.send).toHaveBeenCalledWith(
             IPC_EVENTS.workspaceSurfaceActionRequested,
-            actionA,
+            {
+                actionId: queuedActionA.actionId,
+                request: actionA,
+            },
         );
         expect(surfaceB.webContents.send).not.toHaveBeenCalled();
+        expect(
+            manager.claimSurfaceAction(
+                asWebContents(surfaceA.webContents),
+                queuedActionA.actionId,
+            ),
+        ).toBe(true);
+        manager.completeSurfaceAction(asWebContents(surfaceA.webContents), {
+            actionId: queuedActionA.actionId,
+            status: "completed",
+        });
+        expect(host.send).toHaveBeenCalledWith(
+            IPC_EVENTS.workspaceSurfaceActionStatus,
+            { actionId: queuedActionA.actionId, status: "completed" },
+        );
 
         manager.activate("host-1", "project-b::__primary__");
         expect(manager.dispatchActiveSurfaceAction("host-1", actionA)).toEqual({
@@ -115,12 +140,39 @@ describe("WorkspaceSurfaceManager action routing", () => {
 
         const actionB = createFileAction("project-b::__primary__", "project-b");
         manager.notifySurfaceReady(asWebContents(surfaceB.webContents));
-        expect(manager.dispatchActiveSurfaceAction("host-1", actionB)).toEqual({
+        const sentActionB = manager.dispatchActiveSurfaceAction("host-1", actionB);
+        expect(sentActionB).toMatchObject({
             delivered: true,
+            state: "sent",
         });
+        if (!sentActionB.delivered) {
+            throw new Error("Expected the action to send.");
+        }
         expect(surfaceB.webContents.send).toHaveBeenCalledWith(
             IPC_EVENTS.workspaceSurfaceActionRequested,
-            actionB,
+            {
+                actionId: sentActionB.actionId,
+                request: actionB,
+            },
+        );
+        expect(
+            manager.claimSurfaceAction(
+                asWebContents(surfaceB.webContents),
+                sentActionB.actionId,
+            ),
+        ).toBe(true);
+        manager.completeSurfaceAction(asWebContents(surfaceB.webContents), {
+            actionId: sentActionB.actionId,
+            error: "Could not open the tab.",
+            status: "failed",
+        });
+        expect(host.send).toHaveBeenCalledWith(
+            IPC_EVENTS.workspaceSurfaceActionStatus,
+            {
+                actionId: sentActionB.actionId,
+                message: "Could not open the tab.",
+                status: "failed",
+            },
         );
 
         expect(
@@ -137,6 +189,39 @@ describe("WorkspaceSurfaceManager action routing", () => {
             reason: "missing-surface",
         });
         expect(surfaceB.webContents.send).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a queued action when its context becomes inactive", () => {
+        const manager = new WorkspaceSurfaceManager();
+        const host = createHostWindow();
+        manager.syncHost(host.window, createHostContext(), createSnapshot());
+        const [surfaceA] = electronMocks.views;
+        const actionA = createFileAction("project-a::__primary__", "project-a");
+        const queuedActionA = manager.dispatchActiveSurfaceAction(
+            "host-1",
+            actionA,
+        );
+        if (!queuedActionA.delivered) {
+            throw new Error("Expected the action to queue.");
+        }
+
+        manager.activate("host-1", "project-b::__primary__");
+        manager.notifySurfaceReady(asWebContents(surfaceA.webContents));
+
+        expect(surfaceA.webContents.send).not.toHaveBeenCalled();
+        expect(
+            manager.claimSurfaceAction(
+                asWebContents(surfaceA.webContents),
+                queuedActionA.actionId,
+            ),
+        ).toBe(false);
+        expect(host.send).toHaveBeenCalledWith(
+            IPC_EVENTS.workspaceSurfaceActionStatus,
+            expect.objectContaining({
+                actionId: queuedActionA.actionId,
+                status: "rejected",
+            }),
+        );
     });
 
     it("reveals a surface file only through its active host context", () => {

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BrowserWindow } from "electron";
+import { IPC_EVENTS } from "@shared/ipc";
+import type {
+    WindowContextSnapshot,
+    WorkspaceNavigationSnapshot,
+    WorkspaceSurfaceActionRequest,
+} from "@shared/ipc";
+
+const electronMocks = vi.hoisted(() => {
+    let nextWebContentsId = 100;
+    const views: FakeView[] = [];
+
+    class FakeWebContents {
+        readonly id = nextWebContentsId++;
+        readonly focus = vi.fn();
+        readonly send = vi.fn();
+        readonly setZoomFactor = vi.fn();
+        destroyed = false;
+
+        readonly close = vi.fn(() => {
+            this.destroyed = true;
+        });
+
+        isDestroyed(): boolean {
+            return this.destroyed;
+        }
+
+        on(): this {
+            return this;
+        }
+
+        once(): this {
+            return this;
+        }
+    }
+
+    class FakeView {
+        readonly setBounds = vi.fn();
+        readonly setVisible = vi.fn();
+        readonly webContents = new FakeWebContents();
+
+        constructor() {
+            views.push(this);
+        }
+    }
+
+    return {
+        FakeView,
+        reset: () => {
+            views.splice(0);
+            nextWebContentsId = 100;
+        },
+        views,
+    };
+});
+
+vi.mock("electron", () => ({
+    BrowserWindow: class {},
+    WebContentsView: electronMocks.FakeView,
+}));
+
+vi.mock("@main/window", () => ({
+    DESKTOP_TITLE_BAR_HEIGHT: 52,
+    getRendererPreloadPath: () => "/tmp/preload.js",
+    loadRendererContents: vi.fn(),
+}));
+
+vi.mock("@main/windows/registry", () => ({
+    windowRegistry: {
+        registerEmbeddedRenderer: vi.fn(),
+        unregisterEmbeddedRenderer: vi.fn(),
+    },
+}));
+
+import { WorkspaceSurfaceManager } from "./surface-manager";
+
+describe("WorkspaceSurfaceManager action routing", () => {
+    beforeEach(() => {
+        electronMocks.reset();
+    });
+
+    it("delivers only to the active surface and rejects stale scopes", () => {
+        const manager = new WorkspaceSurfaceManager();
+        const host = createHostWindow();
+        const snapshot = createSnapshot();
+        manager.syncHost(host.window, createHostContext(), snapshot);
+
+        const [surfaceA, surfaceB] = electronMocks.views;
+        expect(surfaceA).toBeDefined();
+        expect(surfaceB).toBeDefined();
+
+        const actionA = createFileAction("project-a::__primary__", "project-a");
+        expect(manager.dispatchActiveSurfaceAction("host-1", actionA)).toEqual({
+            delivered: true,
+        });
+        expect(surfaceA.webContents.send).toHaveBeenCalledWith(
+            IPC_EVENTS.workspaceSurfaceActionRequested,
+            actionA,
+        );
+        expect(surfaceB.webContents.send).not.toHaveBeenCalled();
+
+        manager.activate("host-1", "project-b::__primary__");
+        expect(manager.dispatchActiveSurfaceAction("host-1", actionA)).toEqual({
+            delivered: false,
+            reason: "inactive-context",
+        });
+        expect(surfaceA.webContents.send).toHaveBeenCalledTimes(1);
+        expect(surfaceB.webContents.send).not.toHaveBeenCalled();
+
+        const actionB = createFileAction("project-b::__primary__", "project-b");
+        expect(manager.dispatchActiveSurfaceAction("host-1", actionB)).toEqual({
+            delivered: true,
+        });
+        expect(surfaceB.webContents.send).toHaveBeenCalledWith(
+            IPC_EVENTS.workspaceSurfaceActionRequested,
+            actionB,
+        );
+
+        expect(
+            manager.dispatchActiveSurfaceAction("host-1", {
+                ...actionB,
+                projectId: "project-a",
+            }),
+        ).toEqual({ delivered: false, reason: "invalid-context" });
+        expect(surfaceB.webContents.send).toHaveBeenCalledTimes(1);
+
+        surfaceB.webContents.destroyed = true;
+        expect(manager.dispatchActiveSurfaceAction("host-1", actionB)).toEqual({
+            delivered: false,
+            reason: "missing-surface",
+        });
+        expect(surfaceB.webContents.send).toHaveBeenCalledTimes(1);
+    });
+});
+
+function createHostWindow(): {
+    readonly window: BrowserWindow;
+} {
+    const webContents = {
+        getZoomFactor: () => 1,
+        isDestroyed: () => false,
+        send: vi.fn(),
+    };
+    const window = {
+        contentView: {
+            addChildView: vi.fn(),
+            removeChildView: vi.fn(),
+        },
+        getContentBounds: () => ({ height: 800, width: 1200, x: 0, y: 0 }),
+        isDestroyed: () => false,
+        on: vi.fn(),
+        webContents,
+    } as unknown as BrowserWindow;
+    return { window };
+}
+
+function createHostContext(): WindowContextSnapshot {
+    return {
+        projectId: "project-a",
+        windowId: "host-1",
+        windowKind: "main",
+        workspaceId: "workspace-1",
+        workspaceSessionId: "workspace-session-1",
+        worktreeId: null,
+    };
+}
+
+function createSnapshot(): WorkspaceNavigationSnapshot {
+    return {
+        activeContextKey: "project-a::__primary__",
+        contexts: [
+            createPersistedContext("project-a::__primary__", "project-a"),
+            createPersistedContext("project-b::__primary__", "project-b"),
+        ],
+        openContextKeys: [
+            "project-a::__primary__",
+            "project-b::__primary__",
+        ],
+        version: 3,
+    };
+}
+
+function createPersistedContext(key: string, projectId: string) {
+    return {
+        key,
+        lastActivatedAt: "2026-07-19T00:00:00.000Z",
+        projectId,
+        workspace: {
+            activePaneId: `pane-${projectId}`,
+            rootNode: {
+                activeTabId: null,
+                id: `pane-${projectId}`,
+                tabIds: [],
+                type: "pane" as const,
+            },
+            tabs: [],
+        },
+        worktreeId: null,
+    };
+}
+
+function createFileAction(
+    contextKey: string,
+    projectId: string,
+): WorkspaceSurfaceActionRequest {
+    return {
+        contextKey,
+        kind: "file",
+        origin: "tree",
+        projectId,
+        relativePath: "README.md",
+        worktreeId: null,
+    };
+}

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -10,6 +10,8 @@ import { IPC_EVENTS } from "@shared/ipc";
 import type {
     WindowContextSnapshot,
     WorkspaceNavigationSnapshot,
+    WorkspaceSurfaceActionDeliveryResult,
+    WorkspaceSurfaceActionRequest,
     WorkspaceSurfaceDragEvent,
     WorkspaceSurfaceGitHubItemOpenRequest,
 } from "@shared/ipc";
@@ -20,6 +22,7 @@ import {
     loadRendererContents,
 } from "@main/window";
 import { windowRegistry } from "@main/windows/registry";
+import { doesWorkspaceSurfaceActionMatchContext } from "./surface-actions";
 
 interface WorkspaceSurfaceRecord {
     bounds: WorkspaceSurfaceBounds | null;
@@ -197,6 +200,37 @@ class WorkspaceSurfaceManager {
             IPC_EVENTS.workspaceSurfaceGitHubItemOpenRequested,
             input,
         );
+    }
+
+    dispatchActiveSurfaceAction(
+        hostWindowId: string,
+        request: WorkspaceSurfaceActionRequest,
+    ): WorkspaceSurfaceActionDeliveryResult {
+        const host = this.#hostsByWindowId.get(hostWindowId);
+        if (host?.activeContextKey !== request.contextKey) {
+            return { delivered: false, reason: "inactive-context" };
+        }
+
+        const activeContext = host.snapshot.contexts.find(
+            (context) => context.key === host.activeContextKey,
+        );
+        if (
+            !activeContext ||
+            !doesWorkspaceSurfaceActionMatchContext(request, activeContext)
+        ) {
+            return { delivered: false, reason: "invalid-context" };
+        }
+
+        const surface = this.#getActiveSurface(hostWindowId);
+        if (!surface || surface.webContents.isDestroyed()) {
+            return { delivered: false, reason: "missing-surface" };
+        }
+
+        surface.webContents.send(
+            IPC_EVENTS.workspaceSurfaceActionRequested,
+            request,
+        );
+        return { delivered: true };
     }
 
     dispatchActiveSurfaceDrag(

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -12,6 +12,7 @@ import type {
     WorkspaceNavigationSnapshot,
     WorkspaceSurfaceActionDeliveryResult,
     WorkspaceSurfaceActionRequest,
+    WorkspaceSurfaceFileRevealRequest,
     WorkspaceSurfaceDragEvent,
 } from "@shared/ipc";
 
@@ -21,7 +22,9 @@ import {
     loadRendererContents,
 } from "@main/window";
 import { windowRegistry } from "@main/windows/registry";
-import { doesWorkspaceSurfaceActionMatchContext } from "./surface-actions";
+import {
+    doesWorkspaceSurfaceContextMatchContext,
+} from "./surface-actions";
 
 interface WorkspaceSurfaceRecord {
     bounds: WorkspaceSurfaceBounds | null;
@@ -200,7 +203,7 @@ export class WorkspaceSurfaceManager {
         );
         if (
             !activeContext ||
-            !doesWorkspaceSurfaceActionMatchContext(request, activeContext)
+            !doesWorkspaceSurfaceContextMatchContext(request, activeContext)
         ) {
             return { delivered: false, reason: "invalid-context" };
         }
@@ -212,6 +215,41 @@ export class WorkspaceSurfaceManager {
 
         surface.webContents.send(
             IPC_EVENTS.workspaceSurfaceActionRequested,
+            request,
+        );
+        return { delivered: true };
+    }
+
+    revealSurfaceFileInHostTree(
+        webContents: WebContents,
+        request: WorkspaceSurfaceFileRevealRequest,
+    ): WorkspaceSurfaceActionDeliveryResult {
+        const surface = this.#getSurfaceByWebContents(webContents);
+        const host = surface
+            ? this.#hostsByWindowId.get(surface.hostWindowId)
+            : null;
+        if (!surface || !host || surface.webContents.isDestroyed()) {
+            return { delivered: false, reason: "missing-surface" };
+        }
+        if (host.activeContextKey !== request.contextKey) {
+            return { delivered: false, reason: "inactive-context" };
+        }
+        const activeContext = host.snapshot.contexts.find(
+            (context) => context.key === host.activeContextKey,
+        );
+        if (
+            surface.contextKey !== request.contextKey ||
+            !activeContext ||
+            !doesWorkspaceSurfaceContextMatchContext(request, activeContext)
+        ) {
+            return { delivered: false, reason: "invalid-context" };
+        }
+        if (host.hostWindow.webContents.isDestroyed()) {
+            return { delivered: false, reason: "missing-surface" };
+        }
+
+        host.hostWindow.webContents.send(
+            IPC_EVENTS.workspaceSurfaceFileRevealRequested,
             request,
         );
         return { delivered: true };

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -10,8 +10,13 @@ import { IPC_EVENTS } from "@shared/ipc";
 import type {
     WindowContextSnapshot,
     WorkspaceNavigationSnapshot,
+    WorkspaceSurfaceActionCompletion,
+    WorkspaceSurfaceActionDeliveryFailureReason,
     WorkspaceSurfaceActionDeliveryResult,
+    WorkspaceSurfaceActionDispatchResult,
+    WorkspaceSurfaceActionEnvelope,
     WorkspaceSurfaceActionRequest,
+    WorkspaceSurfaceActionStatus,
     WorkspaceSurfaceFileRevealRequest,
     WorkspaceSurfaceDragEvent,
 } from "@shared/ipc";
@@ -34,7 +39,7 @@ interface WorkspaceSurfaceRecord {
     readonly id: string;
     isVisible: boolean;
     isReady: boolean;
-    readonly pendingActions: WorkspaceSurfaceActionRequest[];
+    readonly pendingActions: WorkspaceSurfaceActionEnvelope[];
     snapshot: WorkspaceNavigationSnapshot;
     readonly view: WebContentsView;
     readonly webContents: WebContents;
@@ -59,6 +64,13 @@ interface WorkspaceSurfaceHostRecord {
     readonly surfaceIdsByContextKey: Map<string, string>;
 }
 
+interface DispatchedWorkspaceSurfaceAction {
+    claimed: boolean;
+    readonly envelope: WorkspaceSurfaceActionEnvelope;
+    readonly hostWindowId: string;
+    readonly surfaceId: string;
+}
+
 interface WorkspaceSurfaceLifecycleHandlers {
     readonly onSurfaceCreated?: (
         webContents: WebContents,
@@ -75,6 +87,10 @@ export class WorkspaceSurfaceManager {
     readonly #hostsByWindowId = new Map<string, WorkspaceSurfaceHostRecord>();
     readonly #surfaceIdsByWebContentsId = new Map<number, string>();
     readonly #surfacesById = new Map<string, WorkspaceSurfaceRecord>();
+    readonly #actionsById = new Map<
+        string,
+        DispatchedWorkspaceSurfaceAction
+    >();
     #lifecycleHandlers: WorkspaceSurfaceLifecycleHandlers = {};
 
     setLifecycleHandlers(handlers: WorkspaceSurfaceLifecycleHandlers): void {
@@ -134,6 +150,7 @@ export class WorkspaceSurfaceManager {
             host.activeContextKey !== nextActiveContextKey;
         host.activeContextKey = nextActiveContextKey;
         host.snapshot = this.#mergeKnownSurfaceSnapshots(host, snapshot);
+        this.#rejectInactiveActions(host);
         this.#applyVisibility(host, { focusActive: activeContextChanged });
         return host.snapshot;
     }
@@ -153,6 +170,7 @@ export class WorkspaceSurfaceManager {
             ...host.snapshot,
             activeContextKey: contextKey,
         };
+        this.#rejectInactiveActions(host);
         this.#applyVisibility(host, { focusActive: true });
         return true;
     }
@@ -194,37 +212,32 @@ export class WorkspaceSurfaceManager {
     dispatchActiveSurfaceAction(
         hostWindowId: string,
         request: WorkspaceSurfaceActionRequest,
-    ): WorkspaceSurfaceActionDeliveryResult {
+    ): WorkspaceSurfaceActionDispatchResult {
         const host = this.#hostsByWindowId.get(hostWindowId);
-        if (host?.activeContextKey !== request.contextKey) {
-            return { delivered: false, reason: "inactive-context" };
-        }
-
-        const activeContext = host.snapshot.contexts.find(
-            (context) => context.key === host.activeContextKey,
-        );
-        if (
-            !activeContext ||
-            !doesWorkspaceSurfaceContextMatchContext(request, activeContext)
-        ) {
-            return { delivered: false, reason: "invalid-context" };
-        }
-
         const surface = this.#getActiveSurface(hostWindowId);
-        if (!surface || surface.webContents.isDestroyed()) {
-            return { delivered: false, reason: "missing-surface" };
-        }
-
-        if (!surface.isReady) {
-            surface.pendingActions.push(request);
-            return { delivered: true };
-        }
-
-        surface.webContents.send(
-            IPC_EVENTS.workspaceSurfaceActionRequested,
+        const failureReason = this.#getActionDeliveryFailure(
+            host,
+            surface,
             request,
         );
-        return { delivered: true };
+        if (failureReason || !host || !surface) {
+            return {
+                delivered: false,
+                reason: failureReason ?? "missing-surface",
+            };
+        }
+        const envelope: WorkspaceSurfaceActionEnvelope = {
+            actionId: randomUUID(),
+            request,
+        };
+
+        if (!surface.isReady) {
+            surface.pendingActions.push(envelope);
+            return { actionId: envelope.actionId, delivered: true, state: "queued" };
+        }
+
+        this.#sendAction(host, surface, envelope);
+        return { actionId: envelope.actionId, delivered: true, state: "sent" };
     }
 
     notifySurfaceReady(webContents: WebContents): void {
@@ -234,12 +247,70 @@ export class WorkspaceSurfaceManager {
         }
 
         surface.isReady = true;
-        for (const request of surface.pendingActions.splice(0)) {
-            surface.webContents.send(
-                IPC_EVENTS.workspaceSurfaceActionRequested,
-                request,
+        const host = this.#hostsByWindowId.get(surface.hostWindowId);
+        for (const envelope of surface.pendingActions.splice(0)) {
+            const failureReason = this.#getActionDeliveryFailure(
+                host,
+                surface,
+                envelope.request,
             );
+            if (failureReason) {
+                this.#notifyActionStatus(host, {
+                    actionId: envelope.actionId,
+                    message: getActionFailureMessage(failureReason),
+                    status: "rejected",
+                });
+                continue;
+            }
+            this.#sendAction(host, surface, envelope);
         }
+    }
+
+    claimSurfaceAction(webContents: WebContents, actionId: string): boolean {
+        const surface = this.#getSurfaceByWebContents(webContents);
+        const action = this.#actionsById.get(actionId);
+        if (!surface || !action || action.surfaceId !== surface.id || action.claimed) {
+            return false;
+        }
+        const host = this.#hostsByWindowId.get(action.hostWindowId);
+        const failureReason = this.#getActionDeliveryFailure(
+            host,
+            surface,
+            action.envelope.request,
+        );
+        if (failureReason) {
+            this.#actionsById.delete(actionId);
+            this.#notifyActionStatus(host, {
+                actionId,
+                message: getActionFailureMessage(failureReason),
+                status: "rejected",
+            });
+            return false;
+        }
+        action.claimed = true;
+        return true;
+    }
+
+    completeSurfaceAction(
+        webContents: WebContents,
+        completion: WorkspaceSurfaceActionCompletion,
+    ): void {
+        const surface = this.#getSurfaceByWebContents(webContents);
+        const action = this.#actionsById.get(completion.actionId);
+        if (!surface || !action || action.surfaceId !== surface.id || !action.claimed) {
+            return;
+        }
+        this.#actionsById.delete(completion.actionId);
+        this.#notifyActionStatus(
+            this.#hostsByWindowId.get(action.hostWindowId),
+            completion.status === "completed"
+                ? { actionId: completion.actionId, status: "completed" }
+                : {
+                      actionId: completion.actionId,
+                      message: completion.error ?? "The workspace action failed.",
+                      status: "failed",
+                  },
+        );
     }
 
     revealSurfaceFileInHostTree(
@@ -601,6 +672,25 @@ export class WorkspaceSurfaceManager {
             return;
         }
 
+        for (const envelope of surface.pendingActions) {
+            this.#notifyActionStatus(host, {
+                actionId: envelope.actionId,
+                message: "The workspace surface closed before the action could run.",
+                status: "rejected",
+            });
+        }
+        for (const [actionId, action] of this.#actionsById) {
+            if (action.surfaceId !== surfaceId) {
+                continue;
+            }
+            this.#actionsById.delete(actionId);
+            this.#notifyActionStatus(host, {
+                actionId,
+                message: "The workspace surface closed before the action completed.",
+                status: action.claimed ? "failed" : "rejected",
+            });
+        }
+
         host.surfaceIdsByContextKey.delete(surface.contextKey);
         this.#surfacesById.delete(surface.id);
         this.#surfaceIdsByWebContentsId.delete(surface.webContentsId);
@@ -612,6 +702,115 @@ export class WorkspaceSurfaceManager {
         if (!surface.webContents.isDestroyed()) {
             surface.webContents.close();
         }
+    }
+
+    #getActionDeliveryFailure(
+        host: WorkspaceSurfaceHostRecord | undefined,
+        surface: WorkspaceSurfaceRecord | null,
+        request: WorkspaceSurfaceActionRequest,
+    ): WorkspaceSurfaceActionDeliveryFailureReason | null {
+        if (!host || !surface || surface.webContents.isDestroyed()) {
+            return "missing-surface";
+        }
+        if (host.activeContextKey !== request.contextKey) {
+            return "inactive-context";
+        }
+        const activeContext = host.snapshot.contexts.find(
+            (context) => context.key === host.activeContextKey,
+        );
+        if (
+            surface.contextKey !== request.contextKey ||
+            !activeContext ||
+            !doesWorkspaceSurfaceContextMatchContext(request, activeContext)
+        ) {
+            return "invalid-context";
+        }
+        return null;
+    }
+
+    #sendAction(
+        host: WorkspaceSurfaceHostRecord | undefined,
+        surface: WorkspaceSurfaceRecord,
+        envelope: WorkspaceSurfaceActionEnvelope,
+    ): void {
+        if (!host || surface.webContents.isDestroyed()) {
+            return;
+        }
+        this.#actionsById.set(envelope.actionId, {
+            claimed: false,
+            envelope,
+            hostWindowId: host.hostWindowId,
+            surfaceId: surface.id,
+        });
+        surface.webContents.send(
+            IPC_EVENTS.workspaceSurfaceActionRequested,
+            envelope,
+        );
+    }
+
+    #rejectInactiveActions(host: WorkspaceSurfaceHostRecord): void {
+        for (const surfaceId of host.surfaceIdsByContextKey.values()) {
+            const surface = this.#surfacesById.get(surfaceId);
+            if (!surface) {
+                continue;
+            }
+            const activePendingActions = surface.pendingActions.filter(
+                (envelope) => {
+                    const failureReason = this.#getActionDeliveryFailure(
+                        host,
+                        surface,
+                        envelope.request,
+                    );
+                    if (!failureReason) {
+                        return true;
+                    }
+                    this.#notifyActionStatus(host, {
+                        actionId: envelope.actionId,
+                        message: getActionFailureMessage(failureReason),
+                        status: "rejected",
+                    });
+                    return false;
+                },
+            );
+            surface.pendingActions.splice(
+                0,
+                surface.pendingActions.length,
+                ...activePendingActions,
+            );
+        }
+        for (const [actionId, action] of this.#actionsById) {
+            if (action.hostWindowId !== host.hostWindowId || action.claimed) {
+                continue;
+            }
+            const surface = this.#surfacesById.get(action.surfaceId) ?? null;
+            const failureReason = this.#getActionDeliveryFailure(
+                host,
+                surface,
+                action.envelope.request,
+            );
+            if (!failureReason) {
+                continue;
+            }
+            this.#actionsById.delete(actionId);
+            this.#notifyActionStatus(host, {
+                actionId,
+                message: getActionFailureMessage(failureReason),
+                status: "rejected",
+            });
+        }
+    }
+
+    #notifyActionStatus(
+        host: WorkspaceSurfaceHostRecord | undefined,
+        status: WorkspaceSurfaceActionStatus,
+    ): void {
+        if (!host || host.hostWindow.webContents.isDestroyed()) {
+            return;
+        }
+        host.hostWindow.webContents.send(
+            IPC_EVENTS.workspaceSurfaceActionStatus,
+            status,
+        );
     }
 
     #applyVisibility(
@@ -719,6 +918,19 @@ function areWorkspaceSurfaceBoundsEqual(
         left.x === right.x &&
         left.y === right.y
     );
+}
+
+function getActionFailureMessage(
+    reason: WorkspaceSurfaceActionDeliveryFailureReason,
+): string {
+    switch (reason) {
+        case "inactive-context":
+            return "The active workspace changed before the action could run.";
+        case "invalid-context":
+            return "The workspace action no longer matches the active project.";
+        case "missing-surface":
+            return "The active workspace surface is no longer available.";
+    }
 }
 
 function resolveWorkspaceSurfaceSwitchDirection(

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -33,6 +33,8 @@ interface WorkspaceSurfaceRecord {
     readonly hostWindowId: string;
     readonly id: string;
     isVisible: boolean;
+    isReady: boolean;
+    readonly pendingActions: WorkspaceSurfaceActionRequest[];
     snapshot: WorkspaceNavigationSnapshot;
     readonly view: WebContentsView;
     readonly webContents: WebContents;
@@ -213,11 +215,31 @@ export class WorkspaceSurfaceManager {
             return { delivered: false, reason: "missing-surface" };
         }
 
+        if (!surface.isReady) {
+            surface.pendingActions.push(request);
+            return { delivered: true };
+        }
+
         surface.webContents.send(
             IPC_EVENTS.workspaceSurfaceActionRequested,
             request,
         );
         return { delivered: true };
+    }
+
+    notifySurfaceReady(webContents: WebContents): void {
+        const surface = this.#getSurfaceByWebContents(webContents);
+        if (!surface || surface.webContents.isDestroyed()) {
+            return;
+        }
+
+        surface.isReady = true;
+        for (const request of surface.pendingActions.splice(0)) {
+            surface.webContents.send(
+                IPC_EVENTS.workspaceSurfaceActionRequested,
+                request,
+            );
+        }
     }
 
     revealSurfaceFileInHostTree(
@@ -516,6 +538,8 @@ export class WorkspaceSurfaceManager {
             hostWindowId: host.hostWindowId,
             id,
             isVisible: false,
+            isReady: false,
+            pendingActions: [],
             snapshot: toSurfaceSnapshot(hostSnapshot, contextKey),
             view,
             webContents,
@@ -525,6 +549,9 @@ export class WorkspaceSurfaceManager {
         this.#surfaceIdsByWebContentsId.set(webContentsId, id);
         host.surfaceIdsByContextKey.set(contextKey, id);
         windowRegistry.registerEmbeddedRenderer(webContents, context);
+        webContents.on("did-start-loading", () => {
+            surface.isReady = false;
+        });
         webContents.on("before-input-event", (event, input) => {
             const direction = resolveWorkspaceSurfaceSwitchDirection(input);
             if (!direction) {

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -13,7 +13,6 @@ import type {
     WorkspaceSurfaceActionDeliveryResult,
     WorkspaceSurfaceActionRequest,
     WorkspaceSurfaceDragEvent,
-    WorkspaceSurfaceGitHubItemOpenRequest,
 } from "@shared/ipc";
 
 import {
@@ -67,7 +66,7 @@ interface WorkspaceSurfaceLifecycleHandlers {
  * Keeps project workspaces alive in isolated WebContents while the host renderer
  * owns the visible title bar and project switcher.
  */
-class WorkspaceSurfaceManager {
+export class WorkspaceSurfaceManager {
     readonly #hostsByWindowId = new Map<string, WorkspaceSurfaceHostRecord>();
     readonly #surfaceIdsByWebContentsId = new Map<number, string>();
     readonly #surfacesById = new Map<string, WorkspaceSurfaceRecord>();
@@ -184,21 +183,6 @@ class WorkspaceSurfaceManager {
 
         surface.webContents.send(
             IPC_EVENTS.workspaceSurfaceProjectMenuRequested,
-        );
-    }
-
-    requestActiveGitHubItemOpen(
-        hostWindowId: string,
-        input: WorkspaceSurfaceGitHubItemOpenRequest,
-    ): void {
-        const surface = this.#getActiveSurface(hostWindowId);
-        if (!surface || surface.webContents.isDestroyed()) {
-            return;
-        }
-
-        surface.webContents.send(
-            IPC_EVENTS.workspaceSurfaceGitHubItemOpenRequested,
-            input,
         );
     }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -180,7 +180,6 @@ import {
     type WorkspaceNavigationSnapshot,
     type WorkspaceSurfaceActionRequest,
     type WorkspaceSurfaceDragEvent,
-    type WorkspaceSurfaceGitHubItemOpenRequest,
     type WorkspaceSurfaceContextRequest,
 } from "@shared/ipc";
 
@@ -931,22 +930,6 @@ const comandoApi: ComandoApi = {
             );
         };
     },
-    onWorkspaceSurfaceGitHubItemOpenRequested: (listener) => {
-        const handleEvent = (
-            _event: Electron.IpcRendererEvent,
-            input: WorkspaceSurfaceGitHubItemOpenRequest,
-        ) => listener(input);
-        ipcRenderer.on(
-            IPC_EVENTS.workspaceSurfaceGitHubItemOpenRequested,
-            handleEvent,
-        );
-        return () => {
-            ipcRenderer.removeListener(
-                IPC_EVENTS.workspaceSurfaceGitHubItemOpenRequested,
-                handleEvent,
-            );
-        };
-    },
     onWorkspaceSurfaceSnapshotUpdated: (listener) => {
         const handleEvent = (
             _event: Electron.IpcRendererEvent,
@@ -1109,8 +1092,6 @@ const comandoApi: ComandoApi = {
             IPC_CHANNELS.dispatchWorkspaceSurfaceAction,
             request,
         ),
-    openWorkspaceSurfaceGitHubItem: (input) =>
-        ipcRenderer.invoke(IPC_CHANNELS.openWorkspaceSurfaceGitHubItem, input),
     notifyWorkspaceSurfaceFocused: () =>
         ipcRenderer.invoke(IPC_CHANNELS.notifyWorkspaceSurfaceFocused),
     requestWorkspaceSurfaceContext: (input) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -178,6 +178,7 @@ import {
     type WriteTerminalInput,
     type PersistedWorkspaceSnapshot,
     type WorkspaceNavigationSnapshot,
+    type WorkspaceSurfaceActionRequest,
     type WorkspaceSurfaceDragEvent,
     type WorkspaceSurfaceGitHubItemOpenRequest,
     type WorkspaceSurfaceContextRequest,
@@ -917,6 +918,19 @@ const comandoApi: ComandoApi = {
             ipcRenderer.removeListener(IPC_EVENTS.workspaceSurfaceDrag, handleEvent);
         };
     },
+    onWorkspaceSurfaceActionRequested: (listener) => {
+        const handleEvent = (
+            _event: Electron.IpcRendererEvent,
+            request: WorkspaceSurfaceActionRequest,
+        ) => listener(request);
+        ipcRenderer.on(IPC_EVENTS.workspaceSurfaceActionRequested, handleEvent);
+        return () => {
+            ipcRenderer.removeListener(
+                IPC_EVENTS.workspaceSurfaceActionRequested,
+                handleEvent,
+            );
+        };
+    },
     onWorkspaceSurfaceGitHubItemOpenRequested: (listener) => {
         const handleEvent = (
             _event: Electron.IpcRendererEvent,
@@ -1090,6 +1104,11 @@ const comandoApi: ComandoApi = {
         ),
     dispatchWorkspaceSurfaceDrag: (event) =>
         ipcRenderer.invoke(IPC_CHANNELS.dispatchWorkspaceSurfaceDrag, event),
+    dispatchWorkspaceSurfaceAction: (request) =>
+        ipcRenderer.invoke(
+            IPC_CHANNELS.dispatchWorkspaceSurfaceAction,
+            request,
+        ),
     openWorkspaceSurfaceGitHubItem: (input) =>
         ipcRenderer.invoke(IPC_CHANNELS.openWorkspaceSurfaceGitHubItem, input),
     notifyWorkspaceSurfaceFocused: () =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -179,6 +179,7 @@ import {
     type PersistedWorkspaceSnapshot,
     type WorkspaceNavigationSnapshot,
     type WorkspaceSurfaceActionRequest,
+    type WorkspaceSurfaceFileRevealRequest,
     type WorkspaceSurfaceDragEvent,
     type WorkspaceSurfaceContextRequest,
 } from "@shared/ipc";
@@ -930,6 +931,22 @@ const comandoApi: ComandoApi = {
             );
         };
     },
+    onWorkspaceSurfaceFileRevealRequested: (listener) => {
+        const handleEvent = (
+            _event: Electron.IpcRendererEvent,
+            request: WorkspaceSurfaceFileRevealRequest,
+        ) => listener(request);
+        ipcRenderer.on(
+            IPC_EVENTS.workspaceSurfaceFileRevealRequested,
+            handleEvent,
+        );
+        return () => {
+            ipcRenderer.removeListener(
+                IPC_EVENTS.workspaceSurfaceFileRevealRequested,
+                handleEvent,
+            );
+        };
+    },
     onWorkspaceSurfaceSnapshotUpdated: (listener) => {
         const handleEvent = (
             _event: Electron.IpcRendererEvent,
@@ -1090,6 +1107,11 @@ const comandoApi: ComandoApi = {
     dispatchWorkspaceSurfaceAction: (request) =>
         ipcRenderer.invoke(
             IPC_CHANNELS.dispatchWorkspaceSurfaceAction,
+            request,
+        ),
+    revealWorkspaceSurfaceFileInHostTree: (request) =>
+        ipcRenderer.invoke(
+            IPC_CHANNELS.revealWorkspaceSurfaceFileInHostTree,
             request,
         ),
     notifyWorkspaceSurfaceFocused: () =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1109,6 +1109,8 @@ const comandoApi: ComandoApi = {
             IPC_CHANNELS.dispatchWorkspaceSurfaceAction,
             request,
         ),
+    notifyWorkspaceSurfaceReady: () =>
+        ipcRenderer.invoke(IPC_CHANNELS.notifyWorkspaceSurfaceReady),
     revealWorkspaceSurfaceFileInHostTree: (request) =>
         ipcRenderer.invoke(
             IPC_CHANNELS.revealWorkspaceSurfaceFileInHostTree,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -178,8 +178,10 @@ import {
     type WriteTerminalInput,
     type PersistedWorkspaceSnapshot,
     type WorkspaceNavigationSnapshot,
-    type WorkspaceSurfaceActionRequest,
+    type WorkspaceSurfaceActionCompletion,
+    type WorkspaceSurfaceActionEnvelope,
     type WorkspaceSurfaceFileRevealRequest,
+    type WorkspaceSurfaceActionStatus,
     type WorkspaceSurfaceDragEvent,
     type WorkspaceSurfaceContextRequest,
 } from "@shared/ipc";
@@ -921,12 +923,25 @@ const comandoApi: ComandoApi = {
     onWorkspaceSurfaceActionRequested: (listener) => {
         const handleEvent = (
             _event: Electron.IpcRendererEvent,
-            request: WorkspaceSurfaceActionRequest,
-        ) => listener(request);
+            envelope: WorkspaceSurfaceActionEnvelope,
+        ) => listener(envelope);
         ipcRenderer.on(IPC_EVENTS.workspaceSurfaceActionRequested, handleEvent);
         return () => {
             ipcRenderer.removeListener(
                 IPC_EVENTS.workspaceSurfaceActionRequested,
+                handleEvent,
+            );
+        };
+    },
+    onWorkspaceSurfaceActionStatus: (listener) => {
+        const handleEvent = (
+            _event: Electron.IpcRendererEvent,
+            status: WorkspaceSurfaceActionStatus,
+        ) => listener(status);
+        ipcRenderer.on(IPC_EVENTS.workspaceSurfaceActionStatus, handleEvent);
+        return () => {
+            ipcRenderer.removeListener(
+                IPC_EVENTS.workspaceSurfaceActionStatus,
                 handleEvent,
             );
         };
@@ -1108,6 +1123,13 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(
             IPC_CHANNELS.dispatchWorkspaceSurfaceAction,
             request,
+        ),
+    claimWorkspaceSurfaceAction: (actionId) =>
+        ipcRenderer.invoke(IPC_CHANNELS.claimWorkspaceSurfaceAction, actionId),
+    completeWorkspaceSurfaceAction: (completion: WorkspaceSurfaceActionCompletion) =>
+        ipcRenderer.invoke(
+            IPC_CHANNELS.completeWorkspaceSurfaceAction,
+            completion,
         ),
     notifyWorkspaceSurfaceReady: () =>
         ipcRenderer.invoke(IPC_CHANNELS.notifyWorkspaceSurfaceReady),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -22,6 +22,7 @@ import type {
     SettingsWindowCategory,
     SettingsSnapshot,
     WorkspaceSurfaceActionRequest,
+    WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
 import { resolveEditorLanguage } from "@shared/editor-language";
 import { isActiveAiRuntimeId } from "@shared/ai-runtimes";
@@ -3664,20 +3665,12 @@ export function App() {
         enabled: stickyFoldersEnabled && !isFilteringFileTree,
     });
 
-    const handleRevealActiveFileInTree = useCallback(async () => {
-        if (
-            activeWorkspaceTab?.kind !== "file" ||
-            !activeWorkspaceTab.projectId
-        ) {
-            return;
-        }
-
-        const targetProjectId = activeWorkspaceTab.projectId;
-        const targetWorktreeId = activeWorkspaceTab.worktreeId ?? null;
-        const targetPath = activeWorkspaceTab.relativePath;
+    const revealFileInHostTree = useCallback(async (
+        request: WorkspaceSurfaceFileRevealRequest,
+    ) => {
         const targetProjectContextKey = getProjectContextKey(
-            targetProjectId,
-            targetWorktreeId,
+            request.projectId,
+            request.worktreeId,
         );
 
         setLeftCollapsed(false);
@@ -3691,20 +3684,73 @@ export function App() {
         if (workspaceActiveContextKey !== targetProjectContextKey) {
             await useWorkspaceStore
                 .getState()
-                .openContext(targetProjectId, targetWorktreeId);
+                .openContext(request.projectId, request.worktreeId);
         }
 
-        await revealPathInTree(targetProjectId, targetPath, targetWorktreeId);
+        await revealPathInTree(
+            request.projectId,
+            request.relativePath,
+            request.worktreeId,
+        );
         setFileTreeRevealSignal((currentSignal) =>
             currentSignal === null ? 0 : currentSignal + 1,
         );
     }, [
-        activeWorkspaceTab,
         revealPathInTree,
         setLeftCollapsed,
         setSidebarView,
         workspaceActiveContextKey,
     ]);
+
+    const handleRevealActiveFileInTree = useCallback(async () => {
+        if (
+            activeWorkspaceTab?.kind !== "file" ||
+            !activeWorkspaceTab.projectId
+        ) {
+            return;
+        }
+        const request: WorkspaceSurfaceFileRevealRequest = {
+            contextKey: getProjectContextKey(
+                activeWorkspaceTab.projectId,
+                activeWorkspaceTab.worktreeId ?? null,
+            ),
+            projectId: activeWorkspaceTab.projectId,
+            relativePath: activeWorkspaceTab.relativePath,
+            worktreeId: activeWorkspaceTab.worktreeId ?? null,
+        };
+
+        if (isWorkspaceSurfaceRenderer) {
+            const result =
+                await getComandoApi()?.revealWorkspaceSurfaceFileInHostTree(
+                    request,
+                );
+            if (result && !result.delivered) {
+                console.error(
+                    "[workspace-surface] file reveal delivery failed",
+                    result,
+                );
+            }
+            return;
+        }
+
+        await revealFileInHostTree(request);
+    }, [activeWorkspaceTab, revealFileInHostTree]);
+
+    useEffect(() => {
+        if (!isWorkspaceHostRenderer) {
+            return;
+        }
+        return getComandoApi()?.onWorkspaceSurfaceFileRevealRequested(
+            (request) => {
+                void revealFileInHostTree(request).catch((error) => {
+                    console.error(
+                        "[workspace-host] file reveal execution failed",
+                        error,
+                    );
+                });
+            },
+        );
+    }, [revealFileInHostTree]);
 
     const handleSidebarViewChange = useCallback(
         (nextSidebarView: SidebarView) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -21,6 +21,7 @@ import type {
     ProjectTreeNode,
     SettingsWindowCategory,
     SettingsSnapshot,
+    WorkspaceSurfaceActionEnvelope,
     WorkspaceSurfaceActionRequest,
     WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
@@ -294,6 +295,27 @@ export function App() {
     const activeProjectId =
         activeWorkspaceContext?.projectId ??
         (workspaceNavigationHydrated ? null : persistedActiveProjectId);
+    const [workspaceSurfaceActionError, setWorkspaceSurfaceActionError] =
+        useState<string | null>(null);
+    const workspaceSurfaceActionErrorTimerRef = useRef<number | null>(null);
+    const reportWorkspaceSurfaceActionError = useCallback((message: string) => {
+        if (workspaceSurfaceActionErrorTimerRef.current !== null) {
+            window.clearTimeout(workspaceSurfaceActionErrorTimerRef.current);
+        }
+        setWorkspaceSurfaceActionError(message);
+        workspaceSurfaceActionErrorTimerRef.current = window.setTimeout(() => {
+            workspaceSurfaceActionErrorTimerRef.current = null;
+            setWorkspaceSurfaceActionError(null);
+        }, 6_000);
+    }, []);
+    useEffect(
+        () => () => {
+            if (workspaceSurfaceActionErrorTimerRef.current !== null) {
+                window.clearTimeout(workspaceSurfaceActionErrorTimerRef.current);
+            }
+        },
+        [],
+    );
     const dispatchWorkspaceSurfaceAction = useCallback(
         async (request: WorkspaceSurfaceActionRequest): Promise<void> => {
             const api = getComandoApi();
@@ -313,9 +335,14 @@ export function App() {
         (request: WorkspaceSurfaceActionRequest) => {
             void dispatchWorkspaceSurfaceAction(request).catch((error) => {
                 console.error("[workspace-host] action delivery failed", error);
+                reportWorkspaceSurfaceActionError(
+                    error instanceof Error
+                        ? error.message
+                        : "The workspace action could not be delivered.",
+                );
             });
         },
-        [dispatchWorkspaceSurfaceAction],
+        [dispatchWorkspaceSurfaceAction, reportWorkspaceSurfaceActionError],
     );
     const addProjects = useProjectsStore((state) => state.addProjects);
     const cloneRepository = useProjectsStore((state) => state.cloneRepository);
@@ -843,18 +870,55 @@ export function App() {
             return;
         }
         const unsubscribe = api.onWorkspaceSurfaceActionRequested(
-            (request: WorkspaceSurfaceActionRequest) => {
-                void executeWorkspaceSurfaceAction(request).catch((error) => {
-                    console.error(
-                        "[workspace-surface] action execution failed",
-                        error,
-                    );
-                });
+            (envelope: WorkspaceSurfaceActionEnvelope) => {
+                void (async () => {
+                    if (
+                        !(await api.claimWorkspaceSurfaceAction(
+                            envelope.actionId,
+                        ))
+                    ) {
+                        return;
+                    }
+                    try {
+                        await executeWorkspaceSurfaceAction(envelope.request);
+                        await api.completeWorkspaceSurfaceAction({
+                            actionId: envelope.actionId,
+                            status: "completed",
+                        });
+                    } catch (error) {
+                        console.error(
+                            "[workspace-surface] action execution failed",
+                            error,
+                        );
+                        await api.completeWorkspaceSurfaceAction({
+                            actionId: envelope.actionId,
+                            error:
+                                error instanceof Error && error.message
+                                    ? error.message.slice(0, 1_000)
+                                    : "The workspace action failed.",
+                            status: "failed",
+                        });
+                    }
+                })();
             },
         );
         void api.notifyWorkspaceSurfaceReady();
         return unsubscribe;
     }, []);
+
+    useEffect(() => {
+        if (!isWorkspaceHostRenderer) {
+            return;
+        }
+        return getComandoApi()?.onWorkspaceSurfaceActionStatus((status) => {
+            if (status.status === "completed") {
+                return;
+            }
+            reportWorkspaceSurfaceActionError(
+                status.message ?? "The workspace action could not be completed.",
+            );
+        });
+    }, [reportWorkspaceSurfaceActionError]);
 
     useEffect(() => {
         if (!isWorkspaceSurfaceRenderer) {
@@ -1925,6 +1989,7 @@ export function App() {
         projectsError,
         workspaceError,
         activeGitError,
+        workspaceSurfaceActionError,
     ]
         .filter(Boolean)
         .join(" ");

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -21,6 +21,7 @@ import type {
     ProjectTreeNode,
     SettingsWindowCategory,
     SettingsSnapshot,
+    WorkspaceSurfaceActionRequest,
     WorkspaceSurfaceGitHubItemOpenRequest,
 } from "@shared/ipc";
 import { resolveEditorLanguage } from "@shared/editor-language";
@@ -62,6 +63,7 @@ import {
     resolveWorkspaceContextRefreshPlan,
     runDeduplicatedContextRefresh,
 } from "./app/workspace/context-activation-refresh";
+import { executeWorkspaceSurfaceAction } from "./app/workspace/surface-actions";
 import { shellLayoutConstraints } from "./app/layout/shell-layout";
 import {
     COMPOSER_PROJECT_FILE_ENTRY_LIST_MIME,
@@ -806,6 +808,22 @@ export function App() {
         }
         return getComandoApi()?.onWorkspaceSurfaceSnapshotRequested(() =>
             useWorkspaceStore.getState().getNavigationSnapshot(),
+        );
+    }, []);
+
+    useEffect(() => {
+        if (!isWorkspaceSurfaceRenderer) {
+            return;
+        }
+        return getComandoApi()?.onWorkspaceSurfaceActionRequested(
+            (request: WorkspaceSurfaceActionRequest) => {
+                void executeWorkspaceSurfaceAction(request).catch((error) => {
+                    console.error(
+                        "[workspace-surface] action execution failed",
+                        error,
+                    );
+                });
+            },
         );
     }, []);
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4477,7 +4477,9 @@ export function App() {
                     <SidebarGitPanel
                         filter={gitChangesFilter}
                         onRequestWorkspaceAction={
-                            requestWorkspaceSurfaceAction
+                            isWorkspaceHostRenderer
+                                ? requestWorkspaceSurfaceAction
+                                : undefined
                         }
                         projectId={activeProjectId}
                         workspaceContextKey={workspaceActiveContextKey}
@@ -4491,9 +4493,19 @@ export function App() {
                             void handleAddGitHubItemsToChat(request)
                         }
                         onOpenSettings={openSettingsWindow}
-                        onOpenItem={handleOpenSidebarGitHubItem}
+                        onOpenItem={
+                            isWorkspaceHostRenderer
+                                ? handleOpenSidebarGitHubItem
+                                : undefined
+                        }
+                        onRequestWorkspaceAction={
+                            isWorkspaceHostRenderer
+                                ? requestWorkspaceSurfaceAction
+                                : undefined
+                        }
                         projectId={activeProjectId}
                         selectionResetSignal={gitHubSidebarSelectionResetSignal}
+                        workspaceContextKey={workspaceActiveContextKey}
                         worktreeId={activeWorktreeId}
                     />
                 ) : sidebarView === "pull_requests" ? (
@@ -4504,15 +4516,31 @@ export function App() {
                             void handleAddGitHubItemsToChat(request)
                         }
                         onOpenSettings={openSettingsWindow}
-                        onOpenItem={handleOpenSidebarGitHubItem}
+                        onOpenItem={
+                            isWorkspaceHostRenderer
+                                ? handleOpenSidebarGitHubItem
+                                : undefined
+                        }
+                        onRequestWorkspaceAction={
+                            isWorkspaceHostRenderer
+                                ? requestWorkspaceSurfaceAction
+                                : undefined
+                        }
                         projectId={activeProjectId}
                         selectionResetSignal={gitHubSidebarSelectionResetSignal}
+                        workspaceContextKey={workspaceActiveContextKey}
                         worktreeId={activeWorktreeId}
                     />
                 ) : sidebarView === "agents" ? (
                     <SidebarAgentsPanel
                         filter={agentsFilter}
+                        onRequestWorkspaceAction={
+                            isWorkspaceHostRenderer
+                                ? requestWorkspaceSurfaceAction
+                                : undefined
+                        }
                         projectId={activeProjectId}
+                        workspaceContextKey={workspaceActiveContextKey}
                         worktreeId={activeWorktreeId}
                     />
                 ) : (

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -838,7 +838,11 @@ export function App() {
         if (!isWorkspaceSurfaceRenderer) {
             return;
         }
-        return getComandoApi()?.onWorkspaceSurfaceActionRequested(
+        const api = getComandoApi();
+        if (!api) {
+            return;
+        }
+        const unsubscribe = api.onWorkspaceSurfaceActionRequested(
             (request: WorkspaceSurfaceActionRequest) => {
                 void executeWorkspaceSurfaceAction(request).catch((error) => {
                     console.error(
@@ -848,6 +852,8 @@ export function App() {
                 });
             },
         );
+        void api.notifyWorkspaceSurfaceReady();
+        return unsubscribe;
     }, []);
 
     useEffect(() => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -22,7 +22,6 @@ import type {
     SettingsWindowCategory,
     SettingsSnapshot,
     WorkspaceSurfaceActionRequest,
-    WorkspaceSurfaceGitHubItemOpenRequest,
 } from "@shared/ipc";
 import { resolveEditorLanguage } from "@shared/editor-language";
 import { isActiveAiRuntimeId } from "@shared/ai-runtimes";
@@ -845,32 +844,6 @@ export function App() {
                         "[workspace-surface] action execution failed",
                         error,
                     );
-                });
-            },
-        );
-    }, []);
-
-    useEffect(() => {
-        if (!isWorkspaceSurfaceRenderer) {
-            return;
-        }
-        return getComandoApi()?.onWorkspaceSurfaceGitHubItemOpenRequested(
-            (input) => {
-                const workspaceState = useWorkspaceStore.getState();
-                if (input.itemKind === "issue") {
-                    void workspaceState.openGitHubIssueTab({
-                        issueNumber: input.itemNumber,
-                        projectId: input.projectId,
-                        ref: input.ref,
-                        worktreeId: input.worktreeId,
-                    });
-                    return;
-                }
-                void workspaceState.openGitHubPullRequestTab({
-                    projectId: input.projectId,
-                    pullRequestNumber: input.itemNumber,
-                    ref: input.ref,
-                    worktreeId: input.worktreeId,
                 });
             },
         );
@@ -2101,10 +2074,12 @@ export function App() {
                             relativePath,
                             worktreeId,
                         ) => {
-                            if (
-                                isWorkspaceHostRenderer &&
-                                workspaceActiveContextKey
-                            ) {
+                            if (isWorkspaceHostRenderer) {
+                                if (!workspaceActiveContextKey) {
+                                    throw new Error(
+                                        "The active workspace surface is unavailable.",
+                                    );
+                                }
                                 await dispatchWorkspaceSurfaceAction({
                                     contextKey: workspaceActiveContextKey,
                                     kind: "file",
@@ -2738,7 +2713,10 @@ export function App() {
                 return;
             }
 
-            if (isWorkspaceHostRenderer && workspaceActiveContextKey) {
+            if (isWorkspaceHostRenderer) {
+                if (!workspaceActiveContextKey) {
+                    return;
+                }
                 requestWorkspaceSurfaceAction({
                     contextKey: workspaceActiveContextKey,
                     files: fileNodes.map((node) => ({
@@ -2909,13 +2887,6 @@ export function App() {
             }
         },
         [createChatTab, lastFocusedRuntimeId, setDraftComposerParts],
-    );
-
-    const handleOpenSidebarGitHubItem = useCallback(
-        (input: WorkspaceSurfaceGitHubItemOpenRequest) => {
-            void getComandoApi()?.openWorkspaceSurfaceGitHubItem(input);
-        },
-        [],
     );
 
     const sidebarFileNodes = useMemo(
@@ -3119,7 +3090,10 @@ export function App() {
             }
 
             clearFileTreeSelection();
-            if (isWorkspaceHostRenderer && workspaceActiveContextKey) {
+            if (isWorkspaceHostRenderer) {
+                if (!workspaceActiveContextKey) {
+                    return;
+                }
                 requestWorkspaceSurfaceAction({
                     contextKey: workspaceActiveContextKey,
                     kind: "file",
@@ -3435,16 +3409,17 @@ export function App() {
                     label: "Open",
                     action: () =>
                         activeProjectId
-                            ? isWorkspaceHostRenderer &&
-                              workspaceActiveContextKey
-                                ? requestWorkspaceSurfaceAction({
-                                      contextKey: workspaceActiveContextKey,
-                                      kind: "file",
-                                      origin: "tree",
-                                      projectId: activeProjectId,
-                                      relativePath: node.path,
-                                      worktreeId: activeWorktreeId ?? null,
-                                  })
+                            ? isWorkspaceHostRenderer
+                                ? workspaceActiveContextKey
+                                    ? requestWorkspaceSurfaceAction({
+                                          contextKey: workspaceActiveContextKey,
+                                          kind: "file",
+                                          origin: "tree",
+                                          projectId: activeProjectId,
+                                          relativePath: node.path,
+                                          worktreeId: activeWorktreeId ?? null,
+                                      })
+                                    : undefined
                                 : void openFileTab(
                                       activeProjectId,
                                       node.path,
@@ -4489,15 +4464,13 @@ export function App() {
                     <SidebarGitHubPanel
                         filter={issuesFilter}
                         kind="issues"
-                        onAddToChat={(request) =>
-                            void handleAddGitHubItemsToChat(request)
+                        onAddToChat={
+                            isWorkspaceHostRenderer
+                                ? undefined
+                                : (request) =>
+                                      void handleAddGitHubItemsToChat(request)
                         }
                         onOpenSettings={openSettingsWindow}
-                        onOpenItem={
-                            isWorkspaceHostRenderer
-                                ? handleOpenSidebarGitHubItem
-                                : undefined
-                        }
                         onRequestWorkspaceAction={
                             isWorkspaceHostRenderer
                                 ? requestWorkspaceSurfaceAction
@@ -4512,15 +4485,13 @@ export function App() {
                     <SidebarGitHubPanel
                         filter={pullRequestsFilter}
                         kind="pull_requests"
-                        onAddToChat={(request) =>
-                            void handleAddGitHubItemsToChat(request)
+                        onAddToChat={
+                            isWorkspaceHostRenderer
+                                ? undefined
+                                : (request) =>
+                                      void handleAddGitHubItemsToChat(request)
                         }
                         onOpenSettings={openSettingsWindow}
-                        onOpenItem={
-                            isWorkspaceHostRenderer
-                                ? handleOpenSidebarGitHubItem
-                                : undefined
-                        }
                         onRequestWorkspaceAction={
                             isWorkspaceHostRenderer
                                 ? requestWorkspaceSurfaceAction

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -294,6 +294,29 @@ export function App() {
     const activeProjectId =
         activeWorkspaceContext?.projectId ??
         (workspaceNavigationHydrated ? null : persistedActiveProjectId);
+    const dispatchWorkspaceSurfaceAction = useCallback(
+        async (request: WorkspaceSurfaceActionRequest): Promise<void> => {
+            const api = getComandoApi();
+            if (!api) {
+                throw new Error("The desktop bridge is unavailable.");
+            }
+            const result = await api.dispatchWorkspaceSurfaceAction(request);
+            if (!result.delivered) {
+                throw new Error(
+                    `The workspace action could not be delivered (${result.reason}).`,
+                );
+            }
+        },
+        [],
+    );
+    const requestWorkspaceSurfaceAction = useCallback(
+        (request: WorkspaceSurfaceActionRequest) => {
+            void dispatchWorkspaceSurfaceAction(request).catch((error) => {
+                console.error("[workspace-host] action delivery failed", error);
+            });
+        },
+        [dispatchWorkspaceSurfaceAction],
+    );
     const addProjects = useProjectsStore((state) => state.addProjects);
     const cloneRepository = useProjectsStore((state) => state.cloneRepository);
     const hydrateProjects = useProjectsStore((state) => state.hydrate);
@@ -2073,13 +2096,41 @@ export function App() {
                 if (kind === "file") {
                     await createWorkspaceQuickFile({
                         createEntry,
-                        openFileTab,
+                        openFileTab: async (
+                            projectId,
+                            relativePath,
+                            worktreeId,
+                        ) => {
+                            if (
+                                isWorkspaceHostRenderer &&
+                                workspaceActiveContextKey
+                            ) {
+                                await dispatchWorkspaceSurfaceAction({
+                                    contextKey: workspaceActiveContextKey,
+                                    kind: "file",
+                                    origin: "quick-create",
+                                    projectId,
+                                    relativePath,
+                                    worktreeId: worktreeId ?? null,
+                                });
+                                return;
+                            }
+                            await openFileTab(
+                                projectId,
+                                relativePath,
+                                worktreeId,
+                            );
+                        },
                         parentRelativePath,
                         projectId: activeProjectId,
                         reportError: (message) => {
                             window.alert(message);
                         },
-                        setLastQuickCreateAction,
+                        setLastQuickCreateAction: (action) => {
+                            if (!isWorkspaceHostRenderer) {
+                                setLastQuickCreateAction(action);
+                            }
+                        },
                         worktreeId: activeWorktreeId,
                     });
                     return;
@@ -2122,9 +2173,11 @@ export function App() {
             activeProjectId,
             activeWorktreeId,
             createEntry,
+            dispatchWorkspaceSurfaceAction,
             openFileTab,
             revealPathInTree,
             setLastQuickCreateAction,
+            workspaceActiveContextKey,
         ],
     );
 
@@ -2685,6 +2738,21 @@ export function App() {
                 return;
             }
 
+            if (isWorkspaceHostRenderer && workspaceActiveContextKey) {
+                requestWorkspaceSurfaceAction({
+                    contextKey: workspaceActiveContextKey,
+                    files: fileNodes.map((node) => ({
+                        name: node.name,
+                        relativePath: node.path,
+                    })),
+                    forceNewChat: options.forceNewChat === true,
+                    kind: "add-files-to-chat",
+                    projectId: activeProjectId,
+                    worktreeId: activeWorktreeId ?? null,
+                });
+                return;
+            }
+
             const currentTabsById = useWorkspaceStore.getState().tabsById;
             const worktreeId = activeWorktreeId ?? null;
             const existingChatTab = Object.values(currentTabsById).find(
@@ -2761,6 +2829,8 @@ export function App() {
             addDraftFileContext,
             createChatTab,
             lastFocusedRuntimeId,
+            requestWorkspaceSurfaceAction,
+            workspaceActiveContextKey,
         ],
     );
 
@@ -3049,6 +3119,17 @@ export function App() {
             }
 
             clearFileTreeSelection();
+            if (isWorkspaceHostRenderer && workspaceActiveContextKey) {
+                requestWorkspaceSurfaceAction({
+                    contextKey: workspaceActiveContextKey,
+                    kind: "file",
+                    origin: "tree",
+                    projectId: activeProjectId,
+                    relativePath: node.path,
+                    worktreeId: activeWorktreeId ?? null,
+                });
+                return;
+            }
             void openFileTab(activeProjectId, node.path, activeWorktreeId);
         },
         [
@@ -3058,7 +3139,9 @@ export function App() {
             effectiveFileTreeSelectedPaths,
             effectiveFileTreeSelectionAnchorPath,
             openFileTab,
+            requestWorkspaceSurfaceAction,
             visibleSidebarNodePaths,
+            workspaceActiveContextKey,
         ],
     );
 
@@ -3352,11 +3435,21 @@ export function App() {
                     label: "Open",
                     action: () =>
                         activeProjectId
-                            ? void openFileTab(
-                                  activeProjectId,
-                                  node.path,
-                                  activeWorktreeId,
-                              )
+                            ? isWorkspaceHostRenderer &&
+                              workspaceActiveContextKey
+                                ? requestWorkspaceSurfaceAction({
+                                      contextKey: workspaceActiveContextKey,
+                                      kind: "file",
+                                      origin: "tree",
+                                      projectId: activeProjectId,
+                                      relativePath: node.path,
+                                      worktreeId: activeWorktreeId ?? null,
+                                  })
+                                : void openFileTab(
+                                      activeProjectId,
+                                      node.path,
+                                      activeWorktreeId,
+                                  )
                             : undefined,
                     disabled: !activeProjectId,
                 },
@@ -3545,6 +3638,8 @@ export function App() {
         openFileTab,
         openFileTreeMovePicker,
         refreshProjectTree,
+        requestWorkspaceSurfaceAction,
+        workspaceActiveContextKey,
     ]);
 
     const openNativeFileTreeContextMenu = useEffectEvent(
@@ -4381,7 +4476,11 @@ export function App() {
                 {sidebarView === "git" && activeProjectId ? (
                     <SidebarGitPanel
                         filter={gitChangesFilter}
+                        onRequestWorkspaceAction={
+                            requestWorkspaceSurfaceAction
+                        }
                         projectId={activeProjectId}
+                        workspaceContextKey={workspaceActiveContextKey}
                         worktreeId={activeWorktreeId}
                     />
                 ) : sidebarView === "issues" ? (

--- a/src/renderer/src/app/workspace/surface-actions.test.ts
+++ b/src/renderer/src/app/workspace/surface-actions.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { WorkspaceSurfaceActionRequest } from "@shared/ipc";
+import {
+    executeWorkspaceSurfaceAction,
+    type WorkspaceSurfaceActionDependencies,
+} from "./surface-actions";
+
+const context = {
+    contextKey: "project-1::__primary__",
+    projectId: "project-1",
+    worktreeId: null,
+} as const;
+
+const ref = {
+    host: "github.com",
+    owner: "openai",
+    repo: "codex",
+} as const;
+
+describe("executeWorkspaceSurfaceAction", () => {
+    it("opens files locally and records quick create ownership", async () => {
+        const harness = createHarness();
+
+        await executeWorkspaceSurfaceAction(
+            {
+                ...context,
+                kind: "file",
+                origin: "quick-create",
+                relativePath: "untitled.txt",
+            },
+            harness.dependencies,
+        );
+
+        expect(harness.workspace.setLastQuickCreateAction).toHaveBeenCalledWith(
+            "file",
+        );
+        expect(harness.workspace.openFileTab).toHaveBeenCalledWith(
+            "project-1",
+            "untitled.txt",
+            null,
+        );
+    });
+
+    it("dispatches Git and chat actions to the local workspace store", async () => {
+        const harness = createHarness();
+        const requests: WorkspaceSurfaceActionRequest[] = [
+            { ...context, kind: "git-history" },
+            { ...context, kind: "git-worktree-diff" },
+            { ...context, kind: "chat-history" },
+            { ...context, kind: "new-chat", runtimeId: "grok" },
+            {
+                ...context,
+                kind: "chat-session",
+                runtimeId: "codex",
+                sessionId: "session-history",
+                sessionProjectId: "project-1",
+                sessionWorktreeId: null,
+                title: "History session",
+            },
+        ];
+
+        for (const request of requests) {
+            await executeWorkspaceSurfaceAction(request, harness.dependencies);
+        }
+
+        expect(harness.workspace.openGitTab).toHaveBeenCalledWith(
+            "project-1",
+            null,
+        );
+        expect(harness.workspace.openGitWorktreeDiffTab).toHaveBeenCalledWith(
+            "project-1",
+            null,
+        );
+        expect(harness.workspace.openChatHistoryTab).toHaveBeenCalledWith(
+            "project-1",
+            null,
+        );
+        expect(harness.workspace.createChatTab).toHaveBeenCalledWith(
+            "project-1",
+            null,
+            "grok",
+        );
+        expect(harness.workspace.openChatSessionTab).toHaveBeenCalledWith({
+            projectId: "project-1",
+            runtimeId: "codex",
+            sessionOpenMode: "history",
+            sessionId: "session-history",
+            title: "History session",
+            worktreeId: null,
+        });
+    });
+
+    it("opens GitHub lists and items locally", async () => {
+        const harness = createHarness();
+
+        await executeWorkspaceSurfaceAction(
+            {
+                ...context,
+                kind: "github-list",
+                listKind: "issues",
+                ref,
+            },
+            harness.dependencies,
+        );
+        await executeWorkspaceSurfaceAction(
+            {
+                ...context,
+                itemKind: "pull_request",
+                itemNumber: 42,
+                kind: "github-item",
+                ref,
+            },
+            harness.dependencies,
+        );
+
+        expect(harness.workspace.openGitHubIssuesTab).toHaveBeenCalledWith(
+            expect.objectContaining({ kind: "github-list", ref }),
+        );
+        expect(
+            harness.workspace.openGitHubPullRequestTab,
+        ).toHaveBeenCalledWith({
+            projectId: "project-1",
+            pullRequestNumber: 42,
+            ref,
+            worktreeId: null,
+        });
+    });
+
+    it("focuses existing terminals and launches Claude locally", async () => {
+        const harness = createHarness({ terminal: true });
+
+        await executeWorkspaceSurfaceAction(
+            { ...context, kind: "focus-terminal", terminalId: "terminal-1" },
+            harness.dependencies,
+        );
+        await executeWorkspaceSurfaceAction(
+            { ...context, kind: "new-claude-terminal" },
+            harness.dependencies,
+        );
+
+        expect(harness.workspace.selectTab).toHaveBeenCalledWith(
+            "pane-1",
+            "terminal-tab-1",
+        );
+        expect(harness.launchClaudeTerminal).toHaveBeenCalledWith({
+            projectId: "project-1",
+            worktreeId: null,
+        });
+    });
+
+    it("adds multiple files to the best matching local chat", async () => {
+        const harness = createHarness({ chat: true });
+
+        await executeWorkspaceSurfaceAction(
+            {
+                ...context,
+                files: [
+                    { name: "index.ts", relativePath: "src/index.ts" },
+                    { name: "README.md", relativePath: "README.md" },
+                ],
+                forceNewChat: false,
+                kind: "add-files-to-chat",
+            },
+            harness.dependencies,
+        );
+
+        expect(harness.ai.addDraftFileContext).toHaveBeenCalledTimes(2);
+        expect(harness.ai.addDraftFileContext).toHaveBeenNthCalledWith(
+            1,
+            "session-1",
+            expect.objectContaining({
+                name: "index.ts",
+                projectId: "project-1",
+                relativePath: "src/index.ts",
+            }),
+        );
+    });
+
+    it("adds multiple GitHub mentions and honors forceNewChat", async () => {
+        const harness = createHarness({ createChatOnDemand: true });
+
+        await executeWorkspaceSurfaceAction(
+            {
+                ...context,
+                forceNewChat: true,
+                itemKind: "issue",
+                items: [
+                    {
+                        number: 1,
+                        title: "First",
+                        url: "https://github.com/openai/codex/issues/1",
+                    },
+                    {
+                        number: 2,
+                        title: "Second",
+                        url: "https://github.com/openai/codex/issues/2",
+                    },
+                ],
+                kind: "add-github-items-to-chat",
+                ref,
+            },
+            harness.dependencies,
+        );
+
+        expect(harness.workspace.createChatTab).toHaveBeenCalledWith(
+            "project-1",
+            null,
+            "codex",
+        );
+        expect(harness.ai.setDraftComposerParts).toHaveBeenCalledWith(
+            "created-session",
+            expect.arrayContaining([
+                expect.objectContaining({
+                    number: 1,
+                    type: "github_issue_mention",
+                }),
+                expect.objectContaining({
+                    number: 2,
+                    type: "github_issue_mention",
+                }),
+            ]),
+        );
+    });
+
+    it("reports a missing terminal instead of mutating another pane", async () => {
+        const harness = createHarness();
+
+        await expect(
+            executeWorkspaceSurfaceAction(
+                {
+                    ...context,
+                    kind: "focus-terminal",
+                    terminalId: "missing",
+                },
+                harness.dependencies,
+            ),
+        ).rejects.toThrow("no longer open");
+        expect(harness.workspace.selectTab).not.toHaveBeenCalled();
+    });
+});
+
+function createHarness(
+    options: {
+        readonly chat?: boolean;
+        readonly createChatOnDemand?: boolean;
+        readonly terminal?: boolean;
+    } = {},
+) {
+    const chatTab = options.chat
+        ? {
+              createdAt: "2026-07-19T00:00:00.000Z",
+              draft: "",
+              id: "chat-tab-1",
+              kind: "chat",
+              projectId: "project-1",
+              runtimeId: "codex",
+              sessionId: "session-1",
+              title: "Codex 1",
+              worktreeId: null,
+          }
+        : null;
+    const terminalTab = options.terminal
+        ? {
+              createdAt: "2026-07-19T00:00:00.000Z",
+              exitCode: null,
+              id: "terminal-tab-1",
+              isReady: true,
+              kind: "terminal",
+              launchError: null,
+              output: "",
+              projectId: "project-1",
+              session: null,
+              sessionId: "terminal-1",
+              signalCode: null,
+              terminalId: "terminal-1",
+              title: "Terminal 1",
+              worktreeId: null,
+          }
+        : null;
+    const tabsById: Record<string, unknown> = {};
+    if (chatTab) tabsById[chatTab.id] = chatTab;
+    if (terminalTab) tabsById[terminalTab.id] = terminalTab;
+    const tabIds = [chatTab?.id, terminalTab?.id].filter(
+        (tabId): tabId is string => Boolean(tabId),
+    );
+
+    const workspace = {
+        activePaneId: "pane-1",
+        createChatTab: vi.fn(() => {
+            if (!options.createChatOnDemand) return Promise.resolve();
+            tabsById["created-chat"] = {
+                ...chatTab,
+                id: "created-chat",
+                kind: "chat",
+                projectId: "project-1",
+                runtimeId: "codex",
+                sessionId: "created-session",
+                title: "Codex 1",
+                worktreeId: null,
+            };
+            workspace.lastFocusedChatTabId = "created-chat";
+            return Promise.resolve();
+        }),
+        lastFocusedChatTabId: chatTab?.id ?? null,
+        lastFocusedRuntimeId: "codex",
+        openChatHistoryTab: vi.fn(() => Promise.resolve()),
+        openChatSessionTab: vi.fn(() => Promise.resolve()),
+        openFileTab: vi.fn(() => Promise.resolve()),
+        openGitHubIssueTab: vi.fn(() => Promise.resolve()),
+        openGitHubIssuesTab: vi.fn(() => Promise.resolve()),
+        openGitHubPullRequestTab: vi.fn(() => Promise.resolve()),
+        openGitHubPullRequestsTab: vi.fn(() => Promise.resolve()),
+        openGitTab: vi.fn(() => Promise.resolve()),
+        openGitWorktreeDiffTab: vi.fn(() => Promise.resolve()),
+        recentFocusedChatTabIds: chatTab ? [chatTab.id] : [],
+        rootNode: {
+            activeTabId: tabIds[0] ?? null,
+            id: "pane-1",
+            tabIds,
+            type: "pane",
+        },
+        selectTab: vi.fn(() => Promise.resolve()),
+        setLastQuickCreateAction: vi.fn(),
+        tabsById,
+    };
+    const ai = {
+        addDraftFileContext: vi.fn(),
+        sessions: {},
+        setDraftComposerParts: vi.fn(),
+    };
+    const launchClaudeTerminal = vi.fn(() =>
+        Promise.resolve({
+            commandWritten: true,
+            terminalId: "terminal-2",
+            terminalTabId: "terminal-tab-2",
+            transcriptSessionId: null,
+        }),
+    );
+    const dependencies = {
+        getAiState: () => ai,
+        getWorkspaceState: () => workspace,
+        launchClaudeTerminal,
+    } as unknown as WorkspaceSurfaceActionDependencies;
+
+    return { ai, dependencies, launchClaudeTerminal, workspace };
+}

--- a/src/renderer/src/app/workspace/surface-actions.ts
+++ b/src/renderer/src/app/workspace/surface-actions.ts
@@ -1,0 +1,243 @@
+import { isActiveAiRuntimeId } from "@shared/ai-runtimes";
+import { resolveEditorLanguage } from "@shared/editor-language";
+import type { WorkspaceSurfaceActionRequest } from "@shared/ipc";
+
+import {
+    createGitHubIssueComposerDragItem,
+    createGitHubPullRequestComposerDragItem,
+} from "@renderer/app/drag-and-drop";
+import { useAiStore } from "@renderer/app/store/ai-store";
+import {
+    getBestMatchingChatTabId,
+    useWorkspaceStore,
+} from "@renderer/app/store/workspace-store";
+import { collectPaneNodes } from "@renderer/app/workspace/tree";
+import {
+    appendWorkspaceTabComposerItems,
+    createEmptyComposerParts,
+} from "@renderer/components/workspace/chat/composerParts";
+import { launchClaudeCodeTerminal } from "@renderer/features/terminal/claudeCodeTerminal";
+
+type AiState = ReturnType<typeof useAiStore.getState>;
+type WorkspaceState = ReturnType<typeof useWorkspaceStore.getState>;
+
+export interface WorkspaceSurfaceActionDependencies {
+    readonly getAiState: () => AiState;
+    readonly getWorkspaceState: () => WorkspaceState;
+    readonly launchClaudeTerminal: typeof launchClaudeCodeTerminal;
+}
+
+const defaultDependencies: WorkspaceSurfaceActionDependencies = {
+    getAiState: useAiStore.getState,
+    getWorkspaceState: useWorkspaceStore.getState,
+    launchClaudeTerminal: launchClaudeCodeTerminal,
+};
+
+export async function executeWorkspaceSurfaceAction(
+    request: WorkspaceSurfaceActionRequest,
+    dependencies: WorkspaceSurfaceActionDependencies = defaultDependencies,
+): Promise<void> {
+    const workspace = dependencies.getWorkspaceState();
+
+    switch (request.kind) {
+        case "file":
+            if (request.origin === "quick-create") {
+                workspace.setLastQuickCreateAction("file");
+            }
+            await workspace.openFileTab(
+                request.projectId,
+                request.relativePath,
+                request.worktreeId,
+            );
+            return;
+        case "git-history":
+            await workspace.openGitTab(request.projectId, request.worktreeId);
+            return;
+        case "git-worktree-diff":
+            await workspace.openGitWorktreeDiffTab(
+                request.projectId,
+                request.worktreeId,
+            );
+            return;
+        case "chat-session":
+            await workspace.openChatSessionTab({
+                projectId: request.sessionProjectId,
+                runtimeId: request.runtimeId,
+                sessionOpenMode: "history",
+                sessionId: request.sessionId,
+                title: request.title,
+                worktreeId: request.sessionWorktreeId,
+            });
+            return;
+        case "chat-history":
+            await workspace.openChatHistoryTab(
+                request.projectId,
+                request.worktreeId,
+            );
+            return;
+        case "new-chat":
+            if (!isActiveAiRuntimeId(request.runtimeId)) {
+                throw new Error("Unsupported chat runtime.");
+            }
+            await workspace.createChatTab(
+                request.projectId,
+                request.worktreeId,
+                request.runtimeId,
+            );
+            return;
+        case "focus-terminal":
+            await focusTerminal(request.terminalId, workspace);
+            return;
+        case "new-claude-terminal":
+            await dependencies.launchClaudeTerminal({
+                projectId: request.projectId,
+                worktreeId: request.worktreeId,
+            });
+            return;
+        case "github-list":
+            if (request.listKind === "issues") {
+                await workspace.openGitHubIssuesTab(request);
+            } else {
+                await workspace.openGitHubPullRequestsTab(request);
+            }
+            return;
+        case "github-item":
+            if (request.itemKind === "issue") {
+                await workspace.openGitHubIssueTab({
+                    issueNumber: request.itemNumber,
+                    projectId: request.projectId,
+                    ref: request.ref,
+                    worktreeId: request.worktreeId,
+                });
+            } else {
+                await workspace.openGitHubPullRequestTab({
+                    projectId: request.projectId,
+                    pullRequestNumber: request.itemNumber,
+                    ref: request.ref,
+                    worktreeId: request.worktreeId,
+                });
+            }
+            return;
+        case "add-files-to-chat":
+            await addFilesToChat(request, dependencies);
+            return;
+        case "add-github-items-to-chat":
+            await addGitHubItemsToChat(request, dependencies);
+    }
+}
+
+async function focusTerminal(
+    terminalId: string,
+    workspace: WorkspaceState,
+): Promise<void> {
+    const tab = Object.values(workspace.tabsById).find(
+        (candidate) =>
+            candidate.kind === "terminal" &&
+            candidate.terminalId === terminalId,
+    );
+    if (!tab) {
+        throw new Error("The requested terminal is no longer open.");
+    }
+
+    const pane = collectPaneNodes(workspace.rootNode).find((candidate) =>
+        candidate.tabIds.includes(tab.id),
+    );
+    if (!pane) {
+        throw new Error("The requested terminal pane is unavailable.");
+    }
+
+    await workspace.selectTab(pane.id, tab.id);
+}
+
+async function addFilesToChat(
+    request: Extract<
+        WorkspaceSurfaceActionRequest,
+        { readonly kind: "add-files-to-chat" }
+    >,
+    dependencies: WorkspaceSurfaceActionDependencies,
+): Promise<void> {
+    const sessionId = await resolveChatSession(request, dependencies);
+    if (!sessionId) {
+        throw new Error("Could not create a chat tab for these files.");
+    }
+
+    const ai = dependencies.getAiState();
+    for (const file of request.files) {
+        ai.addDraftFileContext(sessionId, {
+            extension: file.relativePath.split(".").pop() ?? null,
+            id: `file-ctx:${crypto.randomUUID()}`,
+            languageId: resolveEditorLanguage({
+                filePath: file.relativePath,
+            }).id,
+            name: file.name,
+            projectId: request.projectId,
+            relativePath: file.relativePath,
+        });
+    }
+}
+
+async function addGitHubItemsToChat(
+    request: Extract<
+        WorkspaceSurfaceActionRequest,
+        { readonly kind: "add-github-items-to-chat" }
+    >,
+    dependencies: WorkspaceSurfaceActionDependencies,
+): Promise<void> {
+    const sessionId = await resolveChatSession(request, dependencies);
+    if (!sessionId) {
+        throw new Error("Could not create a chat tab for these GitHub items.");
+    }
+
+    const composerItems = request.items.map((item) =>
+        request.itemKind === "issue"
+            ? createGitHubIssueComposerDragItem(request.ref, item)
+            : createGitHubPullRequestComposerDragItem(request.ref, item),
+    );
+    const ai = dependencies.getAiState();
+    const existingParts =
+        ai.sessions[sessionId]?.draftComposerParts ?? createEmptyComposerParts();
+    ai.setDraftComposerParts(
+        sessionId,
+        appendWorkspaceTabComposerItems(existingParts, composerItems),
+    );
+}
+
+async function resolveChatSession(
+    request: {
+        readonly forceNewChat: boolean;
+        readonly projectId: string;
+        readonly worktreeId: string | null;
+    },
+    dependencies: WorkspaceSurfaceActionDependencies,
+): Promise<string | null> {
+    let workspace = dependencies.getWorkspaceState();
+    const targetChatTabId = request.forceNewChat
+        ? null
+        : getBestMatchingChatTabId(workspace, {
+              currentPaneId: workspace.activePaneId,
+              lastFocusedChatTabId: workspace.lastFocusedChatTabId,
+              projectId: request.projectId,
+              recentFocusedChatTabIds: workspace.recentFocusedChatTabIds,
+              worktreeId: request.worktreeId,
+          });
+    const targetChatTab = targetChatTabId
+        ? workspace.tabsById[targetChatTabId]
+        : null;
+    if (targetChatTab?.kind === "chat") {
+        return targetChatTab.sessionId;
+    }
+
+    const runtimeId = isActiveAiRuntimeId(workspace.lastFocusedRuntimeId)
+        ? workspace.lastFocusedRuntimeId
+        : "codex";
+    await workspace.createChatTab(
+        request.projectId,
+        request.worktreeId,
+        runtimeId,
+    );
+    workspace = dependencies.getWorkspaceState();
+    const createdTab = workspace.lastFocusedChatTabId
+        ? workspace.tabsById[workspace.lastFocusedChatTabId]
+        : null;
+    return createdTab?.kind === "chat" ? createdTab.sessionId : null;
+}

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
@@ -212,6 +212,30 @@ describe("SidebarAgentsPanel workspace surface actions", () => {
             worktreeId: "worktree-1",
         });
     });
+
+    it("requests history opening in the active surface", async () => {
+        const onRequestWorkspaceAction = vi.fn();
+        const container = await mountSidebarAgentsPanel([], {
+            onRequestWorkspaceAction,
+            workspaceContextKey: "project-1::worktree-1",
+        });
+        const historyButton = Array.from(
+            container.querySelectorAll<HTMLButtonElement>("button"),
+        ).find((button) => button.textContent === "History");
+
+        expect(historyButton).toBeDefined();
+        await act(async () => {
+            historyButton?.click();
+            await Promise.resolve();
+        });
+
+        expect(onRequestWorkspaceAction).toHaveBeenCalledWith({
+            contextKey: "project-1::worktree-1",
+            kind: "chat-history",
+            projectId: "project-1",
+            worktreeId: "worktree-1",
+        });
+    });
 });
 
 function persistFolderState(

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
@@ -131,6 +131,12 @@ function createSnapshot(
 
 async function mountSidebarAgentsPanel(
     sessions: readonly AiHistorySessionSummary[],
+    options: {
+        readonly onRequestWorkspaceAction?: Parameters<
+            typeof SidebarAgentsPanel
+        >[0]["onRequestWorkspaceAction"];
+        readonly workspaceContextKey?: string;
+    } = {},
 ): Promise<HTMLDivElement> {
     writeSidebarAgentsHistoryCache(
         "project-1",
@@ -160,7 +166,9 @@ async function mountSidebarAgentsPanel(
     await act(async () => {
         root.render(
             <SidebarAgentsPanel
+                onRequestWorkspaceAction={options.onRequestWorkspaceAction}
                 projectId="project-1"
+                workspaceContextKey={options.workspaceContextKey}
                 worktreeId="worktree-1"
             />,
         );
@@ -169,6 +177,42 @@ async function mountSidebarAgentsPanel(
 
     return container;
 }
+
+describe("SidebarAgentsPanel workspace surface actions", () => {
+    it("requests chat session opening in the active surface", async () => {
+        Object.defineProperty(globalThis, "localStorage", {
+            configurable: true,
+            value: new MemoryStorage(),
+        });
+        const onRequestWorkspaceAction = vi.fn();
+        const session = createSummary();
+        const container = await mountSidebarAgentsPanel([session], {
+            onRequestWorkspaceAction,
+            workspaceContextKey: "project-1::worktree-1",
+        });
+        const row = container.querySelector<HTMLElement>(
+            '.sidebar-agents-row[title="Cached Session"]',
+        );
+
+        expect(row).not.toBeNull();
+        await act(async () => {
+            row?.click();
+            await Promise.resolve();
+        });
+
+        expect(onRequestWorkspaceAction).toHaveBeenCalledWith({
+            contextKey: "project-1::worktree-1",
+            kind: "chat-session",
+            projectId: "project-1",
+            runtimeId: session.runtimeId,
+            sessionId: session.sessionId,
+            sessionProjectId: session.projectId,
+            sessionWorktreeId: session.worktreeId,
+            title: session.title,
+            worktreeId: "worktree-1",
+        });
+    });
+});
 
 function persistFolderState(
     sessionFolderIds: Readonly<Record<string, string>> = {},

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -1463,6 +1463,7 @@ export function SidebarAgentsPanel({
                 </button>
                 <button
                     className="sidebar-toolbar-action"
+                    disabled={Boolean(onRequestWorkspaceAction) && (!projectId || !workspaceContextKey)}
                     onClick={handleOpenHistoryTab}
                     title="Open full history"
                     type="button"

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -14,6 +14,7 @@ import type {
     AiHistorySessionSummary,
     AiRuntimeId,
     ComandoApi,
+    WorkspaceSurfaceActionRequest,
 } from "@shared/ipc";
 import {
     ACTIVE_AI_RUNTIME_IDS,
@@ -147,11 +148,17 @@ const CLAUDE_CODE_NOT_FOUND_MESSAGE =
 
 export function SidebarAgentsPanel({
     filter,
+    onRequestWorkspaceAction,
     projectId,
+    workspaceContextKey,
     worktreeId,
 }: {
     readonly filter?: string;
+    readonly onRequestWorkspaceAction?: (
+        request: WorkspaceSurfaceActionRequest,
+    ) => void;
     readonly projectId: string | null;
+    readonly workspaceContextKey?: string | null;
     readonly worktreeId: string | null;
 }) {
     const openChatSessionTab = useWorkspaceStore(
@@ -560,7 +567,40 @@ export function SidebarAgentsPanel({
     const handleOpenSession = useCallback(
         (session: SidebarAgentSessionSummary) => {
             if (isClaudeCodeSidebarSession(session)) {
+                if (
+                    onRequestWorkspaceAction &&
+                    projectId &&
+                    workspaceContextKey
+                ) {
+                    onRequestWorkspaceAction({
+                        contextKey: workspaceContextKey,
+                        kind: "focus-terminal",
+                        projectId,
+                        terminalId: session.terminalId,
+                        worktreeId,
+                    });
+                    return;
+                }
                 void focusClaudeCodeSidebarSession(session);
+                return;
+            }
+
+            if (
+                onRequestWorkspaceAction &&
+                projectId &&
+                workspaceContextKey
+            ) {
+                onRequestWorkspaceAction({
+                    contextKey: workspaceContextKey,
+                    kind: "chat-session",
+                    projectId,
+                    runtimeId: session.runtimeId as AiRuntimeId,
+                    sessionId: session.sessionId,
+                    sessionProjectId: session.projectId,
+                    sessionWorktreeId: session.worktreeId ?? null,
+                    title: session.title,
+                    worktreeId,
+                });
                 return;
             }
 
@@ -573,12 +613,33 @@ export function SidebarAgentsPanel({
                 worktreeId: session.worktreeId ?? null,
             });
         },
-        [openChatSessionTab],
+        [
+            onRequestWorkspaceAction,
+            openChatSessionTab,
+            projectId,
+            workspaceContextKey,
+            worktreeId,
+        ],
     );
 
     const handleOpenHistoryTab = useCallback(() => {
+        if (onRequestWorkspaceAction && projectId && workspaceContextKey) {
+            onRequestWorkspaceAction({
+                contextKey: workspaceContextKey,
+                kind: "chat-history",
+                projectId,
+                worktreeId,
+            });
+            return;
+        }
         void openChatHistoryTab(projectId, worktreeId);
-    }, [openChatHistoryTab, projectId, worktreeId]);
+    }, [
+        onRequestWorkspaceAction,
+        openChatHistoryTab,
+        projectId,
+        workspaceContextKey,
+        worktreeId,
+    ]);
 
     const handleOpenNewAgentMenu = useCallback(
         (event: ReactMouseEvent<HTMLButtonElement>) => {
@@ -596,16 +657,46 @@ export function SidebarAgentsPanel({
 
     const handleCreateNewAgentTab = useCallback(
         (runtimeId: ActiveAiRuntimeId) => {
+            if (onRequestWorkspaceAction && projectId && workspaceContextKey) {
+                onRequestWorkspaceAction({
+                    contextKey: workspaceContextKey,
+                    kind: "new-chat",
+                    projectId,
+                    runtimeId,
+                    worktreeId,
+                });
+                return;
+            }
             void createChatTab(projectId, worktreeId, runtimeId);
         },
-        [createChatTab, projectId, worktreeId],
+        [
+            createChatTab,
+            onRequestWorkspaceAction,
+            projectId,
+            workspaceContextKey,
+            worktreeId,
+        ],
     );
     const handleOpenClaudeCodeTerminal = useCallback(() => {
+        if (onRequestWorkspaceAction && projectId && workspaceContextKey) {
+            onRequestWorkspaceAction({
+                contextKey: workspaceContextKey,
+                kind: "new-claude-terminal",
+                projectId,
+                worktreeId,
+            });
+            return;
+        }
         void launchClaudeCodeTerminal({
             projectId,
             worktreeId,
         });
-    }, [projectId, worktreeId]);
+    }, [
+        onRequestWorkspaceAction,
+        projectId,
+        workspaceContextKey,
+        worktreeId,
+    ]);
 
     useEffect(() => {
         let cancelled = false;

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -567,11 +567,10 @@ export function SidebarAgentsPanel({
     const handleOpenSession = useCallback(
         (session: SidebarAgentSessionSummary) => {
             if (isClaudeCodeSidebarSession(session)) {
-                if (
-                    onRequestWorkspaceAction &&
-                    projectId &&
-                    workspaceContextKey
-                ) {
+                if (onRequestWorkspaceAction) {
+                    if (!projectId || !workspaceContextKey) {
+                        return;
+                    }
                     onRequestWorkspaceAction({
                         contextKey: workspaceContextKey,
                         kind: "focus-terminal",
@@ -585,11 +584,10 @@ export function SidebarAgentsPanel({
                 return;
             }
 
-            if (
-                onRequestWorkspaceAction &&
-                projectId &&
-                workspaceContextKey
-            ) {
+            if (onRequestWorkspaceAction) {
+                if (!projectId || !workspaceContextKey) {
+                    return;
+                }
                 onRequestWorkspaceAction({
                     contextKey: workspaceContextKey,
                     kind: "chat-session",
@@ -623,7 +621,10 @@ export function SidebarAgentsPanel({
     );
 
     const handleOpenHistoryTab = useCallback(() => {
-        if (onRequestWorkspaceAction && projectId && workspaceContextKey) {
+        if (onRequestWorkspaceAction) {
+            if (!projectId || !workspaceContextKey) {
+                return;
+            }
             onRequestWorkspaceAction({
                 contextKey: workspaceContextKey,
                 kind: "chat-history",
@@ -657,7 +658,10 @@ export function SidebarAgentsPanel({
 
     const handleCreateNewAgentTab = useCallback(
         (runtimeId: ActiveAiRuntimeId) => {
-            if (onRequestWorkspaceAction && projectId && workspaceContextKey) {
+            if (onRequestWorkspaceAction) {
+                if (!projectId || !workspaceContextKey) {
+                    return;
+                }
                 onRequestWorkspaceAction({
                     contextKey: workspaceContextKey,
                     kind: "new-chat",
@@ -678,7 +682,10 @@ export function SidebarAgentsPanel({
         ],
     );
     const handleOpenClaudeCodeTerminal = useCallback(() => {
-        if (onRequestWorkspaceAction && projectId && workspaceContextKey) {
+        if (onRequestWorkspaceAction) {
+            if (!projectId || !workspaceContextKey) {
+                return;
+            }
             onRequestWorkspaceAction({
                 contextKey: workspaceContextKey,
                 kind: "new-claude-terminal",

--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.test.ts
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.test.ts
@@ -16,6 +16,7 @@ import type {
 
 import {
     buildSidebarGitHubComposerParts,
+    createSidebarGitHubAddToChatSurfaceAction,
     getSidebarGitHubAddToChatLabel,
     getSidebarGitHubContextNumbers,
     getSidebarGitHubDragItems,
@@ -552,6 +553,43 @@ describe("SidebarGitHubDraggableRow", () => {
 });
 
 describe("SidebarGitHubPanel chat helpers", () => {
+    it("normalizes multi-item surface actions without store objects", () => {
+        expect(
+            createSidebarGitHubAddToChatSurfaceAction({
+                contextKey: "project-1::__primary__",
+                forceNewChat: true,
+                itemKind: "issue",
+                items: [
+                    createIssue({ number: 7, title: "Crash on launch" }),
+                    createIssue({ number: 8, title: "Slow indexing" }),
+                ],
+                projectId: "project-1",
+                ref: repoRef,
+                worktreeId: null,
+            }),
+        ).toEqual({
+            contextKey: "project-1::__primary__",
+            forceNewChat: true,
+            itemKind: "issue",
+            items: [
+                {
+                    number: 7,
+                    title: "Crash on launch",
+                    url: "https://github.com/example/comando/issues/7",
+                },
+                {
+                    number: 8,
+                    title: "Slow indexing",
+                    url: "https://github.com/example/comando/issues/8",
+                },
+            ],
+            kind: "add-github-items-to-chat",
+            projectId: "project-1",
+            ref: repoRef,
+            worktreeId: null,
+        });
+    });
+
     it("pluralizes issue and pull request add-to-chat labels", () => {
         expect(
             getSidebarGitHubAddToChatLabel({

--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
@@ -19,7 +19,6 @@ import type {
     GitHubRepositoryRef,
     GitRepositorySnapshot,
     WorkspaceSurfaceActionRequest,
-    WorkspaceSurfaceGitHubItemOpenRequest,
 } from "@shared/ipc";
 
 import {
@@ -233,7 +232,6 @@ export function SidebarGitHubPanel({
     filter,
     kind,
     onAddToChat,
-    onOpenItem,
     onOpenSettings,
     onRequestWorkspaceAction,
     projectId,
@@ -244,9 +242,6 @@ export function SidebarGitHubPanel({
     readonly filter?: string;
     readonly kind: SidebarGitHubPanelKind;
     readonly onAddToChat?: (request: SidebarGitHubAddToChatRequest) => void;
-    readonly onOpenItem?: (
-        request: WorkspaceSurfaceGitHubItemOpenRequest,
-    ) => void;
     readonly onOpenSettings: () => void;
     readonly onRequestWorkspaceAction?: (
         request: WorkspaceSurfaceActionRequest,
@@ -721,18 +716,10 @@ export function SidebarGitHubPanel({
                 return;
             }
 
-            const input = {
-                itemKind: "issue" as const,
-                itemNumber: issueNumber,
-                projectId,
-                ref: repoRef,
-                worktreeId,
-            };
-            if (
-                onRequestWorkspaceAction &&
-                projectId &&
-                workspaceContextKey
-            ) {
+            if (onRequestWorkspaceAction) {
+                if (!projectId || !workspaceContextKey) {
+                    return;
+                }
                 onRequestWorkspaceAction({
                     contextKey: workspaceContextKey,
                     itemKind: "issue",
@@ -744,10 +731,6 @@ export function SidebarGitHubPanel({
                 });
                 return;
             }
-            if (onOpenItem) {
-                onOpenItem(input);
-                return;
-            }
             void openGitHubIssueTab({
                 issueNumber,
                 projectId,
@@ -756,7 +739,6 @@ export function SidebarGitHubPanel({
             });
         },
         [
-            onOpenItem,
             onRequestWorkspaceAction,
             openGitHubIssueTab,
             projectId,
@@ -770,18 +752,10 @@ export function SidebarGitHubPanel({
             if (!repoRef) {
                 return;
             }
-            const input = {
-                itemKind: "pull_request" as const,
-                itemNumber: pullRequestNumber,
-                projectId,
-                ref: repoRef,
-                worktreeId,
-            };
-            if (
-                onRequestWorkspaceAction &&
-                projectId &&
-                workspaceContextKey
-            ) {
+            if (onRequestWorkspaceAction) {
+                if (!projectId || !workspaceContextKey) {
+                    return;
+                }
                 onRequestWorkspaceAction({
                     contextKey: workspaceContextKey,
                     itemKind: "pull_request",
@@ -793,10 +767,6 @@ export function SidebarGitHubPanel({
                 });
                 return;
             }
-            if (onOpenItem) {
-                onOpenItem(input);
-                return;
-            }
             void openGitHubPullRequestTab({
                 projectId,
                 pullRequestNumber,
@@ -805,7 +775,6 @@ export function SidebarGitHubPanel({
             });
         },
         [
-            onOpenItem,
             onRequestWorkspaceAction,
             openGitHubPullRequestTab,
             projectId,
@@ -838,11 +807,10 @@ export function SidebarGitHubPanel({
                 return;
             }
 
-            if (
-                onRequestWorkspaceAction &&
-                projectId &&
-                workspaceContextKey
-            ) {
+            if (onRequestWorkspaceAction) {
+                if (!projectId || !workspaceContextKey) {
+                    return;
+                }
                 const sourceItems =
                     kind === "issues" ? contextIssues : contextPullRequests;
                 onRequestWorkspaceAction(
@@ -1135,7 +1103,10 @@ export function SidebarGitHubPanel({
             worktreeId,
         };
 
-        if (onRequestWorkspaceAction && workspaceContextKey) {
+        if (onRequestWorkspaceAction) {
+            if (!workspaceContextKey) {
+                return;
+            }
             onRequestWorkspaceAction({
                 contextKey: workspaceContextKey,
                 kind: "github-list",

--- a/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitHubPanel.tsx
@@ -18,6 +18,7 @@ import type {
     GitHubPullRequestSummary,
     GitHubRepositoryRef,
     GitRepositorySnapshot,
+    WorkspaceSurfaceActionRequest,
     WorkspaceSurfaceGitHubItemOpenRequest,
 } from "@shared/ipc";
 
@@ -175,6 +176,37 @@ export type SidebarGitHubAddToChatRequest =
           readonly worktreeId: string | null;
       };
 
+export function createSidebarGitHubAddToChatSurfaceAction(input: {
+    readonly contextKey: string;
+    readonly forceNewChat: boolean;
+    readonly itemKind: "issue" | "pull_request";
+    readonly items: readonly Pick<
+        GitHubIssueSummary | GitHubPullRequestSummary,
+        "number" | "title" | "url"
+    >[];
+    readonly projectId: string;
+    readonly ref: GitHubRepositoryRef;
+    readonly worktreeId: string | null;
+}): Extract<
+    WorkspaceSurfaceActionRequest,
+    { readonly kind: "add-github-items-to-chat" }
+> {
+    return {
+        contextKey: input.contextKey,
+        forceNewChat: input.forceNewChat,
+        itemKind: input.itemKind,
+        items: input.items.map((item) => ({
+            number: item.number,
+            title: item.title,
+            url: item.url,
+        })),
+        kind: "add-github-items-to-chat",
+        projectId: input.projectId,
+        ref: input.ref,
+        worktreeId: input.worktreeId,
+    };
+}
+
 interface SidebarGitHubSelectionState {
     readonly anchorNumber: number | null;
     readonly selectedNumbers: readonly number[];
@@ -203,8 +235,10 @@ export function SidebarGitHubPanel({
     onAddToChat,
     onOpenItem,
     onOpenSettings,
+    onRequestWorkspaceAction,
     projectId,
     selectionResetSignal = 0,
+    workspaceContextKey,
     worktreeId,
 }: {
     readonly filter?: string;
@@ -214,8 +248,12 @@ export function SidebarGitHubPanel({
         request: WorkspaceSurfaceGitHubItemOpenRequest,
     ) => void;
     readonly onOpenSettings: () => void;
+    readonly onRequestWorkspaceAction?: (
+        request: WorkspaceSurfaceActionRequest,
+    ) => void;
     readonly projectId: string | null;
     readonly selectionResetSignal?: number;
+    readonly workspaceContextKey?: string | null;
     readonly worktreeId: string | null;
 }) {
     const snapshot = useGitStore((state) =>
@@ -690,6 +728,22 @@ export function SidebarGitHubPanel({
                 ref: repoRef,
                 worktreeId,
             };
+            if (
+                onRequestWorkspaceAction &&
+                projectId &&
+                workspaceContextKey
+            ) {
+                onRequestWorkspaceAction({
+                    contextKey: workspaceContextKey,
+                    itemKind: "issue",
+                    itemNumber: issueNumber,
+                    kind: "github-item",
+                    projectId,
+                    ref: repoRef,
+                    worktreeId,
+                });
+                return;
+            }
             if (onOpenItem) {
                 onOpenItem(input);
                 return;
@@ -701,7 +755,15 @@ export function SidebarGitHubPanel({
                 worktreeId,
             });
         },
-        [onOpenItem, openGitHubIssueTab, projectId, repoRef, worktreeId],
+        [
+            onOpenItem,
+            onRequestWorkspaceAction,
+            openGitHubIssueTab,
+            projectId,
+            repoRef,
+            workspaceContextKey,
+            worktreeId,
+        ],
     );
     const openPullRequestTab = useCallback(
         (pullRequestNumber: number) => {
@@ -715,6 +777,22 @@ export function SidebarGitHubPanel({
                 ref: repoRef,
                 worktreeId,
             };
+            if (
+                onRequestWorkspaceAction &&
+                projectId &&
+                workspaceContextKey
+            ) {
+                onRequestWorkspaceAction({
+                    contextKey: workspaceContextKey,
+                    itemKind: "pull_request",
+                    itemNumber: pullRequestNumber,
+                    kind: "github-item",
+                    projectId,
+                    ref: repoRef,
+                    worktreeId,
+                });
+                return;
+            }
             if (onOpenItem) {
                 onOpenItem(input);
                 return;
@@ -726,7 +804,15 @@ export function SidebarGitHubPanel({
                 worktreeId,
             });
         },
-        [onOpenItem, openGitHubPullRequestTab, projectId, repoRef, worktreeId],
+        [
+            onOpenItem,
+            onRequestWorkspaceAction,
+            openGitHubPullRequestTab,
+            projectId,
+            repoRef,
+            workspaceContextKey,
+            worktreeId,
+        ],
     );
     const openLabelPicker = useCallback(
         (
@@ -748,7 +834,33 @@ export function SidebarGitHubPanel({
     );
     const addGitHubItemsToChat = useCallback(
         (options: { readonly forceNewChat: boolean }) => {
-            if (!repoRef || !onAddToChat || contextItemCount === 0) {
+            if (!repoRef || contextItemCount === 0) {
+                return;
+            }
+
+            if (
+                onRequestWorkspaceAction &&
+                projectId &&
+                workspaceContextKey
+            ) {
+                const sourceItems =
+                    kind === "issues" ? contextIssues : contextPullRequests;
+                onRequestWorkspaceAction(
+                    createSidebarGitHubAddToChatSurfaceAction({
+                        contextKey: workspaceContextKey,
+                        forceNewChat: options.forceNewChat,
+                        itemKind:
+                            kind === "issues" ? "issue" : "pull_request",
+                        items: sourceItems,
+                        projectId,
+                        ref: repoRef,
+                        worktreeId,
+                    }),
+                );
+                return;
+            }
+
+            if (!onAddToChat) {
                 return;
             }
 
@@ -787,8 +899,10 @@ export function SidebarGitHubPanel({
             contextPullRequests,
             kind,
             onAddToChat,
+            onRequestWorkspaceAction,
             projectId,
             repoRef,
+            workspaceContextKey,
             worktreeId,
         ],
     );
@@ -1021,6 +1135,18 @@ export function SidebarGitHubPanel({
             worktreeId,
         };
 
+        if (onRequestWorkspaceAction && workspaceContextKey) {
+            onRequestWorkspaceAction({
+                contextKey: workspaceContextKey,
+                kind: "github-list",
+                listKind: kind,
+                projectId,
+                ref: repoRef,
+                worktreeId,
+            });
+            return;
+        }
+
         if (kind === "issues") {
             void openGitHubIssuesTab(input);
             return;
@@ -1029,10 +1155,12 @@ export function SidebarGitHubPanel({
         void openGitHubPullRequestsTab(input);
     }, [
         kind,
+        onRequestWorkspaceAction,
         openGitHubIssuesTab,
         openGitHubPullRequestsTab,
         projectId,
         repoRef,
+        workspaceContextKey,
         worktreeId,
     ]);
 

--- a/src/renderer/src/components/sidebar/SidebarGitPanel.test.ts
+++ b/src/renderer/src/components/sidebar/SidebarGitPanel.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { createSidebarGitSurfaceAction } from "./SidebarGitPanel";
+
+describe("createSidebarGitSurfaceAction", () => {
+    it("builds file, history, and review actions for the active context", () => {
+        const context = {
+            contextKey: "project-1::__primary__",
+            projectId: "project-1",
+            worktreeId: null,
+        } as const;
+
+        expect(
+            createSidebarGitSurfaceAction({
+                ...context,
+                kind: "file",
+                relativePath: "src/index.ts",
+            }),
+        ).toEqual({
+            ...context,
+            kind: "file",
+            origin: "git",
+            relativePath: "src/index.ts",
+        });
+        expect(
+            createSidebarGitSurfaceAction({
+                ...context,
+                kind: "git-history",
+            }),
+        ).toEqual({ ...context, kind: "git-history" });
+        expect(
+            createSidebarGitSurfaceAction({
+                ...context,
+                kind: "git-worktree-diff",
+            }),
+        ).toEqual({ ...context, kind: "git-worktree-diff" });
+    });
+});

--- a/src/renderer/src/components/sidebar/SidebarGitPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitPanel.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 
-import type { GitChangeEntry, GitRepositorySnapshot } from "@shared/ipc";
+import type {
+    GitChangeEntry,
+    GitRepositorySnapshot,
+    WorkspaceSurfaceActionRequest,
+} from "@shared/ipc";
 
 import {
     buildGitChangeGroups,
@@ -23,13 +27,40 @@ function getContextKey(projectId: string, worktreeId: string | null): string {
     return getGitContextKey(projectId, worktreeId);
 }
 
+export function createSidebarGitSurfaceAction(
+    input:
+        | {
+              readonly contextKey: string;
+              readonly kind: "file";
+              readonly projectId: string;
+              readonly relativePath: string;
+              readonly worktreeId: string | null;
+          }
+        | {
+              readonly contextKey: string;
+              readonly kind: "git-history" | "git-worktree-diff";
+              readonly projectId: string;
+              readonly worktreeId: string | null;
+          },
+): WorkspaceSurfaceActionRequest {
+    return input.kind === "file"
+        ? { ...input, origin: "git" }
+        : input;
+}
+
 export function SidebarGitPanel({
     filter,
+    onRequestWorkspaceAction,
     projectId,
+    workspaceContextKey,
     worktreeId,
 }: {
     readonly filter?: string;
+    readonly onRequestWorkspaceAction?: (
+        request: WorkspaceSurfaceActionRequest,
+    ) => void;
     readonly projectId: string;
+    readonly workspaceContextKey?: string | null;
     readonly worktreeId: string | null;
 }) {
     const contextKey = getContextKey(projectId, worktreeId);
@@ -217,10 +248,26 @@ export function SidebarGitPanel({
     const handleNodeClick = useCallback(
         (node: GitTreeNode) => {
             if (node.kind === "file") {
+                if (onRequestWorkspaceAction && workspaceContextKey) {
+                    onRequestWorkspaceAction(createSidebarGitSurfaceAction({
+                        contextKey: workspaceContextKey,
+                        kind: "file",
+                        projectId,
+                        relativePath: node.path,
+                        worktreeId,
+                    }));
+                    return;
+                }
                 void openFileTab(projectId, node.path, worktreeId);
             }
         },
-        [openFileTab, projectId, worktreeId],
+        [
+            onRequestWorkspaceAction,
+            openFileTab,
+            projectId,
+            workspaceContextKey,
+            worktreeId,
+        ],
     );
 
     const handleToggleGroup = useCallback(
@@ -245,13 +292,47 @@ export function SidebarGitPanel({
     }, [commitChanges, commitMessage, projectId, worktreeId]);
 
     const handleOpenHistory = useCallback(
-        () => void openGitTab(projectId, worktreeId),
-        [openGitTab, projectId, worktreeId],
+        () => {
+            if (onRequestWorkspaceAction && workspaceContextKey) {
+                onRequestWorkspaceAction(createSidebarGitSurfaceAction({
+                    contextKey: workspaceContextKey,
+                    kind: "git-history",
+                    projectId,
+                    worktreeId,
+                }));
+                return;
+            }
+            void openGitTab(projectId, worktreeId);
+        },
+        [
+            onRequestWorkspaceAction,
+            openGitTab,
+            projectId,
+            workspaceContextKey,
+            worktreeId,
+        ],
     );
 
     const handleReviewChanges = useCallback(
-        () => void openGitWorktreeDiffTab(projectId, worktreeId),
-        [openGitWorktreeDiffTab, projectId, worktreeId],
+        () => {
+            if (onRequestWorkspaceAction && workspaceContextKey) {
+                onRequestWorkspaceAction(createSidebarGitSurfaceAction({
+                    contextKey: workspaceContextKey,
+                    kind: "git-worktree-diff",
+                    projectId,
+                    worktreeId,
+                }));
+                return;
+            }
+            void openGitWorktreeDiffTab(projectId, worktreeId);
+        },
+        [
+            onRequestWorkspaceAction,
+            openGitWorktreeDiffTab,
+            projectId,
+            workspaceContextKey,
+            worktreeId,
+        ],
     );
 
     const renderNodeMeta = useCallback(

--- a/src/renderer/src/components/sidebar/SidebarGitPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitPanel.tsx
@@ -248,7 +248,10 @@ export function SidebarGitPanel({
     const handleNodeClick = useCallback(
         (node: GitTreeNode) => {
             if (node.kind === "file") {
-                if (onRequestWorkspaceAction && workspaceContextKey) {
+                if (onRequestWorkspaceAction) {
+                    if (!workspaceContextKey) {
+                        return;
+                    }
                     onRequestWorkspaceAction(createSidebarGitSurfaceAction({
                         contextKey: workspaceContextKey,
                         kind: "file",
@@ -293,7 +296,10 @@ export function SidebarGitPanel({
 
     const handleOpenHistory = useCallback(
         () => {
-            if (onRequestWorkspaceAction && workspaceContextKey) {
+            if (onRequestWorkspaceAction) {
+                if (!workspaceContextKey) {
+                    return;
+                }
                 onRequestWorkspaceAction(createSidebarGitSurfaceAction({
                     contextKey: workspaceContextKey,
                     kind: "git-history",
@@ -315,7 +321,10 @@ export function SidebarGitPanel({
 
     const handleReviewChanges = useCallback(
         () => {
-            if (onRequestWorkspaceAction && workspaceContextKey) {
+            if (onRequestWorkspaceAction) {
+                if (!workspaceContextKey) {
+                    return;
+                }
                 onRequestWorkspaceAction(createSidebarGitSurfaceAction({
                     contextKey: workspaceContextKey,
                     kind: "git-worktree-diff",

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -131,6 +131,7 @@ export const IPC_CHANNELS = {
     activateWorkspaceSurface: "workspace:activate-surface",
     captureWorkspaceSurfaceContext: "workspace:capture-surface-context",
     dispatchWorkspaceSurfaceDrag: "workspace:dispatch-surface-drag",
+    dispatchWorkspaceSurfaceAction: "workspace:dispatch-surface-action",
     openWorkspaceSurfaceGitHubItem: "workspace:open-surface-github-item",
     notifyWorkspaceSurfaceFocused: "workspace:notify-surface-focused",
     requestWorkspaceSurfaceContext: "workspace:request-surface-context",
@@ -205,6 +206,7 @@ export const IPC_EVENTS = {
     workspaceSurfaceFocused: "workspace:surface-focused",
     workspaceSurfaceContextRequested: "workspace:surface-context-requested",
     workspaceSurfaceDrag: "workspace:surface-drag",
+    workspaceSurfaceActionRequested: "workspace:surface-action-requested",
     workspaceSurfaceGitHubItemOpenRequested:
         "workspace:surface-github-item-open-requested",
     workspaceSurfaceGitScopeMenuRequested:
@@ -2177,6 +2179,90 @@ export interface WorkspaceSurfaceContextRequest {
     readonly worktreeId?: string | null;
 }
 
+interface WorkspaceSurfaceActionContext {
+    readonly contextKey: WorkspaceContextKey;
+    readonly projectId: string;
+    readonly worktreeId: string | null;
+}
+
+export interface WorkspaceSurfaceGitHubComposerItem {
+    readonly number: number;
+    readonly title: string;
+    readonly url: string;
+}
+
+export type WorkspaceSurfaceActionRequest = WorkspaceSurfaceActionContext &
+    (
+        | {
+              readonly kind: "file";
+              readonly origin: "git" | "quick-create" | "tree";
+              readonly relativePath: string;
+          }
+        | {
+              readonly kind: "git-history" | "git-worktree-diff";
+          }
+        | {
+              readonly kind: "chat-session";
+              readonly runtimeId: AiRuntimeId;
+              readonly sessionId: string;
+              readonly sessionProjectId: string | null;
+              readonly sessionWorktreeId: string | null;
+              readonly title: string;
+          }
+        | {
+              readonly kind: "chat-history";
+          }
+        | {
+              readonly kind: "new-chat";
+              readonly runtimeId: AiRuntimeId;
+          }
+        | {
+              readonly kind: "focus-terminal";
+              readonly terminalId: string;
+          }
+        | {
+              readonly kind: "new-claude-terminal";
+          }
+        | {
+              readonly kind: "github-list";
+              readonly listKind: "issues" | "pull_requests";
+              readonly ref: GitHubRepositoryRef;
+          }
+        | {
+              readonly itemKind: "issue" | "pull_request";
+              readonly itemNumber: number;
+              readonly kind: "github-item";
+              readonly ref: GitHubRepositoryRef;
+          }
+        | {
+              readonly files: readonly {
+                  readonly name: string;
+                  readonly relativePath: string;
+              }[];
+              readonly forceNewChat: boolean;
+              readonly kind: "add-files-to-chat";
+          }
+        | {
+              readonly forceNewChat: boolean;
+              readonly itemKind: "issue" | "pull_request";
+              readonly items: readonly WorkspaceSurfaceGitHubComposerItem[];
+              readonly kind: "add-github-items-to-chat";
+              readonly ref: GitHubRepositoryRef;
+          }
+    );
+
+export type WorkspaceSurfaceActionDeliveryFailureReason =
+    | "inactive-context"
+    | "invalid-context"
+    | "missing-surface";
+
+export type WorkspaceSurfaceActionDeliveryResult =
+    | { readonly delivered: true }
+    | {
+          readonly delivered: false;
+          readonly reason: WorkspaceSurfaceActionDeliveryFailureReason;
+      };
+
 export interface WorkspaceSurfaceGitHubItemOpenRequest {
     readonly itemKind: "issue" | "pull_request";
     readonly itemNumber: number;
@@ -3312,6 +3398,9 @@ export interface ComandoApi {
     dispatchWorkspaceSurfaceDrag: (
         event: WorkspaceSurfaceDragEvent,
     ) => Promise<void>;
+    dispatchWorkspaceSurfaceAction: (
+        request: WorkspaceSurfaceActionRequest,
+    ) => Promise<WorkspaceSurfaceActionDeliveryResult>;
     openWorkspaceSurfaceGitHubItem: (
         input: WorkspaceSurfaceGitHubItemOpenRequest,
     ) => Promise<void>;
@@ -3456,6 +3545,9 @@ export interface ComandoApi {
     ) => () => void;
     onWorkspaceSurfaceDrag: (
         listener: (event: WorkspaceSurfaceDragEvent) => void,
+    ) => () => void;
+    onWorkspaceSurfaceActionRequested: (
+        listener: (request: WorkspaceSurfaceActionRequest) => void,
     ) => () => void;
     onWorkspaceSurfaceGitHubItemOpenRequested: (
         listener: (input: WorkspaceSurfaceGitHubItemOpenRequest) => void,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -132,6 +132,8 @@ export const IPC_CHANNELS = {
     captureWorkspaceSurfaceContext: "workspace:capture-surface-context",
     dispatchWorkspaceSurfaceDrag: "workspace:dispatch-surface-drag",
     dispatchWorkspaceSurfaceAction: "workspace:dispatch-surface-action",
+    claimWorkspaceSurfaceAction: "workspace:claim-surface-action",
+    completeWorkspaceSurfaceAction: "workspace:complete-surface-action",
     notifyWorkspaceSurfaceReady: "workspace:notify-surface-ready",
     revealWorkspaceSurfaceFileInHostTree:
         "workspace:reveal-surface-file-in-host-tree",
@@ -209,6 +211,7 @@ export const IPC_EVENTS = {
     workspaceSurfaceContextRequested: "workspace:surface-context-requested",
     workspaceSurfaceDrag: "workspace:surface-drag",
     workspaceSurfaceActionRequested: "workspace:surface-action-requested",
+    workspaceSurfaceActionStatus: "workspace:surface-action-status",
     workspaceSurfaceFileRevealRequested:
         "workspace:surface-file-reveal-requested",
     workspaceSurfaceGitScopeMenuRequested:
@@ -2259,6 +2262,23 @@ export type WorkspaceSurfaceActionRequest = WorkspaceSurfaceActionContext &
           }
     );
 
+export interface WorkspaceSurfaceActionEnvelope {
+    readonly actionId: string;
+    readonly request: WorkspaceSurfaceActionRequest;
+}
+
+export interface WorkspaceSurfaceActionCompletion {
+    readonly actionId: string;
+    readonly error?: string;
+    readonly status: "completed" | "failed";
+}
+
+export interface WorkspaceSurfaceActionStatus {
+    readonly actionId: string;
+    readonly message?: string;
+    readonly status: "completed" | "failed" | "rejected";
+}
+
 export type WorkspaceSurfaceActionDeliveryFailureReason =
     | "inactive-context"
     | "invalid-context"
@@ -2270,6 +2290,14 @@ export type WorkspaceSurfaceActionDeliveryResult =
           readonly delivered: false;
           readonly reason: WorkspaceSurfaceActionDeliveryFailureReason;
       };
+
+export type WorkspaceSurfaceActionDispatchResult =
+    | {
+          readonly actionId: string;
+          readonly delivered: true;
+          readonly state: "queued" | "sent";
+      }
+    | Extract<WorkspaceSurfaceActionDeliveryResult, { readonly delivered: false }>;
 
 export interface WorkspaceContextMenuInput {
     readonly canCopyFullPath: boolean;
@@ -3400,7 +3428,11 @@ export interface ComandoApi {
     ) => Promise<void>;
     dispatchWorkspaceSurfaceAction: (
         request: WorkspaceSurfaceActionRequest,
-    ) => Promise<WorkspaceSurfaceActionDeliveryResult>;
+    ) => Promise<WorkspaceSurfaceActionDispatchResult>;
+    claimWorkspaceSurfaceAction: (actionId: string) => Promise<boolean>;
+    completeWorkspaceSurfaceAction: (
+        completion: WorkspaceSurfaceActionCompletion,
+    ) => Promise<void>;
     notifyWorkspaceSurfaceReady: () => Promise<void>;
     revealWorkspaceSurfaceFileInHostTree: (
         request: WorkspaceSurfaceFileRevealRequest,
@@ -3548,7 +3580,10 @@ export interface ComandoApi {
         listener: (event: WorkspaceSurfaceDragEvent) => void,
     ) => () => void;
     onWorkspaceSurfaceActionRequested: (
-        listener: (request: WorkspaceSurfaceActionRequest) => void,
+        listener: (envelope: WorkspaceSurfaceActionEnvelope) => void,
+    ) => () => void;
+    onWorkspaceSurfaceActionStatus: (
+        listener: (status: WorkspaceSurfaceActionStatus) => void,
     ) => () => void;
     onWorkspaceSurfaceFileRevealRequested: (
         listener: (request: WorkspaceSurfaceFileRevealRequest) => void,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -132,7 +132,6 @@ export const IPC_CHANNELS = {
     captureWorkspaceSurfaceContext: "workspace:capture-surface-context",
     dispatchWorkspaceSurfaceDrag: "workspace:dispatch-surface-drag",
     dispatchWorkspaceSurfaceAction: "workspace:dispatch-surface-action",
-    openWorkspaceSurfaceGitHubItem: "workspace:open-surface-github-item",
     notifyWorkspaceSurfaceFocused: "workspace:notify-surface-focused",
     requestWorkspaceSurfaceContext: "workspace:request-surface-context",
     openWorkspaceSurfaceGitScopeMenu: "workspace:open-surface-git-scope-menu",
@@ -207,8 +206,6 @@ export const IPC_EVENTS = {
     workspaceSurfaceContextRequested: "workspace:surface-context-requested",
     workspaceSurfaceDrag: "workspace:surface-drag",
     workspaceSurfaceActionRequested: "workspace:surface-action-requested",
-    workspaceSurfaceGitHubItemOpenRequested:
-        "workspace:surface-github-item-open-requested",
     workspaceSurfaceGitScopeMenuRequested:
         "workspace:surface-git-scope-menu-requested",
     workspaceSurfaceProjectMenuRequested: "workspace:surface-project-menu-requested",
@@ -2263,14 +2260,6 @@ export type WorkspaceSurfaceActionDeliveryResult =
           readonly reason: WorkspaceSurfaceActionDeliveryFailureReason;
       };
 
-export interface WorkspaceSurfaceGitHubItemOpenRequest {
-    readonly itemKind: "issue" | "pull_request";
-    readonly itemNumber: number;
-    readonly projectId: string | null;
-    readonly ref: GitHubRepositoryRef;
-    readonly worktreeId: string | null;
-}
-
 export interface WorkspaceContextMenuInput {
     readonly canCopyFullPath: boolean;
     readonly x: number;
@@ -3401,9 +3390,6 @@ export interface ComandoApi {
     dispatchWorkspaceSurfaceAction: (
         request: WorkspaceSurfaceActionRequest,
     ) => Promise<WorkspaceSurfaceActionDeliveryResult>;
-    openWorkspaceSurfaceGitHubItem: (
-        input: WorkspaceSurfaceGitHubItemOpenRequest,
-    ) => Promise<void>;
     notifyWorkspaceSurfaceFocused: () => Promise<void>;
     onWorkspaceSurfaceSnapshotRequested: (
         listener: () => WorkspaceNavigationSnapshot,
@@ -3548,9 +3534,6 @@ export interface ComandoApi {
     ) => () => void;
     onWorkspaceSurfaceActionRequested: (
         listener: (request: WorkspaceSurfaceActionRequest) => void,
-    ) => () => void;
-    onWorkspaceSurfaceGitHubItemOpenRequested: (
-        listener: (input: WorkspaceSurfaceGitHubItemOpenRequest) => void,
     ) => () => void;
     onWorkspaceSurfaceGitScopeMenuRequested: (
         listener: (anchor: { readonly width: number; readonly x: number }) => void,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -132,6 +132,8 @@ export const IPC_CHANNELS = {
     captureWorkspaceSurfaceContext: "workspace:capture-surface-context",
     dispatchWorkspaceSurfaceDrag: "workspace:dispatch-surface-drag",
     dispatchWorkspaceSurfaceAction: "workspace:dispatch-surface-action",
+    revealWorkspaceSurfaceFileInHostTree:
+        "workspace:reveal-surface-file-in-host-tree",
     notifyWorkspaceSurfaceFocused: "workspace:notify-surface-focused",
     requestWorkspaceSurfaceContext: "workspace:request-surface-context",
     openWorkspaceSurfaceGitScopeMenu: "workspace:open-surface-git-scope-menu",
@@ -206,6 +208,8 @@ export const IPC_EVENTS = {
     workspaceSurfaceContextRequested: "workspace:surface-context-requested",
     workspaceSurfaceDrag: "workspace:surface-drag",
     workspaceSurfaceActionRequested: "workspace:surface-action-requested",
+    workspaceSurfaceFileRevealRequested:
+        "workspace:surface-file-reveal-requested",
     workspaceSurfaceGitScopeMenuRequested:
         "workspace:surface-git-scope-menu-requested",
     workspaceSurfaceProjectMenuRequested: "workspace:surface-project-menu-requested",
@@ -2176,10 +2180,16 @@ export interface WorkspaceSurfaceContextRequest {
     readonly worktreeId?: string | null;
 }
 
-interface WorkspaceSurfaceActionContext {
+export interface WorkspaceSurfaceActionContext {
     readonly contextKey: WorkspaceContextKey;
     readonly projectId: string;
     readonly worktreeId: string | null;
+}
+
+/** A request emitted by a workspace surface to reveal its active file in the host sidebar. */
+export interface WorkspaceSurfaceFileRevealRequest
+    extends WorkspaceSurfaceActionContext {
+    readonly relativePath: string;
 }
 
 export interface WorkspaceSurfaceGitHubComposerItem {
@@ -3390,6 +3400,9 @@ export interface ComandoApi {
     dispatchWorkspaceSurfaceAction: (
         request: WorkspaceSurfaceActionRequest,
     ) => Promise<WorkspaceSurfaceActionDeliveryResult>;
+    revealWorkspaceSurfaceFileInHostTree: (
+        request: WorkspaceSurfaceFileRevealRequest,
+    ) => Promise<WorkspaceSurfaceActionDeliveryResult>;
     notifyWorkspaceSurfaceFocused: () => Promise<void>;
     onWorkspaceSurfaceSnapshotRequested: (
         listener: () => WorkspaceNavigationSnapshot,
@@ -3534,6 +3547,9 @@ export interface ComandoApi {
     ) => () => void;
     onWorkspaceSurfaceActionRequested: (
         listener: (request: WorkspaceSurfaceActionRequest) => void,
+    ) => () => void;
+    onWorkspaceSurfaceFileRevealRequested: (
+        listener: (request: WorkspaceSurfaceFileRevealRequest) => void,
     ) => () => void;
     onWorkspaceSurfaceGitScopeMenuRequested: (
         listener: (anchor: { readonly width: number; readonly x: number }) => void,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -132,6 +132,7 @@ export const IPC_CHANNELS = {
     captureWorkspaceSurfaceContext: "workspace:capture-surface-context",
     dispatchWorkspaceSurfaceDrag: "workspace:dispatch-surface-drag",
     dispatchWorkspaceSurfaceAction: "workspace:dispatch-surface-action",
+    notifyWorkspaceSurfaceReady: "workspace:notify-surface-ready",
     revealWorkspaceSurfaceFileInHostTree:
         "workspace:reveal-surface-file-in-host-tree",
     notifyWorkspaceSurfaceFocused: "workspace:notify-surface-focused",
@@ -3400,6 +3401,7 @@ export interface ComandoApi {
     dispatchWorkspaceSurfaceAction: (
         request: WorkspaceSurfaceActionRequest,
     ) => Promise<WorkspaceSurfaceActionDeliveryResult>;
+    notifyWorkspaceSurfaceReady: () => Promise<void>;
     revealWorkspaceSurfaceFileInHostTree: (
         request: WorkspaceSurfaceFileRevealRequest,
     ) => Promise<WorkspaceSurfaceActionDeliveryResult>;


### PR DESCRIPTION
## Summary

- Introduce one validated host-to-surface action contract with explicit context ownership and delivery results.
- Route Files, Git, Agents, Claude Code terminals, GitHub, and Add to Chat actions to the active workspace surface.
- Remove the dedicated GitHub item bridge and cover routing across two persistent surfaces.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test` — 250 files, 2288 passed, 1 skipped
- `git diff --check`