### PR TITLE
Fix autosave when switching files

### DIFF
--- a/src/renderer/src/components/settings/SettingsWindow.test.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.test.tsx
@@ -142,6 +142,32 @@ describe("SettingsWindow terminal settings", () => {
         expect(markup).toContain("Terminal");
     });
 
+    it("warns when the autosave delay can overlap with agent edits", () => {
+        const highDelayMarkup = renderToStaticMarkup(
+            <SettingsWindow
+                {...createSettingsWindowProps({
+                    initialCategory: "editor",
+                    appEditor: {
+                        ...createSettingsWindowProps().appEditor,
+                        autoSaveDelayMs: 2000,
+                    },
+                })}
+            />,
+        );
+        const defaultMarkup = renderToStaticMarkup(
+            <SettingsWindow
+                {...createSettingsWindowProps({ initialCategory: "editor" })}
+            />,
+        );
+
+        expect(highDelayMarkup).toContain(
+            "Long autosave delays can leave edits pending while agents modify files",
+        );
+        expect(defaultMarkup).not.toContain(
+            "Long autosave delays can leave edits pending while agents modify files",
+        );
+    });
+
     it("renders the default tool activity expansion preference in AI settings", () => {
         const props = createSettingsWindowProps({ initialCategory: "ai" });
         const markup = renderToStaticMarkup(

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -95,6 +95,9 @@ const CATEGORIES: { id: Category; label: string }[] = [
     { id: "updates", label: "Updates" },
 ];
 
+// Long delays make it more likely that agent changes reach disk before local edits do.
+const HIGH_AUTOSAVE_DELAY_MS_WARNING_THRESHOLD = 2_000;
+
 const CATEGORY_DESCRIPTIONS: Record<Category, string> = {
     appearance: "Theme mode and visual presets",
     editor: "Typography and editor behavior",
@@ -2017,6 +2020,19 @@ function EditorContent({
                     />
                 }
             />
+            {state.autoSaveDelayMs >=
+            HIGH_AUTOSAVE_DELAY_MS_WARNING_THRESHOLD ? (
+                <div className="mx-3 mb-3 flex gap-2 rounded-md border border-[color-mix(in_srgb,var(--diff-warn)_30%,var(--color-border))] bg-[color-mix(in_srgb,var(--diff-warn)_10%,transparent)] px-3 py-2 text-[11px] leading-4 text-text-secondary">
+                    <span aria-hidden="true" className="text-[var(--diff-warn)]">
+                        ⚠
+                    </span>
+                    <span>
+                        Long autosave delays can leave edits pending while agents
+                        modify files, increasing the chance of save conflicts.
+                        Consider 1000 ms or less.
+                    </span>
+                </div>
+            ) : null}
             <SearchableRow
                 searchQuery={searchQuery}
                 section="Typography"

--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -1018,11 +1018,13 @@ function renderHost({
     activeFileTab,
     fileTabs,
     onDraftChange = vi.fn(),
+    onSave = vi.fn(() => Promise.resolve()),
     recentActiveTabIds = [],
 }: {
     readonly activeFileTab: RuntimeWorkspaceFileTab | null;
     readonly fileTabs: readonly RuntimeWorkspaceFileTab[];
     readonly onDraftChange?: (tabId: string, draft: string) => void;
+    readonly onSave?: (tabId: string) => Promise<void>;
     readonly recentActiveTabIds?: readonly string[];
 }): ReactNode {
     return (
@@ -1033,7 +1035,7 @@ function renderHost({
             onAttachLineFragment={vi.fn()}
             onDraftChange={onDraftChange}
             onReload={vi.fn(() => Promise.resolve())}
-            onSave={vi.fn(() => Promise.resolve())}
+            onSave={onSave}
             recentActiveTabIds={recentActiveTabIds}
         />
     );
@@ -1226,6 +1228,43 @@ describe("WorkspaceFileEditorHost", () => {
         expect(monacoHarness.codeEditors).toHaveLength(1);
         expect(monacoHarness.codeEditors[0]?.disposed).toBe(false);
         expect(container.querySelector("[aria-hidden='true']")).not.toBeNull();
+    });
+
+    it("saves a dirty file immediately when another file replaces it before its debounce fires", async () => {
+        const onSave = vi.fn(() => Promise.resolve());
+        const firstTab = {
+            ...createFileTab("file-1"),
+            draftContent: "const value = 2;\n",
+            isDirty: true,
+        } satisfies RuntimeWorkspaceFileTab;
+        const secondTab = createFileTab("file-2", "src/other.ts");
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: firstTab,
+                    fileTabs: [firstTab, secondTab],
+                    onSave,
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(onSave).not.toHaveBeenCalled();
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: secondTab,
+                    fileTabs: [secondTab],
+                    onSave,
+                }),
+            );
+        });
+        await flushEffects();
+
+        expect(onSave).toHaveBeenCalledOnce();
+        expect(onSave).toHaveBeenCalledWith("file-1");
     });
 
     it("restores a saved Monaco view state only once per tab activation", async () => {

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -3139,6 +3139,22 @@ export function WorkspaceFileEditorHost({
         return fileTabs[0] ?? null;
     }, [activeFileTab, fileTabs, recentActiveTabIds]);
     const isVisible = activeFileTab !== null;
+    const hostedTabId = hostedTab?.id ?? null;
+    const previousHostedTabIdRef = useRef(hostedTabId);
+
+    useEffect(() => {
+        const previousHostedTabId = previousHostedTabIdRef.current;
+        previousHostedTabIdRef.current = hostedTabId;
+
+        if (
+            previousHostedTabId !== null &&
+            previousHostedTabId !== hostedTabId
+        ) {
+            // The file view's debounce is disposed on a tab switch, so flush
+            // the outgoing tab before it can be left dirty without a timer.
+            void onSave(previousHostedTabId);
+        }
+    }, [hostedTabId, onSave]);
 
     useRenderProbe("WorkspaceFileEditorHost", {
         hostedTabId: hostedTab?.id ?? null,


### PR DESCRIPTION
## Summary
- save a pending dirty file when it is replaced in the file editor host
- add a contextual warning for autosave delays of 2000 ms or more
- cover the tab-switch regression

## Verification
- pnpm exec vitest run src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
- pnpm run typecheck
- pnpm run lint:renderer