### PR TITLE
Fix chat scroll restoration after tab reactivation

### DIFF
--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -253,6 +253,13 @@ type ChatSemanticRestoreAnchor = NonNullable<
     PersistedChatViewState["anchor"]
 >;
 
+interface PendingChatViewRestore {
+    readonly anchor: ChatSemanticRestoreAnchor | null;
+    readonly fallbackScrollTop: number;
+    readonly generation: number;
+    phase: "loading-anchor" | "awaiting-range" | "applying-fallback";
+}
+
 function selectChatSessionViewState(
     state: ReturnType<typeof useAiStore.getState>,
     sessionId: string,
@@ -471,7 +478,10 @@ export const ChatTabView = memo(function ChatTabView({
     const semanticAnchorRef = useRef<PersistedChatViewState["anchor"]>(
         null,
     );
-    const semanticRestoreFallbackScrollTopRef = useRef<number | null>(null);
+    const pendingChatViewRestoreRef = useRef<PendingChatViewRestore | null>(
+        null,
+    );
+    const chatViewRestoreGenerationRef = useRef(0);
     const initialComposerParts = readInitialComposerPartsForTab(tab);
     const composerPartsRef = useRef<AIComposerPart[]>(initialComposerParts);
     const persistedDraftRef = useRef(tab.draft);
@@ -1573,28 +1583,72 @@ export const ChatTabView = memo(function ChatTabView({
         [requestChatScroll],
     );
 
-    const handleSemanticAnchorRestored = useCallback(() => {
-        semanticRestoreFallbackScrollTopRef.current = null;
+    const applyPendingChatViewRestoreFallback = useCallback(
+        (generation: number) => {
+            const pendingRestore = pendingChatViewRestoreRef.current;
+            if (
+                !pendingRestore ||
+                pendingRestore.generation !== generation
+            ) {
+                return;
+            }
+
+            pendingRestore.phase = "applying-fallback";
+            setSemanticRestoreAnchor(null);
+        },
+        [],
+    );
+
+    const cancelPendingChatViewRestore = useCallback(() => {
+        if (!pendingChatViewRestoreRef.current) {
+            return;
+        }
+
+        // A direct reader action becomes authoritative over queued restoration.
+        pendingChatViewRestoreRef.current = null;
+        semanticAnchorRef.current = null;
         setSemanticRestoreAnchor(null);
+    }, []);
+
+    const handleSemanticAnchorRestored = useCallback((entryId: string) => {
+        const pendingRestore = pendingChatViewRestoreRef.current;
+        if (
+            !pendingRestore ||
+            pendingRestore.anchor?.entryId !== entryId ||
+            pendingRestore.phase !== "loading-anchor"
+        ) {
+            return;
+        }
+
+        // scrollToIndex only requests movement; the visible range confirms it.
+        pendingRestore.phase = "awaiting-range";
         setShowJumpToBottom(true);
     }, []);
 
-    const handleSemanticAnchorUnavailable = useCallback(() => {
-        const fallbackScrollTop = semanticRestoreFallbackScrollTopRef.current;
-        semanticRestoreFallbackScrollTopRef.current = null;
-        setSemanticRestoreAnchor(null);
-        if (fallbackScrollTop !== null) {
-            writeProgrammaticScroll(fallbackScrollTop, "restore");
+    const handleSemanticAnchorUnavailable = useCallback((entryId: string) => {
+        const pendingRestore = pendingChatViewRestoreRef.current;
+        if (!pendingRestore || pendingRestore.anchor?.entryId !== entryId) {
+            return;
         }
-        setShowJumpToBottom(true);
-    }, [writeProgrammaticScroll]);
+
+        applyPendingChatViewRestoreFallback(pendingRestore.generation);
+    }, [applyPendingChatViewRestoreFallback]);
 
     useEffect(() => {
         if (!active || !semanticRestoreAnchor) {
             return;
         }
+        const pendingRestore = pendingChatViewRestoreRef.current;
+        if (
+            !pendingRestore ||
+            pendingRestore.anchor?.entryId !== semanticRestoreAnchor.entryId ||
+            pendingRestore.phase !== "loading-anchor"
+        ) {
+            return;
+        }
+        const restoreGeneration = pendingRestore.generation;
         if (!transcriptWindow?.capabilityVersion) {
-            handleSemanticAnchorUnavailable();
+            applyPendingChatViewRestoreFallback(restoreGeneration);
             return;
         }
 
@@ -1605,7 +1659,7 @@ export const ChatTabView = memo(function ChatTabView({
                 semanticRestoreAnchor.entryId,
             );
         if (!blockId) {
-            handleSemanticAnchorUnavailable();
+            applyPendingChatViewRestoreFallback(restoreGeneration);
             return;
         }
 
@@ -1629,15 +1683,19 @@ export const ChatTabView = memo(function ChatTabView({
         }
 
         void loadTranscriptWindowBlock(tab.sessionId, blockId).then((block) => {
-            if (!block) {
-                handleSemanticAnchorUnavailable();
+            if (
+                !block &&
+                pendingChatViewRestoreRef.current?.generation ===
+                    restoreGeneration
+            ) {
+                applyPendingChatViewRestoreFallback(restoreGeneration);
             }
         });
     }, [
         active,
-        handleSemanticAnchorUnavailable,
+        applyPendingChatViewRestoreFallback,
         loadTranscriptWindowBlock,
-        semanticRestoreAnchor?.blockId,
+        semanticRestoreAnchor,
         setTranscriptWindowAnchor,
         tab.sessionId,
         transcriptWindow?.blocksById,
@@ -1656,42 +1714,15 @@ export const ChatTabView = memo(function ChatTabView({
     );
 
     const handleTimelineVirtualRangeChange = useCallback((range: MeasuredVirtualRange) => {
-        const firstVisibleTimelineRow = transcriptTimelineItems
-            .slice(range.visibleStartIndex, range.visibleEndIndex + 1)
-            .find(isChatTimelineRowItem);
+        const visibleTimelineRows = transcriptTimelineItems.slice(
+            range.visibleStartIndex,
+            range.visibleEndIndex + 1,
+        );
+        const firstVisibleTimelineRow = visibleTimelineRows.find(
+            isChatTimelineRowItem,
+        );
         const scrollElement = scrollRef.current;
-        const listItemElement = firstVisibleTimelineRow
-            ? [...(
-                  timelineContentRef.current?.querySelectorAll<HTMLElement>(
-                      "[data-list-key]",
-                  ) ?? []
-              )].find((element) => element.dataset.listKey === firstVisibleTimelineRow.id)
-            : null;
-        const offsetWithinEntry =
-            scrollElement && listItemElement
-                ? Math.max(
-                      0,
-                      scrollElement.scrollTop -
-                          (scrollElement.scrollTop +
-                              listItemElement.getBoundingClientRect().top -
-                              scrollElement.getBoundingClientRect().top),
-                  )
-                : 0;
-        const nextAnchor = captureTranscriptSemanticAnchor({
-            entryId: firstVisibleTimelineRow
-                ? getTranscriptTimelineItemAnchorEntryId(firstVisibleTimelineRow)
-                : null,
-            offsetWithinEntry,
-        });
-        semanticAnchorRef.current = nextAnchor
-            ? {
-                  ...nextAnchor,
-                  blockId: resolveTranscriptEntryBlockId(
-                      transcriptWindow?.blocksById ?? new Map(),
-                      nextAnchor.entryId,
-                  ),
-              }
-            : null;
+        const pendingRestore = pendingChatViewRestoreRef.current;
         const visibleBlockIds = resolveUnloadedTranscriptBlockIdsInRange(
             transcriptTimelineItems,
             range.visibleStartIndex,
@@ -1704,11 +1735,114 @@ export const ChatTabView = memo(function ChatTabView({
         );
         setTranscriptWindowAnchor(
             tab.sessionId,
-            residentBlockIds[0] ?? null,
+            pendingRestore && pendingRestore.phase !== "applying-fallback"
+                ? (semanticAnchorRef.current?.blockId ??
+                  residentBlockIds[0] ??
+                  null)
+                : (residentBlockIds[0] ?? null),
             shouldAutoFollowRef.current,
         );
         for (const blockId of visibleBlockIds) {
             void loadTranscriptWindowBlock(tab.sessionId, blockId);
+        }
+
+        if (pendingRestore?.phase === "awaiting-range" && pendingRestore.anchor) {
+            const restoredTimelineRow = visibleTimelineRows.find(
+                (row) =>
+                    isChatTimelineRowItem(row) &&
+                    getTranscriptTimelineItemAnchorEntryId(row) ===
+                        pendingRestore.anchor?.entryId,
+            );
+            if (restoredTimelineRow) {
+                const restoredElement = [...(
+                    timelineContentRef.current?.querySelectorAll<HTMLElement>(
+                        "[data-list-key]",
+                    ) ?? []
+                )].find(
+                    (element) =>
+                        element.dataset.listKey === restoredTimelineRow.id,
+                );
+                const offsetWithinEntry =
+                    scrollElement && restoredElement
+                        ? Math.max(
+                              0,
+                              scrollElement.scrollTop -
+                                  (scrollElement.scrollTop +
+                                      restoredElement.getBoundingClientRect()
+                                          .top -
+                                      scrollElement.getBoundingClientRect()
+                                          .top),
+                          )
+                        : pendingRestore.anchor.offsetWithinEntry;
+                const confirmedAnchor = captureTranscriptSemanticAnchor({
+                    entryId: pendingRestore.anchor.entryId,
+                    offsetWithinEntry,
+                });
+
+                // Keep the persisted anchor frozen until the virtual range sees it.
+                semanticAnchorRef.current = confirmedAnchor
+                    ? {
+                          ...confirmedAnchor,
+                          blockId:
+                              resolveTranscriptEntryBlockId(
+                                  transcriptWindow?.blocksById ?? new Map(),
+                                  confirmedAnchor.entryId,
+                              ) ?? pendingRestore.anchor.blockId,
+                      }
+                    : pendingRestore.anchor;
+                pendingChatViewRestoreRef.current = null;
+                setSemanticRestoreAnchor(null);
+            }
+        } else if (pendingRestore?.phase === "applying-fallback") {
+            if (scrollElement && range.endIndex >= range.startIndex) {
+                // A range means the virtualizer has enough geometry to clamp safely.
+                pendingChatViewRestoreRef.current = null;
+                semanticAnchorRef.current = null;
+                setSemanticRestoreAnchor(null);
+                writeProgrammaticScroll(
+                    pendingRestore.fallbackScrollTop,
+                    "restore",
+                );
+                setShowJumpToBottom(true);
+            }
+        } else if (!pendingRestore) {
+            const listItemElement = firstVisibleTimelineRow
+                ? [...(
+                      timelineContentRef.current?.querySelectorAll<HTMLElement>(
+                          "[data-list-key]",
+                      ) ?? []
+                  )].find(
+                      (element) =>
+                          element.dataset.listKey === firstVisibleTimelineRow.id,
+                  )
+                : null;
+            const offsetWithinEntry =
+                scrollElement && listItemElement
+                    ? Math.max(
+                          0,
+                          scrollElement.scrollTop -
+                              (scrollElement.scrollTop +
+                                  listItemElement.getBoundingClientRect().top -
+                                  scrollElement.getBoundingClientRect().top),
+                      )
+                    : 0;
+            const nextAnchor = captureTranscriptSemanticAnchor({
+                entryId: firstVisibleTimelineRow
+                    ? getTranscriptTimelineItemAnchorEntryId(
+                          firstVisibleTimelineRow,
+                      )
+                    : null,
+                offsetWithinEntry,
+            });
+            semanticAnchorRef.current = nextAnchor
+                ? {
+                      ...nextAnchor,
+                      blockId: resolveTranscriptEntryBlockId(
+                          transcriptWindow?.blocksById ?? new Map(),
+                          nextAnchor.entryId,
+                      ),
+                  }
+                : null;
         }
         recordChatPerformanceMetric("virtual_range", {
             sessionId: tab.sessionId,
@@ -1726,6 +1860,7 @@ export const ChatTabView = memo(function ChatTabView({
         tab.sessionId,
         transcriptWindow?.blocksById,
         transcriptTimelineItems,
+        writeProgrammaticScroll,
     ]);
 
     const handleTimelineVirtualResizeAutoFollow = useCallback(() => {
@@ -1759,21 +1894,25 @@ export const ChatTabView = memo(function ChatTabView({
         }) => {
             const scrollEl = scrollRef.current;
             const previousViewState = persistedViewStateRef.current;
-            const scrollTop =
-                overrides?.scrollTop ??
-                scrollEl?.scrollTop ??
-                previousViewState?.scrollTop ??
-                0;
-            const nextIsNearBottom =
-                overrides?.isNearBottom ??
-                (scrollEl
-                    ? isNearBottom(scrollEl)
-                    : previousViewState?.isNearBottom ?? true);
+            const pendingRestore = pendingChatViewRestoreRef.current;
+            const scrollTop = pendingRestore
+                ? pendingRestore.fallbackScrollTop
+                : (overrides?.scrollTop ??
+                  scrollEl?.scrollTop ??
+                  previousViewState?.scrollTop ??
+                  0);
+            const nextIsNearBottom = pendingRestore
+                ? false
+                : (overrides?.isNearBottom ??
+                  (scrollEl
+                      ? isNearBottom(scrollEl)
+                      : previousViewState?.isNearBottom ?? true));
+            const anchor = pendingRestore?.anchor ?? semanticAnchorRef.current;
 
             // Inactive chat views can unmount, so keep the last confirmed
             // viewport available for the next activation.
             persistedViewStateRef.current = {
-                anchor: semanticAnchorRef.current,
+                anchor,
                 isNearBottom: nextIsNearBottom,
                 scrollTop,
             };
@@ -1783,7 +1922,8 @@ export const ChatTabView = memo(function ChatTabView({
                 tab.worktreeId ?? null,
                 tab.sessionId,
                 {
-                    anchor: semanticAnchorRef.current,
+                    // Never persist the virtualizer's first incomplete range.
+                    anchor,
                     isNearBottom: nextIsNearBottom,
                     scrollTop,
                 },
@@ -1897,6 +2037,7 @@ export const ChatTabView = memo(function ChatTabView({
 
     const handleTimelineWheelCapture = useCallback(
         (event: WheelEvent<HTMLDivElement>) => {
+            cancelPendingChatViewRestore();
             if (
                 !shouldAutoFollowRef.current ||
                 (event.deltaY >= 0 &&
@@ -1913,11 +2054,12 @@ export const ChatTabView = memo(function ChatTabView({
             resizeBottomLockRef.current = false;
             resizeStartedNearBottomRef.current = false;
         },
-        [cancelPendingScrollToBottom],
+        [cancelPendingChatViewRestore, cancelPendingScrollToBottom],
     );
 
     const handleTimelineTouchStart = useCallback(
         () => {
+            cancelPendingChatViewRestore();
             if (!shouldAutoFollowRef.current) {
                 return;
             }
@@ -1931,7 +2073,7 @@ export const ChatTabView = memo(function ChatTabView({
             resizeBottomLockRef.current = false;
             resizeStartedNearBottomRef.current = false;
         },
-        [cancelPendingScrollToBottom],
+        [cancelPendingChatViewRestore, cancelPendingScrollToBottom],
     );
 
     useEffect(() => {
@@ -1951,6 +2093,7 @@ export const ChatTabView = memo(function ChatTabView({
             return;
         }
 
+        const restoreGeneration = ++chatViewRestoreGenerationRef.current;
         let cancelled = false;
         const setJumpToBottomVisibility = (visible: boolean) => {
             queueMicrotask(() => {
@@ -1985,9 +2128,13 @@ export const ChatTabView = memo(function ChatTabView({
                     shouldAutoFollow: shouldAutoFollowRef.current,
                 }),
             );
+            pendingChatViewRestoreRef.current = null;
+            setSemanticRestoreAnchor(null);
         };
 
         if (shouldRestoreBottom) {
+            pendingChatViewRestoreRef.current = null;
+            setSemanticRestoreAnchor(null);
             shouldAutoFollowRef.current = true;
             scrollIntentRef.current = followChatScrollEnd(scrollIntentRef.current);
             scrollToBottom();
@@ -1996,14 +2143,20 @@ export const ChatTabView = memo(function ChatTabView({
             shouldAutoFollowRef.current = false;
             scrollIntentRef.current = readChatScroll(scrollIntentRef.current);
             const persistedAnchor = persistedViewStateRef.current?.anchor ?? null;
+            pendingChatViewRestoreRef.current = {
+                anchor: persistedAnchor,
+                fallbackScrollTop: restoreScrollTop,
+                generation: restoreGeneration,
+                phase: persistedAnchor
+                    ? "loading-anchor"
+                    : "applying-fallback",
+            };
             if (persistedAnchor) {
                 semanticAnchorRef.current = persistedAnchor;
-                semanticRestoreFallbackScrollTopRef.current = restoreScrollTop;
                 setSemanticRestoreAnchor(persistedAnchor);
             } else {
-                semanticRestoreFallbackScrollTopRef.current = null;
+                semanticAnchorRef.current = null;
                 setSemanticRestoreAnchor(null);
-                writeProgrammaticScroll(restoreScrollTop, "restore");
             }
             setJumpToBottomVisibility(!isNearBottom(scrollEl));
         }
@@ -2015,7 +2168,6 @@ export const ChatTabView = memo(function ChatTabView({
         persistCurrentViewState,
         scrollToBottom,
         takeScheduledScrollPersist,
-        writeProgrammaticScroll,
         active,
         tab.sessionId,
     ]);
@@ -2108,6 +2260,7 @@ export const ChatTabView = memo(function ChatTabView({
     ]);
 
     const handleJumpToBottom = useCallback(() => {
+        cancelPendingChatViewRestore();
         cancelPendingScrollToBottom();
         shouldAutoFollowRef.current = true;
         scrollIntentRef.current = followChatScrollEnd(scrollIntentRef.current);
@@ -2121,6 +2274,7 @@ export const ChatTabView = memo(function ChatTabView({
         const scrollEl = scrollRef.current;
         scheduleScrollPersist(scrollEl?.scrollTop ?? 0, true);
     }, [
+        cancelPendingChatViewRestore,
         cancelPendingScrollToBottom,
         scheduleScrollPersist,
         scrollToBottom,
@@ -3158,8 +3312,8 @@ type ChatTimelineProps = {
     readonly liveTailRowId: string | null;
     readonly newTurnAnchorRowId: string | null;
     readonly onNewTurnScrollTarget?: (target: number) => void;
-    readonly onSemanticAnchorRestored?: () => void;
-    readonly onSemanticAnchorUnavailable?: () => void;
+    readonly onSemanticAnchorRestored?: (entryId: string) => void;
+    readonly onSemanticAnchorUnavailable?: (entryId: string) => void;
     readonly onVirtualScrollRequest?: (
         request: MeasuredVirtualScrollRequest,
     ) => void;
@@ -3434,8 +3588,8 @@ export type ChatTimelineHistoryProps = {
     readonly liveTailRowId: string | null;
     readonly newTurnAnchorRowId: string | null;
     readonly onNewTurnScrollTarget?: (target: number) => void;
-    readonly onSemanticAnchorRestored?: () => void;
-    readonly onSemanticAnchorUnavailable?: () => void;
+    readonly onSemanticAnchorRestored?: (entryId: string) => void;
+    readonly onSemanticAnchorUnavailable?: (entryId: string) => void;
     readonly onVirtualScrollRequest?: (
         request: MeasuredVirtualScrollRequest,
     ) => void;

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -1590,14 +1590,39 @@ export const ChatTabView = memo(function ChatTabView({
     }, [writeProgrammaticScroll]);
 
     useEffect(() => {
-        if (!active || !semanticRestoreAnchor?.blockId) {
+        if (!active || !semanticRestoreAnchor) {
             return;
         }
         if (!transcriptWindow?.capabilityVersion) {
+            handleSemanticAnchorUnavailable();
             return;
         }
 
-        const blockId = semanticRestoreAnchor.blockId;
+        const blockId =
+            semanticRestoreAnchor.blockId ??
+            resolveTranscriptEntryBlockId(
+                transcriptWindow.blocksById,
+                semanticRestoreAnchor.entryId,
+            );
+        if (!blockId) {
+            handleSemanticAnchorUnavailable();
+            return;
+        }
+
+        // Hydration may discover a legacy anchor's block after activation.
+        semanticAnchorRef.current = {
+            ...semanticRestoreAnchor,
+            blockId,
+        };
+        if (semanticRestoreAnchor.blockId !== blockId) {
+            setSemanticRestoreAnchor((current) =>
+                current?.blockId === blockId
+                    ? current
+                    : current
+                      ? { ...current, blockId }
+                      : null,
+            );
+        }
         setTranscriptWindowAnchor(tab.sessionId, blockId, false);
         if (transcriptWindow.blocksById.has(blockId)) {
             return;
@@ -1745,8 +1770,8 @@ export const ChatTabView = memo(function ChatTabView({
                     ? isNearBottom(scrollEl)
                     : previousViewState?.isNearBottom ?? true);
 
-            // Retained chat views do not remount between tab switches, so keep
-            // the latest persisted position in memory for the next activation.
+            // Inactive chat views can unmount, so keep the last confirmed
+            // viewport available for the next activation.
             persistedViewStateRef.current = {
                 anchor: semanticAnchorRef.current,
                 isNearBottom: nextIsNearBottom,
@@ -1772,7 +1797,7 @@ export const ChatTabView = memo(function ChatTabView({
         ],
     );
 
-    const flushScheduledScrollPersist = useCallback((): {
+    const takeScheduledScrollPersist = useCallback((): {
         readonly isNearBottom: boolean | null;
         readonly scrollTop: number | null;
     } | null => {
@@ -1790,18 +1815,22 @@ export const ChatTabView = memo(function ChatTabView({
                   }
                 : null;
 
+        pendingPersistedNearBottomRef.current = null;
+        pendingPersistedScrollTopRef.current = null;
+
+        return pendingState;
+    }, []);
+
+    const flushScheduledScrollPersist = useCallback(() => {
+        const pendingState = takeScheduledScrollPersist();
         if (pendingState) {
             persistCurrentViewState({
                 isNearBottom: pendingState.isNearBottom ?? undefined,
                 scrollTop: pendingState.scrollTop ?? undefined,
             });
         }
-
-        pendingPersistedNearBottomRef.current = null;
-        pendingPersistedScrollTopRef.current = null;
-
         return pendingState;
-    }, [persistCurrentViewState]);
+    }, [persistCurrentViewState, takeScheduledScrollPersist]);
 
     const scheduleScrollPersist = useCallback(
         (scrollTop: number, nextIsNearBottom: boolean) => {
@@ -1946,7 +1975,7 @@ export const ChatTabView = memo(function ChatTabView({
         const persistViewStateOnDeactivate = () => {
             cancelled = true;
             cancelPendingScrollToBottom();
-            const flushedState = flushScheduledScrollPersist();
+            const flushedState = takeScheduledScrollPersist();
             persistCurrentViewState(
                 resolveChatScrollPersistenceState({
                     currentScrollTop: scrollEl.scrollTop,
@@ -1967,22 +1996,10 @@ export const ChatTabView = memo(function ChatTabView({
             shouldAutoFollowRef.current = false;
             scrollIntentRef.current = readChatScroll(scrollIntentRef.current);
             const persistedAnchor = persistedViewStateRef.current?.anchor ?? null;
-            const semanticBlockId =
-                persistedAnchor?.blockId ??
-                (persistedAnchor
-                    ? resolveTranscriptEntryBlockId(
-                          transcriptWindow?.blocksById ?? new Map(),
-                          persistedAnchor.entryId,
-                      )
-                    : null);
-            if (persistedAnchor && semanticBlockId) {
-                const restoreAnchor = {
-                    ...persistedAnchor,
-                    blockId: semanticBlockId,
-                };
-                semanticAnchorRef.current = restoreAnchor;
+            if (persistedAnchor) {
+                semanticAnchorRef.current = persistedAnchor;
                 semanticRestoreFallbackScrollTopRef.current = restoreScrollTop;
-                setSemanticRestoreAnchor(restoreAnchor);
+                setSemanticRestoreAnchor(persistedAnchor);
             } else {
                 semanticRestoreFallbackScrollTopRef.current = null;
                 setSemanticRestoreAnchor(null);
@@ -1994,14 +2011,13 @@ export const ChatTabView = memo(function ChatTabView({
         return persistViewStateOnDeactivate;
     }, [
         cancelPendingScrollToBottom,
-        flushScheduledScrollPersist,
         isNearBottom,
         persistCurrentViewState,
         scrollToBottom,
+        takeScheduledScrollPersist,
         writeProgrammaticScroll,
         active,
         tab.sessionId,
-        transcriptWindow?.blocksById,
     ]);
 
     useLayoutEffect(() => {

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -9,6 +9,8 @@ import {
     useState,
     type ReactNode,
     type RefObject,
+    type KeyboardEvent,
+    type PointerEvent,
     type TouchEvent,
     type WheelEvent,
 } from "react";
@@ -2076,6 +2078,33 @@ export const ChatTabView = memo(function ChatTabView({
         [cancelPendingChatViewRestore, cancelPendingScrollToBottom],
     );
 
+    const handleTimelinePointerDown = useCallback(() => {
+        // Scrollbar drags bypass wheel and touch handlers.
+        cancelPendingChatViewRestore();
+    }, [cancelPendingChatViewRestore]);
+
+    const handleTimelineKeyDown = useCallback(
+        (event: KeyboardEvent<HTMLDivElement>) => {
+            if (
+                ![
+                    "ArrowDown",
+                    "ArrowUp",
+                    "End",
+                    "Home",
+                    "PageDown",
+                    "PageUp",
+                    " ",
+                ].includes(event.key)
+            ) {
+                return;
+            }
+
+            // Keyboard navigation must beat an asynchronous anchor restore.
+            cancelPendingChatViewRestore();
+        },
+        [cancelPendingChatViewRestore],
+    );
+
     useEffect(() => {
         return () => {
             cancelPendingScrollToBottom();
@@ -2818,8 +2847,10 @@ export const ChatTabView = memo(function ChatTabView({
                     }
                     onRevealFileReference={handleRevealResolvedFileReference}
                     onScroll={handleScroll}
+                    onPointerDown={handleTimelinePointerDown}
                     onTouchStart={handleTimelineTouchStart}
                     onWheelCapture={handleTimelineWheelCapture}
+                    onKeyDown={handleTimelineKeyDown}
                     onJumpToBottom={handleJumpToBottom}
                     onVirtualRangeChange={handleTimelineVirtualRangeChange}
                     onVirtualResizeEnd={handleTimelineVirtualResizeEnd}
@@ -3346,6 +3377,8 @@ type ChatTimelineProps = {
     ) => void;
     readonly onOpenSession?: (sessionId: string) => Promise<void> | void;
     readonly onJumpToBottom: () => void;
+    readonly onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
+    readonly onPointerDown?: (event: PointerEvent<HTMLDivElement>) => void;
     readonly onRevealFileReference?: (
         reference: ResolvedProjectFileReference,
     ) => void;
@@ -3378,8 +3411,8 @@ function areChatTimelinePropsEqual(
     previous: Readonly<ChatTimelineProps>,
     next: Readonly<ChatTimelineProps>,
 ): boolean {
-    // Hidden warm views should retain their last committed DOM until they are
-    // activated again. The next active render receives the latest timeline.
+    // Inactive views normally unmount under the workspace budget. If teardown
+    // is deferred for one render, avoid reconciling an invisible timeline.
     if (!previous.active && !next.active) {
         return true;
     }
@@ -3414,6 +3447,8 @@ const ChatTimeline = memo(function ChatTimeline({
     onOpenResolvedFileReference,
     onOpenSession,
     onJumpToBottom,
+    onKeyDown,
+    onPointerDown,
     onRevealFileReference,
     onScroll,
     onTouchStart,
@@ -3453,6 +3488,8 @@ const ChatTimeline = memo(function ChatTimeline({
                     visible={showJumpToBottom}
                 />
             }
+            onKeyDown={onKeyDown}
+            onPointerDown={onPointerDown}
             onScroll={onScroll}
             onTouchStart={onTouchStart}
             onWheelCapture={onWheelCapture}

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -409,7 +409,7 @@ describe("ChatTimelineHistoryRows", () => {
         root.unmount();
     });
 
-    it("restores the same semantic anchor after a retained tab is reactivated", () => {
+    it("restores the same semantic anchor after a chat remount", () => {
         const rows = createRows(3);
         const scrollContainer = document.createElement("div");
         const mountNode = document.createElement("div");
@@ -580,6 +580,7 @@ describe("ChatTimelineHistoryRows", () => {
         remountedRoot.unmount();
     });
     beforeEach(() => {
+        window.localStorage.clear();
         (
             globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
         ).IS_REACT_ACT_ENVIRONMENT = true;
@@ -618,6 +619,7 @@ describe("ChatTimelineHistoryRows", () => {
     });
 
     afterEach(() => {
+        window.localStorage.clear();
         useShellStore.setState({ isResizingPanel: false });
         vi.unstubAllGlobals();
         vi.restoreAllMocks();
@@ -963,7 +965,7 @@ describe("ChatTimelineHistoryRows", () => {
         expect(markup.match(/data-row-id=/g)).toHaveLength(2);
     });
 
-    it("keeps virtual layout but stops row measurements while retained and hidden", () => {
+    it("keeps virtual layout but stops row measurements while inactive", () => {
         const rows = createRows(SMALL_HISTORY_ROW_COUNT);
 
         const markup = renderHistoryRows(rows, false);

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -400,6 +400,7 @@ describe("ChatTimelineHistoryRows", () => {
             reason: "restore",
         });
         expect(onSemanticAnchorRestored).toHaveBeenCalledTimes(1);
+        expect(onSemanticAnchorRestored).toHaveBeenCalledWith(rows[1]?.id);
 
         root.unmount();
     });
@@ -471,6 +472,9 @@ describe("ChatTimelineHistoryRows", () => {
         });
 
         expect(onSemanticAnchorUnavailable).toHaveBeenCalledTimes(1);
+        expect(onSemanticAnchorUnavailable).toHaveBeenCalledWith(
+            "missing-entry",
+        );
         expect(mockScrollToIndex).not.toHaveBeenCalled();
 
         root.unmount();

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.test.tsx
@@ -21,6 +21,10 @@ import {
     CHAT_TIMELINE_CONTENT_MAX_WIDTH_PX,
     getChatTimelineVirtualMeasurementWidth,
 } from "./chatTimelineVirtualization";
+import {
+    persistChatViewState,
+    readPersistedChatViewState,
+} from "./chatViewPersistence";
 
 const SMALL_HISTORY_ROW_COUNT = 3;
 const ACTIVITY_HEAVY_ENTRY_COUNT = 24;
@@ -478,6 +482,102 @@ describe("ChatTimelineHistoryRows", () => {
         expect(mockScrollToIndex).not.toHaveBeenCalled();
 
         root.unmount();
+    });
+
+    it("restores a persisted anchor after its virtualized chat remounts", () => {
+        const anchor = {
+            alignment: "start" as const,
+            blockId: "block-1",
+            entryId: "message:message-1",
+            offsetWithinEntry: 14,
+        };
+        const persisted = persistChatViewState(
+            "project-1",
+            "worktree-1",
+            "session-1",
+            {
+                anchor,
+                isNearBottom: false,
+                scrollTop: 420,
+            },
+        );
+        const storageWrite = vi.spyOn(window.localStorage, "setItem");
+        storageWrite.mockClear();
+        const scrollContainer = document.createElement("div");
+        const firstMountNode = document.createElement("div");
+        document.body.append(scrollContainer, firstMountNode);
+        const firstRoot = createRoot(firstMountNode);
+        const onSemanticAnchorRestored = vi.fn();
+
+        act(() => {
+            firstRoot.render(
+                <ChatTimelineHistoryRows
+                    historyRows={[createLoadedBlockSpacer()]}
+                    hotTailRowId={null}
+                    hotTailRows={[]}
+                    onSemanticAnchorRestored={onSemanticAnchorRestored}
+                    renderRow={({ row }) => <div>{row.id}</div>}
+                    renderStreamingIndicator={() => <div>Streaming</div>}
+                    scrollRef={{ current: scrollContainer }}
+                    semanticAnchorBlockLoaded={false}
+                    semanticRestoreAnchor={anchor}
+                    showStreamingIndicator={false}
+                />,
+            );
+        });
+
+        expect(mockScrollToIndex).not.toHaveBeenCalled();
+        expect(onSemanticAnchorRestored).not.toHaveBeenCalled();
+
+        // The active chat B replaces A; A must restore from storage on remount.
+        firstRoot.unmount();
+        firstMountNode.remove();
+
+        const remountNode = document.createElement("div");
+        document.body.appendChild(remountNode);
+        const remountedRoot = createRoot(remountNode);
+        virtualListMockOptions.renderSecondItem = true;
+        const remountedAnchor = readPersistedChatViewState(
+            "project-1",
+            "worktree-1",
+            "session-1",
+        )?.anchor;
+
+        act(() => {
+            remountedRoot.render(
+                <ChatTimelineHistoryRows
+                    historyRows={createRows(3)}
+                    hotTailRowId={null}
+                    hotTailRows={[]}
+                    onSemanticAnchorRestored={onSemanticAnchorRestored}
+                    renderRow={({ row }) => <div>{row.id}</div>}
+                    renderStreamingIndicator={() => <div>Streaming</div>}
+                    scrollRef={{ current: scrollContainer }}
+                    semanticAnchorBlockLoaded
+                    semanticRestoreAnchor={remountedAnchor}
+                    showStreamingIndicator={false}
+                />,
+            );
+        });
+
+        expect(mockScrollToIndex).toHaveBeenCalledWith(1, {
+            align: "start",
+            offset: 14,
+            reason: "restore",
+        });
+        expect(onSemanticAnchorRestored).toHaveBeenCalledWith(
+            "message:message-1",
+        );
+        expect(storageWrite).not.toHaveBeenCalled();
+        expect(
+            readPersistedChatViewState(
+                "project-1",
+                "worktree-1",
+                "session-1",
+            ),
+        ).toEqual(persisted);
+
+        remountedRoot.unmount();
     });
     beforeEach(() => {
         (

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -183,8 +183,8 @@ export const ChatTimelineHistoryRows = memo(
             useState(0);
         useEffect(() => {
             if (!semanticRestoreAnchor) {
-                // The same entry may be restored after reactivating a retained
-                // tab whose virtual geometry changed while it was hidden.
+                // A remounted timeline may need the same entry after its
+                // virtual geometry was discarded with the inactive view.
                 restoredSemanticAnchorKeyRef.current = null;
             }
         }, [semanticRestoreAnchor]);

--- a/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTimelineHistoryRows.tsx
@@ -69,8 +69,8 @@ interface ChatTimelineHistoryRowsProps {
     readonly onVirtualResizeAutoFollow?: () => void;
     readonly onVirtualResizeStart?: () => void;
     readonly onNewTurnScrollTarget?: (target: number) => void;
-    readonly onSemanticAnchorRestored?: () => void;
-    readonly onSemanticAnchorUnavailable?: () => void;
+    readonly onSemanticAnchorRestored?: (entryId: string) => void;
+    readonly onSemanticAnchorUnavailable?: (entryId: string) => void;
     readonly onVirtualScrollRequest?: (
         request: MeasuredVirtualScrollRequest,
     ) => void;
@@ -328,7 +328,9 @@ export const ChatTimelineHistoryRows = memo(
             if (anchorIndex < 0) {
                 if (semanticAnchorBlockLoaded) {
                     restoredSemanticAnchorKeyRef.current = restoreKey;
-                    onSemanticAnchorUnavailable?.();
+                    onSemanticAnchorUnavailable?.(
+                        semanticRestoreAnchor.entryId,
+                    );
                 }
                 return;
             }
@@ -346,7 +348,7 @@ export const ChatTimelineHistoryRows = memo(
                 reason: "restore",
             });
             restoredSemanticAnchorKeyRef.current = restoreKey;
-            onSemanticAnchorRestored?.();
+            onSemanticAnchorRestored?.(semanticRestoreAnchor.entryId);
         }, [
             active,
             historyRows,

--- a/src/renderer/src/components/workspace/chat/ChatTranscriptSurface.test.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTranscriptSurface.test.tsx
@@ -1,0 +1,63 @@
+/** @vitest-environment jsdom */
+import { act, type RefObject } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ChatTranscriptSurface } from "./ChatTranscriptSurface";
+
+describe("ChatTranscriptSurface", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("forwards pointer and keyboard navigation from the scroll container", () => {
+        const container = document.createElement("div");
+        const root = createRoot(container);
+        const onKeyDown = vi.fn();
+        const onPointerDown = vi.fn();
+        const scrollRef: RefObject<HTMLDivElement | null> = { current: null };
+        const timelineContentRef: RefObject<HTMLDivElement | null> = {
+            current: null,
+        };
+        document.body.appendChild(container);
+
+        act(() => {
+            root.render(
+                <ChatTranscriptSurface
+                    covered={false}
+                    jumpToBottom={null}
+                    onKeyDown={onKeyDown}
+                    onPointerDown={onPointerDown}
+                    onScroll={() => {}}
+                    scopeKey="session-1"
+                    scrollRef={scrollRef}
+                    timelineContentRef={timelineContentRef}
+                >
+                    <div>Timeline</div>
+                </ChatTranscriptSurface>,
+            );
+        });
+
+        const scrollContainer = container.querySelector(".chat-scroll");
+        if (!scrollContainer) {
+            throw new Error("expected the chat scroll container");
+        }
+
+        act(() => {
+            scrollContainer.dispatchEvent(
+                new Event("pointerdown", { bubbles: true }),
+            );
+            scrollContainer.dispatchEvent(
+                new KeyboardEvent("keydown", {
+                    bubbles: true,
+                    key: "PageDown",
+                }),
+            );
+        });
+
+        expect(onPointerDown).toHaveBeenCalledTimes(1);
+        expect(onKeyDown).toHaveBeenCalledTimes(1);
+
+        root.unmount();
+    });
+});

--- a/src/renderer/src/components/workspace/chat/ChatTranscriptSurface.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatTranscriptSurface.tsx
@@ -1,4 +1,12 @@
-import { memo, type ReactNode, type RefObject, type TouchEvent, type WheelEvent } from "react";
+import {
+    memo,
+    type KeyboardEvent,
+    type PointerEvent,
+    type ReactNode,
+    type RefObject,
+    type TouchEvent,
+    type WheelEvent,
+} from "react";
 
 import { ChatContentColumn } from "./ChatContentColumn";
 import { ToolExpansionStoreProvider } from "./toolExpansionStore";
@@ -8,6 +16,8 @@ interface ChatTranscriptSurfaceProps {
     readonly children: ReactNode;
     readonly covered: boolean;
     readonly jumpToBottom: ReactNode;
+    readonly onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
+    readonly onPointerDown?: (event: PointerEvent<HTMLDivElement>) => void;
     readonly onScroll: () => void;
     readonly onTouchStart?: (event: TouchEvent<HTMLDivElement>) => void;
     readonly onWheelCapture?: (event: WheelEvent<HTMLDivElement>) => void;
@@ -22,6 +32,8 @@ export const ChatTranscriptSurface = memo(function ChatTranscriptSurface({
     children,
     covered,
     jumpToBottom,
+    onKeyDown,
+    onPointerDown,
     onScroll,
     onTouchStart,
     onWheelCapture,
@@ -43,6 +55,8 @@ export const ChatTranscriptSurface = memo(function ChatTranscriptSurface({
                 <div
                     ref={scrollRef}
                     className="chat-scroll h-full min-h-0 min-w-0 overflow-y-auto px-3 py-3"
+                    onKeyDown={onKeyDown}
+                    onPointerDown={onPointerDown}
                     onScroll={onScroll}
                     onTouchStart={onTouchStart}
                     onWheelCapture={onWheelCapture}


### PR DESCRIPTION
## Summary
- preserve semantic scroll anchors while inactive chats remount
- keep reader navigation authoritative during pending restoration
- cover virtualized remount behavior

## Validation
- Not run: dependencies are not installed in this worktree.