### PR TITLE
Keep pinned tabs from shrinking

### DIFF
--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -2831,7 +2831,7 @@ function WorkspacePaneView({
                                         className={[
                                             "group app-no-drag relative flex h-7.75 items-center gap-1.5 border-r border-border-subtle text-[12px] transition",
                                             isPinned
-                                                ? "w-8 justify-center px-0"
+                                                ? "w-8 shrink-0 justify-center px-0"
                                                 : "px-3",
                                             tabDrag.draggedTab?.tabId ===
                                                 tab.id && tabDrag.isDragging


### PR DESCRIPTION
## Summary

- keep compact pinned tabs at their fixed width when the tab strip overflows

## Testing

- `pnpm exec vitest run src/renderer/src/components/workspace/workspaceTabStrip.test.ts`
- `pnpm exec eslint src/renderer/src/components/workspace/WorkspaceView.tsx`
- `pnpm run typecheck`