### PR TITLE
feat(markdown): fit preview tables with wide-table scrolling

### DIFF
--- a/src/renderer/src/components/workspace/MarkdownFilePreview.test.tsx
+++ b/src/renderer/src/components/workspace/MarkdownFilePreview.test.tsx
@@ -690,7 +690,7 @@ describe("MarkdownFilePreview", () => {
         expect(markup).toContain('aria-label="Diagram"');
     });
 
-    it("wraps large tables in the horizontal overflow container", () => {
+    it("uses horizontal scrolling for tables wider than the fit-to-width limit", () => {
         const columns = Array.from({ length: 12 }, (_, index) => `Col ${index}`);
         const content = [
             `| ${columns.join(" | ")} |`,
@@ -700,9 +700,46 @@ describe("MarkdownFilePreview", () => {
 
         const markup = renderStaticMarkdownFilePreview({ content });
 
-        expect(markup).toContain("markdown-file-preview__table-wrap");
+        expect(markup).toContain(
+            "markdown-file-preview__table-wrap--wide",
+        );
+        expect(markup).toContain(
+            "--markdown-file-preview-table-columns:12",
+        );
         expect(markup).toContain("<table>");
         expect(markup).toContain("Col 11 value");
+    });
+
+    it("fits Markdown tables to the preview column and wraps cell content", () => {
+        const styles = readMarkdownPreviewStyles();
+        const tableRule =
+            styles.match(/\.markdown-file-preview table\s*\{[^}]*\}/)?.[0] ??
+            "";
+        const cellRule =
+            styles.match(
+                /\.markdown-file-preview th,\s*\.markdown-file-preview td\s*\{[^}]*\}/,
+            )?.[0] ?? "";
+
+        expect(tableRule).toContain("width: 100%");
+        expect(tableRule).toContain("min-width: 0");
+        expect(tableRule).toContain("table-layout: fixed");
+        expect(cellRule).toContain("overflow-wrap: anywhere");
+    });
+
+    it("keeps tables with up to eight columns fit to the preview width", () => {
+        const columns = Array.from({ length: 8 }, (_, index) => `Col ${index}`);
+        const content = [
+            `| ${columns.join(" | ")} |`,
+            `| ${columns.map(() => "---").join(" | ")} |`,
+            `| ${columns.map((column) => `${column} value`).join(" | ")} |`,
+        ].join("\n");
+
+        const markup = renderStaticMarkdownFilePreview({ content });
+
+        expect(markup).toContain("markdown-file-preview__table-wrap");
+        expect(markup).not.toContain(
+            "markdown-file-preview__table-wrap--wide",
+        );
     });
 
     it("keeps rendered Markdown stable when large content rerenders with unchanged content", () => {

--- a/src/renderer/src/components/workspace/MarkdownFilePreview.tsx
+++ b/src/renderer/src/components/workspace/MarkdownFilePreview.tsx
@@ -6,6 +6,7 @@ import {
     isValidElement,
     memo,
     type AnchorHTMLAttributes,
+    type CSSProperties,
     type HTMLAttributes,
     type ImgHTMLAttributes,
     type InputHTMLAttributes,
@@ -150,6 +151,7 @@ function reactNodeToText(node: ReactNode): string {
 
 interface MarkdownAstNode {
     children?: MarkdownAstNode[];
+    tagName?: string;
     type?: string;
 }
 
@@ -402,15 +404,51 @@ function createMarkdownPreviewComponents({
     };
 }
 
-function MarkdownPreviewTable({
-    children,
-    node: _node,
-    ...props
-}: TableHTMLAttributes<HTMLTableElement> & { readonly node?: unknown }) {
-    void _node;
+const MARKDOWN_TABLE_FIT_COLUMN_LIMIT = 8;
+
+function getMarkdownTableColumnCount(node: unknown): number {
+    if (!node || typeof node !== "object") {
+        return 0;
+    }
+
+    const tableNode = node as MarkdownAstNode;
+    const header = tableNode.children?.find(
+        (child) => child.tagName === "thead",
+    );
+    const headerRow = header?.children?.find(
+        (child) => child.tagName === "tr",
+    );
 
     return (
-        <div className="markdown-file-preview__table-wrap">
+        headerRow?.children?.filter((child) => child.tagName === "th")
+            .length ?? 0
+    );
+}
+
+function MarkdownPreviewTable({
+    children,
+    node,
+    ...props
+}: TableHTMLAttributes<HTMLTableElement> & { readonly node?: unknown }) {
+    const columnCount = getMarkdownTableColumnCount(node);
+    const shouldEnableWideTableScroll =
+        columnCount > MARKDOWN_TABLE_FIT_COLUMN_LIMIT;
+    const tableWrapClassName = [
+        "markdown-file-preview__table-wrap",
+        shouldEnableWideTableScroll &&
+            "markdown-file-preview__table-wrap--wide",
+    ]
+        .filter(Boolean)
+        .join(" ");
+    const tableWrapStyle = shouldEnableWideTableScroll
+        ? ({
+              // Reserve a readable width per column before falling back to scroll.
+              "--markdown-file-preview-table-columns": columnCount,
+          } as CSSProperties)
+        : undefined;
+
+    return (
+        <div className={tableWrapClassName} style={tableWrapStyle}>
             <table {...props}>{children}</table>
         </div>
     );

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1475,9 +1475,16 @@ body {
 
 .markdown-file-preview table {
     width: 100%;
-    min-width: max-content;
+    min-width: 0;
     border-collapse: collapse;
     font-size: 0.94em;
+    /* Fixed layout keeps tables within the Markdown preview reading column. */
+    table-layout: fixed;
+}
+
+.markdown-file-preview__table-wrap--wide > table {
+    /* Wide tables keep readable columns and use the wrapper as a scroll surface. */
+    min-width: calc(var(--markdown-file-preview-table-columns) * 9rem);
 }
 
 .markdown-file-preview th,
@@ -1486,6 +1493,8 @@ body {
     border-bottom: 1px solid color-mix(in srgb, var(--color-border) 72%, transparent);
     text-align: left;
     vertical-align: top;
+    /* Long tokens must wrap instead of widening the table beyond the preview. */
+    overflow-wrap: anywhere;
 }
 
 .markdown-file-preview th {


### PR DESCRIPTION
## Summary
- fit Markdown tables to the preview width through eight columns
- retain horizontal scrolling for tables with nine or more columns
- cover both table layouts with preview tests

## Verification
- pnpm exec vitest run src/renderer/src/components/workspace/MarkdownFilePreview.test.tsx
- pnpm exec eslint src/renderer/src/components/workspace/MarkdownFilePreview.tsx src/renderer/src/components/workspace/MarkdownFilePreview.test.tsx
- git diff --check