### PR TITLE
Publish persisted Codex session titles

### DIFF
--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -5273,7 +5273,11 @@ mod tests {
         let event = receiver.recv().unwrap();
         assert_eq!(event.event_name, AI_SESSION_UPDATED_EVENT);
         assert_eq!(event.payload["title"], "Investigate startup crash");
-        assert!(event.payload["updatedAt"].as_str().is_some_and(|value| !value.is_empty()));
+        assert!(
+            event.payload["updatedAt"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty())
+        );
         assert_eq!(
             sessions
                 .lock()

--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -5265,13 +5265,15 @@ mod tests {
             "runtime-parent",
             SessionUpdate::SessionInfoUpdate(
                 agent_client_protocol::schema::v1::SessionInfoUpdate::new()
-                    .title("Investigate startup crash"),
+                    .title("Investigate startup crash")
+                    .updated_at("2026-07-20T12:00:00.000Z"),
             ),
         ));
 
         let event = receiver.recv().unwrap();
         assert_eq!(event.event_name, AI_SESSION_UPDATED_EVENT);
         assert_eq!(event.payload["title"], "Investigate startup crash");
+        assert!(event.payload["updatedAt"].as_str().is_some_and(|value| !value.is_empty()));
         assert_eq!(
             sessions
                 .lock()

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -3163,6 +3163,23 @@ mod tests {
     }
 
     #[test]
+    fn custom_title_remains_the_display_title_after_reloading_history() {
+        let (temp, store) = store();
+        let metadata = metadata("session_1");
+        store.create_session(metadata.clone()).unwrap();
+        store
+            .rename_session(&metadata.session_id, "Manual title".to_string())
+            .unwrap();
+        drop(store);
+
+        let reloaded = AiHistoryStore::new(temp.path()).unwrap();
+        let metadata = reloaded.load_metadata(&metadata.session_id).unwrap();
+
+        assert_eq!(metadata.custom_title.as_deref(), Some("Manual title"));
+        assert_eq!(metadata.display_title(), "Manual title");
+    }
+
+    #[test]
     fn deleting_a_session_removes_its_persisted_subtree() {
         let (_temp, store) = store();
         let parent = metadata("parent");

--- a/src/main/ai/session-core.test.ts
+++ b/src/main/ai/session-core.test.ts
@@ -5,6 +5,7 @@ import type { AiSessionSnapshot } from "@shared/ipc";
 import {
     applyNormalizedSessionCatalogToSnapshot,
     applySessionCatalogToSnapshot,
+    getSessionDisplayTitle,
     isPathInsideRoot,
     isSamePath,
     normalizeAdditionalRoots,
@@ -740,6 +741,7 @@ describe("session-core model reconciliation", () => {
             title: "Manual title",
             updatedAt: "2026-04-23T00:02:00.000Z",
         });
+        expect(getSessionDisplayTitle(updated)).toBe("Manual title");
     });
 
     it("applies runtime titles when the session was not manually renamed", () => {

--- a/vendor/codex-acp/src/codex_agent.rs
+++ b/vendor/codex-acp/src/codex_agent.rs
@@ -50,8 +50,8 @@ use std::{
 };
 use tokio::time::{MissedTickBehavior, interval};
 use tracing::{debug, info, warn};
-use unicode_segmentation::UnicodeSegmentation;
 
+use crate::session_title::stored_session_title;
 use crate::subagents;
 use crate::thread::Thread;
 
@@ -99,7 +99,6 @@ enum SubagentRegistrationState {
 }
 
 const SESSION_LIST_PAGE_SIZE: usize = 25;
-const SESSION_TITLE_MAX_GRAPHEMES: usize = 120;
 const SUBAGENT_NOTIFICATION_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
 fn debug_ai_worker_enabled() -> bool {
@@ -1303,44 +1302,6 @@ fn mcp_server_config_from_acp(
     }
 }
 
-fn truncate_graphemes(text: &str, max_graphemes: usize) -> String {
-    let mut graphemes = text.grapheme_indices(true);
-
-    if let Some((byte_index, _)) = graphemes.nth(max_graphemes) {
-        if max_graphemes >= 3 {
-            let mut truncate_graphemes = text.grapheme_indices(true);
-            if let Some((truncate_byte_index, _)) = truncate_graphemes.nth(max_graphemes - 3) {
-                let truncated = &text[..truncate_byte_index];
-                format!("{truncated}...")
-            } else {
-                text.to_string()
-            }
-        } else {
-            let truncated = &text[..byte_index];
-            truncated.to_string()
-        }
-    } else {
-        text.to_string()
-    }
-}
-
-fn format_session_title(message: &str) -> Option<String> {
-    let normalized = message.replace(['\r', '\n'], " ");
-    let trimmed = normalized.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(truncate_graphemes(trimmed, SESSION_TITLE_MAX_GRAPHEMES))
-    }
-}
-
-fn stored_session_title(name: Option<&str>, preview: &str) -> Option<String> {
-    [name, Some(preview)]
-        .into_iter()
-        .flatten()
-        .find_map(format_session_title)
-}
-
 fn list_session_allowed_sources() -> Vec<SessionSource> {
     vec![
         SessionSource::Cli,
@@ -1379,7 +1340,7 @@ fn stored_thread_matches_list_request(
 }
 
 fn stored_thread_session_info(item: StoredThread) -> SessionInfo {
-    let title = stored_session_title(item.name.as_deref(), &item.preview);
+    let title = stored_session_title(&item);
     let updated_at = item.updated_at.to_rfc3339();
 
     SessionInfo::new(SessionId::new(item.thread_id.to_string()), item.cwd)
@@ -1407,26 +1368,6 @@ mod tests {
         finish_subagent_notification(&states, child_session_id.clone(), true);
 
         assert!(!begin_subagent_notification(&states, &child_session_id));
-    }
-
-    #[test]
-    fn stored_session_title_prefers_thread_name() {
-        assert_eq!(
-            stored_session_title(Some("renamed"), "preview"),
-            Some("renamed".to_string())
-        );
-    }
-
-    #[test]
-    fn stored_session_title_falls_back_to_preview() {
-        assert_eq!(
-            stored_session_title(None, "preview"),
-            Some("preview".to_string())
-        );
-        assert_eq!(
-            stored_session_title(Some("  "), "preview"),
-            Some("preview".to_string())
-        );
     }
 
     #[test]

--- a/vendor/codex-acp/src/codex_agent.rs
+++ b/vendor/codex-acp/src/codex_agent.rs
@@ -388,6 +388,7 @@ impl CodexAgent {
             register_subagent_thread(
                 thread_id,
                 self.thread_manager.clone(),
+                self.thread_store.clone(),
                 self.sessions.clone(),
                 self.session_roots.clone(),
                 self.subagent_registration_states.clone(),
@@ -409,6 +410,7 @@ impl CodexAgent {
         }
 
         let thread_manager = self.thread_manager.clone();
+        let thread_store = self.thread_store.clone();
         let sessions = self.sessions.clone();
         let session_roots = self.session_roots.clone();
         let subagent_registration_states = self.subagent_registration_states.clone();
@@ -431,6 +433,7 @@ impl CodexAgent {
                             if let Err(error) = register_subagent_thread(
                                 thread_id,
                                 thread_manager.clone(),
+                                thread_store.clone(),
                                 sessions.clone(),
                                 session_roots.clone(),
                                 subagent_registration_states.clone(),
@@ -453,6 +456,7 @@ impl CodexAgent {
                                 if let Err(error) = register_subagent_thread(
                                     thread_id,
                                     thread_manager.clone(),
+                                    thread_store.clone(),
                                     sessions.clone(),
                                     session_roots.clone(),
                                     subagent_registration_states.clone(),
@@ -479,6 +483,7 @@ impl CodexAgent {
                             if let Err(error) = register_subagent_thread(
                                 thread_id,
                                 thread_manager.clone(),
+                                thread_store.clone(),
                                 sessions.clone(),
                                 session_roots.clone(),
                                 subagent_registration_states.clone(),
@@ -623,6 +628,7 @@ impl CodexAgent {
 async fn register_subagent_thread(
     child_thread_id: ThreadId,
     thread_manager: Arc<ThreadManager>,
+    thread_store: Arc<dyn ThreadStore>,
     sessions: Arc<Mutex<HashMap<SessionId, Arc<Thread>>>>,
     session_roots: Arc<Mutex<HashMap<SessionId, PathBuf>>>,
     subagent_registration_states: Arc<Mutex<HashMap<SessionId, SubagentRegistrationState>>>,
@@ -650,6 +656,8 @@ async fn register_subagent_thread(
             let thread = Arc::new(Thread::new(
                 registration.child_session_id.clone(),
                 child_thread,
+                thread_store,
+                child_thread_id,
                 auth_manager,
                 models_manager,
                 client_capabilities,
@@ -711,8 +719,9 @@ fn begin_subagent_notification(
 ) -> bool {
     let mut states = states.lock().unwrap();
     match states.get(child_session_id) {
-        Some(SubagentRegistrationState::Notified)
-        | Some(SubagentRegistrationState::Notifying) => false,
+        Some(SubagentRegistrationState::Notified) | Some(SubagentRegistrationState::Notifying) => {
+            false
+        }
         Some(SubagentRegistrationState::Registered) | None => {
             states.insert(
                 child_session_id.clone(),
@@ -904,6 +913,8 @@ impl CodexAgent {
         let thread = Arc::new(Thread::new(
             session_id.clone(),
             thread,
+            self.thread_store.clone(),
+            thread_id,
             self.auth_manager.clone(),
             Arc::new(self.thread_manager.get_models_manager()),
             self.client_capabilities.clone(),
@@ -1003,7 +1014,7 @@ impl CodexAgent {
         let mut config = self.build_session_config(&cwd, mcp_servers)?;
 
         let NewThread {
-            thread_id: _,
+            thread_id,
             thread,
             session_configured,
         } = Box::pin(self.thread_manager.resume_thread_from_rollout(
@@ -1021,6 +1032,8 @@ impl CodexAgent {
         let thread = Arc::new(Thread::new(
             session_id.clone(),
             thread,
+            self.thread_store.clone(),
+            thread_id,
             self.auth_manager.clone(),
             Arc::new(self.thread_manager.get_models_manager()),
             self.client_capabilities.clone(),

--- a/vendor/codex-acp/src/lib.rs
+++ b/vendor/codex-acp/src/lib.rs
@@ -10,6 +10,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tracing_subscriber::EnvFilter;
 
 mod codex_agent;
+mod session_title;
 mod subagents;
 mod thread;
 

--- a/vendor/codex-acp/src/session_title.rs
+++ b/vendor/codex-acp/src/session_title.rs
@@ -1,0 +1,93 @@
+use codex_thread_store::StoredThread;
+use unicode_segmentation::UnicodeSegmentation;
+
+const SESSION_TITLE_MAX_GRAPHEMES: usize = 120;
+
+pub(crate) fn stored_session_title(thread: &StoredThread) -> Option<String> {
+    resolve_session_title(thread.name.as_deref(), &thread.preview)
+}
+
+fn resolve_session_title(name: Option<&str>, preview: &str) -> Option<String> {
+    [name, Some(preview)]
+        .into_iter()
+        .flatten()
+        .find_map(format_session_title)
+}
+
+fn format_session_title(message: &str) -> Option<String> {
+    let normalized = message.replace(['\r', '\n'], " ");
+    let trimmed = normalized.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(truncate_graphemes(trimmed, SESSION_TITLE_MAX_GRAPHEMES))
+    }
+}
+
+fn truncate_graphemes(text: &str, max_graphemes: usize) -> String {
+    let mut graphemes = text.grapheme_indices(true);
+
+    if let Some((byte_index, _)) = graphemes.nth(max_graphemes) {
+        if max_graphemes >= 3 {
+            let mut truncate_graphemes = text.grapheme_indices(true);
+            if let Some((truncate_byte_index, _)) = truncate_graphemes.nth(max_graphemes - 3) {
+                let truncated = &text[..truncate_byte_index];
+                format!("{truncated}...")
+            } else {
+                text.to_string()
+            }
+        } else {
+            let truncated = &text[..byte_index];
+            truncated.to_string()
+        }
+    } else {
+        text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefers_a_non_empty_thread_name_over_preview() {
+        assert_eq!(
+            resolve_session_title(Some("renamed"), "preview"),
+            Some("renamed".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_preview_when_name_is_missing_or_blank() {
+        assert_eq!(
+            resolve_session_title(None, "preview"),
+            Some("preview".to_string())
+        );
+        assert_eq!(
+            resolve_session_title(Some("  "), "preview"),
+            Some("preview".to_string())
+        );
+        assert_eq!(resolve_session_title(Some("  "), "\n\r"), None);
+    }
+
+    #[test]
+    fn normalizes_line_breaks_and_outer_whitespace() {
+        assert_eq!(
+            resolve_session_title(None, "  first line\r\nsecond line  "),
+            Some("first line  second line".to_string())
+        );
+    }
+
+    #[test]
+    fn truncates_composed_graphemes_without_splitting_them() {
+        let grapheme = "e\u{301}";
+        let title = format_session_title(&grapheme.repeat(121)).expect("title should be present");
+
+        assert!(title.ends_with("..."));
+        assert_eq!(title.graphemes(true).count(), SESSION_TITLE_MAX_GRAPHEMES);
+        assert_eq!(
+            title.strip_suffix("..."),
+            Some(grapheme.repeat(117).as_str())
+        );
+    }
+}

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -37,6 +37,7 @@ use codex_login::auth::AuthManager;
 use codex_models_manager::manager::{ModelsManager, RefreshStrategy};
 use codex_protocol::review_format::format_review_findings_block;
 use codex_protocol::{
+    ThreadId,
     approvals::{
         ElicitationRequest, ElicitationRequestEvent, GuardianAssessmentAction,
         GuardianCommandSource,
@@ -85,6 +86,7 @@ use codex_protocol::{
     user_input::UserInput,
 };
 use codex_shell_command::parse_command::parse_command;
+use codex_thread_store::{ReadThreadParams, ThreadStore};
 use codex_utils_approval_presets::{ApprovalPreset, builtin_approval_presets};
 use heck::ToTitleCase;
 use itertools::Itertools;
@@ -94,6 +96,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
+use crate::session_title::stored_session_title;
 use crate::subagents::{self, SubagentProjection};
 
 /// Abstraction over the ACP connection for sending notifications and requests
@@ -657,6 +660,8 @@ impl Thread {
     pub fn new(
         session_id: SessionId,
         thread: Arc<dyn CodexThreadImpl>,
+        thread_store: Arc<dyn ThreadStore>,
+        thread_id: ThreadId,
         auth: Arc<AuthManager>,
         models_manager: Arc<dyn ModelsManagerImpl>,
         client_capabilities: Arc<Mutex<ClientCapabilities>>,
@@ -670,6 +675,8 @@ impl Thread {
             auth,
             SessionClient::new(session_id, cx, client_capabilities),
             thread.clone(),
+            thread_store,
+            thread_id,
             models_manager,
             config,
             message_rx,
@@ -3867,6 +3874,12 @@ impl SessionClient {
         ));
     }
 
+    fn send_session_title(&self, title: String, updated_at: String) {
+        self.send_notification(SessionUpdate::SessionInfoUpdate(
+            SessionInfoUpdate::new().title(title).updated_at(updated_at),
+        ));
+    }
+
     /// Send a completed tool call (used for replay and simple cases)
     fn send_completed_tool_call(
         &self,
@@ -3940,6 +3953,10 @@ struct ThreadActor<A> {
     client: SessionClient,
     /// The thread associated with this task.
     thread: Arc<dyn CodexThreadImpl>,
+    /// Store containing the durable metadata for this thread.
+    thread_store: Arc<dyn ThreadStore>,
+    /// Identifier used to look up the durable metadata.
+    thread_id: ThreadId,
     /// The configuration for the thread.
     config: Config,
     /// The models available for this thread.
@@ -3958,6 +3975,8 @@ struct ThreadActor<A> {
     resolution_rx: mpsc::UnboundedReceiver<ThreadMessage>,
     /// Last config options state we emitted to the client, used for deduping updates.
     last_sent_config_options: Option<Vec<SessionConfigOption>>,
+    /// Last persisted title sent during this ACP connection.
+    last_sent_title: Option<String>,
 }
 
 impl<A: Auth> ThreadActor<A> {
@@ -3966,6 +3985,8 @@ impl<A: Auth> ThreadActor<A> {
         auth: A,
         client: SessionClient,
         thread: Arc<dyn CodexThreadImpl>,
+        thread_store: Arc<dyn ThreadStore>,
+        thread_id: ThreadId,
         models_manager: Arc<dyn ModelsManagerImpl>,
         config: Config,
         message_rx: mpsc::UnboundedReceiver<ThreadMessage>,
@@ -3976,6 +3997,8 @@ impl<A: Auth> ThreadActor<A> {
             auth,
             client,
             thread,
+            thread_store,
+            thread_id,
             config,
             models_manager,
             resolution_tx,
@@ -3985,6 +4008,7 @@ impl<A: Auth> ThreadActor<A> {
             message_rx,
             resolution_rx,
             last_sent_config_options: None,
+            last_sent_title: None,
         }
     }
 
@@ -5097,6 +5121,7 @@ impl<A: Auth> ThreadActor<A> {
     }
 
     async fn handle_event(&mut self, Event { id, msg }: Event) {
+        let completed_turn = matches!(&msg, EventMsg::TurnComplete(..));
         if let Some(submission) = self.submissions.get_mut(&id) {
             self.pending_prompt_client_ids_by_submission_id.remove(&id);
             submission.handle_event(&self.client, msg).await;
@@ -5114,6 +5139,42 @@ impl<A: Auth> ThreadActor<A> {
                 self.event_projections.remove(&id);
             }
         }
+
+        if completed_turn {
+            self.maybe_emit_persisted_session_title().await;
+        }
+    }
+
+    async fn maybe_emit_persisted_session_title(&mut self) {
+        // Turn completion is the first point where Codex guarantees the thread metadata is durable.
+        let stored_thread = match self
+            .thread_store
+            .read_thread(ReadThreadParams {
+                thread_id: self.thread_id,
+                include_archived: false,
+                include_history: false,
+            })
+            .await
+        {
+            Ok(thread) => thread,
+            Err(error) => {
+                warn!(
+                    thread_id = %self.thread_id,
+                    "Failed to read persisted session title: {error}"
+                );
+                return;
+            }
+        };
+        let Some(title) = stored_session_title(&stored_thread) else {
+            return;
+        };
+        if self.last_sent_title.as_deref() == Some(title.as_str()) {
+            return;
+        }
+
+        self.client
+            .send_session_title(title.clone(), stored_thread.updated_at.to_rfc3339());
+        self.last_sent_title = Some(title);
     }
 
     fn rebind_raced_steering_prompt(&mut self, active_turn_id: &str, event: &EventMsg) {
@@ -5990,14 +6051,21 @@ mod tests {
     use std::time::Duration;
 
     use agent_client_protocol::schema::{
-        RequestPermissionResponse, SessionConfigKind, SessionConfigSelectOptions, TextContent,
+        MaybeUndefined, RequestPermissionResponse, SessionConfigKind, SessionConfigSelectOptions,
+        TextContent,
     };
     use codex_core::{config::ConfigOverrides, test_support::all_model_presets};
     use codex_protocol::config_types::ModeKind;
-    use codex_protocol::models::AgentMessageInputContent;
+    use codex_protocol::models::{AgentMessageInputContent, BaseInstructions};
     use codex_protocol::{
-        ThreadId,
-        protocol::{EnteredReviewModeEvent, ThreadGoal},
+        SessionId as CodexSessionId, ThreadId,
+        protocol::{
+            EnteredReviewModeEvent, SessionSource, ThreadGoal, ThreadHistoryMode, ThreadMemoryMode,
+        },
+    };
+    use codex_thread_store::{
+        CreateThreadParams, InMemoryThreadStore, ThreadMetadataPatch, ThreadPersistenceMetadata,
+        UpdateThreadMetadataParams,
     };
     use tokio::sync::{Mutex, Notify, mpsc::UnboundedSender};
 
@@ -8163,6 +8231,8 @@ mod tests {
             StubAuth,
             session_client,
             conversation.clone(),
+            Arc::new(InMemoryThreadStore::default()),
+            ThreadId::new(),
             models_manager,
             config,
             message_rx,
@@ -8172,6 +8242,103 @@ mod tests {
 
         let handle = tokio::spawn(actor.spawn());
         Ok((session_id, client, conversation, message_tx, handle))
+    }
+
+    async fn title_store(preview: &str) -> (Arc<InMemoryThreadStore>, ThreadId) {
+        let store = Arc::new(InMemoryThreadStore::default());
+        let thread_id = ThreadId::new();
+        store
+            .create_thread(CreateThreadParams {
+                session_id: CodexSessionId::from_string(&thread_id.to_string())
+                    .expect("valid session id"),
+                thread_id,
+                extra_config: None,
+                forked_from_id: None,
+                parent_thread_id: None,
+                source: SessionSource::Unknown,
+                thread_source: None,
+                originator: "test".to_string(),
+                base_instructions: BaseInstructions::default(),
+                dynamic_tools: Vec::new(),
+                selected_capability_roots: Vec::new(),
+                multi_agent_version: None,
+                history_mode: ThreadHistoryMode::Legacy,
+                initial_window_id: Uuid::now_v7().to_string(),
+                metadata: ThreadPersistenceMetadata {
+                    cwd: None,
+                    model_provider: "test".to_string(),
+                    memory_mode: ThreadMemoryMode::Enabled,
+                },
+            })
+            .await
+            .expect("create persisted thread");
+        store
+            .update_thread_metadata(UpdateThreadMetadataParams {
+                thread_id,
+                include_archived: false,
+                patch: ThreadMetadataPatch {
+                    preview: Some(preview.to_string()),
+                    ..Default::default()
+                },
+            })
+            .await
+            .expect("persist title preview");
+        (store, thread_id)
+    }
+
+    #[tokio::test]
+    async fn turn_completion_emits_each_persisted_title_once() -> anyhow::Result<()> {
+        let (store, thread_id) = title_store("Persisted title").await;
+        let client = Arc::new(StubClient::new());
+        let session_client =
+            SessionClient::with_client(SessionId::new("test"), client.clone(), Arc::default());
+        let config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        let (_message_tx, message_rx) = mpsc::unbounded_channel();
+        let (resolution_tx, resolution_rx) = mpsc::unbounded_channel();
+        let mut actor = ThreadActor::new(
+            StubAuth,
+            session_client,
+            Arc::new(StubCodexThread::new()),
+            store,
+            thread_id,
+            Arc::new(StubModelsManager),
+            config,
+            message_rx,
+            resolution_tx,
+            resolution_rx,
+        );
+        let completed_turn = || Event {
+            id: "turn-1".to_string(),
+            msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                last_agent_message: None,
+                turn_id: "turn-1".to_string(),
+                completed_at: None,
+                duration_ms: None,
+                time_to_first_token_ms: None,
+            }),
+        };
+
+        actor.handle_event(completed_turn()).await;
+        actor.handle_event(completed_turn()).await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let titles = notifications
+            .iter()
+            .filter_map(|notification| match &notification.update {
+                SessionUpdate::SessionInfoUpdate(update) => match update.title.clone() {
+                    MaybeUndefined::Value(title) => Some(title),
+                    MaybeUndefined::Null | MaybeUndefined::Undefined => None,
+                },
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(titles, vec!["Persisted title"]);
+
+        Ok(())
     }
 
     struct StubAuth;
@@ -9240,6 +9407,8 @@ mod tests {
             StubAuth,
             session_client,
             conversation.clone(),
+            Arc::new(InMemoryThreadStore::default()),
+            ThreadId::new(),
             models_manager,
             config,
             message_rx,


### PR DESCRIPTION
## Summary
- publish persisted Codex thread titles after completed turns
- share title normalization between session listing and live ACP updates
- preserve manual chat titles across later runtime updates

## Testing
- `cargo test --locked --manifest-path vendor/codex-acp/Cargo.toml`
- `cargo test -p comando-ai session_info_title_updates_the_registry_used_by_turn_statuses`
- `cargo test -p comando-ai custom_title_remains_the_display_title_after_reloading_history`
- `pnpm exec vitest run src/main/ai/session-core.test.ts src/main/ai/service.prepare.test.ts`