### PR TITLE
fix(deps): update brace-expansion to 5.0.7

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   undici@7.27.2: 7.28.0
   '@xmldom/xmldom': 0.8.13
   postcss: 8.5.15
-  brace-expansion@5.0.5: 5.0.6
+  brace-expansion@5.0.5: 5.0.7
   ip-address@10.1.0: 10.2.0
 
 importers:
@@ -1443,8 +1443,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -4859,7 +4859,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6434,7 +6434,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,5 +18,5 @@ overrides:
   "undici@7.27.2": 7.28.0
   "@xmldom/xmldom": 0.8.13
   postcss: 8.5.15
-  "brace-expansion@5.0.5": 5.0.6
+  "brace-expansion@5.0.5": 5.0.7
   "ip-address@10.1.0": 10.2.0


### PR DESCRIPTION
## Summary
- update the pnpm override for `brace-expansion` from 5.0.6 to 5.0.7
- regenerate the lockfile to resolve Dependabot alert #28 (GHSA-3jxr-9vmj-r5cp)

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`