### PR TITLE
Fix workspace switching race

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -230,6 +230,10 @@ import type { WorkspaceGateway } from "@main/workspace/service";
 import { windowRegistry } from "@main/windows/registry";
 import { workspaceSurfaceManager } from "@main/workspace/surface-manager";
 import {
+    activateWorkspaceSurfaceAndNotifyHost,
+    persistWorkspaceSurfaceSnapshot,
+} from "@main/workspace/surface-snapshot-persistence";
+import {
     isWorkspaceSurfaceActionRequest,
     isWorkspaceSurfaceActionCompletion,
     isWorkspaceSurfaceFileRevealRequest,
@@ -1793,21 +1797,21 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             const normalizedSnapshot = normalizeWorkspaceNavigationSnapshot(
                 snapshot,
             ).snapshot;
-            const surfaceUpdate = workspaceSurfaceManager.mergeSurfaceSnapshot(
-                event.sender,
-                normalizedSnapshot,
-            );
-            if (surfaceUpdate) {
-                await options.workspaceService.saveSnapshot(
-                    context.workspaceId!,
-                    surfaceUpdate.snapshot,
-                );
-                workspaceSurfaceManager
-                    .getHostWebContents(surfaceUpdate.hostWindowId)
-                    ?.send(
-                        IPC_EVENTS.workspaceSurfaceSnapshotUpdated,
-                        surfaceUpdate.snapshot,
-                    );
+            if (
+                await persistWorkspaceSurfaceSnapshot({
+                    manager: workspaceSurfaceManager,
+                    saveSnapshot: (workspaceId, nextSnapshot) =>
+                        Promise.resolve(
+                            options.workspaceService.saveSnapshot(
+                                workspaceId,
+                                nextSnapshot,
+                            ),
+                        ),
+                    sender: event.sender,
+                    snapshot: normalizedSnapshot,
+                    workspaceId: context.workspaceId!,
+                })
+            ) {
                 return;
             }
             if (workspaceSurfaceManager.isSurface(event.sender)) {
@@ -2017,7 +2021,13 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             if (workspaceSurfaceManager.isSurface(event.sender)) {
                 return;
             }
-            if (!workspaceSurfaceManager.activate(context.windowId, contextKey)) {
+            if (
+                !activateWorkspaceSurfaceAndNotifyHost({
+                    contextKey,
+                    hostWindowId: context.windowId,
+                    manager: workspaceSurfaceManager,
+                })
+            ) {
                 return;
             }
             const activeContext = workspaceSurfaceManager.getActiveContext(

--- a/src/main/workspace/surface-snapshot-persistence.test.ts
+++ b/src/main/workspace/surface-snapshot-persistence.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+import type { WebContents } from "electron";
+
+import { IPC_EVENTS } from "@shared/ipc";
+import type { WorkspaceNavigationSnapshot } from "@shared/ipc";
+
+import {
+    activateWorkspaceSurfaceAndNotifyHost,
+    persistWorkspaceSurfaceSnapshot,
+} from "./surface-snapshot-persistence";
+
+describe("activateWorkspaceSurfaceAndNotifyHost", () => {
+    it("publishes the authoritative snapshot produced by main activation", () => {
+        const contextB = "project-b::__primary__";
+        const snapshotB = createSnapshot(contextB);
+        const send = vi.fn();
+        let activeSnapshot = createSnapshot("project-a::__primary__");
+        const manager = {
+            activate: vi.fn((_hostWindowId: string, contextKey: string) => {
+                activeSnapshot = createSnapshot(contextKey);
+                return true;
+            }),
+            getHostSnapshotForWindow: vi.fn(() => activeSnapshot),
+            getHostWebContents: vi.fn(() => ({ send })),
+        };
+
+        expect(
+            activateWorkspaceSurfaceAndNotifyHost({
+                contextKey: contextB,
+                hostWindowId: "host-1",
+                manager,
+            }),
+        ).toBe(true);
+        expect(send).toHaveBeenCalledWith(
+            IPC_EVENTS.workspaceSurfaceSnapshotUpdated,
+            snapshotB,
+        );
+    });
+});
+
+describe("persistWorkspaceSurfaceSnapshot", () => {
+    it("does not republish a stale active context after navigation wins the race", async () => {
+        const contextA = "project-a::__primary__";
+        const contextB = "project-b::__primary__";
+        const snapshotA = createSnapshot(contextA);
+        const snapshotB = createSnapshot(contextB);
+        const saveGate = createDeferred<void>();
+        const send = vi.fn();
+        let currentHostSnapshot = snapshotA;
+        const manager = {
+            activate: vi.fn((contextKey: string) => {
+                currentHostSnapshot = createSnapshot(contextKey);
+            }),
+            getHostSnapshotForWindow: vi.fn(() => currentHostSnapshot),
+            getHostWebContents: vi.fn(() => ({ send })),
+            mergeSurfaceSnapshot: vi.fn(() => ({
+                hostWindowId: "host-1",
+                snapshot: snapshotA,
+            })),
+        };
+        const saveSnapshot = vi.fn(() => saveGate.promise);
+
+        const persistence = persistWorkspaceSurfaceSnapshot({
+            manager,
+            saveSnapshot,
+            sender: {} as WebContents,
+            snapshot: snapshotA,
+            workspaceId: "workspace-1",
+        });
+        await vi.waitFor(() => expect(saveSnapshot).toHaveBeenCalledOnce());
+
+        // Navigation can advance while durable persistence is still pending.
+        manager.activate(contextB);
+        saveGate.resolve();
+        await persistence;
+
+        expect(send).toHaveBeenCalledWith(
+            IPC_EVENTS.workspaceSurfaceSnapshotUpdated,
+            snapshotB,
+        );
+    });
+
+    it("publishes the merged snapshot when navigation does not advance", async () => {
+        const snapshot = createSnapshot("project-a::__primary__");
+        const send = vi.fn();
+
+        await persistWorkspaceSurfaceSnapshot({
+            manager: {
+                getHostSnapshotForWindow: vi.fn(() => snapshot),
+                getHostWebContents: vi.fn(() => ({ send })),
+                mergeSurfaceSnapshot: vi.fn(() => ({
+                    hostWindowId: "host-1",
+                    snapshot,
+                })),
+            },
+            saveSnapshot: vi.fn(() => Promise.resolve()),
+            sender: {} as WebContents,
+            snapshot,
+            workspaceId: "workspace-1",
+        });
+
+        expect(send).toHaveBeenCalledWith(
+            IPC_EVENTS.workspaceSurfaceSnapshotUpdated,
+            snapshot,
+        );
+    });
+});
+
+function createSnapshot(activeContextKey: string): WorkspaceNavigationSnapshot {
+    const contextKeys = ["project-a::__primary__", "project-b::__primary__"];
+    return {
+        activeContextKey,
+        contexts: contextKeys.map((key) => ({
+            key,
+            lastActivatedAt: "2026-07-20T00:00:00.000Z",
+            projectId: key.startsWith("project-a") ? "project-a" : "project-b",
+            workspace: {
+                activePaneId: `pane-${key}`,
+                rootNode: {
+                    activeTabId: null,
+                    id: `pane-${key}`,
+                    tabIds: [],
+                    type: "pane",
+                },
+                tabs: [],
+            },
+            worktreeId: null,
+        })),
+        openContextKeys: contextKeys,
+        version: 3,
+    };
+}
+
+function createDeferred<T>(): {
+    readonly promise: Promise<T>;
+    readonly resolve: (value: T | PromiseLike<T>) => void;
+} {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    const promise = new Promise<T>((promiseResolve) => {
+        resolve = promiseResolve;
+    });
+    return { promise, resolve };
+}

--- a/src/main/workspace/surface-snapshot-persistence.ts
+++ b/src/main/workspace/surface-snapshot-persistence.ts
@@ -1,0 +1,81 @@
+import type { WebContents } from "electron";
+
+import { IPC_EVENTS } from "@shared/ipc";
+import type { WorkspaceNavigationSnapshot } from "@shared/ipc";
+
+interface WorkspaceSurfaceHostSnapshotManager {
+    getHostSnapshotForWindow: (
+        hostWindowId: string,
+    ) => WorkspaceNavigationSnapshot | null;
+    getHostWebContents: (
+        hostWindowId: string,
+    ) => Pick<WebContents, "send"> | null;
+}
+
+interface WorkspaceSurfaceSnapshotManager
+    extends WorkspaceSurfaceHostSnapshotManager {
+    mergeSurfaceSnapshot: (
+        webContents: WebContents,
+        snapshot: WorkspaceNavigationSnapshot,
+    ) => {
+        readonly hostWindowId: string;
+        readonly snapshot: WorkspaceNavigationSnapshot;
+    } | null;
+}
+
+export function activateWorkspaceSurfaceAndNotifyHost({
+    contextKey,
+    hostWindowId,
+    manager,
+}: {
+    readonly contextKey: string;
+    readonly hostWindowId: string;
+    readonly manager: WorkspaceSurfaceHostSnapshotManager & {
+        activate: (hostWindowId: string, contextKey: string) => boolean;
+    };
+}): boolean {
+    if (!manager.activate(hostWindowId, contextKey)) {
+        return false;
+    }
+
+    const hostSnapshot = manager.getHostSnapshotForWindow(hostWindowId);
+    if (hostSnapshot) {
+        manager
+            .getHostWebContents(hostWindowId)
+            ?.send(IPC_EVENTS.workspaceSurfaceSnapshotUpdated, hostSnapshot);
+    }
+    return true;
+}
+
+export async function persistWorkspaceSurfaceSnapshot({
+    manager,
+    saveSnapshot,
+    sender,
+    snapshot,
+    workspaceId,
+}: {
+    readonly manager: WorkspaceSurfaceSnapshotManager;
+    readonly saveSnapshot: (
+        workspaceId: string,
+        snapshot: WorkspaceNavigationSnapshot,
+    ) => Promise<void>;
+    readonly sender: WebContents;
+    readonly snapshot: WorkspaceNavigationSnapshot;
+    readonly workspaceId: string;
+}): Promise<boolean> {
+    const surfaceUpdate = manager.mergeSurfaceSnapshot(sender, snapshot);
+    if (!surfaceUpdate) {
+        return false;
+    }
+
+    await saveSnapshot(workspaceId, surfaceUpdate.snapshot);
+    // Persistence may resolve after navigation has advanced to another context.
+    // Publish the manager's current snapshot so an older save cannot navigate back.
+    const latestSnapshot =
+        manager.getHostSnapshotForWindow(surfaceUpdate.hostWindowId) ??
+        surfaceUpdate.snapshot;
+    manager
+        .getHostWebContents(surfaceUpdate.hostWindowId)
+        ?.send(IPC_EVENTS.workspaceSurfaceSnapshotUpdated, latestSnapshot);
+    return true;
+}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -823,16 +823,6 @@ export function App() {
             return;
         }
         return comandoApi.onWorkspaceSurfaceSnapshotUpdated((snapshot) => {
-            const currentContextKey =
-                useWorkspaceStore.getState().activeContextKey;
-            if (
-                snapshot.activeContextKey &&
-                snapshot.activeContextKey !== currentContextKey
-            ) {
-                void comandoApi.activateWorkspaceSurface(
-                    snapshot.activeContextKey,
-                );
-            }
             useWorkspaceStore
                 .getState()
                 .applySurfaceNavigationSnapshot(snapshot);
@@ -4896,6 +4886,7 @@ export function App() {
     const activateWorkspaceContext = (contextKey: string) => {
         if (isWorkspaceHostRenderer) {
             void getComandoApi()?.activateWorkspaceSurface(contextKey);
+            return;
         }
         void useWorkspaceStore.getState().activateContext(contextKey);
     };


### PR DESCRIPTION
## Summary
- make main authoritative for workspace activation
- prevent stale surface saves from restoring the previous workspace
- add deterministic regression coverage

## Testing
- `pnpm test`
- `pnpm run typecheck`
- `pnpm run build:ci`