### PR TITLE
Improve chat streaming stability and transcript performance

### DIFF
--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -231,6 +231,7 @@ impl NativeBackend {
             | "ai_load_transcript_block_metadata"
             | "ai_load_transcript_block"
             | "ai_load_transcript_payload"
+            | "ai_load_transcript_payloads"
             | "ai_get_transcript_storage_state"
             | "ai_load_session_snapshot"
             | "ai_list_session_runtime_mappings"
@@ -364,6 +365,7 @@ impl NativeBackend {
             | "ai_load_transcript_block_metadata"
             | "ai_load_transcript_block"
             | "ai_load_transcript_payload"
+            | "ai_load_transcript_payloads"
             | "ai_get_transcript_storage_state"
             | "ai_load_session_snapshot"
             | "ai_list_session_runtime_mappings"
@@ -2488,6 +2490,29 @@ impl NativeBackend {
                     Ok(payload) => response_only(
                         request.id,
                         serde_json::to_value(payload).expect("AI transcript payload serializes"),
+                    ),
+                    Err(error) => error_only(request.id, error),
+                }
+            }
+            "ai_load_transcript_payloads" => {
+                let input =
+                    match parse_args::<native_ai::NativeAiLoadTranscriptPayloadsInput>(&request) {
+                        Ok(input) => input,
+                        Err(error) => return error_only(request.id, error),
+                    };
+                match self.ai_history_store().and_then(|store| {
+                    store
+                        .load_native_transcript_payloads(
+                            &input.session_id,
+                            &input.payload_refs,
+                            input.max_bytes,
+                        )
+                        .map_err(|error| error.to_native_error())
+                }) {
+                    Ok(payloads) => response_only(
+                        request.id,
+                        serde_json::to_value(payloads)
+                            .expect("AI transcript payload batch serializes"),
                     ),
                     Err(error) => error_only(request.id, error),
                 }

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -6,14 +6,16 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use comando_types::ai::{
-    AI_TRANSCRIPT_BLOCK_CAPABILITY_VERSION, NativeAiCheckpointOpenTranscriptTailInput,
-    NativeAiHistorySessionSummary, NativeAiHistoryStorageHealth, NativeAiListSessionHistoryInput,
+    AI_TRANSCRIPT_BLOCK_CAPABILITY_VERSION, AI_TRANSCRIPT_PAYLOAD_BATCH_MAX_REFS,
+    NativeAiCheckpointOpenTranscriptTailInput, NativeAiHistorySessionSummary,
+    NativeAiHistoryStorageHealth, NativeAiListSessionHistoryInput,
     NativeAiLoadSessionTranscriptPageInput, NativeAiOpenTranscriptTail,
     NativeAiRuntimeSessionMapping, NativeAiSessionSnapshot, NativeAiSessionStatus,
     NativeAiSessionTranscriptPage, NativeAiTranscriptBlock, NativeAiTranscriptBlockMetadata,
     NativeAiTranscriptBlockMetadataOutput, NativeAiTranscriptEntryEnvelope,
     NativeAiTranscriptEntryKind, NativeAiTranscriptEntrySummary, NativeAiTranscriptPayload,
-    NativeAiTranscriptStorageMode, NativeAiTranscriptStorageState,
+    NativeAiTranscriptPayloadsOutput, NativeAiTranscriptStorageMode,
+    NativeAiTranscriptStorageState,
 };
 use comando_types::ids::{ProjectId, RuntimeId, RuntimeSessionId, SessionId, WorktreeId};
 use rusqlite::{Connection, OptionalExtension};
@@ -644,6 +646,45 @@ impl AiHistoryStore {
             content_hash: payload.sha256,
             byte_length: payload.byte_length,
             value: payload.value,
+        })
+    }
+
+    pub fn load_native_transcript_payloads(
+        &self,
+        session_id: &SessionId,
+        payload_refs: &[String],
+        max_bytes: usize,
+    ) -> AiResult<NativeAiTranscriptPayloadsOutput> {
+        if payload_refs.len() > AI_TRANSCRIPT_PAYLOAD_BATCH_MAX_REFS {
+            return Err(AiError::TooLarge(format!(
+                "a transcript payload batch may contain at most {AI_TRANSCRIPT_PAYLOAD_BATCH_MAX_REFS} refs"
+            )));
+        }
+        let transcript_revision = self
+            .transcript_store(session_id)
+            .transcript_revision(session_id)?;
+        let mut seen = HashSet::new();
+        let payloads = payload_refs
+            .iter()
+            .filter(|payload_ref| seen.insert(payload_ref.as_str()))
+            .map(|payload_ref| {
+                let payload = self.load_transcript_payload(session_id, payload_ref, max_bytes)?;
+                Ok(NativeAiTranscriptPayload {
+                    capability_version: AI_TRANSCRIPT_BLOCK_CAPABILITY_VERSION,
+                    session_id: session_id.clone(),
+                    transcript_revision,
+                    payload_ref: payload.payload_ref,
+                    content_hash: payload.sha256,
+                    byte_length: payload.byte_length,
+                    value: payload.value,
+                })
+            })
+            .collect::<AiResult<Vec<_>>>()?;
+        Ok(NativeAiTranscriptPayloadsOutput {
+            capability_version: AI_TRANSCRIPT_BLOCK_CAPABILITY_VERSION,
+            session_id: session_id.clone(),
+            payloads,
+            transcript_revision,
         })
     }
 

--- a/crates/comando-types/src/ai.rs
+++ b/crates/comando-types/src/ai.rs
@@ -586,6 +586,7 @@ pub struct NativeAiTranscriptBlock {
 pub const AI_TRANSCRIPT_BLOCK_CAPABILITY_VERSION: u32 = 1;
 pub const AI_TRANSCRIPT_BLOCK_CAPABILITY_FEATURE: &str = "native-ai-transcript-block-v1";
 pub const AI_TRANSCRIPT_PAYLOAD_LIMIT_MAX: usize = 64 * 1024 * 1024;
+pub const AI_TRANSCRIPT_PAYLOAD_BATCH_MAX_REFS: usize = 8;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -605,6 +606,15 @@ pub struct NativeAiLoadTranscriptPayloadInput {
     pub max_bytes: usize,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeAiLoadTranscriptPayloadsInput {
+    pub session_id: SessionId,
+    pub payload_refs: Vec<String>,
+    #[serde(default = "default_transcript_payload_limit")]
+    pub max_bytes: usize,
+}
+
 fn default_transcript_payload_limit() -> usize {
     AI_TRANSCRIPT_PAYLOAD_LIMIT_MAX
 }
@@ -619,6 +629,15 @@ pub struct NativeAiTranscriptPayload {
     pub content_hash: String,
     pub byte_length: usize,
     pub value: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeAiTranscriptPayloadsOutput {
+    pub capability_version: u32,
+    pub session_id: SessionId,
+    pub payloads: Vec<NativeAiTranscriptPayload>,
+    pub transcript_revision: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/comando-types/src/commands.rs
+++ b/crates/comando-types/src/commands.rs
@@ -162,6 +162,7 @@ pub const AI_COMMANDS: &[&str] = &[
     "ai_load_transcript_block_metadata",
     "ai_load_transcript_block",
     "ai_load_transcript_payload",
+    "ai_load_transcript_payloads",
     "ai_get_transcript_storage_state",
     "ai_load_session_snapshot",
     "ai_list_session_runtime_mappings",

--- a/e2e/harness/main.tsx
+++ b/e2e/harness/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import {
     useCallback,
     useEffect,
+    useLayoutEffect,
     useMemo,
     useRef,
     useState,
@@ -11,11 +12,15 @@ import {
 import type { AiSessionSnapshot } from "@shared/ipc";
 import {
     markChatPerformanceFrame,
-    recordChatScrollWrite,
     setChatPerformanceProbeEnabledForTests,
     type ChatPerformanceProbeEvent,
 } from "@renderer/app/debug/chatPerformanceProbe";
 import { ChatTimelineHistory } from "@renderer/components/workspace/ChatTabView";
+import {
+    createChatScrollCoordinator,
+    type ChatScrollCoordinator,
+} from "@renderer/components/workspace/chat/chatScrollCoordinator";
+import type { MeasuredVirtualScrollRequest } from "@renderer/components/virtual/MeasuredVirtualList";
 import type { ChatTimelineRow } from "@renderer/components/workspace/chat/chatTimelineModel";
 
 import "@renderer/styles.css";
@@ -211,7 +216,9 @@ function TranscriptHarness() {
     const diagnosticFrame = useRef(0);
     const diagnosticPhase = useRef("idle");
     const previousFrameAt = useRef(0);
-    const bottomFollowFrameRef = useRef<number | null>(null);
+    const [scrollCoordinator] = useState<ChatScrollCoordinator>(
+        createChatScrollCoordinator,
+    );
     const [historyRows, setHistoryRows] = useState(createInitialHistory);
     const [streamingText, setStreamingText] = useState<string | null>(null);
 
@@ -309,50 +316,61 @@ function TranscriptHarness() {
         [],
     );
 
-    const writeToBottom = useCallback((reason: "follow-end" | "settle") => {
-        const scrollElement = scrollRef.current;
-        if (!scrollElement) {
-            return;
-        }
-        const before = scrollElement.scrollTop;
-        const after = Math.max(
-            0,
-            scrollElement.scrollHeight - scrollElement.clientHeight,
-        );
-        if (Math.abs(after - before) < 1) {
-            return;
-        }
-        scrollElement.scrollTop = after;
-        recordChatScrollWrite({
-            after,
-            before,
-            clientHeight: scrollElement.clientHeight,
-            navigationGeneration: 0,
-            reason,
-            scrollHeight: scrollElement.scrollHeight,
-            sessionId: "e2e-transcript",
-        });
-    }, []);
+    const requestScroll = useCallback(
+        (request: {
+            readonly reason: "follow-end" | "measure-anchor" | "scroll-to-index";
+            readonly target: "end" | number;
+        }) => {
+            scrollCoordinator.request(request, {
+                element: scrollRef.current,
+                navigationGeneration: 0,
+                sessionId: "e2e-transcript",
+            });
+        },
+        [scrollCoordinator],
+    );
 
-    const scheduleBottomFollow = useCallback(() => {
-        if (bottomFollowFrameRef.current !== null) {
-            return;
-        }
-        let remainingFrames = 4;
-        const follow = () => {
-            bottomFollowFrameRef.current = null;
-            writeToBottom(remainingFrames === 4 ? "follow-end" : "settle");
-            remainingFrames -= 1;
-            if (remainingFrames > 0) {
-                bottomFollowFrameRef.current = requestAnimationFrame(follow);
-            }
-        };
-        bottomFollowFrameRef.current = requestAnimationFrame(follow);
-    }, [writeToBottom]);
+    const handleVirtualScrollRequest = useCallback(
+        (request: MeasuredVirtualScrollRequest) => {
+            requestScroll(request);
+        },
+        [requestScroll],
+    );
+
+    const handleVirtualResizeAutoFollow = useCallback(() => {
+        requestScroll({ reason: "follow-end", target: "end" });
+    }, [requestScroll]);
+
+    const followEndNow = useCallback(() => {
+        requestScroll({ reason: "follow-end", target: "end" });
+        scrollCoordinator.flush();
+    }, [requestScroll, scrollCoordinator]);
+
+    useLayoutEffect(() => {
+        followEndNow();
+    }, [followEndNow, hotTailRow, timelineItems]);
 
     useEffect(() => {
-        scheduleBottomFollow();
-    }, [hotTailRow, scheduleBottomFollow, timelineItems]);
+        // Initial virtual geometry is asynchronous in this isolated harness.
+        // Keep its bounded startup reconciliation separate from normal stream
+        // updates, which are resolved synchronously in the layout effect above.
+        let remainingFrames = 4;
+        let followFrame: number | null = null;
+        const followInitialGeometry = () => {
+            followEndNow();
+            remainingFrames -= 1;
+            if (remainingFrames > 0) {
+                followFrame = requestAnimationFrame(followInitialGeometry);
+            }
+        };
+        followFrame = requestAnimationFrame(followInitialGeometry);
+
+        return () => {
+            if (followFrame !== null) {
+                cancelAnimationFrame(followFrame);
+            }
+        };
+    }, [followEndNow]);
 
     useEffect(() => {
         const scrollElement = scrollRef.current;
@@ -516,13 +534,14 @@ function TranscriptHarness() {
                             streamingText === null ? null : STREAMING_ROW_ID
                         }
                         newTurnAnchorRowId={null}
+                        onVirtualScrollRequest={handleVirtualScrollRequest}
                         onOpenFile={() => Promise.resolve()}
                         onOpenImage={() => Promise.resolve()}
                         onOpenResolvedFileReference={() => undefined}
                         onSetActivityGroupExpanded={() => undefined}
                         onSetActivityRangeExpanded={() => undefined}
                         onVirtualRangeChange={handleVirtualRangeChange}
-                        onVirtualResizeAutoFollow={scheduleBottomFollow}
+                        onVirtualResizeAutoFollow={handleVirtualResizeAutoFollow}
                         projectId={null}
                         resolveFileReference={() => null}
                         scrollRef={scrollRef}

--- a/e2e/harness/main.tsx
+++ b/e2e/harness/main.tsx
@@ -3,23 +3,35 @@ import { createRoot } from "react-dom/client";
 import {
     useCallback,
     useEffect,
-    useLayoutEffect,
     useMemo,
     useRef,
     useState,
 } from "react";
 
 import type { AiSessionSnapshot } from "@shared/ipc";
-import { ChatTimelineHistoryRows } from "@renderer/components/workspace/chat/ChatTimelineHistoryRows";
+import {
+    markChatPerformanceFrame,
+    recordChatScrollWrite,
+    setChatPerformanceProbeEnabledForTests,
+    type ChatPerformanceProbeEvent,
+} from "@renderer/app/debug/chatPerformanceProbe";
+import { ChatTimelineHistory } from "@renderer/components/workspace/ChatTabView";
 import type { ChatTimelineRow } from "@renderer/components/workspace/chat/chatTimelineModel";
+import {
+    createTranscriptStreamingIndicatorItem,
+    type TranscriptTimelineItem,
+} from "@renderer/components/workspace/chat/transcriptBlockVirtualization";
 
 import "@renderer/styles.css";
 import "./transcript-harness.css";
 
 const INITIAL_HISTORY_SIZE = 2_000;
 const HISTORY_ROW_ID = "message:assistant-1999";
+const STREAMING_ROW_ID = "message:assistant-live";
 
 interface TranscriptHarnessSnapshot {
+    readonly bottomGap: number;
+    readonly clientHeight: number;
     readonly historyRowMounts: number;
     readonly historyRowUnmounts: number;
     readonly mountedHistoryRowIds: readonly string[];
@@ -29,7 +41,13 @@ interface TranscriptHarnessSnapshot {
 
 interface TranscriptDiagnosticSample extends TranscriptHarnessSnapshot {
     readonly frame: number;
+    readonly frameDuration: number;
+    readonly markdownContentChars: number;
+    readonly markdownRenderedChars: number;
+    readonly markdownStableChars: number;
+    readonly measurementKey: string | null;
     readonly phase: string;
+    readonly rowKey: string | null;
 }
 
 interface TranscriptVirtualRangeEvent {
@@ -50,11 +68,20 @@ interface TranscriptScrollWrite extends TranscriptDiagnosticEvent {
     readonly value: number;
 }
 
+interface TranscriptStreamingViolations {
+    readonly bottomGapFrames: readonly number[];
+    readonly longTaskCount: number;
+    readonly markdownLagFrames: readonly number[];
+    readonly multiScrollWriteFrames: readonly number[];
+}
+
 interface TranscriptStreamingDiagnostic {
     readonly mutations: readonly TranscriptDiagnosticEvent[];
+    readonly performanceEvents: readonly ChatPerformanceProbeEvent[];
     readonly resizeEvents: readonly TranscriptDiagnosticEvent[];
     readonly samples: readonly TranscriptDiagnosticSample[];
     readonly scrollWrites: readonly TranscriptScrollWrite[];
+    readonly violations: TranscriptStreamingViolations;
     readonly virtualRanges: readonly TranscriptVirtualRangeEvent[];
 }
 
@@ -73,15 +100,29 @@ interface ComandoTranscriptHarness {
     startTurn(): Promise<void>;
 }
 
+type PerformanceProbeRoot = typeof globalThis & {
+    __comandoChatPerformanceProbeDump?: () => readonly ChatPerformanceProbeEvent[];
+    __comandoChatPerformanceProbeReset?: () => void;
+};
+
 declare global {
     interface Window {
         comandoTranscriptHarness: ComandoTranscriptHarness;
     }
 }
 
-function nextPaint(): Promise<void> {
+setChatPerformanceProbeEnabledForTests(true);
+
+function waitForAnimationFrames(count: number): Promise<void> {
     return new Promise((resolve) => {
-        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        const wait = (remaining: number) => {
+            if (remaining <= 0) {
+                resolve();
+                return;
+            }
+            requestAnimationFrame(() => wait(remaining - 1));
+        };
+        wait(count);
     });
 }
 
@@ -99,6 +140,7 @@ function createMessageRow(
     id: string,
     content: string,
     kind: "assistant" | "user" = "assistant",
+    status: AiSessionSnapshot["messages"][number]["status"] = "completed",
 ): ChatTimelineRow {
     const message: AiSessionSnapshot["messages"][number] = {
         attachments: [],
@@ -106,7 +148,7 @@ function createMessageRow(
         createdAt: "2026-07-19T00:00:00.000Z",
         id,
         kind,
-        status: "completed",
+        status,
     };
     return { id: `message:${id}`, kind: "message", message };
 }
@@ -120,6 +162,50 @@ function createInitialHistory(): readonly ChatTimelineRow[] {
     );
 }
 
+function readNumericDataset(
+    element: HTMLElement | null,
+    key: keyof DOMStringMap,
+): number {
+    return Number(element?.dataset[key] ?? 0);
+}
+
+function collectViolations(
+    diagnostic: MutableTranscriptStreamingDiagnostic,
+    performanceEvents: readonly ChatPerformanceProbeEvent[],
+): TranscriptStreamingViolations {
+    const writesByFrame = new Map<number, number>();
+    for (const event of performanceEvents) {
+        if (event.metric !== "scroll_write") {
+            continue;
+        }
+        const frameTime = event.values.frameTime ?? 0;
+        writesByFrame.set(frameTime, (writesByFrame.get(frameTime) ?? 0) + 1);
+    }
+
+    return {
+        bottomGapFrames: diagnostic.samples
+            .filter(
+                (sample) =>
+                    sample.phase.startsWith("stream-") &&
+                    Math.abs(sample.bottomGap) > 2,
+            )
+            .map((sample) => sample.frame),
+        longTaskCount: performanceEvents.filter(
+            (event) => event.metric === "long_task",
+        ).length,
+        markdownLagFrames: diagnostic.samples
+            .filter(
+                (sample) =>
+                    sample.markdownContentChars >
+                    sample.markdownRenderedChars,
+            )
+            .map((sample) => sample.frame),
+        multiScrollWriteFrames: [...writesByFrame.entries()]
+            .filter(([, count]) => count > 1)
+            .map(([frame]) => frame),
+    };
+}
+
 function TranscriptHarness() {
     const scrollRef = useRef<HTMLDivElement | null>(null);
     const lifecycle = useRef(new Map<string, { mounts: number; unmounts: number }>());
@@ -128,46 +214,84 @@ function TranscriptHarness() {
     );
     const diagnosticFrame = useRef(0);
     const diagnosticPhase = useRef("idle");
+    const previousFrameAt = useRef(0);
+    const bottomFollowFrameRef = useRef<number | null>(null);
     const [historyRows, setHistoryRows] = useState(createInitialHistory);
-    const [streamingText, setStreamingText] = useState("");
+    const [streamingText, setStreamingText] = useState<string | null>(null);
 
-    const historyRow = useMemo(
-        () => historyRows.find((row) => row.id === HISTORY_ROW_ID) ?? null,
-        [historyRows],
-    );
-
-    useLayoutEffect(() => {
-        const scrollElement = scrollRef.current;
-        if (!scrollElement) {
-            return;
+    const timelineItems = useMemo<readonly TranscriptTimelineItem[]>(() => {
+        if (streamingText === null) {
+            return historyRows;
         }
-        scrollElement.scrollTop = scrollElement.scrollHeight;
-        scrollElement.dispatchEvent(new Event("scroll"));
-    }, [historyRows.length, streamingText]);
+        return [
+            ...historyRows,
+            createMessageRow(
+                "assistant-live",
+                streamingText,
+                "assistant",
+                "streaming",
+            ),
+            createTranscriptStreamingIndicatorItem("0s"),
+        ];
+    }, [historyRows, streamingText]);
 
     const snapshot = useCallback((): TranscriptHarnessSnapshot => {
         const scrollElement = scrollRef.current;
         const rowLifecycle = lifecycle.current.get(HISTORY_ROW_ID);
+        const scrollHeight = scrollElement?.scrollHeight ?? 0;
+        const scrollTop = scrollElement?.scrollTop ?? 0;
+        const clientHeight = scrollElement?.clientHeight ?? 0;
         return {
+            bottomGap: scrollHeight - clientHeight - scrollTop,
+            clientHeight,
             historyRowMounts: rowLifecycle?.mounts ?? 0,
             historyRowUnmounts: rowLifecycle?.unmounts ?? 0,
             mountedHistoryRowIds: [
-                ...document.querySelectorAll<HTMLElement>("[data-history-row-id]"),
-            ].map((element) => element.dataset.historyRowId ?? ""),
-            scrollHeight: scrollElement?.scrollHeight ?? 0,
-            scrollTop: scrollElement?.scrollTop ?? 0,
+                ...document.querySelectorAll<HTMLElement>("[data-list-key]"),
+            ].map((element) => element.dataset.listKey ?? ""),
+            scrollHeight,
+            scrollTop,
         };
     }, []);
 
     const recordSample = useCallback(
-        (phase: string) => {
+        (phase: string, frameAt: number) => {
+            markChatPerformanceFrame(frameAt);
             diagnosticFrame.current += 1;
             diagnosticPhase.current = phase;
+            const tail = document.querySelector<HTMLElement>(
+                '[data-current-turn-tail="true"]',
+            );
+            const measured = tail?.closest<HTMLElement>(
+                "[data-measurement-key]",
+            );
+            const markdown = tail?.querySelector<HTMLElement>(
+                '[data-markdown-live="true"]',
+            );
             diagnostic.current.samples.push({
                 ...snapshot(),
                 frame: diagnosticFrame.current,
+                frameDuration:
+                    previousFrameAt.current === 0
+                        ? 0
+                        : frameAt - previousFrameAt.current,
+                markdownContentChars: readNumericDataset(
+                    markdown ?? null,
+                    "markdownContentChars",
+                ),
+                markdownRenderedChars: readNumericDataset(
+                    markdown ?? null,
+                    "markdownRenderedChars",
+                ),
+                markdownStableChars: readNumericDataset(
+                    markdown ?? null,
+                    "markdownStableChars",
+                ),
+                measurementKey: measured?.dataset.measurementKey ?? null,
                 phase,
+                rowKey: measured?.dataset.listKey ?? null,
             });
+            previousFrameAt.current = frameAt;
         },
         [snapshot],
     );
@@ -188,13 +312,102 @@ function TranscriptHarness() {
         [],
     );
 
+    const writeToBottom = useCallback((reason: "follow-end" | "settle") => {
+        const scrollElement = scrollRef.current;
+        if (!scrollElement) {
+            return;
+        }
+        const before = scrollElement.scrollTop;
+        const after = Math.max(
+            0,
+            scrollElement.scrollHeight - scrollElement.clientHeight,
+        );
+        if (Math.abs(after - before) < 1) {
+            return;
+        }
+        scrollElement.scrollTop = after;
+        recordChatScrollWrite({
+            after,
+            before,
+            clientHeight: scrollElement.clientHeight,
+            navigationGeneration: 0,
+            reason,
+            scrollHeight: scrollElement.scrollHeight,
+            sessionId: "e2e-transcript",
+        });
+    }, []);
+
+    const scheduleBottomFollow = useCallback(() => {
+        if (bottomFollowFrameRef.current !== null) {
+            return;
+        }
+        let remainingFrames = 4;
+        const follow = () => {
+            bottomFollowFrameRef.current = null;
+            writeToBottom(remainingFrames === 4 ? "follow-end" : "settle");
+            remainingFrames -= 1;
+            if (remainingFrames > 0) {
+                bottomFollowFrameRef.current = requestAnimationFrame(follow);
+            }
+        };
+        bottomFollowFrameRef.current = requestAnimationFrame(follow);
+    }, [writeToBottom]);
+
+    useEffect(() => {
+        scheduleBottomFollow();
+    }, [scheduleBottomFollow, timelineItems]);
+
     useEffect(() => {
         const scrollElement = scrollRef.current;
         if (!scrollElement) {
             return;
         }
 
-        const mutationObserver = new MutationObserver(() => {
+        const trackedRow = scrollElement.querySelector<HTMLElement>(
+            `[data-list-key="${HISTORY_ROW_ID}"]`,
+        );
+        if (trackedRow) {
+            lifecycle.current.set(HISTORY_ROW_ID, { mounts: 1, unmounts: 0 });
+        }
+        const mutationObserver = new MutationObserver((records) => {
+            for (const record of records) {
+                for (const node of record.addedNodes) {
+                    if (
+                        node instanceof HTMLElement &&
+                        (node.dataset.listKey === HISTORY_ROW_ID ||
+                            node.querySelector(
+                                `[data-list-key="${HISTORY_ROW_ID}"]`,
+                            ))
+                    ) {
+                        const current = lifecycle.current.get(HISTORY_ROW_ID) ?? {
+                            mounts: 0,
+                            unmounts: 0,
+                        };
+                        lifecycle.current.set(HISTORY_ROW_ID, {
+                            ...current,
+                            mounts: current.mounts + 1,
+                        });
+                    }
+                }
+                for (const node of record.removedNodes) {
+                    if (
+                        node instanceof HTMLElement &&
+                        (node.dataset.listKey === HISTORY_ROW_ID ||
+                            node.querySelector(
+                                `[data-list-key="${HISTORY_ROW_ID}"]`,
+                            ))
+                    ) {
+                        const current = lifecycle.current.get(HISTORY_ROW_ID) ?? {
+                            mounts: 0,
+                            unmounts: 0,
+                        };
+                        lifecycle.current.set(HISTORY_ROW_ID, {
+                            ...current,
+                            unmounts: current.unmounts + 1,
+                        });
+                    }
+                }
+            }
             diagnostic.current.mutations.push({
                 frame: diagnosticFrame.current,
                 phase: diagnosticPhase.current,
@@ -208,10 +421,6 @@ function TranscriptHarness() {
         });
         mutationObserver.observe(scrollElement, { childList: true, subtree: true });
         resizeObserver.observe(scrollElement);
-        const liveTail = scrollElement.querySelector<HTMLElement>(".live-tail");
-        if (liveTail) {
-            resizeObserver.observe(liveTail);
-        }
         const handleScroll = () => {
             diagnostic.current.scrollWrites.push({
                 frame: diagnosticFrame.current,
@@ -232,29 +441,56 @@ function TranscriptHarness() {
         window.comandoTranscriptHarness = {
             appendDelta: async (delta) => {
                 flushSync(() => {
-                    setStreamingText((current) => current + delta);
+                    setStreamingText((current) => (current ?? "") + delta);
                 });
-                await nextPaint();
+                await waitForAnimationFrames(3);
             },
             runStreamingDiagnostic: async () => {
+                const probeRoot = globalThis as PerformanceProbeRoot;
+                probeRoot.__comandoChatPerformanceProbeReset?.();
                 diagnostic.current = createEmptyDiagnostic();
                 diagnosticFrame.current = 0;
-                recordSample("before-turn");
+                previousFrameAt.current = 0;
+                let stopSampling = false;
+                const sampling = new Promise<void>((resolve) => {
+                    const sample = (frameAt: number) => {
+                        recordSample(diagnosticPhase.current, frameAt);
+                        if (stopSampling) {
+                            resolve();
+                            return;
+                        }
+                        requestAnimationFrame(sample);
+                    };
+                    requestAnimationFrame(sample);
+                });
+
                 diagnosticPhase.current = "turn-started";
                 await window.comandoTranscriptHarness.startTurn();
-                recordSample("turn-started");
-
                 for (const [index, delta] of [
-                    "First streamed chunk. ",
-                    "Second streamed chunk changes the live tail height. ",
-                    "Third streamed chunk adds enough content to trigger another measurement.",
+                    "## Streamed answer\n\n",
+                    "A paragraph grows while the model streams.\n\n- first item",
+                    "\n- second item\n\n| Name | Value |\n| --- | --- |\n| alpha | 1 |\n\n",
+                    "```ts\nexport function streamed() {\n",
+                    "    return true;\n}\n```\n",
                 ].entries()) {
                     diagnosticPhase.current = `stream-${index + 1}`;
                     await window.comandoTranscriptHarness.appendDelta(delta);
-                    recordSample(`stream-${index + 1}`);
                 }
+                await waitForAnimationFrames(4);
+                stopSampling = true;
+                await sampling;
 
-                return diagnostic.current;
+                const performanceEvents = [
+                    ...(probeRoot.__comandoChatPerformanceProbeDump?.() ?? []),
+                ];
+                return {
+                    ...diagnostic.current,
+                    performanceEvents,
+                    violations: collectViolations(
+                        diagnostic.current,
+                        performanceEvents,
+                    ),
+                };
             },
             snapshot,
             startTurn: async () => {
@@ -265,53 +501,38 @@ function TranscriptHarness() {
                     ]);
                     setStreamingText("");
                 });
-                await nextPaint();
+                await waitForAnimationFrames(3);
             },
         };
     }, [recordSample, snapshot]);
 
-    if (!historyRow) {
-        throw new Error("expected the tracked historical row");
-    }
-
     return (
         <main className="transcript-harness">
-            <div className="transcript-scroll" ref={scrollRef}>
-                <ChatTimelineHistoryRows
-                    historyRows={historyRows}
-                    onVirtualRangeChange={handleVirtualRangeChange}
-                    renderRow={({ row }) => <TranscriptRow lifecycle={lifecycle.current} row={row} />}
-                    scrollRef={scrollRef}
-                    sessionId="e2e-transcript"
-                />
-                <article className="live-tail" data-testid="live-tail">
-                    {streamingText || "Waiting for a streamed response…"}
-                </article>
+            <div className="transcript-scroll chat-scroll" ref={scrollRef}>
+                <div className="min-w-0 space-y-2">
+                    <ChatTimelineHistory
+                        active
+                        historyRows={timelineItems}
+                        liveTailRowId={
+                            streamingText === null ? null : STREAMING_ROW_ID
+                        }
+                        newTurnAnchorRowId={null}
+                        onOpenFile={() => Promise.resolve()}
+                        onOpenImage={() => Promise.resolve()}
+                        onOpenResolvedFileReference={() => undefined}
+                        onSetActivityGroupExpanded={() => undefined}
+                        onSetActivityRangeExpanded={() => undefined}
+                        onVirtualRangeChange={handleVirtualRangeChange}
+                        onVirtualResizeAutoFollow={scheduleBottomFollow}
+                        projectId={null}
+                        resolveFileReference={() => null}
+                        scrollRef={scrollRef}
+                        sessionId="e2e-transcript"
+                        worktreeId={null}
+                    />
+                </div>
             </div>
         </main>
-    );
-}
-
-function TranscriptRow({
-    lifecycle,
-    row,
-}: {
-    readonly lifecycle: Map<string, { mounts: number; unmounts: number }>;
-    readonly row: ChatTimelineRow;
-}) {
-    useEffect(() => {
-        const current = lifecycle.get(row.id) ?? { mounts: 0, unmounts: 0 };
-        lifecycle.set(row.id, { ...current, mounts: current.mounts + 1 });
-        return () => {
-            const next = lifecycle.get(row.id) ?? { mounts: 0, unmounts: 0 };
-            lifecycle.set(row.id, { ...next, unmounts: next.unmounts + 1 });
-        };
-    }, [lifecycle, row.id]);
-
-    return (
-        <article className="transcript-row" data-history-row-id={row.id}>
-            {row.kind === "message" ? row.message.content : row.id}
-        </article>
     );
 }
 

--- a/e2e/harness/main.tsx
+++ b/e2e/harness/main.tsx
@@ -17,10 +17,6 @@ import {
 } from "@renderer/app/debug/chatPerformanceProbe";
 import { ChatTimelineHistory } from "@renderer/components/workspace/ChatTabView";
 import type { ChatTimelineRow } from "@renderer/components/workspace/chat/chatTimelineModel";
-import {
-    createTranscriptStreamingIndicatorItem,
-    type TranscriptTimelineItem,
-} from "@renderer/components/workspace/chat/transcriptBlockVirtualization";
 
 import "@renderer/styles.css";
 import "./transcript-harness.css";
@@ -219,21 +215,19 @@ function TranscriptHarness() {
     const [historyRows, setHistoryRows] = useState(createInitialHistory);
     const [streamingText, setStreamingText] = useState<string | null>(null);
 
-    const timelineItems = useMemo<readonly TranscriptTimelineItem[]>(() => {
-        if (streamingText === null) {
-            return historyRows;
-        }
-        return [
-            ...historyRows,
-            createMessageRow(
+    const timelineItems = historyRows;
+    const hotTailRow = useMemo<ChatTimelineRow | null>(
+        () =>
+            streamingText === null
+                ? null
+                : createMessageRow(
                 "assistant-live",
                 streamingText,
                 "assistant",
                 "streaming",
             ),
-            createTranscriptStreamingIndicatorItem("0s"),
-        ];
-    }, [historyRows, streamingText]);
+        [streamingText],
+    );
 
     const snapshot = useCallback((): TranscriptHarnessSnapshot => {
         const scrollElement = scrollRef.current;
@@ -289,7 +283,10 @@ function TranscriptHarness() {
                 ),
                 measurementKey: measured?.dataset.measurementKey ?? null,
                 phase,
-                rowKey: measured?.dataset.listKey ?? null,
+                rowKey:
+                    measured?.dataset.listKey ??
+                    tail?.dataset.hotTranscriptTail ??
+                    null,
             });
             previousFrameAt.current = frameAt;
         },
@@ -355,7 +352,7 @@ function TranscriptHarness() {
 
     useEffect(() => {
         scheduleBottomFollow();
-    }, [scheduleBottomFollow, timelineItems]);
+    }, [hotTailRow, scheduleBottomFollow, timelineItems]);
 
     useEffect(() => {
         const scrollElement = scrollRef.current;
@@ -513,6 +510,8 @@ function TranscriptHarness() {
                     <ChatTimelineHistory
                         active
                         historyRows={timelineItems}
+                        hotTailRowId={hotTailRow?.id ?? null}
+                        hotTailRows={hotTailRow ? [hotTailRow] : []}
                         liveTailRowId={
                             streamingText === null ? null : STREAMING_ROW_ID
                         }
@@ -528,6 +527,8 @@ function TranscriptHarness() {
                         resolveFileReference={() => null}
                         scrollRef={scrollRef}
                         sessionId="e2e-transcript"
+                        showStreamingIndicator={streamingText !== null}
+                        streamingStartedAt={null}
                         worktreeId={null}
                     />
                 </div>

--- a/e2e/tests/transcript-virtualization.spec.ts
+++ b/e2e/tests/transcript-virtualization.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 
 interface TranscriptHarnessSnapshot {
+    readonly bottomGap: number;
+    readonly clientHeight: number;
     readonly historyRowMounts: number;
     readonly historyRowUnmounts: number;
     readonly mountedHistoryRowIds: readonly string[];
@@ -37,14 +39,43 @@ test("virtualized history remains mounted while a new turn streams", async ({ pa
     expect(after.historyRowMounts).toBe(before.historyRowMounts);
     expect(after.historyRowUnmounts).toBe(before.historyRowUnmounts);
     expect(after.mountedHistoryRowIds).toContain("message:assistant-1999");
-    expect(after.scrollTop).toBeGreaterThanOrEqual(after.scrollHeight - 620);
-    expect(diagnostic.samples.map((sample) => sample.phase)).toEqual([
-        "before-turn",
+    expect(after.bottomGap).toBeLessThanOrEqual(120);
+    expect(diagnostic.samples.map((sample) => sample.phase)).toContain(
         "turn-started",
-        "stream-1",
-        "stream-2",
-        "stream-3",
-    ]);
+    );
+    expect(diagnostic.samples.map((sample) => sample.phase)).toContain(
+        "stream-5",
+    );
     expect(diagnostic.virtualRanges.length).toBeGreaterThan(0);
-    await expect(page.getByTestId("live-tail")).toContainText("Third streamed chunk");
+    expect(
+        diagnostic.performanceEvents.some(
+            (event: { readonly metric: string }) =>
+                event.metric === "markdown_commit",
+        ),
+    ).toBe(true);
+    await expect(page.getByText("return true;", { exact: false })).toBeVisible();
+});
+
+test("streaming has no transient frame continuity violations", async ({
+    page,
+}, testInfo) => {
+    test.fail(
+        true,
+        "The current virtualized hot tail is expected to expose transient frame violations until Fases 1-3 land.",
+    );
+
+    const diagnostic = await page.evaluate(async () => {
+        return window.comandoTranscriptHarness.runStreamingDiagnostic();
+    });
+    await testInfo.attach("transcript-frame-continuity-diagnostic", {
+        body: JSON.stringify(diagnostic, null, 2),
+        contentType: "application/json",
+    });
+
+    expect(diagnostic.violations).toEqual({
+        bottomGapFrames: [],
+        longTaskCount: 0,
+        markdownLagFrames: [],
+        multiScrollWriteFrames: [],
+    });
 });

--- a/e2e/tests/transcript-virtualization.spec.ts
+++ b/e2e/tests/transcript-virtualization.spec.ts
@@ -53,6 +53,15 @@ test("virtualized history remains mounted while a new turn streams", async ({ pa
                 event.metric === "markdown_commit",
         ),
     ).toBe(true);
+    await expect(page.locator("[data-hot-transcript-tail]")).toHaveCount(1);
+    await expect(
+        page.locator(
+            "[data-hot-transcript-tail] [data-measurement-key]",
+        ),
+    ).toHaveCount(0);
+    await expect(
+        page.locator("[data-list-key] [data-streaming-indicator-host]"),
+    ).toHaveCount(0);
     await expect(page.getByText("return true;", { exact: false })).toBeVisible();
 });
 
@@ -61,7 +70,7 @@ test("streaming has no transient frame continuity violations", async ({
 }, testInfo) => {
     test.fail(
         true,
-        "The current virtualized hot tail is expected to expose transient frame violations until Fases 1-3 land.",
+        "The extracted hot tail still exposes Markdown/scroll continuity violations until Fases 2-3 land.",
     );
 
     const diagnostic = await page.evaluate(async () => {

--- a/e2e/tests/transcript-virtualization.spec.ts
+++ b/e2e/tests/transcript-virtualization.spec.ts
@@ -53,6 +53,7 @@ test("virtualized history remains mounted while a new turn streams", async ({ pa
                 event.metric === "markdown_commit",
         ),
     ).toBe(true);
+    expect(diagnostic.violations.markdownLagFrames).toEqual([]);
     await expect(page.locator("[data-hot-transcript-tail]")).toHaveCount(1);
     await expect(
         page.locator(
@@ -70,7 +71,7 @@ test("streaming has no transient frame continuity violations", async ({
 }, testInfo) => {
     test.fail(
         true,
-        "The extracted hot tail still exposes Markdown/scroll continuity violations until Fases 2-3 land.",
+        "The extracted hot tail still exposes scroll continuity violations until Fase 3 lands.",
     );
 
     const diagnostic = await page.evaluate(async () => {

--- a/e2e/tests/transcript-virtualization.spec.ts
+++ b/e2e/tests/transcript-virtualization.spec.ts
@@ -69,11 +69,6 @@ test("virtualized history remains mounted while a new turn streams", async ({ pa
 test("streaming has no transient frame continuity violations", async ({
     page,
 }, testInfo) => {
-    test.fail(
-        true,
-        "The extracted hot tail still exposes scroll continuity violations until Fase 3 lands.",
-    );
-
     const diagnostic = await page.evaluate(async () => {
         return window.comandoTranscriptHarness.runStreamingDiagnostic();
     });

--- a/fixtures/native-backend/protocol/capabilities.v1.json
+++ b/fixtures/native-backend/protocol/capabilities.v1.json
@@ -136,6 +136,7 @@
       "ai_load_transcript_block_metadata",
       "ai_load_transcript_block",
       "ai_load_transcript_payload",
+      "ai_load_transcript_payloads",
       "ai_get_transcript_storage_state",
       "ai_load_session_snapshot",
       "ai_list_session_runtime_mappings",

--- a/fixtures/native-backend/protocol/registry.commands.json
+++ b/fixtures/native-backend/protocol/registry.commands.json
@@ -112,6 +112,7 @@
   "ai_load_transcript_block_metadata",
   "ai_load_transcript_block",
   "ai_load_transcript_payload",
+  "ai_load_transcript_payloads",
   "ai_get_transcript_storage_state",
   "ai_load_session_snapshot",
   "ai_list_session_runtime_mappings",

--- a/src/main/ai/contracts.ts
+++ b/src/main/ai/contracts.ts
@@ -31,7 +31,9 @@ import type {
     AiTranscriptCapability,
     AiTranscriptEntryEnvelope,
     AiLoadTranscriptPayloadInput,
+    AiLoadTranscriptPayloadsInput,
     AiTranscriptPayload,
+    AiTranscriptPayloadsOutput,
     AiTranscriptStorageState,
     AiSealTranscriptTurnInput,
     AiUserInputResponseInput,
@@ -174,6 +176,7 @@ export interface NativeAiGateway {
     getTranscriptStorageState?(sessionId: string): Promise<AiTranscriptStorageState>;
     loadTranscriptBlockMetadata?(sessionId: string): Promise<AiTranscriptBlockMetadataOutput>;
     loadTranscriptPayload?(input: AiLoadTranscriptPayloadInput): Promise<AiTranscriptPayload>;
+    loadTranscriptPayloads?(input: AiLoadTranscriptPayloadsInput): Promise<AiTranscriptPayloadsOutput>;
     migrateSessionHistory?(input: AiHistoryMigrationInput): Promise<AiHistoryMigrationResult>;
     getRuntimeStatus?(runtimeId: AiRuntimeId): Promise<AiRuntimeStatus>;
     saveRuntimeSettings?(input: NativeAiRuntimeSettingsRpcInput): Promise<AiRuntimeStatus>;

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -29,7 +29,9 @@ import type {
     AiTranscriptBlockMetadataOutput,
     AiTranscriptCapability,
     AiLoadTranscriptPayloadInput,
+    AiLoadTranscriptPayloadsInput,
     AiTranscriptPayload,
+    AiTranscriptPayloadsOutput,
     AiTrackedFileHunkMutationInput,
     AiTrackedFileMutationInput,
     AiTrackedFile,
@@ -1395,6 +1397,22 @@ export class AiService {
             return null;
         }
         return await nativeAi.loadTranscriptPayload(input);
+    }
+
+    async getTranscriptPayloads(
+        input: AiLoadTranscriptPayloadsInput,
+    ): Promise<AiTranscriptPayloadsOutput | null> {
+        const nativeAi = this.#nativeAi;
+        if (
+            !nativeAi?.getTranscriptCapability?.().blockNativeVersion ||
+            !nativeAi.loadTranscriptPayloads
+        ) {
+            return null;
+        }
+        if (!(await this.#refreshTranscriptStorageMode(input.sessionId))) {
+            return null;
+        }
+        return await nativeAi.loadTranscriptPayloads(input);
     }
 
     async prepareSession(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -18,6 +18,7 @@ import {
     type AiSessionConfigOptionMutationInput,
     type GetAiSessionTranscriptPageInput,
     type AiLoadTranscriptPayloadInput,
+    type AiLoadTranscriptPayloadsInput,
     type AiSessionModeMutationInput,
     type AiSessionModelMutationInput,
     type AiSessionRenameMutationInput,
@@ -399,6 +400,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.getAiTranscriptBlockMetadata);
     ipcMain.removeHandler(IPC_CHANNELS.getAiTranscriptBlock);
     ipcMain.removeHandler(IPC_CHANNELS.getAiTranscriptPayload);
+    ipcMain.removeHandler(IPC_CHANNELS.getAiTranscriptPayloads);
     ipcMain.removeHandler(IPC_CHANNELS.getAiPromptQueue);
     ipcMain.removeHandler(IPC_CHANNELS.enqueueAiPrompt);
     ipcMain.removeHandler(IPC_CHANNELS.removeAiQueuedPrompt);
@@ -2292,6 +2294,9 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     );
     ipcMain.handle(IPC_CHANNELS.getAiTranscriptPayload, (_event, input: AiLoadTranscriptPayloadInput) =>
         options.aiService.getTranscriptPayload(input),
+    );
+    ipcMain.handle(IPC_CHANNELS.getAiTranscriptPayloads, (_event, input: AiLoadTranscriptPayloadsInput) =>
+        options.aiService.getTranscriptPayloads(input),
     );
     ipcMain.handle(IPC_CHANNELS.getAiPromptQueue, (event, sessionId: string) => {
         const context = requireWindowContext(event.sender, "main");

--- a/src/main/native-backend/ai.test.ts
+++ b/src/main/native-backend/ai.test.ts
@@ -960,6 +960,63 @@ describe("NativeAiGateway", () => {
         ).rejects.toThrow("belongs to another session");
     });
 
+    it("batches payloads only when the negotiated backend command is available", async () => {
+        const payload = {
+            byteLength: 10,
+            capabilityVersion: 1,
+            contentHash: "abc123",
+            payloadRef: "payload:assistant-1",
+            sessionId: "session-1",
+            transcriptRevision: 2,
+            value: { kind: "message" },
+        };
+        const batchClient = createClient();
+        batchClient.request.mockResolvedValue({
+            capabilityVersion: 1,
+            payloads: [payload],
+            sessionId: "session-1",
+            transcriptRevision: 2,
+        });
+        const batchGateway = createGateway(batchClient, {
+            capabilities: {
+                commands: ["ai_load_transcript_payloads"],
+                domains: ["ai"],
+                events: [],
+                features: ["native-ai-transcript-block-v1"],
+            },
+        });
+
+        await expect(
+            batchGateway.loadTranscriptPayloads({
+                payloadRefs: [payload.payloadRef],
+                sessionId: "session-1",
+            }),
+        ).resolves.toMatchObject({ payloads: [payload] });
+        expect(batchClient.request).toHaveBeenCalledWith(
+            "ai_load_transcript_payloads",
+            expect.any(Object),
+        );
+
+        const legacyClient = createClient();
+        legacyClient.request.mockResolvedValue(payload);
+        const legacyGateway = createGateway(legacyClient, {
+            capabilities: {
+                commands: [],
+                domains: ["ai"],
+                events: [],
+                features: ["native-ai-transcript-block-v1"],
+            },
+        });
+        await legacyGateway.loadTranscriptPayloads({
+            payloadRefs: [payload.payloadRef],
+            sessionId: "session-1",
+        });
+        expect(legacyClient.request).toHaveBeenCalledWith(
+            "ai_load_transcript_payload",
+            expect.any(Object),
+        );
+    });
+
     it("does not hydrate review state when loading historical snapshots", async () => {
         const client = createClient();
         const legacyFile = createNativeTrackedFile({

--- a/src/main/native-backend/ai.ts
+++ b/src/main/native-backend/ai.ts
@@ -28,7 +28,9 @@ import type {
     AiTranscriptCapability,
     AiTranscriptEntryEnvelope,
     AiLoadTranscriptPayloadInput,
+    AiLoadTranscriptPayloadsInput,
     AiTranscriptPayload,
+    AiTranscriptPayloadsOutput,
     AiTranscriptStorageState,
     AiSealTranscriptTurnInput,
     AiTrackedFile,
@@ -63,6 +65,7 @@ import {
     type NativeAiTranscriptBlockMetadata,
     type NativeAiTranscriptBlockMetadataOutput,
     type NativeAiTranscriptPayload,
+    type NativeAiTranscriptPayloadsOutput,
     type NativeAiTranscriptStorageState,
     type NativeCapabilitySet,
     type NativeAiRuntimeConnectionPayload,
@@ -123,6 +126,7 @@ export class NativeAiGateway implements NativeAiGatewayContract {
     readonly #enabledRuntimeIds: ReadonlySet<AiRuntimeId>;
     readonly #historyEnabled: boolean;
     readonly #transcriptBlockCapabilityVersion: number | null;
+    readonly #transcriptPayloadBatchEnabled: boolean;
     readonly #onDiagnostic?: (message: string) => void;
     readonly #onRuntimeStatus: (status: AiRuntimeStatus) => void;
     readonly #onSessionEvent: (
@@ -147,6 +151,11 @@ export class NativeAiGateway implements NativeAiGatewayContract {
         this.#historyEnabled = true;
         this.#transcriptBlockCapabilityVersion =
             getNativeAiTranscriptBlockCapabilityVersion(options.capabilities);
+        this.#transcriptPayloadBatchEnabled = Boolean(
+            options.capabilities?.commands.includes(
+                "ai_load_transcript_payloads",
+            ),
+        );
         this.#reviewEnabled = true;
         this.#onDiagnostic = options.onDiagnostic;
         this.#onRuntimeStatus = options.onRuntimeStatus;
@@ -489,6 +498,40 @@ export class NativeAiGateway implements NativeAiGatewayContract {
             output,
             input.sessionId,
             "payload",
+        );
+    }
+
+    async loadTranscriptPayloads(
+        input: AiLoadTranscriptPayloadsInput,
+    ): Promise<AiTranscriptPayloadsOutput> {
+        if (!this.#transcriptPayloadBatchEnabled) {
+            const payloads = await Promise.all(
+                [...new Set(input.payloadRefs)].map((payloadRef) =>
+                    this.loadTranscriptPayload({
+                        maxBytes: input.maxBytes,
+                        payloadRef,
+                        sessionId: input.sessionId,
+                    }),
+                ),
+            );
+            return {
+                payloads,
+                sessionId: input.sessionId,
+            };
+        }
+        const output = await this.#client.request<unknown>(
+            "ai_load_transcript_payloads",
+            {
+                maxBytes:
+                    input.maxBytes ?? AI_TRANSCRIPT_PAYLOAD_LIMIT_MAX,
+                payloadRefs: [...new Set(input.payloadRefs)],
+                sessionId: input.sessionId,
+            },
+        );
+        return requireTranscriptResponse<NativeAiTranscriptPayloadsOutput>(
+            output,
+            input.sessionId,
+            "payload batch",
         );
     }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,7 +33,9 @@ import {
     type AiTranscriptBlockMetadataOutput,
     type AiTranscriptCapability,
     type AiLoadTranscriptPayloadInput,
+    type AiLoadTranscriptPayloadsInput,
     type AiTranscriptPayload,
+    type AiTranscriptPayloadsOutput,
     type AiTrackedFileHunkMutationInput,
     type AiTrackedFileMutationInput,
     type AiUserInputResponseInput,
@@ -1607,6 +1609,11 @@ const comandoApi: ComandoApi = {
         assertIpcObjectOrNull<AiTranscriptPayload>(
             IPC_CHANNELS.getAiTranscriptPayload,
             await ipcRenderer.invoke(IPC_CHANNELS.getAiTranscriptPayload, input),
+        ),
+    getAiTranscriptPayloads: async (input: AiLoadTranscriptPayloadsInput) =>
+        assertIpcObjectOrNull<AiTranscriptPayloadsOutput>(
+            IPC_CHANNELS.getAiTranscriptPayloads,
+            await ipcRenderer.invoke(IPC_CHANNELS.getAiTranscriptPayloads, input),
         ),
     getAiPromptQueue: (sessionId: string) =>
         ipcRenderer.invoke(

--- a/src/renderer/src/app/ai/transcriptModel.ts
+++ b/src/renderer/src/app/ai/transcriptModel.ts
@@ -130,6 +130,19 @@ export function isAiSessionTranscriptMutationFrom(
     );
 }
 
+export function getAiSessionTranscriptMutationChainFrom(
+    transcript: AiSessionTranscriptModel,
+    ancestor: AiSessionTranscriptModel,
+): readonly AiSessionTranscriptModel[] | null {
+    const chain: AiSessionTranscriptModel[] = [];
+    let current: AiSessionTranscriptModel | undefined = transcript;
+    while (current && current !== ancestor) {
+        chain.push(current);
+        current = transcriptMutationParentByModel.get(current);
+    }
+    return current === ancestor ? chain.reverse() : null;
+}
+
 export function createEmptyAiSessionTranscriptModel(): AiSessionTranscriptModel {
     return buildAiSessionTranscriptModel({
         messages: [],
@@ -585,10 +598,38 @@ function removeAiSessionTranscriptEntry(
 
     const entriesById = { ...transcript.entriesById };
     delete entriesById[entryId];
-    return buildAiSessionTranscriptModelFromOrderedEntries(
+    const nextTranscript = buildAiSessionTranscriptModelFromOrderedEntries(
         transcript.orderedEntryIds.filter((candidateId) => candidateId !== entryId),
         entriesById,
     );
+    return markAiSessionTranscriptMutation(
+        nextTranscript,
+        { entryId, kind: "remove" },
+        transcript,
+    );
+}
+
+export function applyAiSessionTranscriptMutationToProjection(
+    projection: AiSessionTranscriptModel,
+    source: AiSessionTranscriptModel,
+): AiSessionTranscriptModel | null {
+    const mutation = getAiSessionTranscriptMutation(source);
+    if (mutation.kind === "rebuild") {
+        return null;
+    }
+
+    if (mutation.kind === "remove") {
+        return removeAiSessionTranscriptEntry(projection, mutation.entryId);
+    }
+
+    const entry = source.entriesById[mutation.entryId];
+    if (!entry) {
+        return null;
+    }
+
+    // Reusing the regular mutation path preserves the projected model's own
+    // parent chain instead of coupling it to the larger source transcript.
+    return upsertAiSessionTranscriptEntry(projection, entry);
 }
 
 export function removeAiSessionTranscriptEntries(

--- a/src/renderer/src/app/ai/transcriptPayloadCache.test.ts
+++ b/src/renderer/src/app/ai/transcriptPayloadCache.test.ts
@@ -79,4 +79,63 @@ describe("TranscriptPayloadCache", () => {
             expect.arrayContaining(["protected", "recoverable"]),
         );
     });
+
+    it("coalesces uncached payloads into one batch request", async () => {
+        const loadMany = vi.fn((payloadRefs: readonly string[]) =>
+            Promise.resolve(
+                new Map(payloadRefs.map((payloadRef) => [payloadRef, payloadRef])),
+            ),
+        );
+        const cache = new TranscriptPayloadCache(
+            { load: vi.fn(), loadMany },
+            100,
+            (value: string) => value.length,
+        );
+
+        await expect(cache.loadMany(["payload-1", "payload-2"])).resolves.toEqual(
+            new Map([
+                ["payload-1", "payload-1"],
+                ["payload-2", "payload-2"],
+            ]),
+        );
+        expect(loadMany).toHaveBeenCalledOnce();
+        expect(loadMany).toHaveBeenCalledWith(["payload-1", "payload-2"]);
+    });
+
+    it("joins concurrent batch loads without double-counting cached payloads", async () => {
+        let resolveBatch!: (payloads: ReadonlyMap<string, string>) => void;
+        const loadMany = vi.fn(() =>
+            new Promise<ReadonlyMap<string, string>>((resolve) => {
+                resolveBatch = resolve;
+            }),
+        );
+        const cache = new TranscriptPayloadCache(
+            { load: vi.fn(), loadMany },
+            100,
+            (value: string) => value.length,
+        );
+
+        const first = cache.loadMany(["payload-1", "payload-2"]);
+        const second = cache.loadMany(["payload-1", "payload-2"]);
+
+        expect(loadMany).toHaveBeenCalledOnce();
+        resolveBatch(new Map([
+            ["payload-1", "a".repeat(40)],
+            ["payload-2", "b".repeat(40)],
+        ]));
+
+        await expect(Promise.all([first, second])).resolves.toEqual([
+            new Map([
+                ["payload-1", "a".repeat(40)],
+                ["payload-2", "b".repeat(40)],
+            ]),
+            new Map([
+                ["payload-1", "a".repeat(40)],
+                ["payload-2", "b".repeat(40)],
+            ]),
+        ]);
+        expect(cache.residentBytes).toBe(80);
+        expect(cache.has("payload-1")).toBe(true);
+        expect(cache.has("payload-2")).toBe(true);
+    });
 });

--- a/src/renderer/src/app/ai/transcriptPayloadCache.ts
+++ b/src/renderer/src/app/ai/transcriptPayloadCache.ts
@@ -1,5 +1,6 @@
 export interface TranscriptPayloadLoader<T> {
     load(payloadRef: string): Promise<T>;
+    loadMany?(payloadRefs: readonly string[]): Promise<ReadonlyMap<string, T>>;
 }
 
 interface CachedPayload<T> {
@@ -44,20 +45,60 @@ export class TranscriptPayloadCache<T> {
         const request = this.loader
             .load(payloadRef)
             .then((payload) => {
-                const cached: CachedPayload<T> = {
-                    estimatedBytes: this.estimateBytes(payload),
-                    payload,
-                    protected: options.protect ?? false,
-                };
-                this.payloads.set(payloadRef, cached);
-                this.residentByteCount += cached.estimatedBytes;
-                this.touch(payloadRef, cached.protected);
-                this.evict();
+                this.cache(payloadRef, payload, options.protect ?? false);
                 return payload;
             })
             .finally(() => this.pending.delete(payloadRef));
         this.pending.set(payloadRef, request);
         return request;
+    }
+
+    loadMany(
+        payloadRefs: readonly string[],
+        options: TranscriptPayloadLoadOptions = {},
+    ): Promise<ReadonlyMap<string, T>> {
+        const uniquePayloadRefs = [...new Set(payloadRefs)];
+        const resolved = new Map<string, T>();
+        const pending: Promise<void>[] = [];
+        const missing: string[] = [];
+
+        for (const payloadRef of uniquePayloadRefs) {
+            const cached = this.payloads.get(payloadRef);
+            if (cached) {
+                if (options.protect && !cached.protected) {
+                    cached.protected = true;
+                }
+                this.touch(payloadRef, cached.protected);
+                resolved.set(payloadRef, cached.payload);
+                continue;
+            }
+            const activeRequest = this.pending.get(payloadRef);
+            if (activeRequest) {
+                pending.push(
+                    activeRequest.then((payload) => {
+                        resolved.set(payloadRef, payload);
+                    }),
+                );
+                continue;
+            }
+            missing.push(payloadRef);
+        }
+
+        const loadMissing = this.loader.loadMany && missing.length > 1
+            ? this.loadBatch(missing, options).then((payloads) => {
+                  for (const [payloadRef, payload] of payloads) {
+                      resolved.set(payloadRef, payload);
+                  }
+              })
+            : Promise.all(
+                  missing.map((payloadRef) =>
+                      this.load(payloadRef, options).then((payload) => {
+                          resolved.set(payloadRef, payload);
+                      }),
+                  ),
+              ).then(() => undefined);
+
+        return Promise.all([...pending, loadMissing]).then(() => resolved);
     }
 
     release(payloadRef: string): void {
@@ -127,5 +168,66 @@ export class TranscriptPayloadCache<T> {
         other.delete(payloadRef);
         target.delete(payloadRef);
         target.set(payloadRef, undefined);
+    }
+
+    private cache(
+        payloadRef: string,
+        payload: T,
+        protect: boolean,
+    ): void {
+        const previous = this.payloads.get(payloadRef);
+        if (previous) {
+            // Replacing a payload must not count the same key twice.
+            this.residentByteCount -= previous.estimatedBytes;
+        }
+        const cached: CachedPayload<T> = {
+            estimatedBytes: this.estimateBytes(payload),
+            payload,
+            protected: protect,
+        };
+        this.payloads.set(payloadRef, cached);
+        this.residentByteCount += cached.estimatedBytes;
+        this.evictedPayloadRefs.delete(payloadRef);
+        this.touch(payloadRef, cached.protected);
+        this.evict();
+    }
+
+    private loadBatch(
+        payloadRefs: readonly string[],
+        options: TranscriptPayloadLoadOptions,
+    ): Promise<ReadonlyMap<string, T>> {
+        if (!this.loader.loadMany) {
+            return Promise.resolve(new Map());
+        }
+
+        const batch = this.loader.loadMany(payloadRefs);
+        const requests = new Map<string, Promise<T>>();
+
+        for (const payloadRef of payloadRefs) {
+            const request = batch
+                .then((payloads) => {
+                    const payload = payloads.get(payloadRef);
+                    if (!payload) {
+                        throw new Error(`The transcript payload ${payloadRef} could not be found.`);
+                    }
+                    this.cache(payloadRef, payload, options.protect ?? false);
+                    return payload;
+                })
+                .finally(() => {
+                    if (this.pending.get(payloadRef) === request) {
+                        this.pending.delete(payloadRef);
+                    }
+                });
+            // Batch refs share the same in-flight registry as single loads.
+            this.pending.set(payloadRef, request);
+            requests.set(payloadRef, request);
+        }
+
+        return Promise.all(
+            payloadRefs.map(async (payloadRef) => [
+                payloadRef,
+                await requests.get(payloadRef)!,
+            ] as const),
+        ).then((payloads) => new Map(payloads));
     }
 }

--- a/src/renderer/src/app/ai/transcriptReviewPayloadRetention.test.ts
+++ b/src/renderer/src/app/ai/transcriptReviewPayloadRetention.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { TranscriptReviewPayloadRetention } from "./transcriptReviewPayloadRetention";
+
+describe("TranscriptReviewPayloadRetention", () => {
+    it("releases a review payload only after its last visible consumer", () => {
+        const retention = new TranscriptReviewPayloadRetention();
+
+        expect(retention.retain("payload:diff")).toBe(true);
+        expect(retention.retain("payload:diff")).toBe(false);
+        expect(retention.release("payload:diff")).toBe(false);
+        expect(retention.release("payload:diff")).toBe(true);
+    });
+});

--- a/src/renderer/src/app/ai/transcriptReviewPayloadRetention.ts
+++ b/src/renderer/src/app/ai/transcriptReviewPayloadRetention.ts
@@ -1,0 +1,33 @@
+/**
+ * Owns review visibility independently from the byte-bounded payload cache.
+ * A payload becomes evictable only after its last visible review releases it.
+ */
+export class TranscriptReviewPayloadRetention {
+    private readonly countsByRef = new Map<string, number>();
+
+    retain(payloadRef: string): boolean {
+        const count = this.countsByRef.get(payloadRef) ?? 0;
+        this.countsByRef.set(payloadRef, count + 1);
+        return count === 0;
+    }
+
+    release(payloadRef: string): boolean {
+        const count = this.countsByRef.get(payloadRef) ?? 0;
+        if (count <= 1) {
+            this.countsByRef.delete(payloadRef);
+            return count > 0;
+        }
+        this.countsByRef.set(payloadRef, count - 1);
+        return false;
+    }
+
+    releaseAll(): readonly string[] {
+        const payloadRefs = [...this.countsByRef.keys()];
+        this.countsByRef.clear();
+        return payloadRefs;
+    }
+
+    has(payloadRef: string): boolean {
+        return this.countsByRef.has(payloadRef);
+    }
+}

--- a/src/renderer/src/app/ai/transcriptWindowProjection.test.ts
+++ b/src/renderer/src/app/ai/transcriptWindowProjection.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type {
+    AiSessionDomainEvent,
+    AiTranscriptBlock,
+    AiTranscriptBlockMetadata,
+} from "@shared/ipc";
+
+import {
+    applyAiSessionDomainEventToTranscript,
+    buildAiSessionTranscriptModel,
+    isAiSessionTranscriptMutationFrom,
+} from "./transcriptModel";
+import { buildBlockNativeTranscriptProjection } from "./transcriptWindowProjection";
+import {
+    readChatPerformanceCounters,
+    resetChatPerformanceCounters,
+} from "@renderer/app/debug/chatPerformanceCounters";
+
+const SESSION_ID = "projection-session";
+const STARTED_AT = "2026-01-01T00:00:00.000Z";
+
+describe("transcriptWindowProjection", () => {
+    beforeEach(() => {
+        resetChatPerformanceCounters();
+    });
+
+    it("preserves the hot transcript mutation chain without revisiting sealed entries", () => {
+        const { blocksById, metadata } = createSealedBlocks(2);
+        const live = createLiveTranscript("", true);
+        const payloadsByRef = new Map();
+        const projection = buildBlockNativeTranscriptProjection(
+            live,
+            blocksById,
+            metadata,
+            payloadsByRef,
+        );
+        resetChatPerformanceCounters();
+
+        const intermediateLive = applyAiSessionDomainEventToTranscript(
+            live,
+            createMessageDelta("hello"),
+        );
+        const nextLive = applyAiSessionDomainEventToTranscript(
+            intermediateLive,
+            createMessageDelta("hello world"),
+        );
+        const nextProjection = buildBlockNativeTranscriptProjection(
+            nextLive,
+            blocksById,
+            metadata,
+            payloadsByRef,
+            projection,
+        );
+
+        expect(nextProjection.sealed).toBe(projection.sealed);
+        expect(nextProjection.hot.parent).toBe(projection.hot);
+        expect(nextProjection.hot.mutation).toEqual({
+            entryId: "message:streaming-assistant",
+            kind: "patch",
+        });
+        expect(
+            isAiSessionTranscriptMutationFrom(
+                nextProjection.hot.transcript,
+                projection.hot.transcript,
+            ),
+        ).toBe(true);
+        expect(nextProjection.hot.transcript.messages.at(-1)?.content).toBe(
+            "hello world",
+        );
+        expect(nextProjection.hot.transcript.messages).toHaveLength(1);
+        expect(readChatPerformanceCounters()).toMatchObject({
+            stable_history_entries_visited: 0,
+            timeline_blocks_built: 0,
+        });
+    });
+
+    it("reuses unchanged block projections and carries entry ownership", () => {
+        const { blocksById, metadata } = createSealedBlocks(2);
+        const payloadsByRef = new Map();
+        const projection = buildBlockNativeTranscriptProjection(
+            createLiveTranscript(""),
+            blocksById,
+            metadata,
+            payloadsByRef,
+        );
+        const changedBlock = {
+            ...blocksById.get("block-2")!,
+            revision: 2,
+        };
+        const nextBlocksById = new Map(blocksById);
+        nextBlocksById.set(changedBlock.blockId, changedBlock);
+        const nextMetadata = metadata.map((item) =>
+            item.blockId === changedBlock.blockId
+                ? { ...item, revision: 2 }
+                : item,
+        );
+        resetChatPerformanceCounters();
+
+        const nextProjection = buildBlockNativeTranscriptProjection(
+            projection.hot.source,
+            nextBlocksById,
+            nextMetadata,
+            payloadsByRef,
+            projection,
+        );
+
+        expect(nextProjection.sealed.blocks[0]).toBe(
+            projection.sealed.blocks[0],
+        );
+        expect(nextProjection.sealed.blocks[1]).not.toBe(
+            projection.sealed.blocks[1],
+        );
+        expect(
+            nextProjection.sealed.blockIdByEntryId.get("message:sealed-1"),
+        ).toBe("block-1");
+        expect(readChatPerformanceCounters()).toMatchObject({
+            stable_history_entries_visited: 1,
+            timeline_blocks_built: 1,
+        });
+    });
+});
+
+function createLiveTranscript(
+    content: string,
+    includeSealedDuplicate = false,
+) {
+    return buildAiSessionTranscriptModel({
+        messages: [
+            ...(includeSealedDuplicate
+                ? [
+                      {
+                          attachments: [],
+                          content: "Duplicate sealed message",
+                          createdAt: "2025-12-31T23:59:01.000Z",
+                          id: "sealed-1",
+                          kind: "assistant" as const,
+                          status: "completed" as const,
+                      },
+                  ]
+                : []),
+            {
+                attachments: [],
+                content,
+                createdAt: STARTED_AT,
+                id: "streaming-assistant",
+                kind: "assistant",
+                status: "streaming",
+            },
+        ],
+        toolActivity: [],
+    });
+}
+
+function createMessageDelta(content: string): AiSessionDomainEvent {
+    return {
+        content,
+        delta: content,
+        kind: "message-delta",
+        messageId: "streaming-assistant",
+        messageKind: "assistant",
+        origin: "live",
+        parentSessionId: null,
+        runtimeId: "codex",
+        runtimeSessionId: "runtime-session",
+        sessionId: SESSION_ID,
+        updatedAt: "2026-01-01T00:00:01.000Z",
+    };
+}
+
+function createSealedBlocks(count: number): {
+    readonly blocksById: ReadonlyMap<string, AiTranscriptBlock>;
+    readonly metadata: readonly AiTranscriptBlockMetadata[];
+} {
+    const metadata = Array.from({ length: count }, (_, index) => {
+        const sequence = index + 1;
+        return {
+            blockId: `block-${sequence}`,
+            endSequence: sequence,
+            entryCount: 1,
+            estimatedHeight: 72,
+            estimatedRowCount: 1,
+            firstCreatedAt: `2025-12-31T23:59:0${sequence}.000Z`,
+            lastCreatedAt: `2025-12-31T23:59:0${sequence}.000Z`,
+            revision: 1,
+            sessionId: SESSION_ID,
+            startSequence: sequence,
+        } satisfies AiTranscriptBlockMetadata;
+    });
+    const blocksById = new Map<string, AiTranscriptBlock>();
+    for (const item of metadata) {
+        blocksById.set(item.blockId, {
+            ...item,
+            capabilityVersion: 1,
+            entries: [
+                {
+                    createdAt: item.firstCreatedAt,
+                    id: `message:sealed-${item.startSequence}`,
+                    kind: "message",
+                    payloadRef: null,
+                    sequence: item.startSequence,
+                    sessionId: SESSION_ID,
+                    summary: {
+                        label: `Sealed ${item.startSequence}`,
+                        preview: `Sealed ${item.startSequence}`,
+                        status: "completed",
+                    },
+                    updatedAt: item.lastCreatedAt,
+                },
+            ],
+            transcriptRevision: 1,
+        });
+    }
+    return { blocksById, metadata };
+}

--- a/src/renderer/src/app/ai/transcriptWindowProjection.ts
+++ b/src/renderer/src/app/ai/transcriptWindowProjection.ts
@@ -8,12 +8,261 @@ import type {
 } from "@shared/ipc";
 
 import {
+    applyAiSessionTranscriptMutationToProjection,
     buildAiSessionTranscriptModel,
+    getAiSessionTranscriptMutation,
+    getAiSessionTranscriptMutationChainFrom,
+    removeAiSessionTranscriptEntries,
     type AiSessionTranscriptModel,
+    type AiSessionTranscriptMutation,
 } from "./transcriptModel";
 import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
 import { measureChatPerformance } from "@renderer/app/debug/chatPerformanceProbe";
 
+export interface SealedTranscriptBlockProjection {
+    readonly blockId: string;
+    readonly entryIds: readonly string[];
+    readonly revision: number;
+    readonly transcript: AiSessionTranscriptModel;
+}
+
+export interface SealedTranscriptProjection {
+    readonly blockIdByEntryId: ReadonlyMap<string, string>;
+    readonly blocks: readonly SealedTranscriptBlockProjection[];
+    readonly entryCount: number;
+    readonly entryIds: ReadonlySet<string>;
+    readonly transcript: AiSessionTranscriptModel;
+}
+
+export interface HotTranscriptProjection {
+    readonly mutation: AiSessionTranscriptMutation;
+    readonly parent: HotTranscriptProjection | null;
+    readonly source: AiSessionTranscriptModel;
+    readonly transcript: AiSessionTranscriptModel;
+}
+
+export interface BlockNativeTranscriptProjection {
+    readonly hot: HotTranscriptProjection;
+    readonly sealed: SealedTranscriptProjection;
+}
+
+interface SealedTranscriptProjectionSource {
+    readonly blocksById: ReadonlyMap<string, AiTranscriptBlock>;
+    readonly metadata: readonly AiTranscriptBlockMetadata[];
+    readonly payloadsByRef: ReadonlyMap<string, AiTranscriptPayload>;
+}
+
+const sealedProjectionSource = new WeakMap<
+    SealedTranscriptProjection,
+    SealedTranscriptProjectionSource
+>();
+
+export function buildSealedTranscriptProjection(
+    blocksById: ReadonlyMap<string, AiTranscriptBlock>,
+    metadata: readonly AiTranscriptBlockMetadata[],
+    payloadsByRef: ReadonlyMap<string, AiTranscriptPayload>,
+    previous: SealedTranscriptProjection | null = null,
+): SealedTranscriptProjection {
+    const previousSource = previous
+        ? sealedProjectionSource.get(previous)
+        : undefined;
+    if (
+        previous &&
+        previousSource?.blocksById === blocksById &&
+        previousSource.metadata === metadata &&
+        previousSource.payloadsByRef === payloadsByRef
+    ) {
+        return previous;
+    }
+
+    return measureChatPerformance(
+        "block_projection_ms",
+        {
+            values: {
+                metadataBlocks: metadata.length,
+                residentBlocks: blocksById.size,
+            },
+        },
+        () => {
+            const blockIdByEntryId = new Map<string, string>();
+            const blocks: SealedTranscriptBlockProjection[] = [];
+            const entryIds = new Set<string>();
+            const messages: AiMessage[] = [];
+            const previousBlocksById = new Map(
+                previous?.blocks.map((block) => [block.blockId, block]),
+            );
+            const toolActivity: AiToolActivity[] = [];
+
+            for (const item of metadata) {
+                const block = blocksById.get(item.blockId);
+                if (!block) continue;
+                const previousBlock = previousBlocksById.get(item.blockId);
+                const canReuseBlock = Boolean(
+                    previousBlock &&
+                        previousSource?.payloadsByRef === payloadsByRef &&
+                        previousBlock.revision === item.revision,
+                );
+                if (!canReuseBlock) {
+                    incrementChatPerformanceCounter("timeline_blocks_built");
+                    incrementChatPerformanceCounter(
+                        "stable_history_entries_visited",
+                        block.entries.length,
+                    );
+                }
+                const blockProjection = canReuseBlock
+                    ? previousBlock!
+                    : projectSealedTranscriptBlock(block, payloadsByRef);
+                blocks.push(blockProjection);
+                for (const entryId of blockProjection.entryIds) {
+                    entryIds.add(entryId);
+                    blockIdByEntryId.set(entryId, item.blockId);
+                }
+                messages.push(...blockProjection.transcript.messages);
+                toolActivity.push(...blockProjection.transcript.toolActivity);
+            }
+
+            const projection: SealedTranscriptProjection = {
+                blockIdByEntryId,
+                blocks,
+                entryCount: entryIds.size,
+                entryIds,
+                transcript: buildAiSessionTranscriptModel({
+                    messages,
+                    toolActivity,
+                }),
+            };
+            sealedProjectionSource.set(projection, {
+                blocksById,
+                metadata,
+                payloadsByRef,
+            });
+            return projection;
+        },
+    );
+}
+
+export function reconcileHotTranscriptProjection(
+    liveTranscript: AiSessionTranscriptModel,
+    sealed: SealedTranscriptProjection,
+    previous: HotTranscriptProjection | null = null,
+): HotTranscriptProjection {
+    if (previous?.source === liveTranscript) {
+        return previous;
+    }
+
+    const mutation = getAiSessionTranscriptMutation(liveTranscript);
+    const sourceChain = previous
+        ? getAiSessionTranscriptMutationChainFrom(
+              liveTranscript,
+              previous.source,
+          )
+        : null;
+    const canCollapseSourceChain = Boolean(
+        sourceChain &&
+            (sourceChain.length === 1 ||
+                hasSingleUpsertTarget(sourceChain)),
+    );
+    if (previous && canCollapseSourceChain) {
+        const entryId = mutation.kind === "rebuild" ? null : mutation.entryId;
+        if (entryId && sealed.entryIds.has(entryId)) {
+            return {
+                mutation,
+                parent: previous,
+                source: liveTranscript,
+                transcript: previous.transcript,
+            };
+        }
+
+        const transcript = applyAiSessionTranscriptMutationToProjection(
+            previous.transcript,
+            liveTranscript,
+        );
+        if (transcript) {
+            return {
+                mutation,
+                parent: previous,
+                source: liveTranscript,
+                transcript,
+            };
+        }
+    }
+
+    return {
+        mutation,
+        parent: null,
+        source: liveTranscript,
+        transcript: removeAiSessionTranscriptEntries(
+            liveTranscript,
+            sealed.entryIds,
+        ),
+    };
+}
+
+function hasSingleUpsertTarget(
+    sourceChain: readonly AiSessionTranscriptModel[],
+): boolean {
+    let entryId: string | null = null;
+    for (const source of sourceChain) {
+        const mutation = getAiSessionTranscriptMutation(source);
+        if (mutation.kind !== "append" && mutation.kind !== "patch") {
+            return false;
+        }
+        entryId ??= mutation.entryId;
+        if (entryId !== mutation.entryId) {
+            return false;
+        }
+    }
+    return entryId !== null;
+}
+
+export function buildBlockNativeTranscriptProjection(
+    liveTranscript: AiSessionTranscriptModel,
+    blocksById: ReadonlyMap<string, AiTranscriptBlock>,
+    metadata: readonly AiTranscriptBlockMetadata[],
+    payloadsByRef: ReadonlyMap<string, AiTranscriptPayload>,
+    previous: BlockNativeTranscriptProjection | null = null,
+): BlockNativeTranscriptProjection {
+    const sealed = buildSealedTranscriptProjection(
+        blocksById,
+        metadata,
+        payloadsByRef,
+        previous?.sealed ?? null,
+    );
+    const hot = reconcileHotTranscriptProjection(
+        liveTranscript,
+        sealed,
+        previous?.sealed === sealed ? previous.hot : null,
+    );
+    if (previous?.sealed === sealed && previous.hot === hot) {
+        return previous;
+    }
+    return { hot, sealed };
+}
+
+export function buildBlockNativeTranscriptBootstrap(
+    projection: BlockNativeTranscriptProjection,
+    snapshot: Pick<
+        AiSessionSnapshot,
+        "activeTurnStartedAt" | "status" | "updatedAt"
+    >,
+): AiSessionTranscriptModel {
+    return buildAiSessionTranscriptModel({
+        activeTurnStartedAt: snapshot.activeTurnStartedAt ?? null,
+        messages: [
+            ...projection.sealed.transcript.messages,
+            ...projection.hot.transcript.messages,
+        ],
+        status: snapshot.status,
+        toolActivity: [
+            ...projection.sealed.transcript.toolActivity,
+            ...projection.hot.transcript.toolActivity,
+        ],
+        updatedAt: snapshot.updatedAt,
+    });
+}
+
+// Kept for callers that need a one-shot materialized transcript. Streaming
+// consumers should retain BlockNativeTranscriptProjection across updates.
 export function buildBlockNativeTranscript(
     liveTranscript: AiSessionTranscriptModel,
     blocksById: ReadonlyMap<string, AiTranscriptBlock>,
@@ -21,89 +270,15 @@ export function buildBlockNativeTranscript(
     payloadsByRef: ReadonlyMap<string, AiTranscriptPayload>,
     snapshot: AiSessionSnapshot,
 ): AiSessionTranscriptModel {
-    return measureChatPerformance(
-        "block_projection_ms",
-        {
-            sessionId: snapshot.sessionId,
-            values: {
-                metadataBlocks: metadata.length,
-                residentBlocks: blocksById.size,
-            },
-        },
-        () =>
-            buildBlockNativeTranscriptUnmeasured(
-                liveTranscript,
-                blocksById,
-                metadata,
-                payloadsByRef,
-                snapshot,
-            ),
+    return buildBlockNativeTranscriptBootstrap(
+        buildBlockNativeTranscriptProjection(
+            liveTranscript,
+            blocksById,
+            metadata,
+            payloadsByRef,
+        ),
+        snapshot,
     );
-}
-
-function buildBlockNativeTranscriptUnmeasured(
-    liveTranscript: AiSessionTranscriptModel,
-    blocksById: ReadonlyMap<string, AiTranscriptBlock>,
-    metadata: readonly AiTranscriptBlockMetadata[],
-    payloadsByRef: ReadonlyMap<string, AiTranscriptPayload>,
-    snapshot: AiSessionSnapshot,
-): AiSessionTranscriptModel {
-    const sealedEntryIds = new Set<string>();
-    const messages: AiMessage[] = [];
-    const toolActivity: AiToolActivity[] = [];
-
-    for (const item of metadata) {
-        const block = blocksById.get(item.blockId);
-        if (!block) continue;
-        incrementChatPerformanceCounter("timeline_blocks_built");
-        incrementChatPerformanceCounter(
-            "stable_history_entries_visited",
-            block.entries.length,
-        );
-        for (const entry of block.entries) {
-            sealedEntryIds.add(entry.id);
-            const payload = entry.payloadRef
-                ? payloadsByRef.get(entry.payloadRef)?.value
-                : null;
-            if (isTranscriptMessagePayload(payload)) {
-                messages.push(payload.message);
-            } else if (isTranscriptToolPayload(payload)) {
-                toolActivity.push(payload.activity);
-            } else if (entry.kind === "tool") {
-                toolActivity.push(createTranscriptToolSummary(entry));
-            } else if (entry.kind !== "plan" && entry.kind !== "status") {
-                messages.push({
-                    attachments: [],
-                    content: entry.summary.preview ?? entry.summary.label ?? "",
-                    createdAt: entry.createdAt,
-                    id: `summary:${entry.id}`,
-                    kind: entry.kind === "thinking" ? "thinking" : "assistant",
-                    status: "completed",
-                });
-            }
-        }
-    }
-
-    return buildAiSessionTranscriptModel({
-        activeTurnStartedAt: snapshot.activeTurnStartedAt ?? null,
-        messages: [
-            ...messages,
-            ...liveTranscript.messages.filter(
-                (message) => !sealedEntryIds.has(`message:${message.id}`),
-            ),
-        ],
-        status: snapshot.status,
-        toolActivity: [
-            ...toolActivity,
-            ...liveTranscript.toolActivity.filter(
-                (activity) =>
-                    !sealedEntryIds.has(
-                        `tool:${activity.sessionId}:${activity.id}`,
-                    ),
-            ),
-        ],
-        updatedAt: snapshot.updatedAt,
-    });
 }
 
 export function buildTranscriptToolPayloadRefs(
@@ -121,6 +296,45 @@ export function buildTranscriptToolPayloadRefs(
         }
     }
     return payloadRefs;
+}
+
+function projectSealedTranscriptBlock(
+    block: AiTranscriptBlock,
+    payloadsByRef: ReadonlyMap<string, AiTranscriptPayload>,
+): SealedTranscriptBlockProjection {
+    const entryIds: string[] = [];
+    const messages: AiMessage[] = [];
+    const toolActivity: AiToolActivity[] = [];
+    for (const entry of block.entries) {
+        entryIds.push(entry.id);
+        const payload = entry.payloadRef
+            ? payloadsByRef.get(entry.payloadRef)?.value
+            : null;
+        if (isTranscriptMessagePayload(payload)) {
+            messages.push(payload.message);
+        } else if (isTranscriptToolPayload(payload)) {
+            toolActivity.push(payload.activity);
+        } else if (entry.kind === "tool") {
+            toolActivity.push(createTranscriptToolSummary(entry));
+        } else if (entry.kind !== "plan" && entry.kind !== "status") {
+            messages.push({
+                attachments: [],
+                content: entry.summary.preview ?? entry.summary.label ?? "",
+                createdAt: entry.createdAt,
+                id: entry.id.startsWith("message:")
+                    ? entry.id.slice("message:".length)
+                    : `summary:${entry.id}`,
+                kind: entry.kind === "thinking" ? "thinking" : "assistant",
+                status: "completed",
+            });
+        }
+    }
+    return {
+        blockId: block.blockId,
+        entryIds,
+        revision: block.revision,
+        transcript: buildAiSessionTranscriptModel({ messages, toolActivity }),
+    };
 }
 
 function createTranscriptToolSummary(

--- a/src/renderer/src/app/ai/transcriptWindowProjection.ts
+++ b/src/renderer/src/app/ai/transcriptWindowProjection.ts
@@ -11,8 +11,37 @@ import {
     buildAiSessionTranscriptModel,
     type AiSessionTranscriptModel,
 } from "./transcriptModel";
+import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
+import { measureChatPerformance } from "@renderer/app/debug/chatPerformanceProbe";
 
 export function buildBlockNativeTranscript(
+    liveTranscript: AiSessionTranscriptModel,
+    blocksById: ReadonlyMap<string, AiTranscriptBlock>,
+    metadata: readonly AiTranscriptBlockMetadata[],
+    payloadsByRef: ReadonlyMap<string, AiTranscriptPayload>,
+    snapshot: AiSessionSnapshot,
+): AiSessionTranscriptModel {
+    return measureChatPerformance(
+        "block_projection_ms",
+        {
+            sessionId: snapshot.sessionId,
+            values: {
+                metadataBlocks: metadata.length,
+                residentBlocks: blocksById.size,
+            },
+        },
+        () =>
+            buildBlockNativeTranscriptUnmeasured(
+                liveTranscript,
+                blocksById,
+                metadata,
+                payloadsByRef,
+                snapshot,
+            ),
+    );
+}
+
+function buildBlockNativeTranscriptUnmeasured(
     liveTranscript: AiSessionTranscriptModel,
     blocksById: ReadonlyMap<string, AiTranscriptBlock>,
     metadata: readonly AiTranscriptBlockMetadata[],
@@ -26,6 +55,11 @@ export function buildBlockNativeTranscript(
     for (const item of metadata) {
         const block = blocksById.get(item.blockId);
         if (!block) continue;
+        incrementChatPerformanceCounter("timeline_blocks_built");
+        incrementChatPerformanceCounter(
+            "stable_history_entries_visited",
+            block.entries.length,
+        );
         for (const entry of block.entries) {
             sealedEntryIds.add(entry.id);
             const payload = entry.payloadRef

--- a/src/renderer/src/app/debug/chatPerformanceCounters.ts
+++ b/src/renderer/src/app/debug/chatPerformanceCounters.ts
@@ -1,10 +1,17 @@
 export type ChatPerformanceCounter =
     | "activity_items_mounted"
+    | "code_highlight_chars_reparsed"
+    | "diff_prepares"
+    | "markdown_cache_hits"
+    | "markdown_chars_reparsed"
+    | "presentation_items_visited"
     | "stable_history_entries_visited"
     | "timeline_blocks_built"
     | "timeline_full_rebuilds"
     | "transcript_blocks_evicted"
-    | "transcript_blocks_loaded";
+    | "transcript_blocks_loaded"
+    | "transcript_payload_bytes"
+    | "transcript_payload_ipc_count";
 
 export type ChatPerformanceCounterSnapshot = Readonly<
     Record<ChatPerformanceCounter, number>
@@ -12,11 +19,18 @@ export type ChatPerformanceCounterSnapshot = Readonly<
 
 const EMPTY_COUNTERS: ChatPerformanceCounterSnapshot = {
     activity_items_mounted: 0,
+    code_highlight_chars_reparsed: 0,
+    diff_prepares: 0,
+    markdown_cache_hits: 0,
+    markdown_chars_reparsed: 0,
+    presentation_items_visited: 0,
     stable_history_entries_visited: 0,
     timeline_blocks_built: 0,
     timeline_full_rebuilds: 0,
     transcript_blocks_evicted: 0,
     transcript_blocks_loaded: 0,
+    transcript_payload_bytes: 0,
+    transcript_payload_ipc_count: 0,
 };
 
 let counters: Record<ChatPerformanceCounter, number> = { ...EMPTY_COUNTERS };

--- a/src/renderer/src/app/debug/chatPerformanceProbe.test.ts
+++ b/src/renderer/src/app/debug/chatPerformanceProbe.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
     measureChatPerformance,
+    measureChatPerformanceAsync,
     recordChatPerformanceMetric,
+    recordChatScrollWrite,
     resetChatPerformanceProbeForTests,
     setChatPerformanceProbeEnabledForTests,
 } from "./chatPerformanceProbe";
@@ -49,7 +51,7 @@ describe("chatPerformanceProbe", () => {
 
     it("caps the in-memory dump", () => {
         setChatPerformanceProbeEnabledForTests(true);
-        for (let index = 0; index < 520; index += 1) {
+        for (let index = 0; index < 10_020; index += 1) {
             recordChatPerformanceMetric("markdown_parse_ms", {
                 values: { contentChars: index },
             });
@@ -58,6 +60,42 @@ describe("chatPerformanceProbe", () => {
             __comandoChatPerformanceProbeDump?: () => readonly unknown[];
         };
 
-        expect(root.__comandoChatPerformanceProbeDump?.()).toHaveLength(500);
+        expect(root.__comandoChatPerformanceProbeDump?.()).toHaveLength(10_000);
+    });
+
+    it("records async work and scroll causes without storing raw labels", async () => {
+        setChatPerformanceProbeEnabledForTests(true);
+        await measureChatPerformanceAsync(
+            "transcript_payload_batch_ms",
+            { sessionId: "sensitive-session", values: { payloadRefs: 3 } },
+            () => Promise.resolve(),
+        );
+        recordChatScrollWrite({
+            after: 120,
+            before: 80,
+            clientHeight: 600,
+            navigationGeneration: 4,
+            reason: "settle",
+            scrollHeight: 720,
+            sessionId: "sensitive-session",
+        });
+
+        const root = globalThis as typeof globalThis & {
+            __comandoChatPerformanceProbeDump?: () => ReadonlyArray<{
+                readonly metric: string;
+                readonly values: Readonly<Record<string, number>>;
+            }>;
+        };
+        const dump = root.__comandoChatPerformanceProbeDump?.() ?? [];
+        expect(dump.map((event) => event.metric)).toEqual([
+            "transcript_payload_batch_ms",
+            "scroll_write",
+        ]);
+        expect(dump[1]?.values).toMatchObject({
+            navigationGeneration: 4,
+            reasonCode: 6,
+        });
+        expect(JSON.stringify(dump)).not.toContain("sensitive-session");
+        expect(JSON.stringify(dump)).not.toContain("settle");
     });
 });

--- a/src/renderer/src/app/debug/chatPerformanceProbe.ts
+++ b/src/renderer/src/app/debug/chatPerformanceProbe.ts
@@ -1,16 +1,35 @@
 const CHAT_PERFORMANCE_PROBE_STORAGE_KEY = "comando:chat-performance-probe";
-const MAX_CHAT_PERFORMANCE_EVENTS = 500;
+const MAX_CHAT_PERFORMANCE_EVENTS = 10_000;
 
 export type ChatPerformanceMetric =
     | "ack_lag_ms"
     | "apply_event_ms"
+    | "block_projection_ms"
+    | "chat_frame"
+    | "code_highlight_ms"
     | "delta_buffer_wait_ms"
+    | "diff_prepare_ms"
+    | "long_task"
+    | "markdown_commit"
     | "markdown_parse_ms"
+    | "presentation_build_ms"
     | "react_commit_ms"
     | "review_index_ms"
+    | "scroll_write"
     | "timeline_reconcile_ms"
+    | "transcript_payload_batch_ms"
+    | "transcript_payload_load_ms"
     | "transcript_patch_ms"
+    | "virtual_measure"
     | "virtual_range";
+
+export type ChatScrollWriteReason =
+    | "follow-end"
+    | "measure-anchor"
+    | "new-turn"
+    | "restore"
+    | "scroll-to-index"
+    | "settle";
 
 export interface ChatPerformanceMetricInput {
     readonly durationMs?: number;
@@ -38,6 +57,18 @@ type ChatPerformanceProbeRoot = typeof globalThis & {
 
 let enabledForTests: boolean | null = null;
 let cachedEnabled: boolean | null = null;
+let longTaskObserver: PerformanceObserver | null = null;
+let longTaskObserverAttempted = false;
+let activeChatPerformanceFrameTime = 0;
+
+const CHAT_SCROLL_REASON_CODE: Readonly<Record<ChatScrollWriteReason, number>> = {
+    "follow-end": 1,
+    "measure-anchor": 2,
+    "new-turn": 3,
+    restore: 4,
+    "scroll-to-index": 5,
+    settle: 6,
+};
 
 export function isChatPerformanceProbeEnabled(): boolean {
     if (enabledForTests !== null) {
@@ -120,6 +151,14 @@ export function recordChatPerformanceMetric(
         return;
     }
 
+    ensureChatLongTaskObserver();
+    appendChatPerformanceEvent(metric, input);
+}
+
+function appendChatPerformanceEvent(
+    metric: ChatPerformanceMetric,
+    input: ChatPerformanceMetricInput,
+): void {
     const store = getChatPerformanceProbeStore();
     store.events.push({
         durationMs:
@@ -134,6 +173,30 @@ export function recordChatPerformanceMetric(
     });
     if (store.events.length > MAX_CHAT_PERFORMANCE_EVENTS) {
         store.events.splice(0, store.events.length - MAX_CHAT_PERFORMANCE_EVENTS);
+    }
+}
+
+function ensureChatLongTaskObserver(): void {
+    if (
+        longTaskObserverAttempted ||
+        typeof PerformanceObserver === "undefined"
+    ) {
+        return;
+    }
+
+    longTaskObserverAttempted = true;
+    try {
+        longTaskObserver = new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+                appendChatPerformanceEvent("long_task", {
+                    durationMs: entry.duration,
+                    values: { startTime: entry.startTime },
+                });
+            }
+        });
+        longTaskObserver.observe({ entryTypes: ["longtask"] });
+    } catch {
+        longTaskObserver = null;
     }
 }
 
@@ -166,6 +229,65 @@ export function measureChatPerformance<T>(
     }
 }
 
+export async function measureChatPerformanceAsync<T>(
+    metric: ChatPerformanceMetric,
+    input: Omit<ChatPerformanceMetricInput, "durationMs">,
+    operation: () => Promise<T>,
+): Promise<T> {
+    if (!isChatPerformanceProbeEnabled()) {
+        return operation();
+    }
+
+    const start = performance.now();
+    try {
+        return await operation();
+    } finally {
+        recordChatPerformanceMetric(metric, {
+            ...input,
+            durationMs: performance.now() - start,
+        });
+    }
+}
+
+export function recordChatScrollWrite(input: {
+    readonly after: number;
+    readonly before: number;
+    readonly clientHeight: number;
+    readonly navigationGeneration?: number;
+    readonly reason: ChatScrollWriteReason;
+    readonly scrollHeight: number;
+    readonly sessionId?: string;
+}): void {
+    recordChatPerformanceMetric("scroll_write", {
+        sessionId: input.sessionId,
+        values: {
+            after: input.after,
+            before: input.before,
+            clientHeight: input.clientHeight,
+            frameTime: activeChatPerformanceFrameTime,
+            navigationGeneration: input.navigationGeneration,
+            reasonCode: CHAT_SCROLL_REASON_CODE[input.reason],
+            scrollHeight: input.scrollHeight,
+        },
+    });
+}
+
+export function markChatPerformanceFrame(frameAt: number): void {
+    if (!isChatPerformanceProbeEnabled() || !Number.isFinite(frameAt)) {
+        return;
+    }
+    activeChatPerformanceFrameTime = Number(frameAt.toFixed(2));
+}
+
+export function hashChatPerformanceLabel(value: string): number {
+    let hash = 2166136261;
+    for (let index = 0; index < value.length; index += 1) {
+        hash ^= value.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+    }
+    return hash >>> 0;
+}
+
 export function setChatPerformanceProbeEnabledForTests(
     enabled: boolean | null,
 ): void {
@@ -178,6 +300,10 @@ export function resetChatPerformanceProbeForTests(): void {
     delete root.__COMANDO_CHAT_PERFORMANCE_PROBE__;
     delete root.__comandoChatPerformanceProbeDump;
     delete root.__comandoChatPerformanceProbeReset;
+    longTaskObserver?.disconnect();
+    longTaskObserver = null;
+    longTaskObserverAttempted = false;
+    activeChatPerformanceFrameTime = 0;
     enabledForTests = null;
     cachedEnabled = null;
 }

--- a/src/renderer/src/app/editor/staticCodeHighlight.tsx
+++ b/src/renderer/src/app/editor/staticCodeHighlight.tsx
@@ -1,6 +1,8 @@
 import { LanguageSupport, type Language } from "@codemirror/language";
 import { highlightTree, tagHighlighter, tags } from "@lezer/highlight";
 import { useMemo, type ReactNode } from "react";
+import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
+import { measureChatPerformance } from "@renderer/app/debug/chatPerformanceProbe";
 
 type HighlightSegment = {
     readonly text: string;
@@ -149,6 +151,21 @@ function buildHighlightSegments(
         return [{ text, className: null }];
     }
 
+    return measureChatPerformance(
+        "code_highlight_ms",
+        { values: { contentChars: text.length } },
+        () => buildLanguageHighlightSegments(text, language),
+    );
+}
+
+function buildLanguageHighlightSegments(
+    text: string,
+    language: Language,
+): HighlightSegment[] {
+    incrementChatPerformanceCounter(
+        "code_highlight_chars_reparsed",
+        text.length,
+    );
     const tree = language.parser.parse(text);
     const segments: HighlightSegment[] = [];
     let cursor = 0;

--- a/src/renderer/src/app/editor/staticCodeHighlight.tsx
+++ b/src/renderer/src/app/editor/staticCodeHighlight.tsx
@@ -212,21 +212,30 @@ function renderHighlightSegments(
 }
 
 export function HighlightedCodeText({
+    deferHighlighting = false,
     text,
     language,
     segmentKeyPrefix = "cm-static",
 }: {
+    /** Keeps an open streaming fence responsive until its syntax is sealed. */
+    readonly deferHighlighting?: boolean;
     readonly text: string;
     readonly language: LanguageSupport | Language | null;
     readonly segmentKeyPrefix?: string;
 }) {
     const segments = useMemo(
-        () => buildHighlightSegments(text, toLanguage(language)),
-        [language, text],
+        () =>
+            deferHighlighting
+                ? [{ className: null, text }]
+                : buildHighlightSegments(text, toLanguage(language)),
+        [deferHighlighting, language, text],
     );
 
     return (
-        <span className="cm-static-code">
+        <span
+            className="cm-static-code"
+            data-code-highlight-deferred={deferHighlighting ? "true" : undefined}
+        >
             {renderHighlightSegments(segments, segmentKeyPrefix)}
         </span>
     );

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -114,6 +114,7 @@ const ensureSessionInFlight = new Map<string, Promise<void>>();
 const transcriptWindowHydrations = new Map<string, Promise<void>>();
 const transcriptWindowRefreshRequests = new Set<string>();
 const TRANSCRIPT_PAYLOAD_CACHE_MAX_BYTES = 16 * 1024 * 1024;
+const TRANSCRIPT_PAYLOAD_BATCH_MAX_REFS = 8;
 // Sharing this cache keeps the payload budget fixed as users open more sessions.
 let transcriptPayloadCache = createTranscriptPayloadCache();
 const transcriptWindowStore = new TranscriptWindowStore(
@@ -387,7 +388,13 @@ interface AiStore {
     loadTranscriptPayload: (
         sessionId: string,
         payloadRef: string,
+        options?: { readonly protect?: boolean; readonly publish?: boolean },
     ) => Promise<AiTranscriptPayload | null>;
+    loadTranscriptPayloads: (
+        sessionId: string,
+        payloadRefs: readonly string[],
+        options?: { readonly protect?: boolean; readonly publish?: boolean },
+    ) => Promise<ReadonlyMap<string, AiTranscriptPayload>>;
     releaseTranscriptPayload: (sessionId: string, payloadRef: string) => void;
     setSessionMode: (
         input: AiSessionModeMutationInput,
@@ -807,6 +814,49 @@ function createTranscriptPayloadCache(): TranscriptPayloadCache<AiTranscriptPayl
                     );
                 }
                 return payload;
+            },
+            loadMany: async (keys) => {
+                const identities = keys.map(parseTranscriptPayloadCacheKey);
+                if (identities.some((identity) => !identity)) {
+                    throw new Error("The transcript payload cache key is invalid.");
+                }
+                const validIdentities = identities as {
+                    readonly payloadRef: string;
+                    readonly sessionId: string;
+                }[];
+                const sessionId = validIdentities[0]?.sessionId;
+                const loadIndividually = async () => {
+                    return new Map(
+                        await Promise.all(keys.map(async (key) => {
+                            const identity = parseTranscriptPayloadCacheKey(key)!;
+                            const payload = await getComandoApi().getAiTranscriptPayload(identity);
+                            if (!payload) throw new Error("The transcript payload could not be found.");
+                            return [key, payload] as const;
+                        })),
+                    );
+                };
+                const loadBatch = getComandoApi().getAiTranscriptPayloads;
+                if (
+                    !sessionId ||
+                    validIdentities.some((identity) => identity.sessionId !== sessionId) ||
+                    typeof loadBatch !== "function"
+                ) {
+                    return loadIndividually();
+                }
+                incrementChatPerformanceCounter("transcript_payload_ipc_count");
+                const output = await loadBatch({
+                    payloadRefs: validIdentities.map((identity) => identity.payloadRef),
+                    sessionId,
+                });
+                if (!output) {
+                    throw new Error("The transcript payload batch could not be found.");
+                }
+                const payloads = new Map<string, AiTranscriptPayload>();
+                for (const payload of output.payloads) {
+                    incrementChatPerformanceCounter("transcript_payload_bytes", payload.byteLength);
+                    payloads.set(transcriptPayloadCacheKey(sessionId, payload.payloadRef), payload);
+                }
+                return payloads;
             },
         },
         TRANSCRIPT_PAYLOAD_CACHE_MAX_BYTES,
@@ -1721,6 +1771,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
 
     loadTranscriptWindowBlock: async (sessionId, blockId) => {
         const block = await transcriptWindowStore.load(sessionId, blockId);
+        let hydratedPayloads: ReadonlyMap<string, AiTranscriptPayload> = new Map();
         if (block) {
             // A sealed turn replaces the live tail with this visible block.
             // Hydrate its tool payloads too so review diffs remain inspectable
@@ -1735,20 +1786,17 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         : [],
                 ),
             );
-            await measureChatPerformanceAsync(
+            hydratedPayloads = await measureChatPerformanceAsync(
                 "transcript_payload_batch_ms",
                 {
                     sessionId,
                     values: { payloadRefs: visiblePayloadRefs.size },
                 },
                 () =>
-                    Promise.all(
-                        [...visiblePayloadRefs].map((payloadRef) =>
-                            get().loadTranscriptPayload(
-                                sessionId,
-                                payloadRef,
-                            ),
-                        ),
+                    get().loadTranscriptPayloads(
+                        sessionId,
+                        [...visiblePayloadRefs],
+                        { protect: false, publish: false },
                     ),
             );
         }
@@ -1782,7 +1830,10 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         payloadsByRef: retainResidentTranscriptPayloads(
                             sessionId,
                             windowSnapshot.blocksById,
-                            latest.payloadsByRef,
+                            new Map([
+                                ...latest.payloadsByRef,
+                                ...hydratedPayloads,
+                            ]),
                         ),
                     },
                 },
@@ -1797,47 +1848,72 @@ export const useAiStore = create<AiStore>((set, get) => ({
         return block;
     },
 
-    loadTranscriptPayload: async (sessionId, payloadRef) => {
-        const cacheKey = transcriptPayloadCacheKey(sessionId, payloadRef);
+    loadTranscriptPayloads: async (sessionId, payloadRefs, options = {}) => {
+        const refs = [...new Set(payloadRefs)];
+        if (refs.length === 0) return new Map();
         try {
-            const payload = await transcriptPayloadCache.load(cacheKey, {
-                protect: true,
-            });
+            const result = new Map<string, AiTranscriptPayload>();
+            for (
+                let start = 0;
+                start < refs.length;
+                start += TRANSCRIPT_PAYLOAD_BATCH_MAX_REFS
+            ) {
+                const batchRefs = refs.slice(
+                    start,
+                    start + TRANSCRIPT_PAYLOAD_BATCH_MAX_REFS,
+                );
+                const payloads = await transcriptPayloadCache.loadMany(
+                    batchRefs.map((payloadRef) =>
+                        transcriptPayloadCacheKey(sessionId, payloadRef),
+                    ),
+                    { protect: options.protect ?? true },
+                );
+                for (const payloadRef of batchRefs) {
+                    const cacheKey = transcriptPayloadCacheKey(
+                        sessionId,
+                        payloadRef,
+                    );
+                    const payload = payloads.get(cacheKey);
+                    if (payload && transcriptPayloadCache.has(cacheKey)) {
+                        result.set(payloadRef, payload);
+                    }
+                }
+            }
             const evictedPayloadRefsBySession =
                 takeEvictedTranscriptPayloadRefs();
-            const isResident = transcriptPayloadCache.has(cacheKey);
-            set((state) => {
-                const sessions = removeEvictedTranscriptPayloads(
-                    state.sessions,
-                    evictedPayloadRefsBySession,
-                );
+            if (options.publish !== false) set((state) => {
+                const sessions = removeEvictedTranscriptPayloads(state.sessions, evictedPayloadRefsBySession);
                 const current = sessions[sessionId]?.transcriptWindow;
-                if (!current) {
-                    return sessions === state.sessions ? state : { sessions };
-                }
+                if (!current) return sessions === state.sessions ? state : { sessions };
                 const payloadsByRef = new Map(current.payloadsByRef);
-                if (isResident) {
-                    payloadsByRef.set(payloadRef, payload);
-                } else {
-                    payloadsByRef.delete(payloadRef);
+                for (const payloadRef of refs) {
+                    const payload = result.get(payloadRef);
+                    if (payload) payloadsByRef.set(payloadRef, payload);
+                    else payloadsByRef.delete(payloadRef);
                 }
                 return {
                     sessions: {
                         ...sessions,
                         [sessionId]: {
                             ...sessions[sessionId],
-                            transcriptWindow: {
-                                ...current,
-                                payloadsByRef,
-                            },
+                            transcriptWindow: { ...current, payloadsByRef },
                         },
                     },
                 };
             });
-            return isResident ? payload : null;
+            return result;
         } catch {
-            return null;
+            return new Map();
         }
+    },
+
+    loadTranscriptPayload: async (sessionId, payloadRef, options) => {
+        const payloads = await get().loadTranscriptPayloads(
+            sessionId,
+            [payloadRef],
+            options,
+        );
+        return payloads.get(payloadRef) ?? null;
     },
 
     releaseTranscriptPayload: (sessionId, payloadRef) => {

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -97,8 +97,10 @@ import { matchesTrackedFilePath } from "@renderer/app/ai/trackedFilePath";
 import {
     getChatPerformanceTimestamp,
     measureChatPerformance,
+    measureChatPerformanceAsync,
     recordChatPerformanceMetric,
 } from "@renderer/app/debug/chatPerformanceProbe";
+import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
 import type {
     RuntimeWorkspaceChatTab,
     RuntimeWorkspaceReviewTab,
@@ -777,12 +779,32 @@ function createTranscriptPayloadCache(): TranscriptPayloadCache<AiTranscriptPayl
                 if (!identity) {
                     throw new Error("The transcript payload cache key is invalid.");
                 }
-                const payload = await getComandoApi().getAiTranscriptPayload({
-                    payloadRef: identity.payloadRef,
-                    sessionId: identity.sessionId,
-                });
+                const startedAt = getChatPerformanceTimestamp();
+                incrementChatPerformanceCounter(
+                    "transcript_payload_ipc_count",
+                );
+                const payload = await getComandoApi().getAiTranscriptPayload(
+                    {
+                        payloadRef: identity.payloadRef,
+                        sessionId: identity.sessionId,
+                    },
+                );
                 if (!payload) {
                     throw new Error("The transcript payload could not be found.");
+                }
+                incrementChatPerformanceCounter(
+                    "transcript_payload_bytes",
+                    payload.byteLength,
+                );
+                if (startedAt !== null) {
+                    recordChatPerformanceMetric(
+                        "transcript_payload_load_ms",
+                        {
+                            durationMs: performance.now() - startedAt,
+                            sessionId: identity.sessionId,
+                            values: { byteLength: payload.byteLength },
+                        },
+                    );
                 }
                 return payload;
             },
@@ -1713,10 +1735,21 @@ export const useAiStore = create<AiStore>((set, get) => ({
                         : [],
                 ),
             );
-            await Promise.all(
-                [...visiblePayloadRefs].map((payloadRef) =>
-                    get().loadTranscriptPayload(sessionId, payloadRef),
-                ),
+            await measureChatPerformanceAsync(
+                "transcript_payload_batch_ms",
+                {
+                    sessionId,
+                    values: { payloadRefs: visiblePayloadRefs.size },
+                },
+                () =>
+                    Promise.all(
+                        [...visiblePayloadRefs].map((payloadRef) =>
+                            get().loadTranscriptPayload(
+                                sessionId,
+                                payloadRef,
+                            ),
+                        ),
+                    ),
             );
         }
         const current = get().sessions[sessionId]?.transcriptWindow;

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -108,6 +108,7 @@ export interface MeasuredVirtualListHandle {
         options?: {
             readonly align?: "center" | "end" | "start";
             readonly offset?: number;
+            readonly reason?: MeasuredVirtualScrollRequest["reason"];
         },
     ) => void;
     readonly scrollToViewportAnchor?: (
@@ -116,7 +117,7 @@ export interface MeasuredVirtualListHandle {
 }
 
 export interface MeasuredVirtualScrollRequest {
-    readonly reason: "measure-anchor" | "scroll-to-index";
+    readonly reason: "measure-anchor" | "restore" | "scroll-to-index";
     readonly target: number;
 }
 
@@ -1363,6 +1364,7 @@ export function MeasuredVirtualList<T>({
             options?: {
                 readonly align?: "center" | "end" | "start";
                 readonly offset?: number;
+                readonly reason?: MeasuredVirtualScrollRequest["reason"];
             },
         ) => {
             const container = scrollContainerRef.current;
@@ -1373,6 +1375,7 @@ export function MeasuredVirtualList<T>({
 
             const align = options?.align ?? "start";
             const offset = options?.offset ?? 0;
+            const reason = options?.reason ?? "scroll-to-index";
             const before = container.scrollTop;
             const after = calculateMeasuredVirtualScrollTop({
                 align,
@@ -1384,7 +1387,7 @@ export function MeasuredVirtualList<T>({
                 viewportHeight: container.clientHeight,
             });
             if (onScrollRequest) {
-                onScrollRequest({ reason: "scroll-to-index", target: after });
+                onScrollRequest({ reason, target: after });
                 return;
             }
 
@@ -1393,7 +1396,7 @@ export function MeasuredVirtualList<T>({
                 after,
                 before,
                 clientHeight: container.clientHeight,
-                reason: "scroll-to-index",
+                reason,
                 scrollHeight: container.scrollHeight,
                 sessionId: measurementCacheKey,
             });

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -9,6 +9,7 @@ import {
     type RefObject,
 } from "react";
 import { MAX_CACHED_CHAT_VIEW_ARTIFACTS } from "@renderer/components/workspace/chatViewResourceBudget";
+import { recordChatScrollWrite } from "@renderer/app/debug/chatPerformanceProbe";
 
 const DEFAULT_OVERSCAN = 4;
 const DEFAULT_VIEWPORT_HEIGHT = 720;
@@ -1234,9 +1235,20 @@ export function MeasuredVirtualList<T>({
             return;
         }
 
-        container.scrollTop = Math.max(0, container.scrollTop + adjustment);
+        const before = container.scrollTop;
+        const after = Math.max(0, before + adjustment);
+        container.scrollTop = after;
+        recordChatScrollWrite({
+            after,
+            before,
+            clientHeight: container.clientHeight,
+            reason: "measure-anchor",
+            scrollHeight: container.scrollHeight,
+            sessionId: measurementCacheKey,
+        });
     }, [
         measuredSizes,
+        measurementCacheKey,
         preserveScrollAnchorOnMeasure,
         shouldPreserveScrollAnchorOnMeasureNow,
         scrollContainerRef,
@@ -1344,7 +1356,8 @@ export function MeasuredVirtualList<T>({
 
             const align = options?.align ?? "start";
             const offset = options?.offset ?? 0;
-            container.scrollTop = calculateMeasuredVirtualScrollTop({
+            const before = container.scrollTop;
+            const after = calculateMeasuredVirtualScrollTop({
                 align,
                 itemSize: getItemSize(index),
                 itemStart: getItemStart(index),
@@ -1353,12 +1366,22 @@ export function MeasuredVirtualList<T>({
                 totalSize: layout.totalSize,
                 viewportHeight: container.clientHeight,
             });
+            container.scrollTop = after;
+            recordChatScrollWrite({
+                after,
+                before,
+                clientHeight: container.clientHeight,
+                reason: "scroll-to-index",
+                scrollHeight: container.scrollHeight,
+                sessionId: measurementCacheKey,
+            });
         },
         [
             getItemSize,
             getItemStart,
             items,
             layout.totalSize,
+            measurementCacheKey,
             normalizedScrollMarginTop,
             scrollContainerRef,
         ],
@@ -1511,6 +1534,7 @@ export function MeasuredVirtualList<T>({
                 <div
                     key={virtualItem.key}
                     data-list-key={virtualItem.key}
+                    data-measurement-key={virtualItem.measurementKey}
                     ref={registerMeasuredElement}
                     style={{
                         left: 0,

--- a/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
+++ b/src/renderer/src/components/virtual/MeasuredVirtualList.tsx
@@ -115,6 +115,11 @@ export interface MeasuredVirtualListHandle {
     ) => void;
 }
 
+export interface MeasuredVirtualScrollRequest {
+    readonly reason: "measure-anchor" | "scroll-to-index";
+    readonly target: number;
+}
+
 export interface MeasuredVirtualListProps<T> {
     readonly items: readonly T[];
     readonly enabled?: boolean;
@@ -147,6 +152,11 @@ export interface MeasuredVirtualListProps<T> {
     readonly geometryCacheSignature?: string | null;
     readonly onRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onReady?: (handle: MeasuredVirtualListHandle | null) => void;
+    /**
+     * Lets a host with richer navigation policy own DOM scroll writes. The list
+     * still calculates its exact target, but reports it as a correction request.
+     */
+    readonly onScrollRequest?: (request: MeasuredVirtualScrollRequest) => void;
     readonly preserveScrollAnchorOnItemsChange?: boolean;
     readonly preserveScrollAnchorOnMeasure?: boolean;
     readonly shouldPreserveScrollAnchorOnItemsChange?: () => boolean;
@@ -527,6 +537,7 @@ export function MeasuredVirtualList<T>({
     geometryCacheSignature = null,
     onRangeChange,
     onReady,
+    onScrollRequest,
     preserveScrollAnchorOnItemsChange = false,
     preserveScrollAnchorOnMeasure = false,
     shouldPreserveScrollAnchorOnItemsChange,
@@ -1237,6 +1248,11 @@ export function MeasuredVirtualList<T>({
 
         const before = container.scrollTop;
         const after = Math.max(0, before + adjustment);
+        if (onScrollRequest) {
+            onScrollRequest({ reason: "measure-anchor", target: after });
+            return;
+        }
+
         container.scrollTop = after;
         recordChatScrollWrite({
             after,
@@ -1250,6 +1266,7 @@ export function MeasuredVirtualList<T>({
         measuredSizes,
         measurementCacheKey,
         preserveScrollAnchorOnMeasure,
+        onScrollRequest,
         shouldPreserveScrollAnchorOnMeasureNow,
         scrollContainerRef,
         virtualizationEnabled,
@@ -1366,6 +1383,11 @@ export function MeasuredVirtualList<T>({
                 totalSize: layout.totalSize,
                 viewportHeight: container.clientHeight,
             });
+            if (onScrollRequest) {
+                onScrollRequest({ reason: "scroll-to-index", target: after });
+                return;
+            }
+
             container.scrollTop = after;
             recordChatScrollWrite({
                 after,
@@ -1383,6 +1405,7 @@ export function MeasuredVirtualList<T>({
             layout.totalSize,
             measurementCacheKey,
             normalizedScrollMarginTop,
+            onScrollRequest,
             scrollContainerRef,
         ],
     );

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -449,7 +449,6 @@ export const ChatTabView = memo(function ChatTabView({
     const scrollPersistTimerRef = useRef<number | null>(null);
     const pendingPersistedScrollTopRef = useRef<number | null>(null);
     const pendingPersistedNearBottomRef = useRef<boolean | null>(null);
-    const hasActivatedViewRef = useRef(false);
     const stableTimelineRef = useRef<{
         readonly activeTurnStartedAt: string | null;
         readonly attentionToolCallIds: ReadonlySet<string>;
@@ -1944,9 +1943,6 @@ export const ChatTabView = memo(function ChatTabView({
             };
         }
 
-        const wasPreviouslyActivated = hasActivatedViewRef.current;
-        hasActivatedViewRef.current = true;
-
         const persistViewStateOnDeactivate = () => {
             cancelled = true;
             cancelPendingScrollToBottom();
@@ -1961,12 +1957,6 @@ export const ChatTabView = memo(function ChatTabView({
                 }),
             );
         };
-
-        // A retained view already owns the correct DOM scroll position. Avoid
-        // forcing layout and scheduling follow-up frames on every tab switch.
-        if (wasPreviouslyActivated) {
-            return persistViewStateOnDeactivate;
-        }
 
         if (shouldRestoreBottom) {
             shouldAutoFollowRef.current = true;

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -127,6 +127,7 @@ import { registerComposerSelectionMentionHandler } from "./chat/composerSelectio
 import {
     persistChatViewState,
     readPersistedChatViewState,
+    type PersistedChatViewState,
 } from "./chat/chatViewPersistence";
 import { EditedFilesBufferPanel } from "./chat/EditedFilesBufferPanel";
 import { PlanMessage } from "./chat/PlanMessage";
@@ -152,6 +153,7 @@ import {
     isTranscriptActivityRangeItem,
     isTranscriptActivitySummaryItem,
     resolveTranscriptBlockIdsInRange,
+    resolveTranscriptEntryBlockId,
     resolveUnloadedTranscriptBlockIdsInRange,
     type TranscriptActivityGroupExpansionById,
     type TranscriptTimelineItem,
@@ -242,6 +244,10 @@ type ChatSessionViewState = Pick<
     | "snapshot"
     | "transcript"
     | "transcriptWindow"
+>;
+
+type ChatSemanticRestoreAnchor = NonNullable<
+    PersistedChatViewState["anchor"]
 >;
 
 function selectChatSessionViewState(
@@ -460,11 +466,10 @@ export const ChatTabView = memo(function ChatTabView({
         trackedFiles: null,
         transcript: null,
     });
-    const semanticAnchorRef = useRef<{
-        readonly alignment: "center" | "end" | "start";
-        readonly entryId: string;
-        readonly offsetWithinEntry: number;
-    } | null>(null);
+    const semanticAnchorRef = useRef<PersistedChatViewState["anchor"]>(
+        null,
+    );
+    const semanticRestoreFallbackScrollTopRef = useRef<number | null>(null);
     const initialComposerParts = readInitialComposerPartsForTab(tab);
     const composerPartsRef = useRef<AIComposerPart[]>(initialComposerParts);
     const persistedDraftRef = useRef(tab.draft);
@@ -473,6 +478,9 @@ export const ChatTabView = memo(function ChatTabView({
     const [isEditingTitle, setIsEditingTitle] = useState(false);
     const [newTurnAnchorRowId, setNewTurnAnchorRowId] = useState<
         string | null
+    >(null);
+    const [semanticRestoreAnchor, setSemanticRestoreAnchor] = useState<
+        PersistedChatViewState["anchor"]
     >(null);
     const [titleDraft, setTitleDraft] = useState("");
     const titleInputRef = useRef<HTMLInputElement | null>(null);
@@ -1495,10 +1503,10 @@ export const ChatTabView = memo(function ChatTabView({
             ),
         [tab.projectId, tab.sessionId, tab.worktreeId],
     );
-    const persistedViewStateRef = useRef<{
-        readonly isNearBottom: boolean;
-        readonly scrollTop: number;
-    } | null>(persistedViewState);
+    const persistedViewStateRef = useRef<Pick<
+        PersistedChatViewState,
+        "anchor" | "isNearBottom" | "scrollTop"
+    > | null>(persistedViewState);
 
     useEffect(() => {
         persistedViewStateRef.current = persistedViewState;
@@ -1579,6 +1587,52 @@ export const ChatTabView = memo(function ChatTabView({
         [requestChatScroll],
     );
 
+    const handleSemanticAnchorRestored = useCallback(() => {
+        semanticRestoreFallbackScrollTopRef.current = null;
+        setSemanticRestoreAnchor(null);
+        setShowJumpToBottom(true);
+    }, []);
+
+    const handleSemanticAnchorUnavailable = useCallback(() => {
+        const fallbackScrollTop = semanticRestoreFallbackScrollTopRef.current;
+        semanticRestoreFallbackScrollTopRef.current = null;
+        setSemanticRestoreAnchor(null);
+        if (fallbackScrollTop !== null) {
+            writeProgrammaticScroll(fallbackScrollTop, "restore");
+        }
+        setShowJumpToBottom(true);
+    }, [writeProgrammaticScroll]);
+
+    useEffect(() => {
+        if (!active || !semanticRestoreAnchor?.blockId) {
+            return;
+        }
+        if (!transcriptWindow?.capabilityVersion) {
+            return;
+        }
+
+        const blockId = semanticRestoreAnchor.blockId;
+        setTranscriptWindowAnchor(tab.sessionId, blockId, false);
+        if (transcriptWindow.blocksById.has(blockId)) {
+            return;
+        }
+
+        void loadTranscriptWindowBlock(tab.sessionId, blockId).then((block) => {
+            if (!block) {
+                handleSemanticAnchorUnavailable();
+            }
+        });
+    }, [
+        active,
+        handleSemanticAnchorUnavailable,
+        loadTranscriptWindowBlock,
+        semanticRestoreAnchor?.blockId,
+        setTranscriptWindowAnchor,
+        tab.sessionId,
+        transcriptWindow?.blocksById,
+        transcriptWindow?.capabilityVersion,
+    ]);
+
     const handleNewTurnScrollTarget = useCallback(
         (target: number) => {
             if (!isAnchoringNewChatTurn(scrollIntentRef.current)) {
@@ -1612,12 +1666,21 @@ export const ChatTabView = memo(function ChatTabView({
                               scrollElement.getBoundingClientRect().top),
                   )
                 : 0;
-        semanticAnchorRef.current = captureTranscriptSemanticAnchor({
+        const nextAnchor = captureTranscriptSemanticAnchor({
             entryId: firstVisibleTimelineRow
                 ? getTranscriptTimelineItemAnchorEntryId(firstVisibleTimelineRow)
                 : null,
             offsetWithinEntry,
         });
+        semanticAnchorRef.current = nextAnchor
+            ? {
+                  ...nextAnchor,
+                  blockId: resolveTranscriptEntryBlockId(
+                      transcriptWindow?.blocksById ?? new Map(),
+                      nextAnchor.entryId,
+                  ),
+              }
+            : null;
         const visibleBlockIds = resolveUnloadedTranscriptBlockIdsInRange(
             transcriptTimelineItems,
             range.visibleStartIndex,
@@ -1650,6 +1713,7 @@ export const ChatTabView = memo(function ChatTabView({
         loadTranscriptWindowBlock,
         setTranscriptWindowAnchor,
         tab.sessionId,
+        transcriptWindow?.blocksById,
         transcriptTimelineItems,
     ]);
 
@@ -1698,6 +1762,7 @@ export const ChatTabView = memo(function ChatTabView({
             // Retained chat views do not remount between tab switches, so keep
             // the latest persisted position in memory for the next activation.
             persistedViewStateRef.current = {
+                anchor: semanticAnchorRef.current,
                 isNearBottom: nextIsNearBottom,
                 scrollTop,
             };
@@ -1924,7 +1989,28 @@ export const ChatTabView = memo(function ChatTabView({
         } else {
             shouldAutoFollowRef.current = false;
             scrollIntentRef.current = readChatScroll(scrollIntentRef.current);
-            writeProgrammaticScroll(restoreScrollTop, "restore");
+            const persistedAnchor = persistedViewStateRef.current?.anchor ?? null;
+            const semanticBlockId =
+                persistedAnchor?.blockId ??
+                (persistedAnchor
+                    ? resolveTranscriptEntryBlockId(
+                          transcriptWindow?.blocksById ?? new Map(),
+                          persistedAnchor.entryId,
+                      )
+                    : null);
+            if (persistedAnchor && semanticBlockId) {
+                const restoreAnchor = {
+                    ...persistedAnchor,
+                    blockId: semanticBlockId,
+                };
+                semanticAnchorRef.current = restoreAnchor;
+                semanticRestoreFallbackScrollTopRef.current = restoreScrollTop;
+                setSemanticRestoreAnchor(restoreAnchor);
+            } else {
+                semanticRestoreFallbackScrollTopRef.current = null;
+                setSemanticRestoreAnchor(null);
+                writeProgrammaticScroll(restoreScrollTop, "restore");
+            }
             setJumpToBottomVisibility(!isNearBottom(scrollEl));
         }
 
@@ -1938,6 +2024,7 @@ export const ChatTabView = memo(function ChatTabView({
         writeProgrammaticScroll,
         active,
         tab.sessionId,
+        transcriptWindow?.blocksById,
     ]);
 
     useLayoutEffect(() => {
@@ -2621,6 +2708,8 @@ export const ChatTabView = memo(function ChatTabView({
                     liveTailRowId={timelineModel.liveTailRowId}
                     newTurnAnchorRowId={newTurnAnchorRowId}
                     onNewTurnScrollTarget={handleNewTurnScrollTarget}
+                    onSemanticAnchorRestored={handleSemanticAnchorRestored}
+                    onSemanticAnchorUnavailable={handleSemanticAnchorUnavailable}
                     onVirtualScrollRequest={handleTimelineVirtualScrollRequest}
                     onSetActivityGroupExpanded={setActivityGroupExpanded}
                     onSetActivityRangeExpanded={setActivityRangeExpanded}
@@ -2648,6 +2737,14 @@ export const ChatTabView = memo(function ChatTabView({
                     projectId={tab.projectId}
                     resolveFileReference={resolveChatFileReference}
                     scrollRef={scrollRef}
+                    semanticAnchorBlockLoaded={
+                        semanticRestoreAnchor?.blockId
+                            ? (transcriptWindow?.blocksById.has(
+                                  semanticRestoreAnchor.blockId,
+                              ) ?? false)
+                            : false
+                    }
+                    semanticRestoreAnchor={semanticRestoreAnchor}
                     sessionId={tab.sessionId}
                     showJumpToBottom={showJumpToBottom}
                     showStreamingIndicator={isStreaming}
@@ -3143,6 +3240,8 @@ type ChatTimelineProps = {
     readonly liveTailRowId: string | null;
     readonly newTurnAnchorRowId: string | null;
     readonly onNewTurnScrollTarget?: (target: number) => void;
+    readonly onSemanticAnchorRestored?: () => void;
+    readonly onSemanticAnchorUnavailable?: () => void;
     readonly onVirtualScrollRequest?: (
         request: MeasuredVirtualScrollRequest,
     ) => void;
@@ -3190,6 +3289,8 @@ type ChatTimelineProps = {
         reference: string,
     ) => ResolvedProjectFileReference | null;
     readonly scrollRef: RefObject<HTMLDivElement | null>;
+    readonly semanticAnchorBlockLoaded?: boolean;
+    readonly semanticRestoreAnchor?: ChatSemanticRestoreAnchor | null;
     readonly sessionId: string;
     readonly showJumpToBottom: boolean;
     readonly showStreamingIndicator: boolean;
@@ -3229,6 +3330,8 @@ const ChatTimeline = memo(function ChatTimeline({
     liveTailRowId,
     newTurnAnchorRowId,
     onNewTurnScrollTarget,
+    onSemanticAnchorRestored,
+    onSemanticAnchorUnavailable,
     onVirtualScrollRequest,
     onSetActivityGroupExpanded,
     onSetActivityRangeExpanded,
@@ -3250,6 +3353,8 @@ const ChatTimeline = memo(function ChatTimeline({
     projectId,
     resolveFileReference,
     scrollRef,
+    semanticAnchorBlockLoaded,
+    semanticRestoreAnchor,
     sessionId,
     showJumpToBottom,
     showStreamingIndicator,
@@ -3304,6 +3409,10 @@ const ChatTimeline = memo(function ChatTimeline({
                             liveTailRowId={liveTailRowId}
                             newTurnAnchorRowId={newTurnAnchorRowId}
                             onNewTurnScrollTarget={onNewTurnScrollTarget}
+                            onSemanticAnchorRestored={onSemanticAnchorRestored}
+                            onSemanticAnchorUnavailable={
+                                onSemanticAnchorUnavailable
+                            }
                             onVirtualScrollRequest={onVirtualScrollRequest}
                             onSetActivityGroupExpanded={
                                 onSetActivityGroupExpanded
@@ -3333,6 +3442,10 @@ const ChatTimeline = memo(function ChatTimeline({
                             projectId={projectId}
                             resolveFileReference={resolveFileReference}
                             scrollRef={scrollRef}
+                            semanticAnchorBlockLoaded={
+                                semanticAnchorBlockLoaded
+                            }
+                            semanticRestoreAnchor={semanticRestoreAnchor}
                             sessionId={sessionId}
                             showStreamingIndicator={showStreamingIndicator}
                             shouldDeferTrailingUserMeasurementAnchor={
@@ -3418,6 +3531,8 @@ export type ChatTimelineHistoryProps = {
     readonly liveTailRowId: string | null;
     readonly newTurnAnchorRowId: string | null;
     readonly onNewTurnScrollTarget?: (target: number) => void;
+    readonly onSemanticAnchorRestored?: () => void;
+    readonly onSemanticAnchorUnavailable?: () => void;
     readonly onVirtualScrollRequest?: (
         request: MeasuredVirtualScrollRequest,
     ) => void;
@@ -3461,6 +3576,8 @@ export type ChatTimelineHistoryProps = {
         reference: string,
     ) => ResolvedProjectFileReference | null;
     readonly scrollRef: RefObject<HTMLDivElement | null>;
+    readonly semanticAnchorBlockLoaded?: boolean;
+    readonly semanticRestoreAnchor?: ChatSemanticRestoreAnchor | null;
     readonly sessionId: string;
     readonly showStreamingIndicator: boolean;
     readonly shouldDeferTrailingUserMeasurementAnchor?: () => boolean;
@@ -3481,6 +3598,8 @@ export const ChatTimelineHistory = memo(function ChatTimelineHistory({
     liveTailRowId,
     newTurnAnchorRowId,
     onNewTurnScrollTarget,
+    onSemanticAnchorRestored,
+    onSemanticAnchorUnavailable,
     onVirtualScrollRequest,
     onSetActivityGroupExpanded,
     onSetActivityRangeExpanded,
@@ -3498,6 +3617,8 @@ export const ChatTimelineHistory = memo(function ChatTimelineHistory({
     projectId,
     resolveFileReference,
     scrollRef,
+    semanticAnchorBlockLoaded,
+    semanticRestoreAnchor,
     sessionId,
     showStreamingIndicator,
     shouldDeferTrailingUserMeasurementAnchor,
@@ -3578,6 +3699,8 @@ export const ChatTimelineHistory = memo(function ChatTimelineHistory({
             liveTailRowId={liveTailRowId}
             newTurnAnchorRowId={newTurnAnchorRowId}
             onNewTurnScrollTarget={onNewTurnScrollTarget}
+            onSemanticAnchorRestored={onSemanticAnchorRestored}
+            onSemanticAnchorUnavailable={onSemanticAnchorUnavailable}
             onVirtualScrollRequest={onVirtualScrollRequest}
             onVirtualRangeChange={onVirtualRangeChange}
             onVirtualResizeEnd={onVirtualResizeEnd}
@@ -3586,6 +3709,8 @@ export const ChatTimelineHistory = memo(function ChatTimelineHistory({
             renderRow={renderRow}
             renderStreamingIndicator={renderStreamingIndicator}
             scrollRef={scrollRef}
+            semanticAnchorBlockLoaded={semanticAnchorBlockLoaded}
+            semanticRestoreAnchor={semanticRestoreAnchor}
             sessionId={sessionId}
             showStreamingIndicator={showStreamingIndicator}
             shouldDeferTrailingUserMeasurementAnchor={

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -62,6 +62,8 @@ import {
     isChatPerformanceProbeEnabled,
     measureChatPerformance,
     recordChatPerformanceMetric,
+    recordChatScrollWrite,
+    type ChatScrollWriteReason,
 } from "@renderer/app/debug/chatPerformanceProbe";
 import type {
     RuntimeWorkspaceChatTab,
@@ -149,6 +151,7 @@ import {
     type TranscriptTimelineVirtualRow,
 } from "./chat/transcriptBlockVirtualization";
 import { splitLongContentRows } from "./chat/longContentVirtualization";
+import { useChatStreamingFrameProbe } from "./chat/useChatStreamingFrameProbe";
 import { requestStopAgentSession } from "./chat/aiSessionLifecycle";
 import {
     collectProjectFileRoots,
@@ -278,6 +281,7 @@ const EMPTY_COMPOSER_PARTS: readonly AIComposerPart[] =
     createEmptyComposerParts();
 const EMPTY_DRAFT_FILE_CONTEXTS: readonly AiFileContextAttachment[] = [];
 const EMPTY_TRANSCRIPT_MODEL = createEmptyAiSessionTranscriptModel();
+const EMPTY_ACTIVITY_EXPANSION: TranscriptActivityGroupExpansionById = {};
 const CLOSED_SUBAGENT_MESSAGE =
     "This subagent was closed by its parent thread and can’t receive new messages.";
 const PROJECT_MENTION_SEARCH_FOLLOWUP_DEBOUNCE_MS = 50;
@@ -1298,41 +1302,55 @@ export const ChatTabView = memo(function ChatTabView({
     const [activityExpansionBySessionId, setActivityExpansionBySessionId] =
         useState<Record<string, TranscriptActivityGroupExpansionById>>({});
     const activityExpansionByGroupId =
-        activityExpansionBySessionId[tab.sessionId] ?? {};
+        activityExpansionBySessionId[tab.sessionId] ?? EMPTY_ACTIVITY_EXPANSION;
     const transcriptTimelineItems = useMemo(
-        () => {
-            const sourceItems = transcriptWindow?.capabilityVersion
-                ? buildTranscriptTimelineItems(
-                      transcriptWindow.metadata,
-                      transcriptWindow.blocksById,
-                      timelineModel.historyRows,
-                  )
-                : timelineModel.historyRows;
-            const itemsWithStreamingIndicator = isStreaming
-                ? [
-                      ...sourceItems,
-                      createTranscriptStreamingIndicatorItem(elapsed),
-                  ]
-                : sourceItems;
-            const flattenedItems = flattenTranscriptTimelineItems(
-                itemsWithStreamingIndicator,
+        () =>
+            measureChatPerformance(
+                "presentation_build_ms",
                 {
-                    activeGroupId:
-                        timelineModel.liveTailRow?.kind === "activity-segment"
-                            ? timelineModel.liveTailRow.id
-                            : null,
-                    defaultExpanded:
-                        aiChatSettings.toolActivityDefaultExpansion ===
-                        "expanded",
-                    expansionByGroupId: activityExpansionByGroupId,
+                    sessionId: tab.sessionId,
+                    values: {
+                        metadataBlocks: transcriptWindow?.metadata.length ?? 0,
+                        timelineRows: timelineModel.historyRows.length,
+                    },
                 },
-            );
-            return splitLongContentRows(
-                flattenedItems,
-                (item): item is typeof item & { readonly kind: "message" } =>
-                    item.kind === "message",
-            );
-        },
+                () => {
+                    const sourceItems = transcriptWindow?.capabilityVersion
+                        ? buildTranscriptTimelineItems(
+                              transcriptWindow.metadata,
+                              transcriptWindow.blocksById,
+                              timelineModel.historyRows,
+                          )
+                        : timelineModel.historyRows;
+                    const itemsWithStreamingIndicator = isStreaming
+                        ? [
+                              ...sourceItems,
+                              createTranscriptStreamingIndicatorItem(elapsed),
+                          ]
+                        : sourceItems;
+                    const flattenedItems = flattenTranscriptTimelineItems(
+                        itemsWithStreamingIndicator,
+                        {
+                            activeGroupId:
+                                timelineModel.liveTailRow?.kind ===
+                                "activity-segment"
+                                    ? timelineModel.liveTailRow.id
+                                    : null,
+                            defaultExpanded:
+                                aiChatSettings.toolActivityDefaultExpansion ===
+                                "expanded",
+                            expansionByGroupId: activityExpansionByGroupId,
+                        },
+                    );
+                    return splitLongContentRows(
+                        flattenedItems,
+                        (item): item is typeof item & {
+                            readonly kind: "message";
+                        } =>
+                            item.kind === "message",
+                    );
+                },
+            ),
         [
             activityExpansionByGroupId,
             aiChatSettings.toolActivityDefaultExpansion,
@@ -1340,11 +1358,24 @@ export const ChatTabView = memo(function ChatTabView({
             isStreaming,
             timelineModel.historyRows,
             timelineModel.liveTailRow,
+            tab.sessionId,
             transcriptWindow?.blocksById,
             transcriptWindow?.capabilityVersion,
             transcriptWindow?.metadata,
         ],
     );
+    const getPerformanceNavigationGeneration = useCallback(
+        () => scrollIntentRef.current.navigationGeneration,
+        [],
+    );
+    useChatStreamingFrameProbe({
+        active,
+        getNavigationGeneration: getPerformanceNavigationGeneration,
+        isStreaming,
+        scrollRef,
+        sessionId: tab.sessionId,
+        timelineContentRef,
+    });
 
     const beginNewTurnAnchor = useCallback(() => {
         if (!shouldAutoFollowRef.current) {
@@ -1499,30 +1530,47 @@ export const ChatTabView = memo(function ChatTabView({
         );
     }, []);
 
-    const writeProgrammaticScroll = useCallback((target: number) => {
-        const el = scrollRef.current;
-        if (!el) {
-            return;
-        }
+    const writeProgrammaticScroll = useCallback(
+        (target: number, reason: ChatScrollWriteReason) => {
+            const el = scrollRef.current;
+            if (!el) {
+                return;
+            }
 
-        const nextScrollTop = Math.max(
-            0,
-            Math.min(target, el.scrollHeight - el.clientHeight),
-        );
-        if (Math.abs(el.scrollTop - nextScrollTop) < 1) {
-            return;
-        }
+            const nextScrollTop = Math.max(
+                0,
+                Math.min(target, el.scrollHeight - el.clientHeight),
+            );
+            if (Math.abs(el.scrollTop - nextScrollTop) < 1) {
+                return;
+            }
 
-        // Centralizing writes prevents concurrent layout paths from fighting.
-        el.scrollTop = nextScrollTop;
-    }, []);
+            const previousScrollTop = el.scrollTop;
+            // Centralizing writes prevents concurrent layout paths from fighting.
+            el.scrollTop = nextScrollTop;
+            recordChatScrollWrite({
+                after: nextScrollTop,
+                before: previousScrollTop,
+                clientHeight: el.clientHeight,
+                navigationGeneration:
+                    scrollIntentRef.current.navigationGeneration,
+                reason,
+                scrollHeight: el.scrollHeight,
+                sessionId: tab.sessionId,
+            });
+        },
+        [tab.sessionId],
+    );
 
-    const scrollToBottom = useCallback(() => {
-        const el = scrollRef.current;
-        if (el) {
-            writeProgrammaticScroll(el.scrollHeight);
-        }
-    }, [writeProgrammaticScroll]);
+    const scrollToBottom = useCallback(
+        (reason: "follow-end" | "settle" = "follow-end") => {
+            const el = scrollRef.current;
+            if (el) {
+                writeProgrammaticScroll(el.scrollHeight, reason);
+            }
+        },
+        [writeProgrammaticScroll],
+    );
 
     const cancelPendingScrollToBottom = useCallback(() => {
         if (pendingScrollFrameRef.current === null) {
@@ -1566,7 +1614,7 @@ export const ChatTabView = memo(function ChatTabView({
                     }
 
                     // Virtual rows can finish measuring after the first restore.
-                    scrollToBottom();
+                    scrollToBottom("settle");
 
                     if (remainingFrames > 1) {
                         runSettleFrame(remainingFrames - 1);
@@ -1619,7 +1667,7 @@ export const ChatTabView = memo(function ChatTabView({
                 return;
             }
 
-            writeProgrammaticScroll(target);
+            writeProgrammaticScroll(target, "new-turn");
         },
         [writeProgrammaticScroll],
     );
@@ -1963,7 +2011,7 @@ export const ChatTabView = memo(function ChatTabView({
         } else {
             shouldAutoFollowRef.current = false;
             scrollIntentRef.current = readChatScroll(scrollIntentRef.current);
-            writeProgrammaticScroll(restoreScrollTop);
+            writeProgrammaticScroll(restoreScrollTop, "restore");
             setJumpToBottomVisibility(!isNearBottom(scrollEl));
         }
 
@@ -3420,7 +3468,7 @@ function ChatJumpToBottomButton(props: {
     );
 }
 
-type ChatTimelineHistoryProps = {
+export type ChatTimelineHistoryProps = {
     readonly active: boolean;
     readonly canRenderFileReference?: (
         rawReference: string,
@@ -3479,7 +3527,7 @@ type ChatTimelineHistoryProps = {
     readonly worktreeId: string | null;
 };
 
-const ChatTimelineHistory = memo(function ChatTimelineHistory({
+export const ChatTimelineHistory = memo(function ChatTimelineHistory({
     active,
     canRenderFileReference,
     chatFontFamily,

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -44,8 +44,9 @@ import {
     type AiSessionTranscriptModel,
 } from "@renderer/app/ai/transcriptModel";
 import {
-    buildBlockNativeTranscript,
+    buildBlockNativeTranscriptProjection,
     buildTranscriptToolPayloadRefs,
+    type BlockNativeTranscriptProjection,
 } from "@renderer/app/ai/transcriptWindowProjection";
 import { getGitContextKey } from "@renderer/app/git/context-key";
 import { useAiChatSettings } from "@renderer/app/hooks/use-ai-chat-settings";
@@ -82,6 +83,7 @@ import { ToolExpansionStoreProvider } from "./chat/toolExpansionStore";
 import { ChatMessageRow } from "./chat/ChatMessageRow";
 import { CHAT_PILL_VARIANTS } from "./chat/chatPillPalette";
 import {
+    reconcileChatTimelineModelFromProjection,
     reconcileChatTimelineModelIncrementallyFromTranscript,
     type ChatTimelineModel,
 } from "./chat/chatTimelineModel";
@@ -439,6 +441,7 @@ export const ChatTabView = memo(function ChatTabView({
         readonly activeTurnStartedAt: string | null;
         readonly attentionToolCallIds: ReadonlySet<string>;
         readonly model: ChatTimelineModel | null;
+        readonly projection: BlockNativeTranscriptProjection | null;
         readonly sessionId: string;
         readonly status: AiSessionSnapshot["status"] | null;
         readonly trackedFiles: AiSessionSnapshot["trackedFiles"] | null;
@@ -447,6 +450,7 @@ export const ChatTabView = memo(function ChatTabView({
         activeTurnStartedAt: null,
         attentionToolCallIds: new Set(),
         model: null,
+        projection: null,
         sessionId: tab.sessionId,
         status: null,
         trackedFiles: null,
@@ -700,26 +704,30 @@ export const ChatTabView = memo(function ChatTabView({
     const storedTranscript =
         sessionState?.transcript ?? EMPTY_TRANSCRIPT_MODEL;
     const transcriptWindow = sessionState?.transcriptWindow ?? null;
-    const transcript = useMemo(
+    /* eslint-disable react-hooks/refs -- Projection and timeline reconciliation read the last committed identities without publishing speculative renders. */
+    const transcriptProjection = useMemo(
         () =>
             transcriptWindow?.capabilityVersion
-                ? buildBlockNativeTranscript(
+                ? buildBlockNativeTranscriptProjection(
                       storedTranscript,
                       transcriptWindow.blocksById,
                       transcriptWindow.metadata,
                       transcriptWindow.payloadsByRef,
-                      snapshot,
+                      stableTimelineRef.current.sessionId === tab.sessionId
+                          ? stableTimelineRef.current.projection
+                          : null,
                   )
-                : storedTranscript,
+                : null,
         [
-            snapshot,
             storedTranscript,
+            tab.sessionId,
             transcriptWindow?.blocksById,
             transcriptWindow?.capabilityVersion,
             transcriptWindow?.metadata,
             transcriptWindow?.payloadsByRef,
         ],
     );
+    const transcript = transcriptProjection?.hot.transcript ?? storedTranscript;
     const toolPayloadRefByActivityId = useMemo(
         () =>
             buildTranscriptToolPayloadRefs(
@@ -1232,7 +1240,6 @@ export const ChatTabView = memo(function ChatTabView({
         };
     }, [active, activeTurnKey, activeTurnStartedAt]);
 
-    /* eslint-disable react-hooks/refs -- The timeline reconciler needs the last committed model to preserve row identity during render. */
     const attentionToolCallIds = useMemo(() => {
         const toolCallIds = new Set<string>();
         if (pendingPermission?.toolCallId) {
@@ -1247,6 +1254,7 @@ export const ChatTabView = memo(function ChatTabView({
         const cachedTimeline = getCachedChatTimeline({
             activeTurnStartedAt,
             attentionToolCallIds,
+            projection: transcriptProjection,
             sessionId: tab.sessionId,
             status: snapshot.status,
             trackedFiles: canonicalTrackedFiles,
@@ -1276,8 +1284,24 @@ export const ChatTabView = memo(function ChatTabView({
                     transcriptRows: transcript.orderedEntryIds.length,
                 },
             },
-            () =>
-                reconcileChatTimelineModelIncrementallyFromTranscript(
+            () => {
+                if (transcriptProjection) {
+                    return reconcileChatTimelineModelFromProjection(
+                        previousTimelineModel,
+                        canReconcileIncrementally
+                            ? previousTimelineState.projection
+                            : null,
+                        {
+                            activeTurnStartedAt,
+                            attentionToolCallIds,
+                            projection: transcriptProjection,
+                            status: snapshot.status,
+                            trackedFiles: canonicalTrackedFiles,
+                            updatedAt: snapshot.updatedAt,
+                        },
+                    );
+                }
+                return reconcileChatTimelineModelIncrementallyFromTranscript(
                     previousTimelineModel,
                     canReconcileIncrementally
                         ? previousTimelineState.transcript
@@ -1289,15 +1313,18 @@ export const ChatTabView = memo(function ChatTabView({
                         trackedFiles: canonicalTrackedFiles,
                         transcript,
                     },
-                ),
+                );
+            },
         );
     }, [
         activeTurnStartedAt,
         attentionToolCallIds,
         canonicalTrackedFiles,
         snapshot.status,
+        snapshot.updatedAt,
         tab.sessionId,
         transcript,
+        transcriptProjection,
     ]);
     const [activityExpansionBySessionId, setActivityExpansionBySessionId] =
         useState<Record<string, TranscriptActivityGroupExpansionById>>({});
@@ -1471,6 +1498,7 @@ export const ChatTabView = memo(function ChatTabView({
             activeTurnStartedAt,
             attentionToolCallIds,
             model: timelineModel,
+            projection: transcriptProjection,
             sessionId: tab.sessionId,
             status: snapshot.status,
             trackedFiles: canonicalTrackedFiles,
@@ -1480,6 +1508,7 @@ export const ChatTabView = memo(function ChatTabView({
             activeTurnStartedAt,
             attentionToolCallIds,
             model: timelineModel,
+            projection: transcriptProjection,
             sessionId: tab.sessionId,
             status: snapshot.status,
             trackedFiles: canonicalTrackedFiles,
@@ -1493,6 +1522,7 @@ export const ChatTabView = memo(function ChatTabView({
         tab.sessionId,
         timelineModel,
         transcript,
+        transcriptProjection,
     ]);
     const persistedViewState = useMemo(
         () =>

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -63,7 +63,6 @@ import {
     isChatPerformanceProbeEnabled,
     measureChatPerformance,
     recordChatPerformanceMetric,
-    recordChatScrollWrite,
     type ChatScrollWriteReason,
 } from "@renderer/app/debug/chatPerformanceProbe";
 import type {
@@ -71,7 +70,10 @@ import type {
     RuntimeWorkspaceFileOpenLocation,
     RuntimeWorkspaceFileReviewContext,
 } from "@renderer/app/workspace/tree";
-import type { MeasuredVirtualRange } from "@renderer/components/virtual/MeasuredVirtualList";
+import type {
+    MeasuredVirtualRange,
+    MeasuredVirtualScrollRequest,
+} from "@renderer/components/virtual/MeasuredVirtualList";
 
 import { AIChatAgentControls } from "./AIChatAgentControls";
 import { LanguageIcon } from "./LanguageIcon";
@@ -103,13 +105,17 @@ import {
 } from "./chat/chatScroll";
 import {
     anchorNewChatTurn,
-    canApplyChatScrollOperation,
     createChatScrollIntent,
     followChatScrollEnd,
     isAnchoringNewChatTurn,
     isFollowingChatScrollEnd,
     readChatScroll,
 } from "./chat/chatScrollIntent";
+import {
+    createChatScrollCoordinator,
+    type ChatScrollCoordinator,
+    type ChatScrollTarget,
+} from "./chat/chatScrollCoordinator";
 import type { AIComposerPart } from "./chat/composerParts";
 import {
     appendSelectionMentionPart,
@@ -275,7 +281,6 @@ const FALLBACK_COMMANDS: readonly AiAvailableCommand[] = [
 ];
 
 const NEAR_BOTTOM_THRESHOLD = 80;
-const BOTTOM_FOLLOW_SETTLE_FRAMES = 3;
 const SCROLL_PERSIST_DELAY_MS = 80;
 const EMPTY_DRAFT_ATTACHMENTS: readonly AiImageAttachment[] = [];
 const EMPTY_COMPOSER_PARTS: readonly AIComposerPart[] =
@@ -427,9 +432,9 @@ export const ChatTabView = memo(function ChatTabView({
         undefined,
     );
     const shouldAutoFollowRef = useRef(true);
-    const pendingScrollFrameRef = useRef<number | null>(null);
-    const bottomFollowSettleFrameRef = useRef<number | null>(null);
-    const bottomFollowSettleActiveRef = useRef(false);
+    const [scrollCoordinator] = useState<ChatScrollCoordinator>(
+        createChatScrollCoordinator,
+    );
     const resizeBottomLockRef = useRef(false);
     const resizeStartedNearBottomRef = useRef(false);
     const scrollPersistTimerRef = useRef<number | null>(null);
@@ -1517,136 +1522,62 @@ export const ChatTabView = memo(function ChatTabView({
         );
     }, []);
 
-    const writeProgrammaticScroll = useCallback(
-        (target: number, reason: ChatScrollWriteReason) => {
-            const el = scrollRef.current;
-            if (!el) {
-                return;
-            }
-
-            const nextScrollTop = Math.max(
-                0,
-                Math.min(target, el.scrollHeight - el.clientHeight),
-            );
-            if (Math.abs(el.scrollTop - nextScrollTop) < 1) {
-                return;
-            }
-
-            const previousScrollTop = el.scrollTop;
-            // Centralizing writes prevents concurrent layout paths from fighting.
-            el.scrollTop = nextScrollTop;
-            recordChatScrollWrite({
-                after: nextScrollTop,
-                before: previousScrollTop,
-                clientHeight: el.clientHeight,
+    const requestChatScroll = useCallback(
+        (request: {
+            readonly reason: Exclude<ChatScrollWriteReason, "settle">;
+            readonly target: ChatScrollTarget;
+        }) => {
+            scrollCoordinator.request(request, {
+                element: scrollRef.current,
                 navigationGeneration:
                     scrollIntentRef.current.navigationGeneration,
-                reason,
-                scrollHeight: el.scrollHeight,
                 sessionId: tab.sessionId,
             });
         },
-        [tab.sessionId],
+        [scrollCoordinator, tab.sessionId],
+    );
+
+    const writeProgrammaticScroll = useCallback(
+        (target: ChatScrollTarget, reason: Exclude<ChatScrollWriteReason, "settle">) => {
+            requestChatScroll({ reason, target });
+            // Layout effects need the followed edge before paint. Requests from
+            // the virtualizer stay microtask-coalesced so one commit picks one
+            // highest-priority movement instead of competing scroll writes.
+            scrollCoordinator.flush();
+        },
+        [requestChatScroll, scrollCoordinator],
     );
 
     const scrollToBottom = useCallback(
-        (reason: "follow-end" | "settle" = "follow-end") => {
-            const el = scrollRef.current;
-            if (el) {
-                writeProgrammaticScroll(el.scrollHeight, reason);
-            }
+        (reason: "follow-end" = "follow-end") => {
+            writeProgrammaticScroll("end", reason);
         },
         [writeProgrammaticScroll],
     );
 
     const cancelPendingScrollToBottom = useCallback(() => {
-        if (pendingScrollFrameRef.current === null) {
-            return;
-        }
-
-        window.cancelAnimationFrame(pendingScrollFrameRef.current);
-        pendingScrollFrameRef.current = null;
-    }, []);
-
-    const cancelBottomFollowSettle = useCallback(() => {
-        bottomFollowSettleActiveRef.current = false;
-
-        if (bottomFollowSettleFrameRef.current === null) {
-            return;
-        }
-
-        window.cancelAnimationFrame(bottomFollowSettleFrameRef.current);
-        bottomFollowSettleFrameRef.current = null;
-    }, []);
-
-    const scheduleBottomFollowSettle = useCallback(() => {
-        const generation = scrollIntentRef.current.navigationGeneration;
-        cancelBottomFollowSettle();
-        bottomFollowSettleActiveRef.current = true;
-
-        const runSettleFrame = (remainingFrames: number) => {
-            bottomFollowSettleFrameRef.current = window.requestAnimationFrame(
-                () => {
-                    bottomFollowSettleFrameRef.current = null;
-
-                    if (
-                        !bottomFollowSettleActiveRef.current ||
-                        !canApplyChatScrollOperation(
-                            scrollIntentRef.current,
-                            generation,
-                        )
-                    ) {
-                        bottomFollowSettleActiveRef.current = false;
-                        return;
-                    }
-
-                    // Virtual rows can finish measuring after the first restore.
-                    scrollToBottom("settle");
-
-                    if (remainingFrames > 1) {
-                        runSettleFrame(remainingFrames - 1);
-                        return;
-                    }
-
-                    bottomFollowSettleActiveRef.current = false;
-                },
-            );
-        };
-
-        runSettleFrame(BOTTOM_FOLLOW_SETTLE_FRAMES);
-    }, [cancelBottomFollowSettle, scrollToBottom]);
+        // A direct user gesture invalidates queued corrections before they can
+        // override the reader's position in the next microtask.
+        scrollCoordinator.cancelPending();
+    }, [scrollCoordinator]);
 
     const scheduleScrollToBottom = useCallback(() => {
         if (!isFollowingChatScrollEnd(scrollIntentRef.current)) {
             return;
         }
 
-        // One frame coalesces the layout changes that happened before paint.
-        if (
-            pendingScrollFrameRef.current !== null ||
-            bottomFollowSettleActiveRef.current
-        ) {
-            return;
-        }
-
-        const generation = scrollIntentRef.current.navigationGeneration;
-        bottomFollowSettleActiveRef.current = true;
-
-        pendingScrollFrameRef.current = window.requestAnimationFrame(() => {
-            pendingScrollFrameRef.current = null;
-            if (
-                !canApplyChatScrollOperation(
-                    scrollIntentRef.current,
-                    generation,
-                )
-            ) {
-                bottomFollowSettleActiveRef.current = false;
-                return;
-            }
-            scrollToBottom();
-            scheduleBottomFollowSettle();
+        requestChatScroll({
+            reason: "follow-end",
+            target: "end",
         });
-    }, [scheduleBottomFollowSettle, scrollToBottom]);
+    }, [requestChatScroll]);
+
+    const handleTimelineVirtualScrollRequest = useCallback(
+        (request: MeasuredVirtualScrollRequest) => {
+            requestChatScroll(request);
+        },
+        [requestChatScroll],
+    );
 
     const handleNewTurnScrollTarget = useCallback(
         (target: number) => {
@@ -1895,7 +1826,6 @@ export const ChatTabView = memo(function ChatTabView({
             }
 
             cancelPendingScrollToBottom();
-            cancelBottomFollowSettle();
             shouldAutoFollowRef.current = false;
             scrollIntentRef.current = readChatScroll(scrollIntentRef.current);
             pendingNewTurnAnchorRef.current = undefined;
@@ -1903,7 +1833,7 @@ export const ChatTabView = memo(function ChatTabView({
             resizeBottomLockRef.current = false;
             resizeStartedNearBottomRef.current = false;
         },
-        [cancelBottomFollowSettle, cancelPendingScrollToBottom],
+        [cancelPendingScrollToBottom],
     );
 
     const handleTimelineTouchStart = useCallback(
@@ -1914,7 +1844,6 @@ export const ChatTabView = memo(function ChatTabView({
 
             // Touch scrolling has no wheel event, so invalidate follow eagerly.
             cancelPendingScrollToBottom();
-            cancelBottomFollowSettle();
             shouldAutoFollowRef.current = false;
             scrollIntentRef.current = readChatScroll(scrollIntentRef.current);
             pendingNewTurnAnchorRef.current = undefined;
@@ -1922,20 +1851,18 @@ export const ChatTabView = memo(function ChatTabView({
             resizeBottomLockRef.current = false;
             resizeStartedNearBottomRef.current = false;
         },
-        [cancelBottomFollowSettle, cancelPendingScrollToBottom],
+        [cancelPendingScrollToBottom],
     );
 
     useEffect(() => {
         return () => {
             cancelPendingScrollToBottom();
-            cancelBottomFollowSettle();
             resizeBottomLockRef.current = false;
             resizeStartedNearBottomRef.current = false;
             flushScheduledScrollPersist();
         };
     }, [
         cancelPendingScrollToBottom,
-        cancelBottomFollowSettle,
         flushScheduledScrollPersist,
     ]);
 
@@ -1971,7 +1898,6 @@ export const ChatTabView = memo(function ChatTabView({
         const persistViewStateOnDeactivate = () => {
             cancelled = true;
             cancelPendingScrollToBottom();
-            cancelBottomFollowSettle();
             const flushedState = flushScheduledScrollPersist();
             persistCurrentViewState(
                 resolveChatScrollPersistenceState({
@@ -1993,7 +1919,7 @@ export const ChatTabView = memo(function ChatTabView({
         if (shouldRestoreBottom) {
             shouldAutoFollowRef.current = true;
             scrollIntentRef.current = followChatScrollEnd(scrollIntentRef.current);
-            scheduleScrollToBottom();
+            scrollToBottom();
             setJumpToBottomVisibility(false);
         } else {
             shouldAutoFollowRef.current = false;
@@ -2005,11 +1931,9 @@ export const ChatTabView = memo(function ChatTabView({
         return persistViewStateOnDeactivate;
     }, [
         cancelPendingScrollToBottom,
-        cancelBottomFollowSettle,
         flushScheduledScrollPersist,
         isNearBottom,
         persistCurrentViewState,
-        scheduleScrollToBottom,
         scrollToBottom,
         writeProgrammaticScroll,
         active,
@@ -2020,9 +1944,9 @@ export const ChatTabView = memo(function ChatTabView({
         if (active && shouldAutoFollowRef.current) {
             // The composer can collapse when a turn starts, changing the viewport
             // height before the new timeline entry has been measured.
-            scheduleScrollToBottom();
+            scrollToBottom();
         }
-    }, [active, composerExpanded, scheduleScrollToBottom, snapshot.updatedAt]);
+    }, [active, composerExpanded, scrollToBottom, snapshot.updatedAt]);
 
     useEffect(() => {
         const scrollEl = scrollRef.current;
@@ -2073,8 +1997,7 @@ export const ChatTabView = memo(function ChatTabView({
         if (
             shouldHoldChatScrollFollowIntent({
                 composerExpanded,
-                programmaticFollowSettling:
-                    bottomFollowSettleActiveRef.current,
+                programmaticFollowSettling: false,
                 shouldAutoFollow: shouldAutoFollowRef.current,
             })
         ) {
@@ -2089,16 +2012,23 @@ export const ChatTabView = memo(function ChatTabView({
             ? followChatScrollEnd(scrollIntentRef.current)
             : readChatScroll(scrollIntentRef.current);
         if (!nextIsNearBottom) {
+            // Scrollbar drags and keyboard navigation do not pass through the
+            // wheel/touch handlers, so they cancel queued writes here as well.
+            cancelPendingScrollToBottom();
             pendingNewTurnAnchorRef.current = undefined;
             setNewTurnAnchorRowId(null);
         }
         setShowJumpToBottom(!nextIsNearBottom);
         scheduleScrollPersist(el.scrollTop, nextIsNearBottom);
-    }, [composerExpanded, isNearBottom, scheduleScrollPersist]);
+    }, [
+        cancelPendingScrollToBottom,
+        composerExpanded,
+        isNearBottom,
+        scheduleScrollPersist,
+    ]);
 
     const handleJumpToBottom = useCallback(() => {
         cancelPendingScrollToBottom();
-        cancelBottomFollowSettle();
         shouldAutoFollowRef.current = true;
         scrollIntentRef.current = followChatScrollEnd(scrollIntentRef.current);
         pendingNewTurnAnchorRef.current = undefined;
@@ -2106,15 +2036,12 @@ export const ChatTabView = memo(function ChatTabView({
         resizeBottomLockRef.current = false;
         resizeStartedNearBottomRef.current = false;
         scrollToBottom();
-        scheduleBottomFollowSettle();
         setShowJumpToBottom(false);
 
         const scrollEl = scrollRef.current;
         scheduleScrollPersist(scrollEl?.scrollTop ?? 0, true);
     }, [
-        cancelBottomFollowSettle,
         cancelPendingScrollToBottom,
-        scheduleBottomFollowSettle,
         scheduleScrollPersist,
         scrollToBottom,
     ]);
@@ -2694,6 +2621,7 @@ export const ChatTabView = memo(function ChatTabView({
                     liveTailRowId={timelineModel.liveTailRowId}
                     newTurnAnchorRowId={newTurnAnchorRowId}
                     onNewTurnScrollTarget={handleNewTurnScrollTarget}
+                    onVirtualScrollRequest={handleTimelineVirtualScrollRequest}
                     onSetActivityGroupExpanded={setActivityGroupExpanded}
                     onSetActivityRangeExpanded={setActivityRangeExpanded}
                     onAddFileReferenceToChat={
@@ -3215,6 +3143,9 @@ type ChatTimelineProps = {
     readonly liveTailRowId: string | null;
     readonly newTurnAnchorRowId: string | null;
     readonly onNewTurnScrollTarget?: (target: number) => void;
+    readonly onVirtualScrollRequest?: (
+        request: MeasuredVirtualScrollRequest,
+    ) => void;
     readonly onSetActivityGroupExpanded: (
         groupId: string,
         expanded: boolean,
@@ -3298,6 +3229,7 @@ const ChatTimeline = memo(function ChatTimeline({
     liveTailRowId,
     newTurnAnchorRowId,
     onNewTurnScrollTarget,
+    onVirtualScrollRequest,
     onSetActivityGroupExpanded,
     onSetActivityRangeExpanded,
     onAddFileReferenceToChat,
@@ -3372,6 +3304,7 @@ const ChatTimeline = memo(function ChatTimeline({
                             liveTailRowId={liveTailRowId}
                             newTurnAnchorRowId={newTurnAnchorRowId}
                             onNewTurnScrollTarget={onNewTurnScrollTarget}
+                            onVirtualScrollRequest={onVirtualScrollRequest}
                             onSetActivityGroupExpanded={
                                 onSetActivityGroupExpanded
                             }
@@ -3485,6 +3418,9 @@ export type ChatTimelineHistoryProps = {
     readonly liveTailRowId: string | null;
     readonly newTurnAnchorRowId: string | null;
     readonly onNewTurnScrollTarget?: (target: number) => void;
+    readonly onVirtualScrollRequest?: (
+        request: MeasuredVirtualScrollRequest,
+    ) => void;
     readonly onSetActivityGroupExpanded: (
         groupId: string,
         expanded: boolean,
@@ -3545,6 +3481,7 @@ export const ChatTimelineHistory = memo(function ChatTimelineHistory({
     liveTailRowId,
     newTurnAnchorRowId,
     onNewTurnScrollTarget,
+    onVirtualScrollRequest,
     onSetActivityGroupExpanded,
     onSetActivityRangeExpanded,
     onAddFileReferenceToChat,
@@ -3641,6 +3578,7 @@ export const ChatTimelineHistory = memo(function ChatTimelineHistory({
             liveTailRowId={liveTailRowId}
             newTurnAnchorRowId={newTurnAnchorRowId}
             onNewTurnScrollTarget={onNewTurnScrollTarget}
+            onVirtualScrollRequest={onVirtualScrollRequest}
             onVirtualRangeChange={onVirtualRangeChange}
             onVirtualResizeEnd={onVirtualResizeEnd}
             onVirtualResizeAutoFollow={onVirtualResizeAutoFollow}

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -52,6 +52,7 @@ import { getGitContextKey } from "@renderer/app/git/context-key";
 import { useAiChatSettings } from "@renderer/app/hooks/use-ai-chat-settings";
 import { buildChatFontFamily } from "@renderer/app/settings/theme";
 import { useAiStore } from "@renderer/app/store/ai-store";
+import { TranscriptReviewPayloadRetention } from "@renderer/app/ai/transcriptReviewPayloadRetention";
 import { chatActivationScheduler } from "@renderer/app/workspace/chatActivationScheduler";
 import { useGitStore } from "@renderer/app/store/git-store";
 import { useFileReferenceValidator } from "@renderer/app/store/projectFileIndexStore";
@@ -79,9 +80,11 @@ import { AIChatAgentControls } from "./AIChatAgentControls";
 import { LanguageIcon } from "./LanguageIcon";
 import { AIChatComposer } from "./chat/AIChatComposer";
 import { AIChatContextUsageBar } from "./chat/AIChatContextUsageBar";
+import { ChatHeader } from "./chat/ChatHeader";
+import { ChatTranscriptSurface } from "./chat/ChatTranscriptSurface";
 import { ChatContentColumn } from "./chat/ChatContentColumn";
+import { ChatComposerShell } from "./chat/ChatComposerShell";
 import { ChatTimelineHistoryRows } from "./chat/ChatTimelineHistoryRows";
-import { ToolExpansionStoreProvider } from "./chat/toolExpansionStore";
 import { ChatMessageRow } from "./chat/ChatMessageRow";
 import { CHAT_PILL_VARIANTS } from "./chat/chatPillPalette";
 import {
@@ -129,7 +132,7 @@ import {
     readPersistedChatViewState,
     type PersistedChatViewState,
 } from "./chat/chatViewPersistence";
-import { EditedFilesBufferPanel } from "./chat/EditedFilesBufferPanel";
+import { ReviewSurface } from "./chat/ReviewSurface";
 import { PlanMessage } from "./chat/PlanMessage";
 import { shouldShowPlanBanner } from "./chat/planBannerState";
 import {
@@ -745,37 +748,22 @@ export const ChatTabView = memo(function ChatTabView({
             ),
         [transcriptWindow?.blocksById],
     );
-    const visibleToolPayloadRefCounts = useRef(new Map<string, number>());
+    const reviewPayloadRetentionRef = useRef(
+        new TranscriptReviewPayloadRetention(),
+    );
     const handleToolPayloadVisibilityChange = useCallback(
         (activityId: string, visible: boolean) => {
             const payloadRef = toolPayloadRefByActivityId.get(activityId);
             if (!payloadRef) return;
             if (!visible) {
-                const nextCount = Math.max(
-                    0,
-                    (visibleToolPayloadRefCounts.current.get(payloadRef) ?? 1) -
-                        1,
-                );
-                if (nextCount > 0) {
-                    visibleToolPayloadRefCounts.current.set(
-                        payloadRef,
-                        nextCount,
-                    );
-                    return;
+                if (reviewPayloadRetentionRef.current.release(payloadRef)) {
+                    releaseTranscriptPayload(tab.sessionId, payloadRef);
                 }
-                visibleToolPayloadRefCounts.current.delete(payloadRef);
-                releaseTranscriptPayload(tab.sessionId, payloadRef);
                 return;
             }
-            const currentCount =
-                visibleToolPayloadRefCounts.current.get(payloadRef) ?? 0;
-            visibleToolPayloadRefCounts.current.set(
-                payloadRef,
-                currentCount + 1,
-            );
-            if (currentCount > 0) return;
+            if (!reviewPayloadRetentionRef.current.retain(payloadRef)) return;
             void loadTranscriptPayload(tab.sessionId, payloadRef).then(() => {
-                if (!visibleToolPayloadRefCounts.current.has(payloadRef)) {
+                if (!reviewPayloadRetentionRef.current.has(payloadRef)) {
                     releaseTranscriptPayload(tab.sessionId, payloadRef);
                 }
             });
@@ -789,10 +777,9 @@ export const ChatTabView = memo(function ChatTabView({
     );
     useEffect(
         () => () => {
-            for (const payloadRef of visibleToolPayloadRefCounts.current.keys()) {
+            for (const payloadRef of reviewPayloadRetentionRef.current.releaseAll()) {
                 releaseTranscriptPayload(tab.sessionId, payloadRef);
             }
-            visibleToolPayloadRefCounts.current.clear();
         },
         [releaseTranscriptPayload, tab.sessionId],
     );
@@ -2598,82 +2585,28 @@ export const ChatTabView = memo(function ChatTabView({
             style={{ backgroundColor: "var(--color-bg-secondary)" }}
         >
             <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
-                <div
-                    className="flex h-6 shrink-0 items-center gap-2 px-3 text-[10.5px] leading-none text-text-secondary"
-                    style={{
-                        backgroundColor: "var(--color-bg-secondary)",
-                        borderBottom:
-                            "1px solid color-mix(in srgb, var(--color-border) 60%, transparent)",
-                        boxSizing: "border-box",
-                        fontFamily: "var(--font-mono)",
+                <ChatHeader
+                    displayTitle={chatDisplayTitle}
+                    editing={isEditingTitle}
+                    onBeginEdit={() => {
+                        skipTitleCommitRef.current = false;
+                        setTitleDraft(chatDisplayTitle);
+                        setIsEditingTitle(true);
                     }}
-                >
-                    {isEditingTitle && !parentSessionId ? (
-                        <input
-                            ref={titleInputRef}
-                            className="min-w-0 flex-1 rounded bg-transparent outline-none"
-                            style={{
-                                border: "none",
-                                borderBottom:
-                                    "1px solid var(--color-accent, var(--color-text-secondary))",
-                                color: "var(--color-text-primary)",
-                                fontFamily: "var(--font-mono)",
-                                fontSize: "10.5px",
-                                padding: 0,
-                            }}
-                            value={titleDraft}
-                            onChange={(e) => setTitleDraft(e.target.value)}
-                            onKeyDown={(e) => {
-                                if (e.key === "Enter") {
-                                    commitTitleEdit();
-                                } else if (e.key === "Escape") {
-                                    skipTitleCommitRef.current = true;
-                                    setIsEditingTitle(false);
-                                }
-                            }}
-                            onBlur={() => commitTitleEdit()}
-                        />
-                    ) : (
-                        <div className="flex min-w-0 flex-1 items-center gap-1.5">
-                            <span
-                                className="min-w-0 cursor-default truncate"
-                                style={{
-                                    color: "var(--color-text-primary)",
-                                }}
-                                onDoubleClick={() => {
-                                    if (parentSessionId) {
-                                        return;
-                                    }
-
-                                    skipTitleCommitRef.current = false;
-                                    setTitleDraft(chatDisplayTitle);
-                                    setIsEditingTitle(true);
-                                }}
-                                title={
-                                    parentSessionId
-                                        ? "Subagent names are managed by Codex"
-                                        : "Double-click to rename"
-                                }
-                            >
-                                {chatDisplayTitle}
-                            </span>
-                            {parentSessionId ? (
-                                <button
-                                    className="app-no-drag min-w-0 shrink truncate rounded px-1 text-[10px] text-text-secondary transition-colors hover:bg-bg-elevated hover:text-text-primary"
-                                    onClick={() =>
-                                        void openAiSessionById(parentSessionId)
-                                    }
-                                    title={`Open parent ${parentSessionContext?.title ?? "thread"}`}
-                                    type="button"
-                                >
-                                    Subagent of{" "}
-                                    {parentSessionContext?.title ??
-                                        "parent thread"}
-                                </button>
-                            ) : null}
-                        </div>
-                    )}
-                </div>
+                    onCancelEdit={() => {
+                        skipTitleCommitRef.current = true;
+                        setIsEditingTitle(false);
+                    }}
+                    onCommitEdit={commitTitleEdit}
+                    onOpenParent={() => {
+                        if (parentSessionId) void openAiSessionById(parentSessionId);
+                    }}
+                    onTitleDraftChange={setTitleDraft}
+                    parentSessionId={parentSessionId}
+                    parentTitle={parentSessionContext?.title ?? null}
+                    titleDraft={titleDraft}
+                    titleInputRef={titleInputRef}
+                />
                 {visiblePlan ? (
                     <div
                         className="shrink-0 px-3 pb-1 pt-2"
@@ -2807,8 +2740,7 @@ export const ChatTabView = memo(function ChatTabView({
                             {composerError ? renderError(composerError) : null}
 
                             {pendingReviewCount > 0 ? (
-                                <EditedFilesBufferPanel
-                                    defaultCollapsed
+                                <ReviewSurface
                                     diffZoom={diffZoom}
                                     items={pendingReviewItems}
                                     onKeepAll={handleKeepAllPendingReview}
@@ -2827,26 +2759,7 @@ export const ChatTabView = memo(function ChatTabView({
                 ) : null}
 
                 {/* Composer area */}
-                <div
-                    className={
-                        composerExpanded
-                            ? "flex min-h-0 flex-1 flex-col border-t"
-                            : "flex shrink-0 flex-col border-t"
-                    }
-                    style={{
-                        backgroundColor:
-                            "color-mix(in srgb, var(--color-accent) 4%, var(--color-bg-panel))",
-                        borderTopColor:
-                            "color-mix(in srgb, var(--color-accent) 14%, var(--color-border))",
-                    }}
-                >
-                    <ChatContentColumn
-                        className={
-                            composerExpanded
-                                ? "flex min-h-0 flex-1 flex-col"
-                                : undefined
-                        }
-                    >
+                <ChatComposerShell expanded={composerExpanded}>
                         <AIChatComposer
                             autoFocusKey={tab.id}
                             composerFontFamily={composerFontFamily}
@@ -2959,8 +2872,7 @@ export const ChatTabView = memo(function ChatTabView({
                             runtimeName={runtimeDisplayName}
                             status={snapshot.status}
                         />
-                    </ChatContentColumn>
-                </div>
+                </ChatComposerShell>
             </div>
         </div>
         </ChatPerformanceProfiler>
@@ -3371,31 +3283,23 @@ const ChatTimeline = memo(function ChatTimeline({
         rows: historyRows.length + hotTailRows.length,
     });
 
-    const timelineContainerClassName = covered
-        ? "pointer-events-none invisible absolute inset-0 min-h-0 min-w-0"
-        : "relative min-h-0 min-w-0 flex-1";
-
     return (
-        <ToolExpansionStoreProvider scopeKey={sessionId}>
-            <div
-                aria-hidden={covered}
-                className={timelineContainerClassName}
-                inert={covered ? true : undefined}
-            >
-                <div
-                    ref={scrollRef}
-                    className="chat-scroll h-full min-h-0 min-w-0 overflow-y-auto px-3 py-3"
-                    onScroll={onScroll}
-                    onTouchStart={onTouchStart}
-                    onWheelCapture={onWheelCapture}
-                >
-                    <ChatContentColumn
-                        ref={timelineContentRef}
-                        className="min-w-0 space-y-2"
-                        style={{
-                            fontFamily: chatFontFamily,
-                        }}
-                    >
+        <ChatTranscriptSurface
+            chatFontFamily={chatFontFamily}
+            covered={covered ?? false}
+            jumpToBottom={
+                <ChatJumpToBottomButton
+                    onClick={onJumpToBottom}
+                    visible={showJumpToBottom}
+                />
+            }
+            onScroll={onScroll}
+            onTouchStart={onTouchStart}
+            onWheelCapture={onWheelCapture}
+            scopeKey={sessionId}
+            scrollRef={scrollRef}
+            timelineContentRef={timelineContentRef}
+        >
                         <ChatTimelineHistory
                             active={active}
                             canRenderFileReference={
@@ -3460,14 +3364,7 @@ const ChatTimeline = memo(function ChatTimeline({
                             streamingStartedAt={streamingStartedAt}
                             worktreeId={worktreeId}
                         />
-                    </ChatContentColumn>
-                </div>
-                <ChatJumpToBottomButton
-                    onClick={onJumpToBottom}
-                    visible={showJumpToBottom}
-                />
-            </div>
-        </ToolExpansionStoreProvider>
+        </ChatTranscriptSurface>
     );
 }, areChatTimelinePropsEqual);
 

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -139,7 +139,6 @@ import { ToolActivityItem } from "./chat/ToolActivityItem";
 import {
     buildTranscriptTimelineItems,
     captureTranscriptSemanticAnchor,
-    createTranscriptStreamingIndicatorItem,
     flattenTranscriptTimelineItems,
     getTranscriptTimelineItemAnchorEntryId,
     isChatTimelineRowItem,
@@ -560,8 +559,6 @@ export const ChatTabView = memo(function ChatTabView({
         },
         [flushChatDraft, flushDraftComposerParts],
     );
-    const streamStartTimeRef = useRef<number | null>(null);
-    const [elapsed, setElapsed] = useState("");
     const [composerError, setComposerError] = useState<string | null>(null);
     const sessionTab = useMemo(
         () => ({
@@ -787,9 +784,6 @@ export const ChatTabView = memo(function ChatTabView({
         [releaseTranscriptPayload, tab.sessionId],
     );
     const isStreaming = isChatStreamingStatus(snapshot.status);
-    const activeTurnKey = isActiveChatTurnStatus(snapshot.status)
-        ? tab.sessionId
-        : null;
     const activeTurnStartedAt = getActiveTurnStartedAt(snapshot, transcript);
     const currentError = sessionState?.localError ?? snapshot.lastError;
     const hasMissingHistoricalSnapshot =
@@ -1194,52 +1188,6 @@ export const ChatTabView = memo(function ChatTabView({
         composerError !== null ||
         pendingReviewCount > 0;
 
-    useEffect(() => {
-        if (!active || activeTurnKey === null || activeTurnStartedAt === null) {
-            streamStartTimeRef.current = null;
-            let cancelled = false;
-            queueMicrotask(() => {
-                if (!cancelled) {
-                    setElapsed("");
-                }
-            });
-            return () => {
-                cancelled = true;
-            };
-        }
-
-        let cancelled = false;
-        const startedAtMs = Date.parse(activeTurnStartedAt);
-        streamStartTimeRef.current = Number.isFinite(startedAtMs)
-            ? startedAtMs
-            : Date.now();
-        const updateElapsed = () => {
-            if (cancelled) {
-                return;
-            }
-
-            const startedAt = streamStartTimeRef.current;
-            if (startedAt === null) return;
-            const totalSec = Math.max(
-                0,
-                Math.floor((Date.now() - startedAt) / 1000),
-            );
-            const min = Math.floor(totalSec / 60);
-            const sec = totalSec % 60;
-            setElapsed(
-                min > 0
-                    ? `${min}m ${String(sec).padStart(2, "0")}s`
-                    : `${sec}s`,
-            );
-        };
-        queueMicrotask(updateElapsed);
-        const interval = window.setInterval(updateElapsed, 500);
-        return () => {
-            cancelled = true;
-            window.clearInterval(interval);
-        };
-    }, [active, activeTurnKey, activeTurnStartedAt]);
-
     const attentionToolCallIds = useMemo(() => {
         const toolCallIds = new Set<string>();
         if (pendingPermission?.toolCallId) {
@@ -1349,20 +1297,10 @@ export const ChatTabView = memo(function ChatTabView({
                               timelineModel.historyRows,
                           )
                         : timelineModel.historyRows;
-                    const itemsWithStreamingIndicator = isStreaming
-                        ? [
-                              ...sourceItems,
-                              createTranscriptStreamingIndicatorItem(elapsed),
-                          ]
-                        : sourceItems;
                     const flattenedItems = flattenTranscriptTimelineItems(
-                        itemsWithStreamingIndicator,
+                        sourceItems,
                         {
-                            activeGroupId:
-                                timelineModel.liveTailRow?.kind ===
-                                "activity-segment"
-                                    ? timelineModel.liveTailRow.id
-                                    : null,
+                            activeGroupId: null,
                             defaultExpanded:
                                 aiChatSettings.toolActivityDefaultExpansion ===
                                 "expanded",
@@ -1381,14 +1319,33 @@ export const ChatTabView = memo(function ChatTabView({
         [
             activityExpansionByGroupId,
             aiChatSettings.toolActivityDefaultExpansion,
-            elapsed,
-            isStreaming,
             timelineModel.historyRows,
-            timelineModel.liveTailRow,
             tab.sessionId,
             transcriptWindow?.blocksById,
             transcriptWindow?.capabilityVersion,
             transcriptWindow?.metadata,
+        ],
+    );
+    const hotTailRow =
+        timelineModel.liveTailRow ?? timelineModel.retainedTailRow;
+    const hotTailRows = useMemo(
+        () =>
+            hotTailRow
+                ? flattenTranscriptTimelineItems([hotTailRow], {
+                      activeGroupId:
+                          hotTailRow.kind === "activity-segment"
+                              ? hotTailRow.id
+                              : null,
+                      defaultExpanded:
+                          aiChatSettings.toolActivityDefaultExpansion ===
+                          "expanded",
+                      expansionByGroupId: activityExpansionByGroupId,
+                  }).filter(isChatTimelineRowItem)
+                : [],
+        [
+            activityExpansionByGroupId,
+            aiChatSettings.toolActivityDefaultExpansion,
+            hotTailRow,
         ],
     );
     const getPerformanceNavigationGeneration = useCallback(
@@ -2732,6 +2689,8 @@ export const ChatTabView = memo(function ChatTabView({
                     chatFontSize={aiChatSettings.chatFontSize}
                     covered={composerExpanded}
                     historyRows={transcriptTimelineItems}
+                    hotTailRowId={hotTailRow?.id ?? null}
+                    hotTailRows={hotTailRows}
                     liveTailRowId={timelineModel.liveTailRowId}
                     newTurnAnchorRowId={newTurnAnchorRowId}
                     onNewTurnScrollTarget={handleNewTurnScrollTarget}
@@ -2763,6 +2722,7 @@ export const ChatTabView = memo(function ChatTabView({
                     scrollRef={scrollRef}
                     sessionId={tab.sessionId}
                     showJumpToBottom={showJumpToBottom}
+                    showStreamingIndicator={isStreaming}
                     shouldPreserveVirtualMeasureAnchor={
                         shouldPreserveTimelineVirtualMeasureAnchor
                     }
@@ -2773,6 +2733,7 @@ export const ChatTabView = memo(function ChatTabView({
                         shouldPreserveTimelineVirtualResizeAnchor
                     }
                     timelineContentRef={timelineContentRef}
+                    streamingStartedAt={activeTurnStartedAt}
                     worktreeId={tab.worktreeId ?? null}
                 />
 
@@ -3249,6 +3210,8 @@ type ChatTimelineProps = {
     readonly chatFontSize?: number;
     readonly covered?: boolean;
     readonly historyRows: readonly TranscriptTimelineItem[];
+    readonly hotTailRowId: string | null;
+    readonly hotTailRows: readonly TranscriptTimelineVirtualRow[];
     readonly liveTailRowId: string | null;
     readonly newTurnAnchorRowId: string | null;
     readonly onNewTurnScrollTarget?: (target: number) => void;
@@ -3298,10 +3261,12 @@ type ChatTimelineProps = {
     readonly scrollRef: RefObject<HTMLDivElement | null>;
     readonly sessionId: string;
     readonly showJumpToBottom: boolean;
+    readonly showStreamingIndicator: boolean;
     readonly shouldDeferTrailingUserMeasurementAnchor?: () => boolean;
     readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
     readonly timelineContentRef: RefObject<HTMLDivElement | null>;
+    readonly streamingStartedAt: string | null;
     readonly worktreeId: string | null;
 };
 
@@ -3328,6 +3293,8 @@ const ChatTimeline = memo(function ChatTimeline({
     chatFontSize,
     covered,
     historyRows,
+    hotTailRowId,
+    hotTailRows,
     liveTailRowId,
     newTurnAnchorRowId,
     onNewTurnScrollTarget,
@@ -3353,16 +3320,18 @@ const ChatTimeline = memo(function ChatTimeline({
     scrollRef,
     sessionId,
     showJumpToBottom,
+    showStreamingIndicator,
     shouldDeferTrailingUserMeasurementAnchor,
     shouldPreserveVirtualMeasureAnchor,
     shouldPreserveVirtualResizeAnchor,
     timelineContentRef,
+    streamingStartedAt,
     worktreeId,
 }: ChatTimelineProps) {
     useRenderProbe("ChatTimeline", {
         active,
         historyRows: historyRows.length,
-        rows: historyRows.length,
+        rows: historyRows.length + hotTailRows.length,
     });
 
     const timelineContainerClassName = covered
@@ -3398,6 +3367,8 @@ const ChatTimeline = memo(function ChatTimeline({
                             chatFontFamily={chatFontFamily}
                             chatFontSize={chatFontSize}
                             historyRows={historyRows}
+                            hotTailRowId={hotTailRowId}
+                            hotTailRows={hotTailRows}
                             liveTailRowId={liveTailRowId}
                             newTurnAnchorRowId={newTurnAnchorRowId}
                             onNewTurnScrollTarget={onNewTurnScrollTarget}
@@ -3430,6 +3401,7 @@ const ChatTimeline = memo(function ChatTimeline({
                             resolveFileReference={resolveFileReference}
                             scrollRef={scrollRef}
                             sessionId={sessionId}
+                            showStreamingIndicator={showStreamingIndicator}
                             shouldDeferTrailingUserMeasurementAnchor={
                                 shouldDeferTrailingUserMeasurementAnchor
                             }
@@ -3439,6 +3411,7 @@ const ChatTimeline = memo(function ChatTimeline({
                             shouldPreserveVirtualResizeAnchor={
                                 shouldPreserveVirtualResizeAnchor
                             }
+                            streamingStartedAt={streamingStartedAt}
                             worktreeId={worktreeId}
                         />
                     </ChatContentColumn>
@@ -3507,6 +3480,8 @@ export type ChatTimelineHistoryProps = {
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
     readonly historyRows: readonly TranscriptTimelineItem[];
+    readonly hotTailRowId: string | null;
+    readonly hotTailRows: readonly TranscriptTimelineVirtualRow[];
     readonly liveTailRowId: string | null;
     readonly newTurnAnchorRowId: string | null;
     readonly onNewTurnScrollTarget?: (target: number) => void;
@@ -3551,9 +3526,11 @@ export type ChatTimelineHistoryProps = {
     ) => ResolvedProjectFileReference | null;
     readonly scrollRef: RefObject<HTMLDivElement | null>;
     readonly sessionId: string;
+    readonly showStreamingIndicator: boolean;
     readonly shouldDeferTrailingUserMeasurementAnchor?: () => boolean;
     readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
+    readonly streamingStartedAt: string | null;
     readonly worktreeId: string | null;
 };
 
@@ -3563,6 +3540,8 @@ export const ChatTimelineHistory = memo(function ChatTimelineHistory({
     chatFontFamily,
     chatFontSize,
     historyRows,
+    hotTailRowId,
+    hotTailRows,
     liveTailRowId,
     newTurnAnchorRowId,
     onNewTurnScrollTarget,
@@ -3583,9 +3562,11 @@ export const ChatTimelineHistory = memo(function ChatTimelineHistory({
     resolveFileReference,
     scrollRef,
     sessionId,
+    showStreamingIndicator,
     shouldDeferTrailingUserMeasurementAnchor,
     shouldPreserveVirtualMeasureAnchor,
     shouldPreserveVirtualResizeAnchor,
+    streamingStartedAt,
     worktreeId,
 }: ChatTimelineHistoryProps) {
     const renderRow = useCallback(
@@ -3640,10 +3621,13 @@ export const ChatTimelineHistory = memo(function ChatTimelineHistory({
         ],
     );
     const renderStreamingIndicator = useCallback(
-        (item: { readonly elapsed: string }) => (
-            <StreamingIndicator elapsed={item.elapsed} />
+        () => (
+            <StreamingIndicator
+                active={active}
+                startedAt={streamingStartedAt}
+            />
         ),
-        [],
+        [active, streamingStartedAt],
     );
 
     return (
@@ -3652,6 +3636,8 @@ export const ChatTimelineHistory = memo(function ChatTimelineHistory({
             chatFontFamily={chatFontFamily}
             chatFontSize={chatFontSize}
             historyRows={historyRows}
+            hotTailRowId={hotTailRowId}
+            hotTailRows={hotTailRows}
             liveTailRowId={liveTailRowId}
             newTurnAnchorRowId={newTurnAnchorRowId}
             onNewTurnScrollTarget={onNewTurnScrollTarget}
@@ -3663,6 +3649,7 @@ export const ChatTimelineHistory = memo(function ChatTimelineHistory({
             renderStreamingIndicator={renderStreamingIndicator}
             scrollRef={scrollRef}
             sessionId={sessionId}
+            showStreamingIndicator={showStreamingIndicator}
             shouldDeferTrailingUserMeasurementAnchor={
                 shouldDeferTrailingUserMeasurementAnchor
             }
@@ -4255,7 +4242,54 @@ function UserInputRequestCard({
 
 /* ─── Streaming indicator ─── */
 
-function StreamingIndicator({ elapsed }: { readonly elapsed: string }) {
+function StreamingIndicator({
+    active,
+    startedAt,
+}: {
+    readonly active: boolean;
+    readonly startedAt: string | null;
+}) {
+    const fallbackStartedAtRef = useRef<number | null>(null);
+    const [elapsed, setElapsed] = useState("");
+
+    useEffect(() => {
+        if (!active) {
+            return;
+        }
+
+        let cancelled = false;
+        const parsedStartedAt = startedAt ? Date.parse(startedAt) : Number.NaN;
+        const startedAtMs = Number.isFinite(parsedStartedAt)
+            ? parsedStartedAt
+            : Date.now();
+        fallbackStartedAtRef.current = startedAtMs;
+        const updateElapsed = () => {
+            if (cancelled || fallbackStartedAtRef.current === null) {
+                return;
+            }
+            const totalSec = Math.max(
+                0,
+                Math.floor(
+                    (Date.now() - fallbackStartedAtRef.current) / 1000,
+                ),
+            );
+            const min = Math.floor(totalSec / 60);
+            const sec = totalSec % 60;
+            setElapsed(
+                min > 0
+                    ? `${min}m ${String(sec).padStart(2, "0")}s`
+                    : `${sec}s`,
+            );
+        };
+
+        queueMicrotask(updateElapsed);
+        const interval = window.setInterval(updateElapsed, 500);
+        return () => {
+            cancelled = true;
+            window.clearInterval(interval);
+        };
+    }, [active, startedAt]);
+
     return (
         <div
             className="flex items-baseline gap-2 py-1"

--- a/src/renderer/src/components/workspace/MarkdownContent.test.ts
+++ b/src/renderer/src/components/workspace/MarkdownContent.test.ts
@@ -83,6 +83,226 @@ describe("MarkdownContent", () => {
         );
     });
 
+    it("seals a completed list without revisiting its stable prefix", () => {
+        const initial = "Introduction.\n\n- first item\n- second item\n\n";
+        const first = parseMarkdownBlocksProgressively(null, initial);
+        const completed = parseMarkdownBlocksProgressively(
+            first,
+            `${initial}Follow-up paragraph.`,
+        );
+        const next = parseMarkdownBlocksProgressively(
+            completed,
+            `${initial}Follow-up paragraph. grows.`,
+        );
+
+        expect(first.stableBlocks[0]).toBe(completed.stableBlocks[0]);
+        expect(completed.stableContentLength).toBe(initial.length);
+        expect(completed.stableBlocks.at(-1)?.content).toContain(
+            "second item",
+        );
+        expect(next.stableBlocks).toEqual(completed.stableBlocks);
+        expect(next.stableBlocks.at(-1)).toBe(completed.stableBlocks.at(-1));
+    });
+
+    it("keeps an indented list continuation mutable across a blank line", () => {
+        const projection = parseMarkdownBlocksProgressively(
+            null,
+            "- parent item\n\n  continuation that can still belong to the list",
+        );
+
+        expect(projection.stableContentLength).toBe(0);
+        expect(projection.blocks).toHaveLength(1);
+        expect(projection.blocks[0]?.isMutable).toBe(true);
+    });
+
+    it("preserves the existing list rendering across a sealed boundary", () => {
+        const content = "- first item\n\n- second item\n\nParagraph after the list.";
+        const staticMarkup = renderToStaticMarkup(
+            createElement(MarkdownContent, { content }),
+        );
+        const liveMarkup = renderToStaticMarkup(
+            createElement(MarkdownContent, { content, live: true }),
+        );
+
+        expect(liveMarkup.match(/<ul/g)?.length).toBe(
+            staticMarkup.match(/<ul/g)?.length,
+        );
+        expect(liveMarkup).toContain("Paragraph after the list.");
+    });
+
+    it("seals a completed table before the following paragraph", () => {
+        const initial = "Heading.\n\nname | value\n--- | ---\nfirst | 1\n\n";
+        const first = parseMarkdownBlocksProgressively(null, initial);
+        const completed = parseMarkdownBlocksProgressively(
+            first,
+            `${initial}Paragraph after the table.`,
+        );
+        const next = parseMarkdownBlocksProgressively(
+            completed,
+            `${initial}Paragraph after the table. grows.`,
+        );
+
+        expect(completed.stableContentLength).toBe(initial.length);
+        expect(completed.stableBlocks.at(-1)?.content).toContain("first | 1");
+        expect(next.stableBlocks.at(-1)).toBe(completed.stableBlocks.at(-1));
+    });
+
+    it("seals a closed fence and defers highlighting only while it is open", () => {
+        const openFence = "Before the fence.\n\n```ts\nconst answer = 42;";
+        const streamingMarkup = renderToStaticMarkup(
+            createElement(MarkdownContent, {
+                content: openFence,
+                live: true,
+            }),
+        );
+        const closedFence = `${openFence}\n\`\`\`\n\nAfter the fence.`;
+        const first = parseMarkdownBlocksProgressively(null, openFence);
+        const completed = parseMarkdownBlocksProgressively(first, closedFence);
+        const next = parseMarkdownBlocksProgressively(
+            completed,
+            `${closedFence} More text.`,
+        );
+        const completedFence = completed.stableBlocks.find(
+            (block) => block.type === "code",
+        );
+
+        expect(streamingMarkup).toContain(
+            'data-code-highlight-deferred="true"',
+        );
+        expect(completedFence?.isMutable).toBe(false);
+        expect(next.stableBlocks.find((block) => block.type === "code")).toBe(
+            completedFence,
+        );
+    });
+
+    it("does not close a fence with four leading spaces", () => {
+        const content = [
+            "```ts",
+            "const value = true;",
+            "    ```",
+            "still part of the code fence",
+        ].join("\n");
+        const projection = parseMarkdownBlocksProgressively(null, content);
+        const codeBlock = projection.blocks.find(
+            (block) => block.type === "code",
+        );
+
+        expect(codeBlock?.isMutable).toBe(true);
+        expect(codeBlock?.content).toContain("    ```");
+        expect(codeBlock?.content).toContain("still part of the code fence");
+    });
+
+    it("preserves terminal whitespace for static Markdown and avoids a split gap", () => {
+        const staticMarkup = renderToStaticMarkup(
+            createElement(MarkdownContent, { content: "Last line\n" }),
+        );
+        const liveMarkup = renderToStaticMarkup(
+            createElement(MarkdownContent, {
+                content: "First block.\n\nSecond block.",
+                live: true,
+            }),
+        );
+
+        expect(staticMarkup).toContain("height:8px");
+        expect(liveMarkup.match(/height:8px/g)).toHaveLength(1);
+    });
+
+    it("keeps sealed blocks referentially stable across 1,000 live deltas", () => {
+        let projection = parseMarkdownBlocksProgressively(
+            null,
+            "Stable introduction.\n\n```ts\nconst stable = true;\n```\n\nLive",
+        );
+        const sealedBlocks = projection.stableBlocks;
+
+        for (let index = 0; index < 1_000; index++) {
+            projection = parseMarkdownBlocksProgressively(
+                projection,
+                `${projection.content} ${index}`,
+            );
+        }
+
+        expect(projection.stableBlocks).toEqual(sealedBlocks);
+        expect(projection.stableBlocks[0]).toBe(sealedBlocks[0]);
+        expect(projection.stableBlocks[1]).toBe(sealedBlocks[1]);
+        expect(projection.blocks.at(-1)?.isMutable).toBe(true);
+    });
+
+    it("renders the published live revision without scheduling another frame", () => {
+        const requestAnimationFrame = vi.fn(() => 1);
+        const cancelAnimationFrame = vi.fn();
+        vi.stubGlobal("requestAnimationFrame", requestAnimationFrame);
+        vi.stubGlobal("cancelAnimationFrame", cancelAnimationFrame);
+
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        mountedRoots.push(root);
+        mountedContainers.push(container);
+
+        act(() => {
+            root.render(
+                createElement(MarkdownContent, {
+                    content: "First revision.",
+                    live: true,
+                }),
+            );
+        });
+        act(() => {
+            root.render(
+                createElement(MarkdownContent, {
+                    content: "Second revision is visible immediately.",
+                    live: true,
+                }),
+            );
+        });
+
+        const content = container.querySelector("[data-markdown-live='true']");
+        expect(content?.getAttribute("data-markdown-content-chars")).toBe(
+            String("Second revision is visible immediately.".length),
+        );
+        expect(content?.getAttribute("data-markdown-rendered-chars")).toBe(
+            String("Second revision is visible immediately.".length),
+        );
+        expect(content?.textContent).toContain("Second revision is visible immediately.");
+        expect(requestAnimationFrame).not.toHaveBeenCalled();
+    });
+
+    it("keeps simultaneous live panels on their current Markdown revision", () => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        mountedRoots.push(root);
+        mountedContainers.push(container);
+
+        const renderPanels = (content: string) =>
+            createElement(
+                "div",
+                null,
+                createElement(MarkdownContent, { content, live: true }),
+                createElement(MarkdownContent, { content, live: true }),
+            );
+
+        act(() => {
+            root.render(renderPanels("Initial revision."));
+        });
+        act(() => {
+            root.render(renderPanels("Current revision in both panels."));
+        });
+
+        const panels = [
+            ...container.querySelectorAll<HTMLElement>(
+                "[data-markdown-live='true']",
+            ),
+        ];
+        expect(panels).toHaveLength(2);
+        expect(panels.map((panel) => panel.dataset.markdownRenderedChars)).toEqual(
+            Array(2).fill(String("Current revision in both panels.".length)),
+        );
+        expect(panels.map((panel) => panel.textContent)).toEqual(
+            Array(2).fill("Current revision in both panels."),
+        );
+    });
+
     it("renders serialized folder mentions as Catppuccin links", () => {
         const markup = renderToStaticMarkup(
             createElement(MarkdownContent, {

--- a/src/renderer/src/components/workspace/MarkdownContent.tsx
+++ b/src/renderer/src/components/workspace/MarkdownContent.tsx
@@ -17,7 +17,11 @@ import {
 } from "@shared/composer-display-markers";
 
 import { extractFenceLanguageToken } from "../../app/editor/codeLanguage";
-import { measureChatPerformance } from "@renderer/app/debug/chatPerformanceProbe";
+import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
+import {
+    measureChatPerformance,
+    recordChatPerformanceMetric,
+} from "@renderer/app/debug/chatPerformanceProbe";
 import { openExternalUrl } from "../../app/utils/external-url";
 import {
     parseMarkdownListItem,
@@ -160,7 +164,11 @@ function parseBlocks(text: string): Block[] {
 
 function parseBlocksUnmeasured(text: string): Block[] {
     const cached = parsedBlockCache.get(text);
-    if (cached) return cached;
+    if (cached) {
+        incrementChatPerformanceCounter("markdown_cache_hits");
+        return cached;
+    }
+    incrementChatPerformanceCounter("markdown_chars_reparsed", text.length);
     const blocks: Block[] = [];
     let cursor = 0;
     let lastIndex = 0;
@@ -2201,7 +2209,16 @@ export const MarkdownContent = memo(function MarkdownContent({
     /* eslint-enable react-hooks/refs */
     useEffect(() => {
         previousParsedBlocksRef.current = parsedBlocks;
-    }, [parsedBlocks]);
+        recordChatPerformanceMetric("markdown_commit", {
+            values: {
+                blockCount: parsedBlocks.blocks.length,
+                contentChars: content.length,
+                live: live ? 1 : 0,
+                renderedChars: renderedContent.length,
+                stableContentChars: parsedBlocks.stableContentLength,
+            },
+        });
+    }, [content.length, live, parsedBlocks, renderedContent.length]);
     const blocks = parsedBlocks.blocks;
     const contentRef = useRef<HTMLDivElement | null>(null);
     const [fileReferenceContextMenu, setFileReferenceContextMenu] =
@@ -2303,6 +2320,10 @@ export const MarkdownContent = memo(function MarkdownContent({
     return (
         <div
             className="chat-assistant-content min-w-0 w-full max-w-full"
+            data-markdown-content-chars={content.length}
+            data-markdown-live={live ? "true" : "false"}
+            data-markdown-rendered-chars={renderedContent.length}
+            data-markdown-stable-chars={parsedBlocks.stableContentLength}
             onContextMenu={handleContextMenu}
             ref={contentRef}
             style={{

--- a/src/renderer/src/components/workspace/MarkdownContent.tsx
+++ b/src/renderer/src/components/workspace/MarkdownContent.tsx
@@ -17,11 +17,7 @@ import {
 } from "@shared/composer-display-markers";
 
 import { extractFenceLanguageToken } from "../../app/editor/codeLanguage";
-import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
-import {
-    measureChatPerformance,
-    recordChatPerformanceMetric,
-} from "@renderer/app/debug/chatPerformanceProbe";
+import { recordChatPerformanceMetric } from "@renderer/app/debug/chatPerformanceProbe";
 import { openExternalUrl } from "../../app/utils/external-url";
 import {
     parseMarkdownListItem,
@@ -51,6 +47,13 @@ import {
     parseProjectFileReference,
     type ResolvedProjectFileReference,
 } from "./projectFileReferences";
+import {
+    parseMarkdownBlocksProgressively,
+    type MarkdownBlock,
+    type ParsedMarkdownBlocks,
+} from "./streamingMarkdownProjection";
+
+export { parseMarkdownBlocksProgressively } from "./streamingMarkdownProjection";
 
 interface MarkdownContentProps {
     readonly canRenderFileReference?: (
@@ -58,7 +61,6 @@ interface MarkdownContentProps {
         reference: ResolvedProjectFileReference,
     ) => boolean;
     readonly content: string;
-    /** Coalesces live output and reuses only Markdown prefixes known to be safe. */
     readonly live?: boolean;
     readonly chatFontSize?: number;
     readonly chatFontFamily?: string;
@@ -74,28 +76,10 @@ interface MarkdownContentProps {
     ) => ResolvedProjectFileReference | null;
 }
 
-interface Block {
-    readonly content: string;
-    readonly info: string;
-    readonly type: "code" | "text";
-}
-
-interface ParsedMarkdownBlocks {
-    readonly blocks: readonly Block[];
-    readonly content: string;
-    readonly stableBlocks: readonly Block[];
-    readonly stableContentLength: number;
-}
-
 interface MarkdownFenceOpening {
     readonly char: "`" | "~";
     readonly info: string;
     readonly length: number;
-}
-
-interface TextRange {
-    readonly from: number;
-    readonly to: number;
 }
 
 /* ─── Table parsing ─── */
@@ -137,160 +121,6 @@ function tryParseTable(lines: string[]): ParsedTable | null {
 
 /* ─── Block parsing ─── */
 
-const PARSED_BLOCK_CACHE_LIMIT = 250;
-const parsedBlockCache = new Map<string, Block[]>();
-
-function rememberParsedBlocks(text: string, blocks: Block[]): Block[] {
-    if (parsedBlockCache.has(text)) {
-        parsedBlockCache.delete(text);
-    }
-    parsedBlockCache.set(text, blocks);
-    if (parsedBlockCache.size > PARSED_BLOCK_CACHE_LIMIT) {
-        const oldestKey = parsedBlockCache.keys().next().value;
-        if (oldestKey !== undefined) {
-            parsedBlockCache.delete(oldestKey);
-        }
-    }
-    return blocks;
-}
-
-function parseBlocks(text: string): Block[] {
-    return measureChatPerformance(
-        "markdown_parse_ms",
-        { values: { contentChars: text.length } },
-        () => parseBlocksUnmeasured(text),
-    );
-}
-
-function parseBlocksUnmeasured(text: string): Block[] {
-    const cached = parsedBlockCache.get(text);
-    if (cached) {
-        incrementChatPerformanceCounter("markdown_cache_hits");
-        return cached;
-    }
-    incrementChatPerformanceCounter("markdown_chars_reparsed", text.length);
-    const blocks: Block[] = [];
-    let cursor = 0;
-    let lastIndex = 0;
-
-    while (cursor < text.length) {
-        const lineEnd = text.indexOf("\n", cursor);
-        const lineTo = lineEnd === -1 ? text.length : lineEnd;
-        const lineText = text.slice(cursor, lineTo);
-        const opening = parseMarkdownFenceOpening(lineText);
-
-        if (!opening) {
-            cursor = lineEnd === -1 ? text.length : lineEnd + 1;
-            continue;
-        }
-
-        const before = text.slice(lastIndex, cursor);
-        if (before) blocks.push({ content: before, info: "", type: "text" });
-
-        const contentStart = lineEnd === -1 ? lineTo : lineEnd + 1;
-        const closing = findMarkdownFenceClosing(text, contentStart, opening);
-        const contentEnd = closing?.from ?? text.length;
-        const content = text.slice(contentStart, contentEnd).replace(/\n$/, "");
-
-        blocks.push({
-            content,
-            info: opening.info.toLowerCase(),
-            type: "code",
-        });
-        lastIndex = closing?.to ?? text.length;
-        cursor = lastIndex;
-    }
-
-    const tail = text.slice(lastIndex);
-    if (tail) {
-        blocks.push({ content: tail, info: "", type: "text" });
-    }
-
-    return rememberParsedBlocks(text, blocks);
-}
-
-function hasUnsafeProgressiveMarkdownStructure(text: string): boolean {
-    return /^(?: {0,3}(?:`{3,}|~{3,})|\s*(?:[-+*]|\d+[.)])\s+.*|.*\|.*)$/m.test(
-        text,
-    );
-}
-
-function getProgressiveMarkdownStableContentLength(text: string): number {
-    if (hasUnsafeProgressiveMarkdownStructure(text)) {
-        return 0;
-    }
-
-    const boundary = text.lastIndexOf("\n\n");
-    return boundary === -1 ? 0 : boundary + 2;
-}
-
-export function parseMarkdownBlocksProgressively(
-    previous: ParsedMarkdownBlocks | null,
-    content: string,
-): ParsedMarkdownBlocks {
-    const stableContentLength = getProgressiveMarkdownStableContentLength(content);
-    if (!previous || !content.startsWith(previous.content)) {
-        const stableBlocks =
-            stableContentLength > 0
-                ? parseBlocks(content.slice(0, stableContentLength))
-                : [];
-        const mutableBlocks = parseBlocks(content.slice(stableContentLength));
-        return {
-            blocks: [...stableBlocks, ...mutableBlocks],
-            content,
-            stableBlocks,
-            stableContentLength,
-        };
-    }
-
-    const stableBlocks =
-        stableContentLength === previous.stableContentLength
-            ? previous.stableBlocks
-            : stableContentLength > 0
-              ? parseBlocks(content.slice(0, stableContentLength))
-              : [];
-    const mutableBlocks = parseBlocks(content.slice(stableContentLength));
-
-    return {
-        blocks: [...stableBlocks, ...mutableBlocks],
-        content,
-        stableBlocks,
-        stableContentLength,
-    };
-}
-
-function useFrameCoalescedMarkdownContent(
-    content: string,
-    live: boolean,
-): string {
-    const [coalescedContent, setCoalescedContent] = useState(content);
-
-    useEffect(() => {
-        if (!live || coalescedContent === content) {
-            return;
-        }
-
-        if (typeof window.requestAnimationFrame !== "function") {
-            const timeoutId = window.setTimeout(
-                () => setCoalescedContent(content),
-                0,
-            );
-            return () => {
-                window.clearTimeout(timeoutId);
-            };
-        }
-
-        const frameId = window.requestAnimationFrame(() => {
-            setCoalescedContent(content);
-        });
-        return () => {
-            window.cancelAnimationFrame(frameId);
-        };
-    }, [coalescedContent, content, live]);
-
-    return live ? coalescedContent : content;
-}
-
 function parseMarkdownFenceOpening(lineText: string): MarkdownFenceOpening | null {
     const match = lineText.match(/^(?: {0,3})(`{3,}|~{3,})(.*)$/);
     if (!match) {
@@ -312,54 +142,6 @@ function parseMarkdownFenceOpening(lineText: string): MarkdownFenceOpening | nul
         info,
         length: marker.length,
     };
-}
-
-function findMarkdownFenceClosing(
-    text: string,
-    startOffset: number,
-    opening: MarkdownFenceOpening,
-): TextRange | null {
-    let cursor = startOffset;
-
-    while (cursor < text.length) {
-        const lineEnd = text.indexOf("\n", cursor);
-        const lineTo = lineEnd === -1 ? text.length : lineEnd;
-        const lineText = text.slice(cursor, lineTo);
-
-        if (isMarkdownFenceClosingLine(lineText, opening)) {
-            return {
-                from: cursor,
-                to: lineEnd === -1 ? lineTo : lineEnd + 1,
-            };
-        }
-
-        if (lineEnd === -1) {
-            break;
-        }
-        cursor = lineEnd + 1;
-    }
-
-    return null;
-}
-
-function isMarkdownFenceClosingLine(
-    lineText: string,
-    opening: MarkdownFenceOpening,
-): boolean {
-    let cursor = 0;
-    while (cursor < lineText.length && lineText[cursor] === " " && cursor < 3) {
-        cursor += 1;
-    }
-
-    let markerLength = 0;
-    while (lineText[cursor + markerLength] === opening.char) {
-        markerLength += 1;
-    }
-    if (markerLength < opening.length) {
-        return false;
-    }
-
-    return lineText.slice(cursor + markerLength).trim().length === 0;
 }
 
 /* ─── Inline rendering ─── */
@@ -1893,9 +1675,11 @@ function parseList(
 const CodeBlock = memo(function CodeBlock({
     block,
     chatFontSize = 14,
+    live,
 }: {
-    readonly block: Block;
+    readonly block: MarkdownBlock;
     readonly chatFontSize?: number;
+    readonly live: boolean;
 }) {
     const languageSupport = useMarkdownCodeLanguageSupport(block.info);
     const languageToken = extractFenceLanguageToken(block.info ?? "");
@@ -1957,9 +1741,10 @@ const CodeBlock = memo(function CodeBlock({
                         }}
                     >
                         <HighlightedCodeText
+                            deferHighlighting={live && block.isMutable}
                             text={block.content}
                             language={languageSupport}
-                            segmentKeyPrefix={`chat-code:${languageToken ?? "plain"}:${block.content.length}`}
+                            segmentKeyPrefix={`chat-code:${block.id}`}
                         />
                     </code>
                 )}
@@ -2039,10 +1824,19 @@ const TextBlock = memo(function TextBlock({
     block,
     inlineOptions,
 }: {
-    readonly block: Block;
+    readonly block: MarkdownBlock;
     readonly inlineOptions?: InlineOptions;
 }) {
     const lines = block.content.split("\n");
+    // Only an explicitly split live prefix owns this separator. Static Markdown
+    // retains its terminal whitespace exactly as before.
+    if (
+        block.suppressTerminalEmptyLine &&
+        lines.length > 1 &&
+        lines.at(-1) === ""
+    ) {
+        lines.pop();
+    }
     const elements: ReactElement[] = [];
     let i = 0;
 
@@ -2193,18 +1987,16 @@ export const MarkdownContent = memo(function MarkdownContent({
     onRevealFileReference,
     resolveFileReference,
 }: MarkdownContentProps) {
-    const renderedContent = useFrameCoalescedMarkdownContent(content, live);
     const previousParsedBlocksRef = useRef<ParsedMarkdownBlocks | null>(null);
     /* eslint-disable react-hooks/refs -- The previous parse is committed after render to avoid writing refs during a discarded StrictMode render. */
     const parsedBlocks = useMemo(
         () =>
-            live
-                ? parseMarkdownBlocksProgressively(
-                      previousParsedBlocksRef.current,
-                      renderedContent,
-                  )
-                : parseMarkdownBlocksProgressively(null, renderedContent),
-        [live, renderedContent],
+            parseMarkdownBlocksProgressively(
+                previousParsedBlocksRef.current,
+                content,
+                { sealAll: !live },
+            ),
+        [content, live],
     );
     /* eslint-enable react-hooks/refs */
     useEffect(() => {
@@ -2214,11 +2006,11 @@ export const MarkdownContent = memo(function MarkdownContent({
                 blockCount: parsedBlocks.blocks.length,
                 contentChars: content.length,
                 live: live ? 1 : 0,
-                renderedChars: renderedContent.length,
+                renderedChars: content.length,
                 stableContentChars: parsedBlocks.stableContentLength,
             },
         });
-    }, [content.length, live, parsedBlocks, renderedContent.length]);
+    }, [content.length, live, parsedBlocks]);
     const blocks = parsedBlocks.blocks;
     const contentRef = useRef<HTMLDivElement | null>(null);
     const [fileReferenceContextMenu, setFileReferenceContextMenu] =
@@ -2322,7 +2114,7 @@ export const MarkdownContent = memo(function MarkdownContent({
             className="chat-assistant-content min-w-0 w-full max-w-full"
             data-markdown-content-chars={content.length}
             data-markdown-live={live ? "true" : "false"}
-            data-markdown-rendered-chars={renderedContent.length}
+            data-markdown-rendered-chars={content.length}
             data-markdown-stable-chars={parsedBlocks.stableContentLength}
             onContextMenu={handleContextMenu}
             ref={contentRef}
@@ -2333,18 +2125,19 @@ export const MarkdownContent = memo(function MarkdownContent({
                 wordBreak: "break-word",
             }}
         >
-            {blocks.map((block, index) =>
+            {blocks.map((block) =>
                 block.type === "code" ? (
                     <CodeBlock
                         block={block}
                         chatFontSize={chatFontSize}
-                        key={index}
+                        key={block.id}
+                        live={live}
                     />
                 ) : (
                     <TextBlock
                         block={block}
                         inlineOptions={inlineOptions}
-                        key={index}
+                        key={block.id}
                     />
                 ),
             )}

--- a/src/renderer/src/components/workspace/chat/ChatComposerShell.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatComposerShell.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+import { ChatContentColumn } from "./ChatContentColumn";
+
+export function ChatComposerShell({
+    children,
+    expanded,
+}: {
+    readonly children: ReactNode;
+    readonly expanded: boolean;
+}) {
+    return (
+        <div
+            className={
+                expanded
+                    ? "flex min-h-0 flex-1 flex-col border-t"
+                    : "flex shrink-0 flex-col border-t"
+            }
+            style={{
+                backgroundColor:
+                    "color-mix(in srgb, var(--color-accent) 4%, var(--color-bg-panel))",
+                borderTopColor:
+                    "color-mix(in srgb, var(--color-accent) 14%, var(--color-border))",
+            }}
+        >
+            <ChatContentColumn
+                className={expanded ? "flex min-h-0 flex-1 flex-col" : undefined}
+            >
+                {children}
+            </ChatContentColumn>
+        </div>
+    );
+}

--- a/src/renderer/src/components/workspace/chat/ChatHeader.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatHeader.tsx
@@ -1,0 +1,92 @@
+import type { RefObject } from "react";
+
+interface ChatHeaderProps {
+    readonly displayTitle: string;
+    readonly editing: boolean;
+    readonly onBeginEdit: () => void;
+    readonly onCancelEdit: () => void;
+    readonly onCommitEdit: () => void;
+    readonly onOpenParent: () => void;
+    readonly onTitleDraftChange: (value: string) => void;
+    readonly parentSessionId: string | null;
+    readonly parentTitle: string | null;
+    readonly titleDraft: string;
+    readonly titleInputRef: RefObject<HTMLInputElement | null>;
+}
+
+export function ChatHeader({
+    displayTitle,
+    editing,
+    onBeginEdit,
+    onCancelEdit,
+    onCommitEdit,
+    onOpenParent,
+    onTitleDraftChange,
+    parentSessionId,
+    parentTitle,
+    titleDraft,
+    titleInputRef,
+}: ChatHeaderProps) {
+    return (
+        <div
+            className="flex h-6 shrink-0 items-center gap-2 px-3 text-[10.5px] leading-none text-text-secondary"
+            style={{
+                backgroundColor: "var(--color-bg-secondary)",
+                borderBottom:
+                    "1px solid color-mix(in srgb, var(--color-border) 60%, transparent)",
+                boxSizing: "border-box",
+                fontFamily: "var(--font-mono)",
+            }}
+        >
+            {editing && !parentSessionId ? (
+                <input
+                    ref={titleInputRef}
+                    className="min-w-0 flex-1 rounded bg-transparent outline-none"
+                    style={{
+                        border: "none",
+                        borderBottom:
+                            "1px solid var(--color-accent, var(--color-text-secondary))",
+                        color: "var(--color-text-primary)",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "10.5px",
+                        padding: 0,
+                    }}
+                    value={titleDraft}
+                    onChange={(event) => onTitleDraftChange(event.target.value)}
+                    onKeyDown={(event) => {
+                        if (event.key === "Enter") onCommitEdit();
+                        if (event.key === "Escape") onCancelEdit();
+                    }}
+                    onBlur={onCommitEdit}
+                />
+            ) : (
+                <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                    <span
+                        className="min-w-0 cursor-default truncate"
+                        style={{ color: "var(--color-text-primary)" }}
+                        onDoubleClick={() => {
+                            if (!parentSessionId) onBeginEdit();
+                        }}
+                        title={
+                            parentSessionId
+                                ? "Subagent names are managed by Codex"
+                                : "Double-click to rename"
+                        }
+                    >
+                        {displayTitle}
+                    </span>
+                    {parentSessionId ? (
+                        <button
+                            className="app-no-drag min-w-0 shrink truncate rounded px-1 text-[10px] text-text-secondary transition-colors hover:bg-bg-elevated hover:text-text-primary"
+                            onClick={onOpenParent}
+                            title={`Open parent ${parentTitle ?? "thread"}`}
+                            type="button"
+                        >
+                            Subagent of {parentTitle ?? "parent thread"}
+                        </button>
+                    ) : null}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -46,6 +46,7 @@ type MeasuredVirtualListMock = (
 const measuredVirtualListMock = vi.hoisted(() =>
     vi.fn<MeasuredVirtualListMock>(),
 );
+const mockScrollToIndex = vi.hoisted(() => vi.fn());
 const virtualListMockOptions = vi.hoisted(() => ({
     renderSecondItem: false,
 }));
@@ -54,7 +55,7 @@ let rectWidthsByElement = new WeakMap<Element, number>();
 let rectWidthFallback = 0;
 
 vi.mock("@renderer/components/virtual/MeasuredVirtualList", async () => {
-    const { createElement } =
+    const { createElement, useEffect } =
         await vi.importActual<typeof import("react")>("react");
 
     return {
@@ -80,7 +81,9 @@ vi.mock("@renderer/components/virtual/MeasuredVirtualList", async () => {
             readonly getItemKey: (item: T, index: number) => string;
             readonly items: readonly T[];
             readonly onRangeChange?: () => void;
-            readonly onReady?: () => void;
+            readonly onReady?: (handle: {
+                readonly scrollToIndex: typeof mockScrollToIndex;
+            } | null) => void;
             readonly observeMeasurements?: boolean;
             readonly overscan?: number;
             readonly preserveScrollAnchorOnItemsChange?: boolean;
@@ -92,6 +95,10 @@ vi.mock("@renderer/components/virtual/MeasuredVirtualList", async () => {
             }) => ReactNode;
             readonly scrollMarginTop?: number;
         }) => {
+            useEffect(() => {
+                onReady?.({ scrollToIndex: mockScrollToIndex });
+                return () => onReady?.(null);
+            }, [onReady]);
             measuredVirtualListMock({
                 firstEstimate:
                     items.length > 0 ? estimateSize(items[0], 0) : null,
@@ -359,6 +366,77 @@ function latestFirstMeasurementKey(): string {
 }
 
 describe("ChatTimelineHistoryRows", () => {
+    it("restores a semantic anchor only after its real row is mounted", () => {
+        const rows = createRows(3);
+        const scrollContainer = document.createElement("div");
+        const mountNode = document.createElement("div");
+        document.body.append(scrollContainer, mountNode);
+        const root = createRoot(mountNode);
+        const onSemanticAnchorRestored = vi.fn();
+
+        act(() => {
+            root.render(
+                <ChatTimelineHistoryRows
+                    historyRows={rows}
+                    hotTailRowId={null}
+                    hotTailRows={[]}
+                    onSemanticAnchorRestored={onSemanticAnchorRestored}
+                    renderRow={({ row }) => <div>{row.id}</div>}
+                    renderStreamingIndicator={() => <div>Streaming</div>}
+                    scrollRef={{ current: scrollContainer }}
+                    semanticAnchorBlockLoaded
+                    semanticRestoreAnchor={{
+                        entryId: rows[1]?.id ?? "",
+                        offsetWithinEntry: 14,
+                    }}
+                    showStreamingIndicator={false}
+                />,
+            );
+        });
+
+        expect(mockScrollToIndex).toHaveBeenCalledWith(1, {
+            align: "start",
+            offset: 14,
+            reason: "restore",
+        });
+        expect(onSemanticAnchorRestored).toHaveBeenCalledTimes(1);
+
+        root.unmount();
+    });
+
+    it("falls back only after the anchor block is resident without its entry", () => {
+        const rows = createRows(2);
+        const scrollContainer = document.createElement("div");
+        const mountNode = document.createElement("div");
+        document.body.append(scrollContainer, mountNode);
+        const root = createRoot(mountNode);
+        const onSemanticAnchorUnavailable = vi.fn();
+
+        act(() => {
+            root.render(
+                <ChatTimelineHistoryRows
+                    historyRows={rows}
+                    hotTailRowId={null}
+                    hotTailRows={[]}
+                    onSemanticAnchorUnavailable={onSemanticAnchorUnavailable}
+                    renderRow={({ row }) => <div>{row.id}</div>}
+                    renderStreamingIndicator={() => <div>Streaming</div>}
+                    scrollRef={{ current: scrollContainer }}
+                    semanticAnchorBlockLoaded
+                    semanticRestoreAnchor={{
+                        entryId: "missing-entry",
+                        offsetWithinEntry: 0,
+                    }}
+                    showStreamingIndicator={false}
+                />,
+            );
+        });
+
+        expect(onSemanticAnchorUnavailable).toHaveBeenCalledTimes(1);
+        expect(mockScrollToIndex).not.toHaveBeenCalled();
+
+        root.unmount();
+    });
     beforeEach(() => {
         (
             globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
@@ -366,6 +444,7 @@ describe("ChatTimelineHistoryRows", () => {
         rectWidthsByElement = new WeakMap<Element, number>();
         rectWidthFallback = 0;
         measuredVirtualListMock.mockClear();
+        mockScrollToIndex.mockClear();
         virtualListMockOptions.renderSecondItem = false;
         useShellStore.setState({ isResizingPanel: false });
         vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -404,6 +404,44 @@ describe("ChatTimelineHistoryRows", () => {
         root.unmount();
     });
 
+    it("restores the same semantic anchor after a retained tab is reactivated", () => {
+        const rows = createRows(3);
+        const scrollContainer = document.createElement("div");
+        const mountNode = document.createElement("div");
+        document.body.append(scrollContainer, mountNode);
+        const root = createRoot(mountNode);
+        const anchor = {
+            entryId: rows[1]?.id ?? "",
+            offsetWithinEntry: 14,
+        };
+        const render = (semanticRestoreAnchor: typeof anchor | null) => (
+            <ChatTimelineHistoryRows
+                historyRows={rows}
+                hotTailRowId={null}
+                hotTailRows={[]}
+                renderRow={({ row }) => <div>{row.id}</div>}
+                renderStreamingIndicator={() => <div>Streaming</div>}
+                scrollRef={{ current: scrollContainer }}
+                semanticAnchorBlockLoaded
+                semanticRestoreAnchor={semanticRestoreAnchor}
+                showStreamingIndicator={false}
+            />
+        );
+
+        act(() => {
+            root.render(render(anchor));
+        });
+        act(() => {
+            root.render(render(null));
+        });
+        act(() => {
+            root.render(render(anchor));
+        });
+
+        expect(mockScrollToIndex).toHaveBeenCalledTimes(2);
+        root.unmount();
+    });
+
     it("falls back only after the anchor block is resident without its entry", () => {
         const rows = createRows(2);
         const scrollContainer = document.createElement("div");

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -163,6 +163,7 @@ function createRows(count: number): ChatTimelineRow[] {
         });
 
         return {
+            blockId: null,
             id: `message:${message.id}`,
             kind: "message",
             message,
@@ -226,6 +227,7 @@ function createSegmentRow(entryCount = 1): ChatTimelineRow {
     }));
 
     return {
+        blockId: null,
         changeStats: { additions: 0, approximate: false, deletions: 0 },
         entries,
         id: "activity-segment:session-1:read-1",
@@ -482,6 +484,7 @@ describe("ChatTimelineHistoryRows", () => {
             throw new Error("expected a historical row");
         }
         const userRow: ChatTimelineRow = {
+            blockId: null,
             id: "message:user-next-turn",
             kind: "message",
             message: createMessage({

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -13,7 +13,6 @@ import {
     type ChatTimelineRow,
 } from "./chatTimelineModel";
 import {
-    createTranscriptStreamingIndicatorItem,
     type TranscriptTimelineItem,
     type TranscriptTimelineVirtualRow,
 } from "./transcriptBlockVirtualization";
@@ -254,11 +253,21 @@ function createSegmentRow(entryCount = 1): ChatTimelineRow {
 function renderHistoryRows(
     historyRows: readonly TranscriptTimelineItem[],
     active = true,
+    options: {
+        readonly hotTailRow?: TranscriptTimelineVirtualRow | null;
+        readonly liveTailRowId?: string | null;
+        readonly showStreamingIndicator?: boolean;
+    } = {},
 ) {
     return renderToStaticMarkup(
         <ChatTimelineHistoryRows
             active={active}
             historyRows={historyRows}
+            hotTailRowId={options.hotTailRow?.id ?? null}
+            hotTailRows={
+                options.hotTailRow ? [options.hotTailRow] : []
+            }
+            liveTailRowId={options.liveTailRowId ?? null}
             onVirtualRangeChange={() => {}}
             renderRow={({ row }) => (
                 <div
@@ -270,6 +279,9 @@ function renderHistoryRows(
             )}
             renderStreamingIndicator={() => <div>Streaming</div>}
             scrollRef={{ current: null }}
+            showStreamingIndicator={
+                options.showStreamingIndicator ?? false
+            }
         />,
     );
 }
@@ -301,6 +313,8 @@ function mountHistoryRows(
         root.render(
             <ChatTimelineHistoryRows
                 historyRows={historyRows}
+                hotTailRowId={null}
+                hotTailRows={[]}
                 renderRow={({ row }) => (
                     <div data-row-id={row.id} key={row.id}>
                         {row.id}
@@ -308,6 +322,7 @@ function mountHistoryRows(
                 )}
                 renderStreamingIndicator={() => <div>Streaming</div>}
                 scrollRef={scrollRef}
+                showStreamingIndicator={false}
             />,
         );
     });
@@ -404,21 +419,42 @@ describe("ChatTimelineHistoryRows", () => {
         );
     });
 
-    it("renders the streaming indicator through the virtual list", () => {
+    it("renders the streaming indicator outside the virtual list", () => {
         const [row] = createRows(1);
         if (!row) {
             throw new Error("expected a timeline row");
         }
 
-        const markup = renderHistoryRows([
-            row,
-            createTranscriptStreamingIndicatorItem("12s"),
-        ]);
+        const markup = renderHistoryRows([row], true, {
+            showStreamingIndicator: true,
+        });
 
         expect(measuredVirtualListMock).toHaveBeenLastCalledWith(
-            expect.objectContaining({ itemCount: 2 }),
+            expect.objectContaining({ itemCount: 1 }),
         );
         expect(markup).toContain("Streaming");
+        expect(markup).toContain("data-streaming-indicator-host");
+    });
+
+    it("renders the hot tail as a normal sibling without virtualizing it", () => {
+        const [historyRow, hotTailRow] = createRows(2);
+        if (!historyRow || !hotTailRow) {
+            throw new Error("expected history and hot-tail rows");
+        }
+
+        const markup = renderHistoryRows([historyRow], true, {
+            hotTailRow,
+            liveTailRowId: hotTailRow.id,
+        });
+
+        expect(measuredVirtualListMock).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                firstKey: historyRow.id,
+                itemCount: 1,
+            }),
+        );
+        expect(markup).toContain(`data-hot-transcript-tail="${hotTailRow.id}"`);
+        expect(markup).toContain('data-current-turn-tail="true"');
     });
 
     it("keeps visible history mounted when block-native hydration starts", () => {
@@ -452,9 +488,12 @@ describe("ChatTimelineHistoryRows", () => {
             root.render(
                 <ChatTimelineHistoryRows
                     historyRows={historyRows}
+                    hotTailRowId={null}
+                    hotTailRows={[]}
                     renderRow={({ row }) => <InstrumentedRow row={row} />}
                     renderStreamingIndicator={() => <div>Streaming</div>}
                     scrollRef={{ current: scrollContainer }}
+                    showStreamingIndicator={false}
                 />,
             );
         };
@@ -476,6 +515,83 @@ describe("ChatTimelineHistoryRows", () => {
         act(() => {
             root.unmount();
         });
+    });
+
+    it("retains the completed hot tail without a remount and transfers it once", () => {
+        const [historyRow, tailTemplate] = createRows(2);
+        if (!historyRow || !tailTemplate || tailTemplate.kind !== "message") {
+            throw new Error("expected message rows");
+        }
+        const streamingTail = {
+            ...tailTemplate,
+            message: { ...tailTemplate.message, status: "streaming" as const },
+        };
+        const completedTail = {
+            ...tailTemplate,
+            message: { ...tailTemplate.message, status: "completed" as const },
+        };
+        const scrollContainer = document.createElement("div");
+        const mountNode = document.createElement("div");
+        document.body.append(scrollContainer, mountNode);
+        const root = createRoot(mountNode);
+        let mounts = 0;
+        let unmounts = 0;
+
+        function InstrumentedRow({
+            row,
+        }: {
+            readonly row: TranscriptTimelineVirtualRow;
+        }) {
+            useEffect(() => {
+                mounts += 1;
+                return () => {
+                    unmounts += 1;
+                };
+            }, []);
+            return <div data-row-id={row.id}>{row.id}</div>;
+        }
+
+        const render = (
+            historyRows: readonly TranscriptTimelineItem[],
+            hotTailRow: TranscriptTimelineVirtualRow | null,
+            liveTailRowId: string | null,
+        ) => {
+            root.render(
+                <ChatTimelineHistoryRows
+                    historyRows={historyRows}
+                    hotTailRowId={hotTailRow?.id ?? null}
+                    hotTailRows={hotTailRow ? [hotTailRow] : []}
+                    liveTailRowId={liveTailRowId}
+                    renderRow={({ row }) => <InstrumentedRow row={row} />}
+                    renderStreamingIndicator={() => <div>Streaming</div>}
+                    scrollRef={{ current: scrollContainer }}
+                    showStreamingIndicator={false}
+                />,
+            );
+        };
+
+        act(() => render([historyRow], streamingTail, streamingTail.id));
+        expect(mounts).toBe(2);
+        expect(unmounts).toBe(0);
+
+        act(() => render([historyRow], completedTail, null));
+        expect(mounts).toBe(2);
+        expect(unmounts).toBe(0);
+        expect(
+            mountNode.querySelectorAll(`[data-row-id="${completedTail.id}"]`),
+        ).toHaveLength(1);
+
+        act(() => render([historyRow, completedTail], null, null));
+        expect(mounts).toBe(3);
+        expect(unmounts).toBe(1);
+        expect(
+            mountNode.querySelectorAll(`[data-row-id="${completedTail.id}"]`),
+        ).toHaveLength(1);
+        expect(
+            mountNode.querySelector("[data-hot-transcript-tail]"),
+        ).toBeNull();
+
+        act(() => root.unmount());
     });
 
     it("keeps virtualized history mounted when a new turn starts and streams", () => {
@@ -521,9 +637,12 @@ describe("ChatTimelineHistoryRows", () => {
             root.render(
                 <ChatTimelineHistoryRows
                     historyRows={historyRows}
+                    hotTailRowId={null}
+                    hotTailRows={[]}
                     renderRow={({ row }) => <InstrumentedRow row={row} />}
                     renderStreamingIndicator={() => <div>Streaming</div>}
                     scrollRef={{ current: scrollContainer }}
+                    showStreamingIndicator={false}
                 />,
             );
         };
@@ -694,9 +813,9 @@ describe("ChatTimelineHistoryRows", () => {
             useShellStore.getState().setResizingPanel(true);
         });
 
-        const historyElement = mounted.mountNode.querySelector(
-            "[data-testid='mock-measured-virtual-list']",
-        )?.parentElement as HTMLElement | null;
+        const historyElement = mounted.mountNode.querySelector<HTMLElement>(
+            "[data-chat-timeline-history]",
+        );
         expect(historyElement?.style.width).toBe(
             `${CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX}px`,
         );
@@ -763,9 +882,9 @@ describe("ChatTimelineHistoryRows", () => {
             useShellStore.getState().setResizingPanel(true);
         });
 
-        const historyElement = mounted.mountNode.querySelector(
-            "[data-testid='mock-measured-virtual-list']",
-        )?.parentElement as HTMLElement | null;
+        const historyElement = mounted.mountNode.querySelector<HTMLElement>(
+            "[data-chat-timeline-history]",
+        );
         expect(historyElement?.style.width).toBe("620px");
 
         mounted.setContentWidth(CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX);

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -26,6 +26,7 @@ import {
 
 import { ChatPresentationErrorBoundary } from "./ChatPresentationErrorBoundary";
 import {
+    getTranscriptTimelineItemAnchorEntryId,
     isChatTimelineRowItem,
     isTranscriptActivitySummaryItem,
     isTranscriptBlockSpacerItem,
@@ -68,6 +69,8 @@ interface ChatTimelineHistoryRowsProps {
     readonly onVirtualResizeAutoFollow?: () => void;
     readonly onVirtualResizeStart?: () => void;
     readonly onNewTurnScrollTarget?: (target: number) => void;
+    readonly onSemanticAnchorRestored?: () => void;
+    readonly onSemanticAnchorUnavailable?: () => void;
     readonly onVirtualScrollRequest?: (
         request: MeasuredVirtualScrollRequest,
     ) => void;
@@ -79,6 +82,11 @@ interface ChatTimelineHistoryRowsProps {
     }) => ReactNode;
     readonly renderStreamingIndicator: () => ReactNode;
     readonly scrollRef: RefObject<HTMLElement | null>;
+    readonly semanticAnchorBlockLoaded?: boolean;
+    readonly semanticRestoreAnchor?: {
+        readonly entryId: string;
+        readonly offsetWithinEntry: number;
+    } | null;
     readonly showStreamingIndicator: boolean;
     readonly shouldDeferTrailingUserMeasurementAnchor?: () => boolean;
     readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
@@ -135,12 +143,16 @@ export const ChatTimelineHistoryRows = memo(
         onVirtualResizeAutoFollow,
         onVirtualResizeStart,
         onNewTurnScrollTarget,
+        onSemanticAnchorRestored,
+        onSemanticAnchorUnavailable,
         onVirtualScrollRequest,
         liveTailRowId,
         newTurnAnchorRowId,
         renderRow,
         renderStreamingIndicator,
         scrollRef,
+        semanticAnchorBlockLoaded = false,
+        semanticRestoreAnchor,
         showStreamingIndicator,
         shouldDeferTrailingUserMeasurementAnchor,
         shouldPreserveVirtualMeasureAnchor,
@@ -160,11 +172,13 @@ export const ChatTimelineHistoryRows = memo(
             null,
         );
         const virtualResizeActiveRef = useRef(false);
+        const restoredSemanticAnchorKeyRef = useRef<string | null>(null);
         const handledTrailingUserMeasurementRef = useRef<string | null>(null);
         // This is intentionally local to the mounted timeline: measurements are
         // only a rendering hint and must never become persisted chat state.
         const estimateCalibrationRef = useRef(new Map<string, number>());
         const [scrollMarginTop, setScrollMarginTop] = useState(0);
+        const [virtualListVersion, setVirtualListVersion] = useState(0);
         const [contentMeasurementWidth, setContentMeasurementWidth] =
             useState(0);
         const trailingUserRowId = getTrailingUserRowId(historyRows);
@@ -283,9 +297,58 @@ export const ChatTimelineHistoryRows = memo(
         const handleVirtualListReady = useCallback(
             (handle: MeasuredVirtualListHandle | null) => {
                 virtualListHandleRef.current = handle;
+                setVirtualListVersion((version) => version + 1);
             },
             [],
         );
+
+        useLayoutEffect(() => {
+            if (!active || !semanticRestoreAnchor) {
+                return;
+            }
+
+            const restoreKey = `${semanticRestoreAnchor.entryId}:${semanticRestoreAnchor.offsetWithinEntry}`;
+            if (restoredSemanticAnchorKeyRef.current === restoreKey) {
+                return;
+            }
+
+            const anchorIndex = historyRows.findIndex(
+                (row) =>
+                    isChatTimelineRowItem(row) &&
+                    getTranscriptTimelineItemAnchorEntryId(row) ===
+                        semanticRestoreAnchor.entryId,
+            );
+            if (anchorIndex < 0) {
+                if (semanticAnchorBlockLoaded) {
+                    restoredSemanticAnchorKeyRef.current = restoreKey;
+                    onSemanticAnchorUnavailable?.();
+                }
+                return;
+            }
+
+            const handle = virtualListHandleRef.current;
+            if (!handle) {
+                return;
+            }
+
+            // The target row is real, not a spacer, so the semantic offset is
+            // meaningful even after estimates have changed around the viewport.
+            handle.scrollToIndex(anchorIndex, {
+                align: "start",
+                offset: semanticRestoreAnchor.offsetWithinEntry,
+                reason: "restore",
+            });
+            restoredSemanticAnchorKeyRef.current = restoreKey;
+            onSemanticAnchorRestored?.();
+        }, [
+            active,
+            historyRows,
+            onSemanticAnchorRestored,
+            onSemanticAnchorUnavailable,
+            semanticAnchorBlockLoaded,
+            semanticRestoreAnchor,
+            virtualListVersion,
+        ]);
 
         useLayoutEffect(() => {
             if (!active || !newTurnAnchorRowId) {

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -20,6 +20,7 @@ import {
     MeasuredVirtualList,
     type MeasuredVirtualListHandle,
     type MeasuredVirtualRange,
+    type MeasuredVirtualScrollRequest,
     type MeasuredVirtualViewportAnchor,
 } from "@renderer/components/virtual/MeasuredVirtualList";
 
@@ -67,6 +68,9 @@ interface ChatTimelineHistoryRowsProps {
     readonly onVirtualResizeAutoFollow?: () => void;
     readonly onVirtualResizeStart?: () => void;
     readonly onNewTurnScrollTarget?: (target: number) => void;
+    readonly onVirtualScrollRequest?: (
+        request: MeasuredVirtualScrollRequest,
+    ) => void;
     readonly liveTailRowId?: string | null;
     readonly newTurnAnchorRowId?: string | null;
     readonly renderRow: (params: {
@@ -131,6 +135,7 @@ export const ChatTimelineHistoryRows = memo(
         onVirtualResizeAutoFollow,
         onVirtualResizeStart,
         onNewTurnScrollTarget,
+        onVirtualScrollRequest,
         liveTailRowId,
         newTurnAnchorRowId,
         renderRow,
@@ -710,6 +715,7 @@ export const ChatTimelineHistoryRows = memo(
                         onRangeChange={onVirtualRangeChange}
                         onItemMeasured={handleVirtualItemMeasured}
                         onReady={handleVirtualListReady}
+                        onScrollRequest={onVirtualScrollRequest}
                         overscan={CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN}
                         preserveScrollAnchorOnItemsChange
                         preserveScrollAnchorOnMeasure

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -12,6 +12,11 @@ import {
 import { useSettingsStore } from "@renderer/app/store/settings-store";
 import { useShellStore } from "@renderer/app/store/shell-store";
 import {
+    hashChatPerformanceLabel,
+    isChatPerformanceProbeEnabled,
+    recordChatPerformanceMetric,
+} from "@renderer/app/debug/chatPerformanceProbe";
+import {
     MeasuredVirtualList,
     type MeasuredVirtualListHandle,
     type MeasuredVirtualRange,
@@ -495,6 +500,23 @@ export const ChatTimelineHistoryRows = memo(
                 if (!isChatTimelineRowItem(item)) {
                     return;
                 }
+                const context = buildRowContext(item, index);
+                if (isChatPerformanceProbeEnabled()) {
+                    recordChatPerformanceMetric("virtual_measure", {
+                        sessionId,
+                        values: {
+                            height: measurement.height,
+                            index,
+                            measurementKeyRevision: hashChatPerformanceLabel(
+                                getChatTimelineRowMeasurementKey(item, context),
+                            ),
+                            previousHeight: measurement.previousHeight,
+                            rowRevision: hashChatPerformanceLabel(
+                                getChatTimelineRowIdentityKey(item, context),
+                            ),
+                        },
+                    });
+                }
                 if (
                     item.kind === "message" &&
                     item.message.status === "streaming"
@@ -504,7 +526,6 @@ export const ChatTimelineHistoryRows = memo(
                     return;
                 }
 
-                const context = buildRowContext(item, index);
                 const baseHeight = estimateChatTimelineRowBaseHeight(
                     item,
                     context,
@@ -546,7 +567,7 @@ export const ChatTimelineHistoryRows = memo(
                     }
                 }
             },
-            [buildRowContext],
+            [buildRowContext, sessionId],
         );
 
         const estimateSize = useCallback(
@@ -624,6 +645,9 @@ export const ChatTimelineHistoryRows = memo(
 
                 return (
                     <div
+                        data-current-turn-tail={
+                            item.id === liveTailRowId ? "true" : undefined
+                        }
                         style={
                             gapPx > 0
                                 ? { paddingBottom: `${gapPx}px` }

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -181,6 +181,13 @@ export const ChatTimelineHistoryRows = memo(
         const [virtualListVersion, setVirtualListVersion] = useState(0);
         const [contentMeasurementWidth, setContentMeasurementWidth] =
             useState(0);
+        useEffect(() => {
+            if (!semanticRestoreAnchor) {
+                // The same entry may be restored after reactivating a retained
+                // tab whose virtual geometry changed while it was hidden.
+                restoredSemanticAnchorKeyRef.current = null;
+            }
+        }, [semanticRestoreAnchor]);
         const trailingUserRowId = getTrailingUserRowId(historyRows);
         const shouldPreserveVirtualMeasureAnchorForItem = useCallback(
             (row: TranscriptTimelineItem) => {

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -31,7 +31,6 @@ import {
     isTranscriptStreamingIndicatorItem,
     type TranscriptTimelineItem,
     type TranscriptTimelineVirtualRow,
-    type TranscriptStreamingIndicatorItem,
 } from "./transcriptBlockVirtualization";
 import {
     CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT,
@@ -60,6 +59,8 @@ interface ChatTimelineHistoryRowsProps {
     readonly chatFontFamily?: string;
     readonly chatFontSize?: number;
     readonly historyRows: readonly TranscriptTimelineItem[];
+    readonly hotTailRowId: string | null;
+    readonly hotTailRows: readonly TranscriptTimelineVirtualRow[];
     readonly sessionId?: string;
     readonly onVirtualRangeChange?: (range: MeasuredVirtualRange) => void;
     readonly onVirtualResizeEnd?: () => void;
@@ -72,10 +73,9 @@ interface ChatTimelineHistoryRowsProps {
         readonly isCurrentTurnTail: boolean;
         readonly row: TranscriptTimelineVirtualRow;
     }) => ReactNode;
-    readonly renderStreamingIndicator: (
-        item: TranscriptStreamingIndicatorItem,
-    ) => ReactNode;
+    readonly renderStreamingIndicator: () => ReactNode;
     readonly scrollRef: RefObject<HTMLElement | null>;
+    readonly showStreamingIndicator: boolean;
     readonly shouldDeferTrailingUserMeasurementAnchor?: () => boolean;
     readonly shouldPreserveVirtualMeasureAnchor?: () => boolean;
     readonly shouldPreserveVirtualResizeAnchor?: () => boolean;
@@ -123,6 +123,8 @@ export const ChatTimelineHistoryRows = memo(
         chatFontFamily,
         chatFontSize,
         historyRows,
+        hotTailRowId,
+        hotTailRows,
         sessionId,
         onVirtualRangeChange,
         onVirtualResizeEnd,
@@ -134,11 +136,13 @@ export const ChatTimelineHistoryRows = memo(
         renderRow,
         renderStreamingIndicator,
         scrollRef,
+        showStreamingIndicator,
         shouldDeferTrailingUserMeasurementAnchor,
         shouldPreserveVirtualMeasureAnchor,
         shouldPreserveVirtualResizeAnchor,
     }: ChatTimelineHistoryRowsProps) {
         const historyRef = useRef<HTMLDivElement | null>(null);
+        const hotTailRef = useRef<HTMLDivElement | null>(null);
         const toolActivityDefaultExpansion = useSettingsStore(
             (state) => state.aiChat.toolActivityDefaultExpansion,
         );
@@ -297,21 +301,24 @@ export const ChatTimelineHistoryRows = memo(
                 return;
             }
 
-            const tailIndex = liveTailRowId
-                ? historyRows.findIndex((row) => row.id === liveTailRowId)
-                : historyRows.length - 1;
             const tail = handle.getItemGeometry?.(
-                tailIndex >= anchorIndex ? tailIndex : anchorIndex,
+                Math.max(anchorIndex, historyRows.length - 1),
             );
-            if (!tail) {
-                return;
-            }
+            const hotTailElement = hotTailRowId ? hotTailRef.current : null;
+            const scrollRect = scrollContainer.getBoundingClientRect();
+            const hotTailEnd = hotTailElement
+                ? scrollContainer.scrollTop +
+                  hotTailElement.getBoundingClientRect().bottom -
+                  scrollRect.top
+                : null;
+            const virtualTailEnd = tail ? tail.start + tail.size : anchor.start;
+            const tailEnd = hotTailEnd ?? virtualTailEnd;
 
             // The composer already reduces the scroll viewport in this flex layout.
             // Keep the prompt visible until the active turn needs more room below it.
             const requiredEnd = Math.max(
                 0,
-                tail.start + tail.size -
+                tailEnd -
                     (anchor.start + scrollContainer.clientHeight),
             );
             // The parent serializes every scroll write against navigation intent.
@@ -325,7 +332,7 @@ export const ChatTimelineHistoryRows = memo(
         }, [
             active,
             historyRows,
-            liveTailRowId,
+            hotTailRowId,
             newTurnAnchorRowId,
             onNewTurnScrollTarget,
             scrollMarginTop,
@@ -630,24 +637,11 @@ export const ChatTimelineHistoryRows = memo(
                 const gapPx = resolveRowGapPx(index);
 
                 if (isTranscriptStreamingIndicatorItem(item)) {
-                    return (
-                        <div
-                            style={
-                                gapPx > 0
-                                    ? { paddingBottom: `${gapPx}px` }
-                                    : undefined
-                            }
-                        >
-                            {renderStreamingIndicator(item)}
-                        </div>
-                    );
+                    return null;
                 }
 
                 return (
                     <div
-                        data-current-turn-tail={
-                            item.id === liveTailRowId ? "true" : undefined
-                        }
                         style={
                             gapPx > 0
                                 ? { paddingBottom: `${gapPx}px` }
@@ -662,10 +656,7 @@ export const ChatTimelineHistoryRows = memo(
                             )}
                         >
                             {renderRow({
-                                isCurrentTurnTail:
-                                    item.id === liveTailRowId ||
-                                    (isTranscriptActivitySummaryItem(item) &&
-                                        item.groupId === liveTailRowId),
+                                isCurrentTurnTail: false,
                                 row: item,
                             })}
                         </ChatPresentationErrorBoundary>
@@ -674,8 +665,6 @@ export const ChatTimelineHistoryRows = memo(
             },
             [
                 renderRow,
-                renderStreamingIndicator,
-                liveTailRowId,
                 resolveRowGapPx,
                 buildRowContext,
             ],
@@ -683,8 +672,8 @@ export const ChatTimelineHistoryRows = memo(
 
         return (
             <div
-                ref={historyRef}
                 className="relative w-full"
+                data-chat-timeline-history="true"
                 // Pin the content width while dragging the splitter so rows keep
                 // their pre-drag layout (no reflow); clip any overhang instead of
                 // letting it spill. Released to fluid width on drag end.
@@ -694,48 +683,95 @@ export const ChatTimelineHistoryRows = memo(
                         : undefined
                 }
             >
-                <MeasuredVirtualList
-                    defaultViewportHeight={
-                        CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT
-                    }
-                    estimateSize={estimateSize}
-                    getItemKey={getTranscriptTimelineItemKey}
-                    getItemIdentityKey={getItemIdentityKey}
-                    getItemMeasurementKey={getItemMeasurementKey}
-                    geometryCacheSignature={
-                        contentMeasurementWidth > 0
-                            ? [
-                                  chatFontFamily ?? "default",
-                                  chatFontSize ?? "default",
-                                  toolActivityDefaultExpansion,
-                                  contentMeasurementWidth,
-                              ].join(":")
-                            : null
-                    }
-                    items={historyRows}
-                    observeMeasurements={active}
-                    measurementCacheKey={
-                        sessionId ? `chat-timeline:${sessionId}` : undefined
-                    }
-                    onRangeChange={onVirtualRangeChange}
-                    onItemMeasured={handleVirtualItemMeasured}
-                    onReady={handleVirtualListReady}
-                    overscan={CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN}
-                    preserveScrollAnchorOnItemsChange
-                    preserveScrollAnchorOnMeasure
-                    shouldPreserveScrollAnchorOnItemsChange={
-                        shouldPreserveVirtualResizeAnchor
-                    }
-                    shouldPreserveScrollAnchorOnMeasure={
-                        shouldPreserveVirtualMeasureAnchor
-                    }
-                    shouldPreserveScrollAnchorForItemMeasurement={
-                        shouldPreserveVirtualMeasureAnchorForItem
-                    }
-                    scrollContainerRef={scrollRef}
-                    scrollMarginTop={scrollMarginTop}
-                    renderItem={renderVirtualItem}
-                />
+                <div ref={historyRef} className="relative w-full">
+                    <MeasuredVirtualList
+                        defaultViewportHeight={
+                            CHAT_TIMELINE_VIRTUAL_DEFAULT_VIEWPORT_HEIGHT
+                        }
+                        estimateSize={estimateSize}
+                        getItemKey={getTranscriptTimelineItemKey}
+                        getItemIdentityKey={getItemIdentityKey}
+                        getItemMeasurementKey={getItemMeasurementKey}
+                        geometryCacheSignature={
+                            contentMeasurementWidth > 0
+                                ? [
+                                      chatFontFamily ?? "default",
+                                      chatFontSize ?? "default",
+                                      toolActivityDefaultExpansion,
+                                      contentMeasurementWidth,
+                                  ].join(":")
+                                : null
+                        }
+                        items={historyRows}
+                        observeMeasurements={active}
+                        measurementCacheKey={
+                            sessionId ? `chat-timeline:${sessionId}` : undefined
+                        }
+                        onRangeChange={onVirtualRangeChange}
+                        onItemMeasured={handleVirtualItemMeasured}
+                        onReady={handleVirtualListReady}
+                        overscan={CHAT_TIMELINE_VIRTUALIZATION_OVERSCAN}
+                        preserveScrollAnchorOnItemsChange
+                        preserveScrollAnchorOnMeasure
+                        shouldPreserveScrollAnchorOnItemsChange={
+                            shouldPreserveVirtualResizeAnchor
+                        }
+                        shouldPreserveScrollAnchorOnMeasure={
+                            shouldPreserveVirtualMeasureAnchor
+                        }
+                        shouldPreserveScrollAnchorForItemMeasurement={
+                            shouldPreserveVirtualMeasureAnchorForItem
+                        }
+                        scrollContainerRef={scrollRef}
+                        scrollMarginTop={scrollMarginTop}
+                        renderItem={renderVirtualItem}
+                    />
+                </div>
+                {hotTailRows.length > 0 ? (
+                    <div
+                        className={historyRows.length > 0 ? "mt-2" : undefined}
+                        data-current-turn-tail={
+                            hotTailRowId === liveTailRowId ? "true" : undefined
+                        }
+                        data-hot-transcript-tail={hotTailRowId ?? undefined}
+                        data-retained-transcript-tail={
+                            hotTailRowId !== liveTailRowId ? "true" : undefined
+                        }
+                        ref={hotTailRef}
+                    >
+                        <div className="flex min-w-0 flex-col gap-2">
+                            {hotTailRows.map((row) => (
+                                <ChatPresentationErrorBoundary
+                                    fallbackKind="row"
+                                    identity={`hot-tail:${row.id}`}
+                                    key={row.id}
+                                >
+                                    {renderRow({
+                                        isCurrentTurnTail:
+                                            row.id === liveTailRowId ||
+                                            (isTranscriptActivitySummaryItem(
+                                                row,
+                                            ) &&
+                                                row.groupId === liveTailRowId),
+                                        row,
+                                    })}
+                                </ChatPresentationErrorBoundary>
+                            ))}
+                        </div>
+                    </div>
+                ) : null}
+                {showStreamingIndicator ? (
+                    <div
+                        className={
+                            historyRows.length > 0 || hotTailRows.length > 0
+                                ? "mt-2"
+                                : undefined
+                        }
+                        data-streaming-indicator-host="true"
+                    >
+                        {renderStreamingIndicator()}
+                    </div>
+                ) : null}
             </div>
         );
     },

--- a/src/renderer/src/components/workspace/chat/ChatTranscriptSurface.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTranscriptSurface.tsx
@@ -1,0 +1,62 @@
+import { memo, type ReactNode, type RefObject, type TouchEvent, type WheelEvent } from "react";
+
+import { ChatContentColumn } from "./ChatContentColumn";
+import { ToolExpansionStoreProvider } from "./toolExpansionStore";
+
+interface ChatTranscriptSurfaceProps {
+    readonly chatFontFamily?: string;
+    readonly children: ReactNode;
+    readonly covered: boolean;
+    readonly jumpToBottom: ReactNode;
+    readonly onScroll: () => void;
+    readonly onTouchStart?: (event: TouchEvent<HTMLDivElement>) => void;
+    readonly onWheelCapture?: (event: WheelEvent<HTMLDivElement>) => void;
+    readonly scopeKey: string;
+    readonly scrollRef: RefObject<HTMLDivElement | null>;
+    readonly timelineContentRef: RefObject<HTMLDivElement | null>;
+}
+
+// Keeps viewport listeners and virtual history in one memoizable surface.
+export const ChatTranscriptSurface = memo(function ChatTranscriptSurface({
+    chatFontFamily,
+    children,
+    covered,
+    jumpToBottom,
+    onScroll,
+    onTouchStart,
+    onWheelCapture,
+    scopeKey,
+    scrollRef,
+    timelineContentRef,
+}: ChatTranscriptSurfaceProps) {
+    return (
+        <ToolExpansionStoreProvider scopeKey={scopeKey}>
+            <div
+                aria-hidden={covered}
+                className={
+                    covered
+                        ? "pointer-events-none invisible absolute inset-0 min-h-0 min-w-0"
+                        : "relative min-h-0 min-w-0 flex-1"
+                }
+                inert={covered ? true : undefined}
+            >
+                <div
+                    ref={scrollRef}
+                    className="chat-scroll h-full min-h-0 min-w-0 overflow-y-auto px-3 py-3"
+                    onScroll={onScroll}
+                    onTouchStart={onTouchStart}
+                    onWheelCapture={onWheelCapture}
+                >
+                    <ChatContentColumn
+                        ref={timelineContentRef}
+                        className="min-w-0 space-y-2"
+                        style={{ fontFamily: chatFontFamily }}
+                    >
+                        {children}
+                    </ChatContentColumn>
+                </div>
+                {jumpToBottom}
+            </div>
+        </ToolExpansionStoreProvider>
+    );
+});

--- a/src/renderer/src/components/workspace/chat/ReviewSurface.tsx
+++ b/src/renderer/src/components/workspace/chat/ReviewSurface.tsx
@@ -1,0 +1,13 @@
+import { memo, type ComponentProps } from "react";
+
+import { EditedFilesBufferPanel } from "./EditedFilesBufferPanel";
+
+type ReviewSurfaceProps = Omit<
+    ComponentProps<typeof EditedFilesBufferPanel>,
+    "defaultCollapsed"
+>;
+
+// Keeps the expensive review surface isolated from streaming transcript updates.
+export const ReviewSurface = memo(function ReviewSurface(props: ReviewSurfaceProps) {
+    return <EditedFilesBufferPanel {...props} defaultCollapsed />;
+});

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.test.tsx
@@ -107,6 +107,7 @@ function createSegment(
     }
 
     return {
+        blockId: null,
         changeStats: deriveActivitySegmentChangeStats(entries),
         entries,
         id: `activity-segment:session-1:${first.id}`,
@@ -156,6 +157,7 @@ function createThinkingSegment(
         status,
     };
     return {
+        blockId: null,
         changeStats: { additions: 0, approximate: false, deletions: 0 },
         entries: [],
         id: "activity-segment:thinking:thinking-1",

--- a/src/renderer/src/components/workspace/chat/chatPerformanceFixtures.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatPerformanceFixtures.test.ts
@@ -4,14 +4,13 @@ import {
     applyAiSessionDomainEventToTranscript,
     buildAiSessionTranscriptModelFromSnapshot,
 } from "@renderer/app/ai/transcriptModel";
-import { buildBlockNativeTranscript } from "@renderer/app/ai/transcriptWindowProjection";
+import { buildBlockNativeTranscriptProjection } from "@renderer/app/ai/transcriptWindowProjection";
 import {
     readChatPerformanceCounters,
     resetChatPerformanceCounters,
 } from "@renderer/app/debug/chatPerformanceCounters";
 import {
-    reconcileChatTimelineModelFromTranscript,
-    reconcileChatTimelineModelIncrementallyFromTranscript,
+    reconcileChatTimelineModelFromProjection,
 } from "./chatTimelineModel";
 
 import {
@@ -156,18 +155,18 @@ describe("chatPerformanceFixtures", () => {
         let liveTranscript = buildAiSessionTranscriptModelFromSnapshot(
             fixture.snapshot,
         );
-        let projectedTranscript = buildBlockNativeTranscript(
+        let projection = buildBlockNativeTranscriptProjection(
             liveTranscript,
             fixture.blocksById,
             fixture.metadata,
             fixture.payloadsByRef,
-            fixture.snapshot,
         );
-        let timeline = reconcileChatTimelineModelFromTranscript(null, {
+        let timeline = reconcileChatTimelineModelFromProjection(null, null, {
             activeTurnStartedAt: fixture.snapshot.activeTurnStartedAt,
+            projection,
             status: fixture.snapshot.status,
             trackedFiles: fixture.snapshot.trackedFiles,
-            transcript: projectedTranscript,
+            updatedAt: fixture.snapshot.updatedAt,
         });
         resetChatPerformanceCounters();
 
@@ -192,24 +191,25 @@ describe("chatPerformanceFixtures", () => {
                     ).toISOString(),
                 } satisfies AiSessionDomainEvent,
             );
-            const nextProjectedTranscript = buildBlockNativeTranscript(
+            const nextProjection = buildBlockNativeTranscriptProjection(
                 liveTranscript,
                 fixture.blocksById,
                 fixture.metadata,
                 fixture.payloadsByRef,
-                fixture.snapshot,
+                projection,
             );
-            timeline = reconcileChatTimelineModelIncrementallyFromTranscript(
+            timeline = reconcileChatTimelineModelFromProjection(
                 timeline,
-                projectedTranscript,
+                projection,
                 {
                     activeTurnStartedAt: fixture.snapshot.activeTurnStartedAt,
+                    projection: nextProjection,
                     status: fixture.snapshot.status,
                     trackedFiles: fixture.snapshot.trackedFiles,
-                    transcript: nextProjectedTranscript,
+                    updatedAt: fixture.snapshot.updatedAt,
                 },
             );
-            projectedTranscript = nextProjectedTranscript;
+            projection = nextProjection;
         }
 
         const counters = readChatPerformanceCounters();
@@ -217,10 +217,13 @@ describe("chatPerformanceFixtures", () => {
             (total, block) => total + block.entries.length,
             0,
         );
-        expect(counters.timeline_full_rebuilds).toBe(fixture.deltaCount);
-        expect(counters.stable_history_entries_visited).toBe(
-            residentEntries * fixture.deltaCount,
-        );
+        expect(counters.timeline_full_rebuilds).toBe(0);
+        expect(counters.stable_history_entries_visited).toBe(0);
+        expect(
+            timeline.atomicLiveTailRow?.kind === "message"
+                ? timeline.atomicLiveTailRow.message.content
+                : null,
+        ).toBe(content);
         expect(
             passesChatPerformanceGate({
                 fullRebuildsDuringStreaming:
@@ -231,6 +234,6 @@ describe("chatPerformanceFixtures", () => {
                 sealedEntriesVisitedDuringStreaming:
                     counters.stable_history_entries_visited,
             }),
-        ).toBe(false);
+        ).toBe(true);
     });
 });

--- a/src/renderer/src/components/workspace/chat/chatPerformanceFixtures.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatPerformanceFixtures.test.ts
@@ -1,8 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AiSessionDomainEvent } from "@shared/ipc";
+import {
+    applyAiSessionDomainEventToTranscript,
+    buildAiSessionTranscriptModelFromSnapshot,
+} from "@renderer/app/ai/transcriptModel";
+import { buildBlockNativeTranscript } from "@renderer/app/ai/transcriptWindowProjection";
+import {
+    readChatPerformanceCounters,
+    resetChatPerformanceCounters,
+} from "@renderer/app/debug/chatPerformanceCounters";
+import {
+    reconcileChatTimelineModelFromTranscript,
+    reconcileChatTimelineModelIncrementallyFromTranscript,
+} from "./chatTimelineModel";
 
 import {
     CHAT_INTERACTION_BUDGETS,
     CHAT_PERFORMANCE_FIXTURES,
+    createBlockNativeStreamingPerformanceFixture,
     createChatPerformanceFixture,
     createChatPerformanceFixtureById,
     createChatPerformanceWorkspaceFixture,
@@ -10,6 +25,8 @@ import {
 } from "./chatPerformanceFixtures";
 
 describe("chatPerformanceFixtures", () => {
+    beforeEach(resetChatPerformanceCounters);
+
     it("declares the long-chat datasets used by the performance plan", () => {
         expect(CHAT_PERFORMANCE_FIXTURES).toEqual([
             {
@@ -101,6 +118,7 @@ describe("chatPerformanceFixtures", () => {
             activityInitialItems: 20,
             maxFullRebuildsDuringStreaming: 0,
             maxMountedRows: 80,
+            maxSealedEntriesVisitedDuringStreaming: 0,
             transcriptBlockEntries: 256,
         });
     });
@@ -112,6 +130,7 @@ describe("chatPerformanceFixtures", () => {
                 mountedRows: 80,
                 residentEntries: 256 * 3,
                 residentPayloadBytes: 16 * 1024 * 1024,
+                sealedEntriesVisitedDuringStreaming: 0,
             }),
         ).toBe(true);
         expect(
@@ -120,6 +139,97 @@ describe("chatPerformanceFixtures", () => {
                 mountedRows: 81,
                 residentEntries: 100_000,
                 residentPayloadBytes: 16 * 1024 * 1024 + 1,
+                sealedEntriesVisitedDuringStreaming: 1,
+            }),
+        ).toBe(false);
+    });
+
+    it("measures the production block-native path instead of trusting literal gate values", () => {
+        const fixture = createBlockNativeStreamingPerformanceFixture();
+        expect(fixture.metadata).toHaveLength(3);
+        expect(
+            [...fixture.blocksById.values()].map(
+                (block) => block.entries.length,
+            ),
+        ).toEqual([256, 256, 256]);
+
+        let liveTranscript = buildAiSessionTranscriptModelFromSnapshot(
+            fixture.snapshot,
+        );
+        let projectedTranscript = buildBlockNativeTranscript(
+            liveTranscript,
+            fixture.blocksById,
+            fixture.metadata,
+            fixture.payloadsByRef,
+            fixture.snapshot,
+        );
+        let timeline = reconcileChatTimelineModelFromTranscript(null, {
+            activeTurnStartedAt: fixture.snapshot.activeTurnStartedAt,
+            status: fixture.snapshot.status,
+            trackedFiles: fixture.snapshot.trackedFiles,
+            transcript: projectedTranscript,
+        });
+        resetChatPerformanceCounters();
+
+        let content = "";
+        for (let index = 0; index < fixture.deltaCount; index += 1) {
+            content += index % 20 === 19 ? "\n" : "x";
+            liveTranscript = applyAiSessionDomainEventToTranscript(
+                liveTranscript,
+                {
+                    content,
+                    delta: content.at(-1) ?? "",
+                    kind: "message-delta",
+                    messageId: "streaming-assistant",
+                    messageKind: "assistant",
+                    origin: "live",
+                    parentSessionId: null,
+                    runtimeId: fixture.snapshot.runtimeId,
+                    runtimeSessionId: fixture.snapshot.runtimeSessionId,
+                    sessionId: fixture.snapshot.sessionId,
+                    updatedAt: new Date(
+                        Date.parse(fixture.snapshot.updatedAt) + index + 1,
+                    ).toISOString(),
+                } satisfies AiSessionDomainEvent,
+            );
+            const nextProjectedTranscript = buildBlockNativeTranscript(
+                liveTranscript,
+                fixture.blocksById,
+                fixture.metadata,
+                fixture.payloadsByRef,
+                fixture.snapshot,
+            );
+            timeline = reconcileChatTimelineModelIncrementallyFromTranscript(
+                timeline,
+                projectedTranscript,
+                {
+                    activeTurnStartedAt: fixture.snapshot.activeTurnStartedAt,
+                    status: fixture.snapshot.status,
+                    trackedFiles: fixture.snapshot.trackedFiles,
+                    transcript: nextProjectedTranscript,
+                },
+            );
+            projectedTranscript = nextProjectedTranscript;
+        }
+
+        const counters = readChatPerformanceCounters();
+        const residentEntries = [...fixture.blocksById.values()].reduce(
+            (total, block) => total + block.entries.length,
+            0,
+        );
+        expect(counters.timeline_full_rebuilds).toBe(fixture.deltaCount);
+        expect(counters.stable_history_entries_visited).toBe(
+            residentEntries * fixture.deltaCount,
+        );
+        expect(
+            passesChatPerformanceGate({
+                fullRebuildsDuringStreaming:
+                    counters.timeline_full_rebuilds,
+                mountedRows: 80,
+                residentEntries,
+                residentPayloadBytes: 0,
+                sealedEntriesVisitedDuringStreaming:
+                    counters.stable_history_entries_visited,
             }),
         ).toBe(false);
     });

--- a/src/renderer/src/components/workspace/chat/chatPerformanceFixtures.ts
+++ b/src/renderer/src/components/workspace/chat/chatPerformanceFixtures.ts
@@ -4,6 +4,9 @@ import type {
     AiSessionSnapshot,
     AiToolActivity,
     AiTrackedFile,
+    AiTranscriptBlock,
+    AiTranscriptBlockMetadata,
+    AiTranscriptPayload,
 } from "@shared/ipc";
 
 const FIXTURE_STARTED_AT_MS = Date.UTC(2026, 0, 1, 0, 0, 0);
@@ -18,6 +21,14 @@ export interface ChatPerformanceFixtureDefinition {
 
 export interface ChatPerformanceFixture {
     readonly definition: ChatPerformanceFixtureDefinition;
+    readonly snapshot: AiSessionSnapshot;
+}
+
+export interface BlockNativeStreamingPerformanceFixture {
+    readonly blocksById: ReadonlyMap<string, AiTranscriptBlock>;
+    readonly deltaCount: 1_000;
+    readonly metadata: readonly AiTranscriptBlockMetadata[];
+    readonly payloadsByRef: ReadonlyMap<string, AiTranscriptPayload>;
     readonly snapshot: AiSessionSnapshot;
 }
 
@@ -52,6 +63,7 @@ export const CHAT_INTERACTION_BUDGETS = {
     activityInitialItems: 20,
     maxFullRebuildsDuringStreaming: 0,
     maxMountedRows: 80,
+    maxSealedEntriesVisitedDuringStreaming: 0,
     transcriptBlockEntries: 256,
 } as const;
 
@@ -60,6 +72,7 @@ export interface ChatPerformanceGateMetrics {
     readonly mountedRows: number;
     readonly residentEntries: number;
     readonly residentPayloadBytes: number;
+    readonly sealedEntriesVisitedDuringStreaming: number;
 }
 
 export function passesChatPerformanceGate(
@@ -69,6 +82,8 @@ export function passesChatPerformanceGate(
         metrics.fullRebuildsDuringStreaming <=
             CHAT_INTERACTION_BUDGETS.maxFullRebuildsDuringStreaming &&
         metrics.mountedRows <= CHAT_INTERACTION_BUDGETS.maxMountedRows &&
+        metrics.sealedEntriesVisitedDuringStreaming <=
+            CHAT_INTERACTION_BUDGETS.maxSealedEntriesVisitedDuringStreaming &&
         metrics.residentEntries <= CHAT_INTERACTION_BUDGETS.transcriptBlockEntries * 3 &&
         metrics.residentPayloadBytes <= 16 * 1024 * 1024
     );
@@ -181,6 +196,84 @@ export function createChatPerformanceWorkspaceFixture(): ChatPerformanceWorkspac
         ],
         id: "workspace-multipane",
         panes,
+    };
+}
+
+export function createBlockNativeStreamingPerformanceFixture(): BlockNativeStreamingPerformanceFixture {
+    const blockEntryCount = CHAT_INTERACTION_BUDGETS.transcriptBlockEntries;
+    const metadata = Array.from({ length: 3 }, (_, blockIndex) => {
+        const startSequence = blockIndex * blockEntryCount + 1;
+        const endSequence = startSequence + blockEntryCount - 1;
+        return {
+            blockId: `${FIXTURE_SESSION_ID}:block-${blockIndex + 1}`,
+            endSequence,
+            entryCount: blockEntryCount,
+            estimatedHeight: blockEntryCount * 72,
+            estimatedRowCount: blockEntryCount,
+            firstCreatedAt: timestampFor(startSequence),
+            lastCreatedAt: timestampFor(endSequence),
+            revision: 1,
+            sessionId: FIXTURE_SESSION_ID,
+            startSequence,
+        } satisfies AiTranscriptBlockMetadata;
+    });
+    const blocksById = new Map<string, AiTranscriptBlock>();
+    for (const item of metadata) {
+        const entries = Array.from({ length: item.entryCount }, (_, index) => {
+            const sequence = item.startSequence + index;
+            const createdAt = timestampFor(sequence);
+            return {
+                createdAt,
+                id: `message:sealed-${sequence}`,
+                kind: "message" as const,
+                payloadRef: null,
+                sequence,
+                sessionId: FIXTURE_SESSION_ID,
+                summary: {
+                    label: `Sealed message ${sequence}`,
+                    preview: `Stable block-native fixture entry ${sequence}.`,
+                    status: "completed",
+                },
+                updatedAt: createdAt,
+            };
+        });
+        blocksById.set(item.blockId, {
+            ...item,
+            capabilityVersion: 1,
+            entries,
+            transcriptRevision: 1,
+        });
+    }
+
+    const baseSnapshot = createChatPerformanceFixture({
+        id: "block-native-streaming",
+        messageCount: 0,
+        toolActivityCount: 0,
+        trackedFileCount: 0,
+    }).snapshot;
+    const activeTurnStartedAt = timestampFor(blockEntryCount * 3 + 1);
+    return {
+        blocksById,
+        deltaCount: 1_000,
+        metadata,
+        payloadsByRef: new Map(),
+        snapshot: {
+            ...baseSnapshot,
+            activeTurnStartedAt,
+            messages: [
+                {
+                    attachments: [],
+                    content: "",
+                    createdAt: activeTurnStartedAt,
+                    id: "streaming-assistant",
+                    kind: "assistant",
+                    status: "streaming",
+                },
+            ],
+            status: "streaming",
+            title: "Performance fixture: block-native-streaming",
+            updatedAt: activeTurnStartedAt,
+        },
     };
 }
 

--- a/src/renderer/src/components/workspace/chat/chatScrollCoordinator.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatScrollCoordinator.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { createChatScrollCoordinator } from "./chatScrollCoordinator";
+
+function createScrollElement({
+    clientHeight = 100,
+    scrollHeight = 1_000,
+    scrollTop = 0,
+}: {
+    readonly clientHeight?: number;
+    readonly scrollHeight?: number;
+    readonly scrollTop?: number;
+} = {}): HTMLElement {
+    return {
+        clientHeight,
+        scrollHeight,
+        scrollTop,
+    } as HTMLElement;
+}
+
+describe("chat scroll coordinator", () => {
+    it("coalesces a visual change to its highest-priority request", async () => {
+        const element = createScrollElement({ scrollTop: 240 });
+        const coordinator = createChatScrollCoordinator();
+        const context = {
+            element,
+            navigationGeneration: 7,
+            sessionId: "session",
+        };
+
+        coordinator.request({ reason: "measure-anchor", target: 300 }, context);
+        coordinator.request({ reason: "follow-end", target: "end" }, context);
+        coordinator.request({ reason: "new-turn", target: 420 }, context);
+        await Promise.resolve();
+
+        expect(element.scrollTop).toBe(420);
+    });
+
+    it("keeps a synchronous restore ahead of later corrections in the same turn", async () => {
+        const element = createScrollElement({ scrollTop: 240 });
+        const coordinator = createChatScrollCoordinator();
+        const context = {
+            element,
+            navigationGeneration: 3,
+            sessionId: "session",
+        };
+
+        coordinator.request({ reason: "restore", target: 640 }, context);
+        coordinator.flush();
+        coordinator.request({ reason: "measure-anchor", target: 680 }, context);
+        await Promise.resolve();
+
+        expect(element.scrollTop).toBe(640);
+    });
+
+    it("lets a user gesture discard a queued programmatic movement", async () => {
+        const element = createScrollElement({ scrollTop: 240 });
+        const coordinator = createChatScrollCoordinator();
+        const context = {
+            element,
+            navigationGeneration: 8,
+            sessionId: "session",
+        };
+
+        coordinator.request({ reason: "follow-end", target: "end" }, context);
+        coordinator.cancelPending();
+        await Promise.resolve();
+
+        expect(element.scrollTop).toBe(240);
+    });
+});

--- a/src/renderer/src/components/workspace/chat/chatScrollCoordinator.ts
+++ b/src/renderer/src/components/workspace/chat/chatScrollCoordinator.ts
@@ -1,0 +1,132 @@
+import {
+    recordChatScrollWrite,
+    type ChatScrollWriteReason,
+} from "@renderer/app/debug/chatPerformanceProbe";
+
+export type ChatScrollTarget = "end" | number;
+
+export interface ChatScrollRequest {
+    readonly reason: Exclude<ChatScrollWriteReason, "settle">;
+    readonly target: ChatScrollTarget;
+}
+
+export interface ChatScrollCoordinator {
+    cancelPending: () => void;
+    flush: () => void;
+    request: (
+        request: ChatScrollRequest,
+        context: ChatScrollRequestContext,
+    ) => void;
+}
+
+export interface ChatScrollRequestContext {
+    readonly element: HTMLElement | null;
+    readonly navigationGeneration: number;
+    readonly sessionId: string;
+}
+
+interface PendingChatScrollRequest extends ChatScrollRequest {
+    readonly context: ChatScrollRequestContext;
+}
+
+const REQUEST_PRIORITY: Readonly<
+    Record<ChatScrollRequest["reason"], number>
+> = {
+    "follow-end": 2,
+    "measure-anchor": 1,
+    "new-turn": 3,
+    restore: 4,
+    "scroll-to-index": 1,
+};
+
+function resolveScrollTarget(
+    element: HTMLElement,
+    target: ChatScrollTarget,
+): number {
+    const maximum = Math.max(0, element.scrollHeight - element.clientHeight);
+    const requested = target === "end" ? maximum : target;
+
+    return Math.max(0, Math.min(requested, maximum));
+}
+
+export function createChatScrollCoordinator(): ChatScrollCoordinator {
+    let pending: PendingChatScrollRequest | null = null;
+    let flushScheduled = false;
+    let priorityFloor = 0;
+
+    const flush = () => {
+        flushScheduled = false;
+        const request = pending;
+        pending = null;
+        const element = request?.context.element;
+
+        if (!request || !element) {
+            return;
+        }
+
+        priorityFloor = Math.max(
+            priorityFloor,
+            REQUEST_PRIORITY[request.reason],
+        );
+        queueMicrotask(() => {
+            priorityFloor = 0;
+        });
+
+        const after = resolveScrollTarget(element, request.target);
+        const before = element.scrollTop;
+        if (Math.abs(before - after) < 1) {
+            return;
+        }
+
+        // One owner applies the selected request, so virtual corrections cannot
+        // race a higher-priority restore, new-turn, or end-follow movement.
+        element.scrollTop = after;
+        recordChatScrollWrite({
+            after,
+            before,
+            clientHeight: element.clientHeight,
+            navigationGeneration: request.context.navigationGeneration,
+            reason: request.reason,
+            scrollHeight: element.scrollHeight,
+            sessionId: request.context.sessionId,
+        });
+    };
+
+    const scheduleFlush = () => {
+        if (flushScheduled) {
+            return;
+        }
+
+        flushScheduled = true;
+        queueMicrotask(flush);
+    };
+
+    return {
+        cancelPending: () => {
+            pending = null;
+        },
+        flush,
+        request: (request, context) => {
+            const next: PendingChatScrollRequest = {
+                ...request,
+                context,
+            };
+            const current = pending;
+
+            // Equal-priority requests use the latest geometry, while lower
+            // priority corrections never displace an explicit navigation.
+            if (REQUEST_PRIORITY[next.reason] < priorityFloor) {
+                return;
+            }
+
+            if (
+                !current ||
+                REQUEST_PRIORITY[next.reason] >= REQUEST_PRIORITY[current.reason]
+            ) {
+                pending = next;
+            }
+
+            scheduleFlush();
+        },
+    };
+}

--- a/src/renderer/src/components/workspace/chat/chatTimelineCache.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineCache.test.ts
@@ -25,6 +25,7 @@ describe("chatTimelineCache", () => {
             activeTurnStartedAt: null,
             attentionToolCallIds,
             model,
+            projection: null,
             sessionId: "session-1",
             status: "idle" as const,
             trackedFiles,

--- a/src/renderer/src/components/workspace/chat/chatTimelineCache.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineCache.ts
@@ -1,5 +1,6 @@
 import type { AiSessionSnapshot } from "@shared/ipc";
 import type { AiSessionTranscriptModel } from "@renderer/app/ai/transcriptModel";
+import type { BlockNativeTranscriptProjection } from "@renderer/app/ai/transcriptWindowProjection";
 import { rendererArtifactCache } from "@renderer/app/workspace/resource-budget";
 
 import type { ChatTimelineModel } from "./chatTimelineModel";
@@ -8,6 +9,7 @@ interface CachedTimeline {
     readonly activeTurnStartedAt: string | null;
     readonly attentionToolCallIdsKey: string;
     readonly model: ChatTimelineModel;
+    readonly projection: BlockNativeTranscriptProjection | null;
     readonly status: AiSessionSnapshot["status"];
     readonly trackedFiles: AiSessionSnapshot["trackedFiles"];
     readonly transcript: AiSessionTranscriptModel;
@@ -23,6 +25,7 @@ export function getCachedChatTimeline(input: {
     readonly activeTurnStartedAt: string | null;
     readonly attentionToolCallIds: ReadonlySet<string>;
     readonly sessionId: string;
+    readonly projection: BlockNativeTranscriptProjection | null;
     readonly status: AiSessionSnapshot["status"];
     readonly trackedFiles: AiSessionSnapshot["trackedFiles"];
     readonly transcript: AiSessionTranscriptModel;
@@ -37,6 +40,7 @@ export function getCachedChatTimeline(input: {
         cached.attentionToolCallIdsKey !==
             getAttentionToolCallIdsKey(input.attentionToolCallIds) ||
         cached.status !== input.status ||
+        cached.projection !== input.projection ||
         cached.trackedFiles !== input.trackedFiles ||
         cached.transcript !== input.transcript
     ) {
@@ -50,6 +54,7 @@ export function cacheChatTimeline(input: {
     readonly activeTurnStartedAt: string | null;
     readonly attentionToolCallIds: ReadonlySet<string>;
     readonly model: ChatTimelineModel;
+    readonly projection: BlockNativeTranscriptProjection | null;
     readonly sessionId: string;
     readonly status: AiSessionSnapshot["status"];
     readonly trackedFiles: AiSessionSnapshot["trackedFiles"];

--- a/src/renderer/src/components/workspace/chat/chatTimelineModel.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineModel.test.ts
@@ -169,9 +169,7 @@ describe("chatTimelineModel", () => {
         expect(incrementalModel.historyRows[0]).toBe(
             initialModel.historyRows[0],
         );
-        expect(incrementalModel.historyRows.at(-1)?.id).toBe(
-            "message:assistant-1",
-        );
+        expect(incrementalModel.historyRows).toBe(initialModel.historyRows);
         expect(incrementalModel.liveTailRow).toEqual(fullModel.liveTailRow);
         expect(incrementalModel.orderedRowIds).toEqual(fullModel.orderedRowIds);
         expect(getChatTimelineReconciliationDiagnostics()).toEqual({
@@ -180,7 +178,7 @@ describe("chatTimelineModel", () => {
         });
     });
 
-    it("appends a chronological assistant row to the virtual timeline", () => {
+    it("appends a chronological assistant row outside the virtual timeline", () => {
         const trackedFiles: AiTrackedFile[] = [];
         const initialTranscript = buildAiSessionTranscriptModel({
             messages: [
@@ -226,9 +224,7 @@ describe("chatTimelineModel", () => {
         expect(incrementalModel.historyRows[0]).toBe(
             initialModel.historyRows[0],
         );
-        expect(incrementalModel.historyRows.at(-1)?.id).toBe(
-            "message:assistant-1",
-        );
+        expect(incrementalModel.historyRows).toBe(initialModel.historyRows);
         expect(incrementalModel.liveTailRow?.id).toBe("message:assistant-1");
         expect(getChatTimelineReconciliationDiagnostics()).toEqual({
             fallbackCount: 0,
@@ -360,7 +356,7 @@ describe("chatTimelineModel", () => {
         }
 
         expect(timeline.historyRows[0]).toBe(initialHistoryRows[0]);
-        expect(timeline.historyRows.at(-1)?.id).toBe("message:assistant-1");
+        expect(timeline.historyRows).toBe(initialHistoryRows);
         expect(timeline.liveTailRow?.id).toBe("message:assistant-1");
         expect(getChatTimelineReconciliationDiagnostics()).toEqual({
             fallbackCount: 0,
@@ -465,14 +461,12 @@ describe("chatTimelineModel", () => {
         });
 
         expect(nextModel.historyRows[0]).toBe(initialModel.historyRows[0]);
-        expect(nextModel.historyRows.at(-1)).not.toBe(
-            initialModel.historyRows.at(-1),
-        );
+        expect(nextModel.historyRows).toBe(initialModel.historyRows);
         expect(nextModel.liveTailRow).not.toBe(initialModel.liveTailRow);
         expect(nextModel.liveTailRow?.id).toBe("message:message-2");
     });
 
-    it("keeps the active tail in virtual history once streaming finishes", () => {
+    it("retains the completed tail outside virtual history until the next turn", () => {
         const streamingModel = reconcileChatTimelineModel(null, {
             messages: [
                 createMessage({
@@ -512,9 +506,42 @@ describe("chatTimelineModel", () => {
         });
 
         expect(completedModel.liveTailRow).toBeNull();
-        expect(completedModel.historyRows).toHaveLength(2);
+        expect(completedModel.historyRows).toHaveLength(1);
         expect(completedModel.historyRows[0]).toBe(streamingModel.historyRows[0]);
-        expect(completedModel.historyRows[1]?.id).toBe("message:message-2");
+        expect(completedModel.retainedTailRow?.id).toBe("message:message-2");
+
+        const nextTurnModel = reconcileChatTimelineModel(completedModel, {
+            messages: [
+                createMessage({
+                    content: "hello",
+                    id: "message-1",
+                    kind: "user",
+                }),
+                createMessage({
+                    content: "done",
+                    createdAt: "2026-04-14T00:00:01.000Z",
+                    id: "message-2",
+                    status: "completed",
+                }),
+                createMessage({
+                    content: "continue",
+                    createdAt: "2026-04-14T00:00:02.000Z",
+                    id: "message-3",
+                    kind: "user",
+                    status: "streaming",
+                }),
+            ],
+            status: "starting",
+            toolActivity: [],
+            trackedFiles: [],
+        });
+
+        expect(nextTurnModel.retainedTailRow).toBeNull();
+        expect(nextTurnModel.historyRowIds).toEqual([
+            "message:message-1",
+            "message:message-2",
+            "message:message-3",
+        ]);
     });
 
     it("keeps the latest user message in history when agent activity starts", () => {
@@ -593,7 +620,6 @@ describe("chatTimelineModel", () => {
             "message:compact-message",
         ]);
         expect(model.historyRowIds).toEqual([
-            "tool:session-1:codex-acp:status:item:compact-1",
             "message:compact-message",
         ]);
         expect(model.liveTailRowId).toBe(
@@ -1744,7 +1770,6 @@ describe("chatTimelineModel activity segments", () => {
         );
         expect(model.historyRowIds).toEqual([
             "message:prompt-1",
-            "activity-segment:session-1:read-1",
         ]);
     });
 

--- a/src/renderer/src/components/workspace/chat/chatTimelineModel.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineModel.ts
@@ -114,6 +114,8 @@ export interface ChatTimelineModel {
     readonly historyRowIds: readonly string[];
     readonly liveTailRow: ChatTimelinePresentationRow | null;
     readonly liveTailRowId: string | null;
+    readonly retainedTailRow: ChatTimelinePresentationRow | null;
+    readonly retainedTailRowId: string | null;
     readonly orderedRowIds: readonly string[];
     readonly orderedAtomicRowIds: readonly string[];
     readonly orderedAtomicRows: readonly ChatTimelineAtomicRow[];
@@ -972,9 +974,9 @@ export function reconcileChatTimelineModel(
         snapshot.activeTurnStartedAt,
     );
     const atomicLiveTailRowId = atomicLiveTailRow?.id ?? null;
-    // The active row remains in the virtual data source. Its live-tail metadata
-    // is retained for incremental reconciliation and presentation only.
-    const nextAtomicHistoryRows = [...orderedAtomicRows];
+    const nextAtomicHistoryRows = atomicLiveTailRow
+        ? orderedAtomicRows.filter((row) => row !== atomicLiveTailRow)
+        : [...orderedAtomicRows];
     const atomicHistoryRows = reuseRows(
         previous?.atomicHistoryRows,
         nextAtomicHistoryRows,
@@ -1000,7 +1002,17 @@ export function reconcileChatTimelineModel(
         atomicLiveTailRow,
     );
     const liveTailRowId = liveTailRow?.id ?? null;
-    const nextHistoryRows = [...orderedRows];
+    const retainedTailRow = resolveRetainedTailRow(
+        previous,
+        orderedRows,
+        liveTailRow,
+        snapshot.status,
+    );
+    const retainedTailRowId = retainedTailRow?.id ?? null;
+    const hotTailRow = liveTailRow ?? retainedTailRow;
+    const nextHistoryRows = hotTailRow
+        ? orderedRows.filter((row) => row !== hotTailRow)
+        : [...orderedRows];
     const historyRows = reuseRows(previous?.historyRows, nextHistoryRows);
     const historyRowIds = reuseRowIds(previous?.historyRowIds, historyRows);
 
@@ -1019,7 +1031,31 @@ export function reconcileChatTimelineModel(
         orderedRowIds,
         orderedRows,
         presentationRowById: createPresentationRowById(orderedRows),
+        retainedTailRow,
+        retainedTailRowId,
     };
+}
+
+function resolveRetainedTailRow(
+    previous: ChatTimelineModel | null,
+    orderedRows: readonly ChatTimelinePresentationRow[],
+    liveTailRow: ChatTimelinePresentationRow | null,
+    status: AiSessionSnapshot["status"],
+): ChatTimelinePresentationRow | null {
+    if (liveTailRow || isStreamingStatus(status)) {
+        return null;
+    }
+
+    const previousTail = previous?.liveTailRow ?? previous?.retainedTailRow;
+    if (!previousTail) {
+        return null;
+    }
+
+    // Retain one completed tail under the same React owner until the next turn
+    // starts, avoiding a completion-time remount in the virtual list.
+    return (
+        orderedRows.find((row) => row.id === previousTail.id) ?? null
+    );
 }
 
 export interface ChatTimelineTranscriptInput {
@@ -1209,18 +1245,10 @@ function reconcileLiveTailPatch(
     atomicRowById.set(nextAtomicRow.id, nextAtomicRow);
     const presentationRowById = new Map(previous.presentationRowById);
     presentationRowById.set(presentation.liveTailRow.id, presentation.liveTailRow);
-    const nextAtomicHistoryRows = replaceLastTimelineRow(
-        previous.atomicHistoryRows,
-        nextAtomicRow,
-    );
-    const nextHistoryRows = presentation.orderedRows;
-
     return {
         ...previous,
-        atomicHistoryRows: nextAtomicHistoryRows,
         atomicLiveTailRow: nextAtomicRow,
         atomicRowById,
-        historyRows: nextHistoryRows,
         liveTailRow: presentation.liveTailRow,
         liveTailRowId: presentation.liveTailRow.id,
         orderedAtomicRows: replaceLastTimelineRow(
@@ -1229,6 +1257,8 @@ function reconcileLiveTailPatch(
         ),
         orderedRows: presentation.orderedRows,
         presentationRowById,
+        retainedTailRow: null,
+        retainedTailRowId: null,
     };
 }
 
@@ -1262,18 +1292,11 @@ function reconcileLiveTailAppend(
     atomicRowById.set(nextAtomicRow.id, nextAtomicRow);
     const presentationRowById = new Map(previous.presentationRowById);
     presentationRowById.set(nextAtomicRow.id, nextAtomicRow);
-    const atomicHistoryRows = [...previous.atomicHistoryRows, nextAtomicRow];
-    const historyRows = [...previous.historyRows, nextAtomicRow];
-
     return {
         ...previous,
-        atomicHistoryRowIds: [...previous.atomicHistoryRowIds, nextAtomicRow.id],
-        atomicHistoryRows,
         atomicLiveTailRow: nextAtomicRow,
         atomicLiveTailRowId: nextAtomicRow.id,
         atomicRowById,
-        historyRowIds: [...previous.historyRowIds, nextAtomicRow.id],
-        historyRows,
         liveTailRow: nextAtomicRow,
         liveTailRowId: nextAtomicRow.id,
         orderedAtomicRowIds: [...previous.orderedAtomicRowIds, nextAtomicRow.id],
@@ -1281,6 +1304,8 @@ function reconcileLiveTailAppend(
         orderedRowIds: [...previous.orderedRowIds, nextAtomicRow.id],
         orderedRows: [...previous.orderedRows, nextAtomicRow],
         presentationRowById,
+        retainedTailRow: null,
+        retainedTailRowId: null,
     };
 }
 

--- a/src/renderer/src/components/workspace/chat/chatTimelineModel.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineModel.ts
@@ -4,12 +4,20 @@ import type {
     AiSessionSnapshot,
 } from "@shared/ipc";
 import {
+    getAiTranscriptMessageEntryId,
+    getAiTranscriptToolEntryId,
+} from "@shared/ai-transcript";
+import {
     getAiSessionTranscriptMessages,
     getAiSessionTranscriptMutation,
     getAiSessionTranscriptToolActivity,
     isAiSessionTranscriptMutationFrom,
     type AiSessionTranscriptModel,
 } from "@renderer/app/ai/transcriptModel";
+import {
+    buildBlockNativeTranscriptBootstrap,
+    type BlockNativeTranscriptProjection,
+} from "@renderer/app/ai/transcriptWindowProjection";
 import { TrackedFilePathReferenceSet } from "@renderer/app/ai/trackedFilePath";
 
 import {
@@ -32,12 +40,14 @@ import {
 } from "./activitySegmentChangeStats";
 
 export interface ChatTimelineMessageRow {
+    readonly blockId: string | null;
     readonly id: string;
     readonly kind: "message";
     readonly message: AiSessionSnapshot["messages"][number];
 }
 
 export interface ChatTimelineToolRow {
+    readonly blockId: string | null;
     readonly id: string;
     readonly kind: "tool";
     readonly reviewEntry: ToolActivityReviewEntry;
@@ -79,6 +89,7 @@ export interface ToolActivitySegmentSummary {
 }
 
 export interface ChatTimelineActivitySegmentRow {
+    readonly blockId: string | null;
     readonly changeStats: ActivitySegmentChangeStats;
     readonly entries: readonly ToolActivitySegmentEntry[];
     readonly id: string;
@@ -464,15 +475,21 @@ function createRowById(
     previous: ChatTimelineModel | null,
     messages: readonly AiSessionSnapshot["messages"][number][],
     toolEntries: readonly ToolActivityReviewEntry[],
+    blockIdByEntryId: ReadonlyMap<string, string>,
 ): Map<string, ChatTimelineAtomicRow> {
     const nextRowById = new Map<string, ChatTimelineAtomicRow>();
 
     for (const message of messages) {
         const rowId = getMessageRowId(message);
         const previousRow = previous?.atomicRowById.get(rowId) ?? null;
+        const blockId =
+            blockIdByEntryId.get(
+                getAiTranscriptMessageEntryId(message.id),
+            ) ?? null;
 
         if (
             previousRow?.kind === "message" &&
+            previousRow.blockId === blockId &&
             areMessagesEquivalent(previousRow.message, message)
         ) {
             nextRowById.set(rowId, previousRow);
@@ -480,6 +497,7 @@ function createRowById(
         }
 
         nextRowById.set(rowId, {
+            blockId,
             id: rowId,
             kind: "message",
             message,
@@ -489,9 +507,17 @@ function createRowById(
     for (const reviewEntry of toolEntries) {
         const rowId = getToolRowId(reviewEntry);
         const previousRow = previous?.atomicRowById.get(rowId) ?? null;
+        const blockId =
+            blockIdByEntryId.get(
+                getAiTranscriptToolEntryId(
+                    reviewEntry.activity.sessionId,
+                    reviewEntry.activity.id,
+                ),
+            ) ?? null;
 
         if (
             previousRow?.kind === "tool" &&
+            previousRow.blockId === blockId &&
             areToolActivityReviewEntriesEquivalent(
                 previousRow.reviewEntry,
                 reviewEntry,
@@ -502,6 +528,7 @@ function createRowById(
         }
 
         nextRowById.set(rowId, {
+            blockId,
             id: rowId,
             kind: "tool",
             reviewEntry,
@@ -652,6 +679,7 @@ function areToolActivitySegmentSummariesEquivalent(
 
 function reuseToolActivitySegmentRow(
     previousRowById: ReadonlyMap<string, ChatTimelinePresentationRow> | null,
+    blockId: string | null,
     id: string,
     items: readonly ActivitySegmentItem[],
 ): ChatTimelineActivitySegmentRow {
@@ -662,6 +690,7 @@ function reuseToolActivitySegmentRow(
     const previousRow = previousRowById?.get(id);
     const itemsAreUnchanged =
         previousRow?.kind === "activity-segment" &&
+        previousRow.blockId === blockId &&
         previousRow.items.length === items.length &&
         previousRow.items.every((item, index) => {
             const nextItem = items[index];
@@ -696,6 +725,7 @@ function reuseToolActivitySegmentRow(
 
     return {
         // Diff aggregation is expensive; only rebuild it with a changed segment.
+        blockId,
         changeStats: deriveActivitySegmentChangeStats(entries),
         entries,
         id,
@@ -712,12 +742,14 @@ export function buildChatTimelinePresentationRows(
 ): ChatTimelinePresentationRow[] {
     const presentationRows: ChatTimelinePresentationRow[] = [];
     let segmentItems: ActivitySegmentItem[] = [];
+    let segmentBlockId: string | null = null;
     let segmentSessionId: string | null = null;
 
     const flushSegment = () => {
         const firstItem = segmentItems[0];
         if (!firstItem) {
             segmentItems = [];
+            segmentBlockId = null;
             segmentSessionId = null;
             return;
         }
@@ -728,13 +760,23 @@ export function buildChatTimelinePresentationRows(
                 : `${firstItem.entry.reviewEntry.activity.sessionId}:${firstItem.entry.reviewEntry.activity.id}`;
         const id = `activity-segment:${firstItemKey}`;
         presentationRows.push(
-            reuseToolActivitySegmentRow(previousRowById, id, segmentItems),
+            reuseToolActivitySegmentRow(
+                previousRowById,
+                segmentBlockId,
+                id,
+                segmentItems,
+            ),
         );
         segmentItems = [];
+        segmentBlockId = null;
         segmentSessionId = null;
     };
 
     for (const row of atomicRows) {
+        if (segmentItems.length > 0 && segmentBlockId !== row.blockId) {
+            flushSegment();
+        }
+        segmentBlockId = row.blockId;
         if (row.kind === "message") {
             if (row.message.kind === "thinking") {
                 segmentItems.push({ kind: "thinking", message: row.message });
@@ -846,6 +888,7 @@ function isStreamingStatus(status: AiSessionSnapshot["status"]): boolean {
 }
 
 const EMPTY_ATTENTION_TOOL_CALL_IDS: ReadonlySet<string> = new Set();
+const EMPTY_BLOCK_ID_BY_ENTRY_ID: ReadonlyMap<string, string> = new Map();
 
 function getStreamingLiveTailRow(
     status: AiSessionSnapshot["status"],
@@ -900,6 +943,7 @@ export function reconcileChatTimelineModel(
     > & {
         readonly activeTurnStartedAt?: string | null;
         readonly attentionToolCallIds?: ReadonlySet<string>;
+        readonly blockIdByEntryId?: ReadonlyMap<string, string>;
     },
 ): ChatTimelineModel {
     const reviewIndex = createToolActivityReviewIndex(snapshot.trackedFiles);
@@ -912,6 +956,7 @@ export function reconcileChatTimelineModel(
         previous,
         snapshot.messages,
         toolEntries,
+        snapshot.blockIdByEntryId ?? EMPTY_BLOCK_ID_BY_ENTRY_ID,
     );
     const orderedAtomicRows = reuseRows(
         previous?.orderedAtomicRows,
@@ -980,9 +1025,19 @@ export function reconcileChatTimelineModel(
 export interface ChatTimelineTranscriptInput {
     readonly activeTurnStartedAt?: string | null;
     readonly attentionToolCallIds?: ReadonlySet<string>;
+    readonly blockIdByEntryId?: ReadonlyMap<string, string>;
     readonly status: AiSessionSnapshot["status"];
     readonly trackedFiles: AiSessionSnapshot["trackedFiles"];
     readonly transcript: AiSessionTranscriptModel;
+}
+
+export interface ChatTimelineProjectionInput {
+    readonly activeTurnStartedAt?: string | null;
+    readonly attentionToolCallIds?: ReadonlySet<string>;
+    readonly projection: BlockNativeTranscriptProjection;
+    readonly status: AiSessionSnapshot["status"];
+    readonly trackedFiles: AiSessionSnapshot["trackedFiles"];
+    readonly updatedAt: string;
 }
 
 interface ChatTimelineReconciliationDiagnostics {
@@ -1013,6 +1068,7 @@ export function reconcileChatTimelineModelFromTranscript(
         messages: getAiSessionTranscriptMessages(input.transcript),
         activeTurnStartedAt: input.activeTurnStartedAt,
         attentionToolCallIds: input.attentionToolCallIds,
+        blockIdByEntryId: input.blockIdByEntryId,
         status: input.status,
         toolActivity: getAiSessionTranscriptToolActivity(input.transcript),
         trackedFiles: input.trackedFiles,
@@ -1023,10 +1079,14 @@ export function reconcileChatTimelineModelIncrementallyFromTranscript(
     previous: ChatTimelineModel | null,
     previousTranscript: AiSessionTranscriptModel | null,
     input: ChatTimelineTranscriptInput,
+    buildFallbackTranscript: (() => AiSessionTranscriptModel) | null = null,
 ): ChatTimelineModel {
     if (!previous || !previousTranscript) {
         incrementChatPerformanceCounter("timeline_full_rebuilds");
-        return reconcileChatTimelineModelFromTranscript(previous, input);
+        return reconcileChatTimelineModelFromTranscript(previous, {
+            ...input,
+            transcript: buildFallbackTranscript?.() ?? input.transcript,
+        });
     }
     if (
         !isAiSessionTranscriptMutationFrom(
@@ -1036,7 +1096,10 @@ export function reconcileChatTimelineModelIncrementallyFromTranscript(
     ) {
         chatTimelineFallbackCount += 1;
         incrementChatPerformanceCounter("timeline_full_rebuilds");
-        return reconcileChatTimelineModelFromTranscript(previous, input);
+        return reconcileChatTimelineModelFromTranscript(previous, {
+            ...input,
+            transcript: buildFallbackTranscript?.() ?? input.transcript,
+        });
     }
 
     const mutation = getAiSessionTranscriptMutation(input.transcript);
@@ -1061,7 +1124,60 @@ export function reconcileChatTimelineModelIncrementallyFromTranscript(
 
     chatTimelineFallbackCount += 1;
     incrementChatPerformanceCounter("timeline_full_rebuilds");
-    return reconcileChatTimelineModelFromTranscript(previous, input);
+    return reconcileChatTimelineModelFromTranscript(previous, {
+        ...input,
+        transcript: buildFallbackTranscript?.() ?? input.transcript,
+    });
+}
+
+export function reconcileChatTimelineModelFromProjection(
+    previous: ChatTimelineModel | null,
+    previousProjection: BlockNativeTranscriptProjection | null,
+    input: ChatTimelineProjectionInput,
+): ChatTimelineModel {
+    const blockIdByEntryId = input.projection.sealed.blockIdByEntryId;
+    if (
+        previous &&
+        previousProjection?.sealed === input.projection.sealed
+    ) {
+        if (
+            previousProjection.hot === input.projection.hot ||
+            previousProjection.hot.transcript === input.projection.hot.transcript
+        ) {
+            return previous;
+        }
+        return reconcileChatTimelineModelIncrementallyFromTranscript(
+            previous,
+            previousProjection.hot.transcript,
+            {
+                activeTurnStartedAt: input.activeTurnStartedAt,
+                attentionToolCallIds: input.attentionToolCallIds,
+                blockIdByEntryId,
+                status: input.status,
+                trackedFiles: input.trackedFiles,
+                transcript: input.projection.hot.transcript,
+            },
+            () =>
+                buildBlockNativeTranscriptBootstrap(input.projection, {
+                    activeTurnStartedAt: input.activeTurnStartedAt ?? null,
+                    status: input.status,
+                    updatedAt: input.updatedAt,
+                }),
+        );
+    }
+
+    return reconcileChatTimelineModelFromTranscript(previous, {
+        activeTurnStartedAt: input.activeTurnStartedAt,
+        attentionToolCallIds: input.attentionToolCallIds,
+        blockIdByEntryId,
+        status: input.status,
+        trackedFiles: input.trackedFiles,
+        transcript: buildBlockNativeTranscriptBootstrap(input.projection, {
+            activeTurnStartedAt: input.activeTurnStartedAt ?? null,
+            status: input.status,
+            updatedAt: input.updatedAt,
+        }),
+    });
 }
 
 function reconcileLiveTailPatch(
@@ -1179,6 +1295,7 @@ function getTranscriptAtomicRow(
 
     if (entry.kind === "message") {
         return {
+            blockId: input.blockIdByEntryId?.get(entryId) ?? null,
             id: getMessageRowId(entry.message),
             kind: "message",
             message: entry.message,
@@ -1191,6 +1308,7 @@ function getTranscriptAtomicRow(
             createToolActivityReviewIndex(input.trackedFiles),
         );
         return {
+            blockId: input.blockIdByEntryId?.get(entryId) ?? null,
             id: getToolRowId(reviewEntry),
             kind: "tool",
             reviewEntry,
@@ -1274,6 +1392,7 @@ function replaceLiveTailPresentationRow(
 
     const nextLiveTailRow = reuseToolActivitySegmentRow(
         new Map([[previousLiveTailRow.id, previousLiveTailRow]]),
+        previousLiveTailRow.blockId,
         previousLiveTailRow.id,
         items,
     );

--- a/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatTimelineVirtualization.test.ts
@@ -87,6 +87,7 @@ function createMessageRow(
 ): ChatTimelineRow {
     const message = createMessage(overrides);
     return {
+        blockId: null,
         id: `message:${message.id}`,
         kind: "message",
         message,
@@ -102,6 +103,7 @@ function createToolRow({
 } = {}): ChatTimelineRow {
     const nextActivity = activity ?? createActivity();
     return {
+        blockId: null,
         id: `tool:${nextActivity.id}`,
         kind: "tool",
         reviewEntry: {

--- a/src/renderer/src/components/workspace/chat/chatViewPersistence.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatViewPersistence.test.ts
@@ -55,6 +55,12 @@ describe("chatViewPersistence", () => {
             "worktree-1",
             "session-1",
             {
+                anchor: {
+                    alignment: "start",
+                    blockId: "block-7",
+                    entryId: "entry-7",
+                    offsetWithinEntry: 12,
+                },
                 isNearBottom: false,
                 scrollTop: 256,
             },
@@ -68,6 +74,10 @@ describe("chatViewPersistence", () => {
                 "session-1",
             ),
         ).toEqual(persisted);
+        expect(persisted?.anchor).toMatchObject({
+            blockId: "block-7",
+            entryId: "entry-7",
+        });
     });
 
     it("clamps negative scroll offsets when persisting", () => {
@@ -83,5 +93,28 @@ describe("chatViewPersistence", () => {
             isNearBottom: false,
             scrollTop: 0,
         });
+    });
+
+    it("reads legacy anchors without a block hint", () => {
+        const key = getChatViewStorageKey("project-1", null, "session-legacy");
+        globalThis.localStorage.setItem(
+            key,
+            JSON.stringify({
+                anchor: {
+                    alignment: "start",
+                    entryId: "entry-legacy",
+                    offsetWithinEntry: 8,
+                },
+                isNearBottom: false,
+                scrollTop: 320,
+                updatedAt: 1,
+                version: 2,
+            }),
+        );
+
+        expect(
+            readPersistedChatViewState("project-1", null, "session-legacy")
+                ?.anchor,
+        ).toMatchObject({ blockId: null, entryId: "entry-legacy" });
     });
 });

--- a/src/renderer/src/components/workspace/chat/chatViewPersistence.ts
+++ b/src/renderer/src/components/workspace/chat/chatViewPersistence.ts
@@ -10,6 +10,7 @@ const CHAT_VIEW_STATE_PREFIX = "comando.ai.chat.view";
 export interface PersistedChatViewState {
     readonly anchor: {
         readonly alignment: "center" | "end" | "start";
+        readonly blockId: string | null;
         readonly entryId: string;
         readonly offsetWithinEntry: number;
     } | null;
@@ -54,6 +55,11 @@ function normalizePersistedState(raw: unknown): PersistedChatViewState | null {
                   alignment: (anchor as {
                       alignment: "center" | "end" | "start";
                   }).alignment,
+                  blockId:
+                      typeof (anchor as { blockId?: unknown }).blockId ===
+                      "string"
+                          ? (anchor as { blockId: string }).blockId
+                          : null,
                   entryId: (anchor as { entryId: string }).entryId,
                   offsetWithinEntry: Math.max(
                       0,
@@ -81,6 +87,7 @@ function statesEqual(
         left.isNearBottom === right.isNearBottom &&
         left.scrollTop === right.scrollTop &&
         left.anchor?.entryId === right.anchor?.entryId &&
+        left.anchor?.blockId === right.anchor?.blockId &&
         left.anchor?.offsetWithinEntry === right.anchor?.offsetWithinEntry &&
         left.anchor?.alignment === right.anchor?.alignment
     );

--- a/src/renderer/src/components/workspace/chat/longContentVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/longContentVirtualization.test.ts
@@ -27,6 +27,7 @@ function createMessage(
 describe("long content virtualization", () => {
     it("replaces a large completed assistant message with stable chunks", () => {
         const row: ChatTimelineMessageRow = {
+            blockId: null,
             id: "message:assistant-1",
             kind: "message",
             message: createMessage("word ".repeat(LONG_CONTENT_MIN_CHARACTERS)),
@@ -49,6 +50,7 @@ describe("long content virtualization", () => {
 
     it("does not split a moving stream or messages with non-text artifacts", () => {
         const streaming: ChatTimelineMessageRow = {
+            blockId: null,
             id: "message:streaming",
             kind: "message",
             message: createMessage("word ".repeat(LONG_CONTENT_MIN_CHARACTERS), {
@@ -56,6 +58,7 @@ describe("long content virtualization", () => {
             }),
         };
         const withAttachment: ChatTimelineMessageRow = {
+            blockId: null,
             id: "message:attachment",
             kind: "message",
             message: createMessage("word ".repeat(LONG_CONTENT_MIN_CHARACTERS), {

--- a/src/renderer/src/components/workspace/chat/longContentVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/longContentVirtualization.ts
@@ -1,6 +1,7 @@
 import type { AiSessionSnapshot } from "@shared/ipc";
 
 import type { ChatTimelineMessageRow } from "./chatTimelineModel";
+import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
 
 // Keep every virtual item comfortably smaller than an entire agent transcript.
 // Both limits apply because minified output can have few newlines, while prose
@@ -29,6 +30,10 @@ export function splitLongContentRows<T>(
     rows: readonly T[],
     isMessageRow: (row: T) => row is T & ChatTimelineMessageRow,
 ): readonly (T | LongContentChunkRow)[] {
+    incrementChatPerformanceCounter(
+        "presentation_items_visited",
+        rows.length,
+    );
     const result: (T | LongContentChunkRow)[] = [];
 
     for (const row of rows) {

--- a/src/renderer/src/components/workspace/chat/longContentVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/longContentVirtualization.ts
@@ -21,6 +21,11 @@ export interface LongContentChunkRow {
     readonly sourceRowId: string;
 }
 
+const presentationChunksByMessage = new WeakMap<
+    AiSessionSnapshot["messages"][number],
+    { readonly content: string; readonly chunks: readonly string[] }
+>();
+
 /**
  * Replaces an exceptionally long, completed assistant message with stable
  * presentation rows. The original message remains the source of truth in the
@@ -42,7 +47,17 @@ export function splitLongContentRows<T>(
             continue;
         }
 
-        const chunks = splitMarkdownIntoPresentationChunks(row.message.content);
+        const cached = presentationChunksByMessage.get(row.message);
+        const chunks = cached?.content === row.message.content
+            ? cached.chunks
+            : splitMarkdownIntoPresentationChunks(row.message.content);
+        if (cached?.content !== row.message.content) {
+            // Keep fragmentation tied to the canonical message, not to mounted rows.
+            presentationChunksByMessage.set(row.message, {
+                chunks,
+                content: row.message.content,
+            });
+        }
         if (chunks.length < 2) {
             result.push(row);
             continue;

--- a/src/renderer/src/components/workspace/chat/transcriptBlockVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/transcriptBlockVirtualization.test.ts
@@ -214,7 +214,14 @@ describe("transcriptBlockVirtualization", () => {
         const loadedRows = buildTranscriptTimelineItems(
             blockMetadata,
             new Map([["block-1", loadedBlock]]),
-            [{ id: "message:message-1", kind: "message", message }],
+            [
+                {
+                    blockId: "block-1",
+                    id: "message:message-1",
+                    kind: "message",
+                    message,
+                },
+            ],
         );
 
         expect(loadedRows.map((row) => row.id)).toEqual([
@@ -336,6 +343,7 @@ function createActivitySegment(
     );
 
     return {
+        blockId: null,
         changeStats: {
             additions: 0,
             approximate: false,

--- a/src/renderer/src/components/workspace/chat/transcriptBlockVirtualization.test.ts
+++ b/src/renderer/src/components/workspace/chat/transcriptBlockVirtualization.test.ts
@@ -17,6 +17,7 @@ import {
     isTranscriptStreamingIndicatorItem,
     resolveAnchorBlockId,
     resolveTranscriptBlockIdsInRange,
+    resolveTranscriptEntryBlockId,
     resolveUnloadedTranscriptBlockIdsInRange,
     transcriptBlockEstimate,
 } from "./transcriptBlockVirtualization";
@@ -292,6 +293,12 @@ describe("transcriptBlockVirtualization", () => {
             resolveAnchorBlockId(
                 { alignment: "start", entryId: "entry-1", offsetWithinEntry: 8 },
                 blocks,
+            ),
+        ).toBe("block-1");
+        expect(
+            resolveTranscriptEntryBlockId(
+                new Map([[block.blockId, block]]),
+                "entry-1",
             ),
         ).toBe("block-1");
     });

--- a/src/renderer/src/components/workspace/chat/transcriptBlockVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/transcriptBlockVirtualization.ts
@@ -151,25 +151,10 @@ export function buildTranscriptTimelineItems(
         return timelineRows;
     }
 
-    const blockIdByEntryId = new Map<string, string>();
-    for (const item of metadata) {
-        const block = loaded.get(item.blockId);
-        if (!block) continue;
-        incrementChatPerformanceCounter(
-            "presentation_items_visited",
-            block.entries.length,
-        );
-        for (const entry of block.entries) {
-            blockIdByEntryId.set(entry.id, item.blockId);
-        }
-    }
-
     const rowsByBlockId = new Map<string, ChatTimelineRow[]>();
     const unassignedRows: ChatTimelineRow[] = [];
     for (const row of timelineRows) {
-        const blockId = timelineEntryIds(row)
-            .map((entryId) => blockIdByEntryId.get(entryId) ?? null)
-            .find((candidate): candidate is string => candidate !== null);
+        const blockId = row.blockId;
         if (!blockId) {
             unassignedRows.push(row);
             continue;
@@ -457,24 +442,4 @@ export function captureTranscriptSemanticAnchor(input: {
         entryId: input.entryId,
         offsetWithinEntry: Math.max(0, input.offsetWithinEntry ?? 0),
     };
-}
-
-function timelineEntryIds(row: ChatTimelineRow): readonly string[] {
-    if (row.kind === "message") {
-        return [messageTranscriptEntryId(row.message.id)];
-    }
-    if (row.kind === "tool") {
-        return [row.id];
-    }
-    return row.items.map((item) =>
-        item.kind === "thinking"
-            ? messageTranscriptEntryId(item.message.id)
-            : `tool:${item.entry.reviewEntry.activity.sessionId}:${item.entry.reviewEntry.activity.id}`,
-    );
-}
-
-function messageTranscriptEntryId(messageId: string): string {
-    return messageId.startsWith("summary:")
-        ? messageId.slice("summary:".length)
-        : `message:${messageId}`;
 }

--- a/src/renderer/src/components/workspace/chat/transcriptBlockVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/transcriptBlockVirtualization.ts
@@ -10,6 +10,7 @@ import type {
     ChatTimelineRow,
 } from "./chatTimelineModel";
 import type { LongContentChunkRow } from "./longContentVirtualization";
+import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
 
 export const ACTIVITY_GROUP_WINDOW_SIZE = 200;
 
@@ -142,6 +143,10 @@ export function buildTranscriptTimelineItems(
     loaded: ReadonlyMap<string, AiTranscriptBlock>,
     timelineRows: readonly ChatTimelineRow[],
 ): readonly TranscriptTimelineSourceItem[] {
+    incrementChatPerformanceCounter(
+        "presentation_items_visited",
+        metadata.length + timelineRows.length,
+    );
     if (metadata.length === 0) {
         return timelineRows;
     }
@@ -150,6 +155,10 @@ export function buildTranscriptTimelineItems(
     for (const item of metadata) {
         const block = loaded.get(item.blockId);
         if (!block) continue;
+        incrementChatPerformanceCounter(
+            "presentation_items_visited",
+            block.entries.length,
+        );
         for (const entry of block.entries) {
             blockIdByEntryId.set(entry.id, item.blockId);
         }
@@ -230,6 +239,10 @@ export function flattenTranscriptTimelineItems(
     sourceItems: readonly TranscriptTimelineSourceItem[],
     options: FlattenTranscriptTimelineItemsOptions,
 ): readonly TranscriptTimelineItem[] {
+    incrementChatPerformanceCounter(
+        "presentation_items_visited",
+        sourceItems.length,
+    );
     const timelineItems: TranscriptTimelineItem[] = [];
 
     for (const sourceItem of sourceItems) {

--- a/src/renderer/src/components/workspace/chat/transcriptBlockVirtualization.ts
+++ b/src/renderer/src/components/workspace/chat/transcriptBlockVirtualization.ts
@@ -425,6 +425,19 @@ export function resolveAnchorBlockId(
     return null;
 }
 
+export function resolveTranscriptEntryBlockId(
+    blocksById: ReadonlyMap<string, AiTranscriptBlock>,
+    entryId: string,
+): string | null {
+    for (const [blockId, block] of blocksById) {
+        if (block.entries.some((entry) => entry.id === entryId)) {
+            return blockId;
+        }
+    }
+
+    return null;
+}
+
 export function transcriptBlockEstimate(block: TranscriptVirtualBlock): number {
     return block.kind === "loaded"
         ? block.block.estimatedHeight

--- a/src/renderer/src/components/workspace/chat/useChatStreamingFrameProbe.ts
+++ b/src/renderer/src/components/workspace/chat/useChatStreamingFrameProbe.ts
@@ -1,0 +1,113 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+import {
+    hashChatPerformanceLabel,
+    isChatPerformanceProbeEnabled,
+    markChatPerformanceFrame,
+    recordChatPerformanceMetric,
+} from "@renderer/app/debug/chatPerformanceProbe";
+
+// The opt-in probe records only numeric geometry and revision metadata. User
+// content never leaves the rendered component tree.
+export function useChatStreamingFrameProbe({
+    active,
+    getNavigationGeneration,
+    isStreaming,
+    scrollRef,
+    sessionId,
+    timelineContentRef,
+}: {
+    readonly active: boolean;
+    readonly getNavigationGeneration: () => number;
+    readonly isStreaming: boolean;
+    readonly scrollRef: RefObject<HTMLElement | null>;
+    readonly sessionId: string;
+    readonly timelineContentRef: RefObject<HTMLElement | null>;
+}): void {
+    const performanceFrameIdRef = useRef(0);
+
+    useEffect(() => {
+        if (
+            !active ||
+            !isStreaming ||
+            !isChatPerformanceProbeEnabled() ||
+            typeof window.requestAnimationFrame !== "function"
+        ) {
+            return;
+        }
+
+        let cancelled = false;
+        let frameId: number | null = null;
+        let previousFrameAt = performance.now();
+        const sampleFrame = (frameAt: number) => {
+            if (cancelled) {
+                return;
+            }
+
+            const scrollElement = scrollRef.current;
+            markChatPerformanceFrame(frameAt);
+            const currentTurnElement =
+                timelineContentRef.current?.querySelector<HTMLElement>(
+                    '[data-current-turn-tail="true"]',
+                ) ?? null;
+            const measuredElement = currentTurnElement?.closest<HTMLElement>(
+                "[data-measurement-key]",
+            );
+            const markdownElement =
+                currentTurnElement?.querySelector<HTMLElement>(
+                    '[data-markdown-live="true"]',
+                ) ?? null;
+            performanceFrameIdRef.current += 1;
+            recordChatPerformanceMetric("chat_frame", {
+                sessionId,
+                values: {
+                    bottomGap: scrollElement
+                        ? scrollElement.scrollHeight -
+                          scrollElement.clientHeight -
+                          scrollElement.scrollTop
+                        : 0,
+                    clientHeight: scrollElement?.clientHeight ?? 0,
+                    frameDuration: Math.max(0, frameAt - previousFrameAt),
+                    frameId: performanceFrameIdRef.current,
+                    markdownContentChars: Number(
+                        markdownElement?.dataset.markdownContentChars ?? 0,
+                    ),
+                    markdownRenderedChars: Number(
+                        markdownElement?.dataset.markdownRenderedChars ?? 0,
+                    ),
+                    measurementKeyRevision: measuredElement?.dataset
+                        .measurementKey
+                        ? hashChatPerformanceLabel(
+                              measuredElement.dataset.measurementKey,
+                          )
+                        : 0,
+                    navigationGeneration: getNavigationGeneration(),
+                    rowRevision: measuredElement?.dataset.listKey
+                        ? hashChatPerformanceLabel(
+                              measuredElement.dataset.listKey,
+                          )
+                        : 0,
+                    scrollHeight: scrollElement?.scrollHeight ?? 0,
+                    scrollTop: scrollElement?.scrollTop ?? 0,
+                },
+            });
+            previousFrameAt = frameAt;
+            frameId = window.requestAnimationFrame(sampleFrame);
+        };
+
+        frameId = window.requestAnimationFrame(sampleFrame);
+        return () => {
+            cancelled = true;
+            if (frameId !== null) {
+                window.cancelAnimationFrame(frameId);
+            }
+        };
+    }, [
+        active,
+        getNavigationGeneration,
+        isStreaming,
+        scrollRef,
+        sessionId,
+        timelineContentRef,
+    ]);
+}

--- a/src/renderer/src/components/workspace/review/EditedFileDiffPreview.tsx
+++ b/src/renderer/src/components/workspace/review/EditedFileDiffPreview.tsx
@@ -10,6 +10,8 @@ import {
 
 import type { AiFileDiff, AiTrackedFile } from "@shared/ipc";
 import { MeasuredVirtualList } from "@renderer/components/virtual/MeasuredVirtualList";
+import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
+import { measureChatPerformance } from "@renderer/app/debug/chatPerformanceProbe";
 
 import { DiffLineView } from "./DiffLineView";
 import { HunkActionBar } from "./HunkActionBar";
@@ -701,15 +703,28 @@ export function EditedFileDiffPreview({
         typeof Worker !== "undefined" &&
         diffLineCount >= EDITED_DIFF_PREVIEW_LINE_VIRTUALIZATION_THRESHOLD;
     const synchronouslyPreparedDiff = useMemo<PreparedDiffPreview | null>(
-        () =>
-            expanded && !shouldPrepareInWorker
-                ? {
-                      decisionHunks: computeDecisionHunks(diff),
-                      lines: computeDiffLines(diff),
-                      visualBlocks: computeVisualDiffBlocks(diff),
-                  }
-                : null,
-        [diff, expanded, shouldPrepareInWorker],
+        () => {
+            if (!expanded || shouldPrepareInWorker) {
+                return null;
+            }
+            incrementChatPerformanceCounter("diff_prepares");
+            return measureChatPerformance(
+                "diff_prepare_ms",
+                {
+                    values: {
+                        cacheHit: 0,
+                        lineCount: diffLineCount,
+                        worker: 0,
+                    },
+                },
+                () => ({
+                    decisionHunks: computeDecisionHunks(diff),
+                    lines: computeDiffLines(diff),
+                    visualBlocks: computeVisualDiffBlocks(diff),
+                }),
+            );
+        },
+        [diff, diffLineCount, expanded, shouldPrepareInWorker],
     );
     const [workerPreparedDiff, setWorkerPreparedDiff] = useState<{
         readonly diff: AiFileDiff;

--- a/src/renderer/src/components/workspace/review/reviewDiffWorkerClient.ts
+++ b/src/renderer/src/components/workspace/review/reviewDiffWorkerClient.ts
@@ -1,4 +1,10 @@
 import type { AiFileDiff } from "@shared/ipc";
+import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
+import {
+    getChatPerformanceTimestamp,
+    measureChatPerformance,
+    recordChatPerformanceMetric,
+} from "@renderer/app/debug/chatPerformanceProbe";
 
 import {
     computeDecisionHunks,
@@ -25,14 +31,26 @@ export function prepareDiffPreview(
     diff: AiFileDiff,
     signal: AbortSignal,
 ): Promise<PreparedDiffPreview> {
+    incrementChatPerformanceCounter("diff_prepares");
+    const lineCount = diff.hunks.reduce(
+        (count, hunk) => count + hunk.lines.length,
+        0,
+    );
     if (typeof Worker === "undefined") {
-        return Promise.resolve({
-            decisionHunks: computeDecisionHunks(diff),
-            lines: computeDiffLines(diff),
-            visualBlocks: computeVisualDiffBlocks(diff),
-        });
+        return Promise.resolve(
+            measureChatPerformance(
+                "diff_prepare_ms",
+                { values: { cacheHit: 0, lineCount, worker: 0 } },
+                () => ({
+                    decisionHunks: computeDecisionHunks(diff),
+                    lines: computeDiffLines(diff),
+                    visualBlocks: computeVisualDiffBlocks(diff),
+                }),
+            ),
+        );
     }
 
+    const startedAt = getChatPerformanceTimestamp();
     const id = nextRequestId;
     nextRequestId += 1;
     return new Promise<PreparedDiffPreview>((resolve, reject) => {
@@ -55,6 +73,12 @@ export function prepareDiffPreview(
             if (data.id !== id) return;
             signal.removeEventListener("abort", abort);
             diffWorker.terminate();
+            if (startedAt !== null) {
+                recordChatPerformanceMetric("diff_prepare_ms", {
+                    durationMs: performance.now() - startedAt,
+                    values: { cacheHit: 0, lineCount, worker: 1 },
+                });
+            }
             resolve({ decisionHunks: data.decisionHunks, lines: data.lines, visualBlocks: data.visualBlocks });
         };
         diffWorker.onerror = (event) => {

--- a/src/renderer/src/components/workspace/streamingMarkdownProjection.ts
+++ b/src/renderer/src/components/workspace/streamingMarkdownProjection.ts
@@ -1,0 +1,344 @@
+import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
+import { measureChatPerformance } from "@renderer/app/debug/chatPerformanceProbe";
+
+export interface MarkdownBlock {
+    readonly content: string;
+    readonly id: string;
+    readonly info: string;
+    readonly isMutable: boolean;
+    readonly suppressTerminalEmptyLine: boolean;
+    readonly type: "code" | "text";
+}
+
+export interface ParsedMarkdownBlocks {
+    readonly blocks: readonly MarkdownBlock[];
+    readonly content: string;
+    readonly stableBlocks: readonly MarkdownBlock[];
+    readonly stableContentLength: number;
+}
+
+interface MarkdownFenceOpening {
+    readonly char: "`" | "~";
+    readonly info: string;
+    readonly length: number;
+}
+
+interface TextRange {
+    readonly from: number;
+    readonly to: number;
+}
+
+interface ParsedSegmentBlock {
+    readonly content: string;
+    readonly info: string;
+    readonly sourceStart: number;
+    readonly type: "code" | "text";
+}
+
+const PARSED_BLOCK_CACHE_LIMIT = 250;
+const parsedBlockCache = new Map<string, readonly ParsedSegmentBlock[]>();
+const listItemPattern = /^\s*(?:[-+*]|\d+[.)])\s+/m;
+
+function rememberParsedBlocks(
+    text: string,
+    blocks: readonly ParsedSegmentBlock[],
+): readonly ParsedSegmentBlock[] {
+    if (parsedBlockCache.has(text)) {
+        parsedBlockCache.delete(text);
+    }
+    parsedBlockCache.set(text, blocks);
+    if (parsedBlockCache.size > PARSED_BLOCK_CACHE_LIMIT) {
+        const oldestKey = parsedBlockCache.keys().next().value;
+        if (oldestKey !== undefined) {
+            parsedBlockCache.delete(oldestKey);
+        }
+    }
+    return blocks;
+}
+
+function parseMarkdownFenceOpening(lineText: string): MarkdownFenceOpening | null {
+    const match = lineText.match(/^(?: {0,3})(`{3,}|~{3,})(.*)$/);
+    if (!match) {
+        return null;
+    }
+
+    const marker = match[1] ?? "";
+    const info = (match[2] ?? "").trim();
+    const char = marker[0];
+    if (char !== "`" && char !== "~") {
+        return null;
+    }
+    if (char === "`" && info.includes("`")) {
+        return null;
+    }
+
+    return { char, info, length: marker.length };
+}
+
+function isMarkdownFenceClosingLine(
+    lineText: string,
+    opening: MarkdownFenceOpening,
+): boolean {
+    let cursor = 0;
+    while (cursor < lineText.length && lineText[cursor] === " " && cursor < 3) {
+        cursor += 1;
+    }
+
+    let markerLength = 0;
+    while (lineText[cursor + markerLength] === opening.char) {
+        markerLength += 1;
+    }
+    if (markerLength < opening.length) {
+        return false;
+    }
+
+    return lineText.slice(cursor + markerLength).trim().length === 0;
+}
+
+function findMarkdownFenceClosing(
+    text: string,
+    startOffset: number,
+    opening: MarkdownFenceOpening,
+): TextRange | null {
+    let cursor = startOffset;
+
+    while (cursor < text.length) {
+        const lineEnd = text.indexOf("\n", cursor);
+        const lineTo = lineEnd === -1 ? text.length : lineEnd;
+        if (isMarkdownFenceClosingLine(text.slice(cursor, lineTo), opening)) {
+            return { from: cursor, to: lineEnd === -1 ? lineTo : lineEnd + 1 };
+        }
+        if (lineEnd === -1) {
+            break;
+        }
+        cursor = lineEnd + 1;
+    }
+
+    return null;
+}
+
+function parseBlocksUnmeasured(text: string): readonly ParsedSegmentBlock[] {
+    const cached = parsedBlockCache.get(text);
+    if (cached) {
+        incrementChatPerformanceCounter("markdown_cache_hits");
+        return cached;
+    }
+
+    incrementChatPerformanceCounter("markdown_chars_reparsed", text.length);
+    const blocks: ParsedSegmentBlock[] = [];
+    let cursor = 0;
+    let lastIndex = 0;
+
+    while (cursor < text.length) {
+        const lineEnd = text.indexOf("\n", cursor);
+        const lineTo = lineEnd === -1 ? text.length : lineEnd;
+        const opening = parseMarkdownFenceOpening(text.slice(cursor, lineTo));
+
+        if (!opening) {
+            cursor = lineEnd === -1 ? text.length : lineEnd + 1;
+            continue;
+        }
+
+        const before = text.slice(lastIndex, cursor);
+        if (before) {
+            blocks.push({
+                content: before,
+                info: "",
+                sourceStart: lastIndex,
+                type: "text",
+            });
+        }
+
+        const contentStart = lineEnd === -1 ? lineTo : lineEnd + 1;
+        const closing = findMarkdownFenceClosing(text, contentStart, opening);
+        const contentEnd = closing?.from ?? text.length;
+        blocks.push({
+            content: text.slice(contentStart, contentEnd).replace(/\n$/, ""),
+            info: opening.info.toLowerCase(),
+            sourceStart: cursor,
+            type: "code",
+        });
+        lastIndex = closing?.to ?? text.length;
+        cursor = lastIndex;
+    }
+
+    const tail = text.slice(lastIndex);
+    if (tail) {
+        blocks.push({
+            content: tail,
+            info: "",
+            sourceStart: lastIndex,
+            type: "text",
+        });
+    }
+
+    return rememberParsedBlocks(text, blocks);
+}
+
+function parseBlocks(
+    text: string,
+    offset: number,
+    isMutable: boolean,
+    suppressTerminalEmptyLine = false,
+): readonly MarkdownBlock[] {
+    return measureChatPerformance(
+        "markdown_parse_ms",
+        { values: { contentChars: text.length } },
+        () =>
+            parseBlocksUnmeasured(text).map((block) => ({
+                ...block,
+                id: `${block.type}:${offset + block.sourceStart}`,
+                isMutable,
+                suppressTerminalEmptyLine:
+                    block.type === "text" && suppressTerminalEmptyLine,
+            })),
+    );
+}
+
+function findNextNonEmptyLine(
+    text: string,
+    start: number,
+): { readonly start: number; readonly text: string } | null {
+    let cursor = start;
+    while (cursor < text.length) {
+        const lineEnd = text.indexOf("\n", cursor);
+        const lineTo = lineEnd === -1 ? text.length : lineEnd;
+        const line = text.slice(cursor, lineTo);
+        if (line.trim().length > 0) {
+            return { start: cursor, text: line };
+        }
+        if (lineEnd === -1) {
+            return null;
+        }
+        cursor = lineEnd + 1;
+    }
+    return null;
+}
+
+function listCanContinueAcrossBlankLine(
+    text: string,
+    blankLineStart: number,
+    nextLine: string,
+): boolean {
+    if (!/^\s+/.test(nextLine)) {
+        return false;
+    }
+
+    // Exclude the separator currently being inspected from the look-behind.
+    const previousBoundary = text.lastIndexOf("\n\n", blankLineStart - 2);
+    return listItemPattern.test(
+        text.slice(previousBoundary === -1 ? 0 : previousBoundary + 2, blankLineStart),
+    );
+}
+
+/**
+ * Returns a conservative cut where the prefix cannot be affected by later
+ * append-only Markdown. The remaining suffix owns every open structure.
+ */
+function findSealablePrefixLength(text: string): number {
+    let cursor = 0;
+    let openFence: MarkdownFenceOpening | null = null;
+    let latestBoundary = 0;
+
+    while (cursor < text.length) {
+        const lineEnd = text.indexOf("\n", cursor);
+        const lineTo = lineEnd === -1 ? text.length : lineEnd;
+        const line = text.slice(cursor, lineTo);
+        const nextCursor = lineEnd === -1 ? text.length : lineEnd + 1;
+
+        if (openFence) {
+            if (isMarkdownFenceClosingLine(line, openFence)) {
+                latestBoundary = nextCursor;
+                openFence = null;
+            }
+            cursor = nextCursor;
+            continue;
+        }
+
+        const opening = parseMarkdownFenceOpening(line);
+        if (opening) {
+            // Text before a fence is independent from the fence body.
+            latestBoundary = Math.max(latestBoundary, cursor);
+            openFence = opening;
+            cursor = nextCursor;
+            continue;
+        }
+
+        if (line.trim().length === 0) {
+            const nextLine = findNextNonEmptyLine(text, nextCursor);
+            if (
+                nextLine &&
+                !listCanContinueAcrossBlankLine(text, cursor, nextLine.text)
+            ) {
+                latestBoundary = Math.max(latestBoundary, nextCursor);
+            }
+        }
+
+        cursor = nextCursor;
+    }
+
+    return latestBoundary;
+}
+
+function projectInitialContent(
+    content: string,
+    sealAll: boolean,
+): ParsedMarkdownBlocks {
+    const stableContentLength = sealAll
+        ? content.length
+        : findSealablePrefixLength(content);
+    const stableBlocks = parseBlocks(
+        content.slice(0, stableContentLength),
+        0,
+        false,
+        !sealAll && stableContentLength < content.length,
+    );
+    const mutableBlocks = parseBlocks(
+        content.slice(stableContentLength),
+        stableContentLength,
+        !sealAll,
+    );
+
+    return {
+        blocks: [...stableBlocks, ...mutableBlocks],
+        content,
+        stableBlocks,
+        stableContentLength,
+    };
+}
+
+export function parseMarkdownBlocksProgressively(
+    previous: ParsedMarkdownBlocks | null,
+    content: string,
+    options: { readonly sealAll?: boolean } = {},
+): ParsedMarkdownBlocks {
+    const sealAll = options.sealAll ?? false;
+    if (!previous || !content.startsWith(previous.content)) {
+        return projectInitialContent(content, sealAll);
+    }
+
+    const mutableContent = content.slice(previous.stableContentLength);
+    const newlyStableLength = sealAll
+        ? mutableContent.length
+        : findSealablePrefixLength(mutableContent);
+    const stableContentLength = previous.stableContentLength + newlyStableLength;
+    const newlyStableBlocks = parseBlocks(
+        mutableContent.slice(0, newlyStableLength),
+        previous.stableContentLength,
+        false,
+        !sealAll && stableContentLength < content.length,
+    );
+    const mutableBlocks = parseBlocks(
+        mutableContent.slice(newlyStableLength),
+        stableContentLength,
+        !sealAll,
+    );
+    const stableBlocks = [...previous.stableBlocks, ...newlyStableBlocks];
+
+    return {
+        blocks: [...stableBlocks, ...mutableBlocks],
+        content,
+        stableBlocks,
+        stableContentLength,
+    };
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -163,6 +163,7 @@ export const IPC_CHANNELS = {
     getAiTranscriptBlockMetadata: "ai:get-transcript-block-metadata",
     getAiTranscriptBlock: "ai:get-transcript-block",
     getAiTranscriptPayload: "ai:get-transcript-payload",
+    getAiTranscriptPayloads: "ai:get-transcript-payloads",
     getAiPromptQueue: "ai:get-prompt-queue",
     enqueueAiPrompt: "ai:enqueue-prompt",
     removeAiQueuedPrompt: "ai:remove-queued-prompt",
@@ -2774,6 +2775,12 @@ export interface AiLoadTranscriptPayloadInput {
     readonly sessionId: string;
 }
 
+export interface AiLoadTranscriptPayloadsInput {
+    readonly maxBytes?: number;
+    readonly payloadRefs: readonly string[];
+    readonly sessionId: string;
+}
+
 export interface AiTranscriptPayload {
     readonly byteLength: number;
     readonly capabilityVersion: number;
@@ -2782,6 +2789,11 @@ export interface AiTranscriptPayload {
     readonly sessionId: string;
     readonly transcriptRevision: number;
     readonly value: unknown;
+}
+
+export interface AiTranscriptPayloadsOutput {
+    readonly payloads: readonly AiTranscriptPayload[];
+    readonly sessionId: string;
 }
 
 export type AiTranscriptStorageMode =
@@ -3641,6 +3653,9 @@ export interface ComandoApi {
     getAiTranscriptPayload: (
         input: AiLoadTranscriptPayloadInput,
     ) => Promise<AiTranscriptPayload | null>;
+    getAiTranscriptPayloads: (
+        input: AiLoadTranscriptPayloadsInput,
+    ) => Promise<AiTranscriptPayloadsOutput | null>;
     getAiPromptQueue: (sessionId: string) => Promise<AiPromptQueueSnapshot>;
     enqueueAiPrompt: (
         input: EnqueueAiPromptInput,

--- a/src/shared/native-backend/ai.ts
+++ b/src/shared/native-backend/ai.ts
@@ -423,6 +423,13 @@ export type NativeAiTranscriptPayload = {
     readonly value: unknown;
 };
 
+export type NativeAiTranscriptPayloadsOutput = {
+    readonly capabilityVersion: number;
+    readonly sessionId: NativeSessionId;
+    readonly payloads: readonly NativeAiTranscriptPayload[];
+    readonly transcriptRevision: number;
+};
+
 export type NativeAiTranscriptStorageState = {
     readonly capabilityVersion: number;
     readonly legacyFallbackAvailable: boolean;

--- a/src/shared/native-backend/commands.ts
+++ b/src/shared/native-backend/commands.ts
@@ -136,6 +136,7 @@ export const NATIVE_AI_COMMANDS = [
     "ai_load_transcript_block_metadata",
     "ai_load_transcript_block",
     "ai_load_transcript_payload",
+    "ai_load_transcript_payloads",
     "ai_get_transcript_storage_state",
     "ai_load_session_snapshot",
     "ai_list_session_runtime_mappings",


### PR DESCRIPTION
This PR optimizes long-running chat sessions and live streaming by:

- Virtualizing transcript history while preserving semantic scroll anchors.
- Keeping the streaming tail outside the virtualized list for smoother updates.
- Batching transcript payload loading and retaining review payloads when needed.
- Reducing live Markdown rendering work with incremental projections.
- Coordinating scroll writes and restoring the prior position when reactivating a chat tab.
- Adding performance instrumentation plus unit and E2E coverage for the new behavior.