### PR TITLE
Show hours in chat elapsed time

### DIFF
--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -88,6 +88,7 @@ import { ChatContentColumn } from "./chat/ChatContentColumn";
 import { ChatComposerShell } from "./chat/ChatComposerShell";
 import { ChatTimelineHistoryRows } from "./chat/ChatTimelineHistoryRows";
 import { ChatMessageRow } from "./chat/ChatMessageRow";
+import { formatChatElapsedDuration } from "./chat/chatElapsedDuration";
 import { CHAT_PILL_VARIANTS } from "./chat/chatPillPalette";
 import {
     reconcileChatTimelineModelFromProjection,
@@ -4615,13 +4616,7 @@ function StreamingIndicator({
                     (Date.now() - fallbackStartedAtRef.current) / 1000,
                 ),
             );
-            const min = Math.floor(totalSec / 60);
-            const sec = totalSec % 60;
-            setElapsed(
-                min > 0
-                    ? `${min}m ${String(sec).padStart(2, "0")}s`
-                    : `${sec}s`,
-            );
+            setElapsed(formatChatElapsedDuration(totalSec));
         };
 
         queueMicrotask(updateElapsed);

--- a/src/renderer/src/components/workspace/chat/chatElapsedDuration.test.ts
+++ b/src/renderer/src/components/workspace/chat/chatElapsedDuration.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { formatChatElapsedDuration } from "./chatElapsedDuration";
+
+describe("formatChatElapsedDuration", () => {
+    it.each([
+        [0, "0s"],
+        [59, "59s"],
+        [60, "1m 00s"],
+        [61, "1m 01s"],
+        [3599, "59m 59s"],
+        [3600, "1h 00m 00s"],
+        [3728, "1h 02m 08s"],
+        [36_000, "10h 00m 00s"],
+    ])("formats %i seconds as %s", (totalSeconds, expected) => {
+        expect(formatChatElapsedDuration(totalSeconds)).toBe(expected);
+    });
+
+    it("normalizes invalid or negative durations", () => {
+        expect(formatChatElapsedDuration(-1)).toBe("0s");
+        expect(formatChatElapsedDuration(Number.NaN)).toBe("0s");
+    });
+});

--- a/src/renderer/src/components/workspace/chat/chatElapsedDuration.ts
+++ b/src/renderer/src/components/workspace/chat/chatElapsedDuration.ts
@@ -1,0 +1,20 @@
+export function formatChatElapsedDuration(totalSeconds: number): string {
+    // Normalize timer input so clock skew or invalid values never leak into the UI.
+    const normalizedSeconds = Number.isFinite(totalSeconds)
+        ? Math.max(0, Math.floor(totalSeconds))
+        : 0;
+    const hours = Math.floor(normalizedSeconds / 3600);
+    const minutes = Math.floor((normalizedSeconds % 3600) / 60);
+    const seconds = normalizedSeconds % 60;
+    const paddedSeconds = String(seconds).padStart(2, "0");
+
+    if (hours > 0) {
+        return `${hours}h ${String(minutes).padStart(2, "0")}m ${paddedSeconds}s`;
+    }
+
+    if (minutes > 0) {
+        return `${minutes}m ${paddedSeconds}s`;
+    }
+
+    return `${seconds}s`;
+}


### PR DESCRIPTION
## Summary
- format active chat elapsed time with hours after 60 minutes
- keep the existing seconds and minutes presentation below one hour
- add boundary coverage for seconds, minutes, and multi-hour durations

## Verification
- pnpm exec vitest run src/renderer/src/components/workspace/chat/chatElapsedDuration.test.ts
- pnpm run typecheck
- pnpm exec eslint src/renderer/src/components/workspace/ChatTabView.tsx src/renderer/src/components/workspace/chat/chatElapsedDuration.ts src/renderer/src/components/workspace/chat/chatElapsedDuration.test.ts

Lint completes with one pre-existing warning in ChatTabView.tsx.