### PR TITLE
Fix cleanup for deleted projects and worktrees

### DIFF
--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -4373,11 +4373,11 @@ fn clear_current_persisted_project_data(
 
     if worktree_id.is_none() {
         let mut project_settings = load_app_data_value(store, PROJECT_SETTINGS_KEY)?;
-        if let Some(settings) = project_settings.as_object_mut() {
-            if settings.remove(&project_id.0).is_some() {
-                cleanup.project_settings_count = 1;
-                save_app_data_value(store, PROJECT_SETTINGS_KEY, &project_settings)?;
-            }
+        if let Some(settings) = project_settings.as_object_mut()
+            && settings.remove(&project_id.0).is_some()
+        {
+            cleanup.project_settings_count = 1;
+            save_app_data_value(store, PROJECT_SETTINGS_KEY, &project_settings)?;
         }
     }
 
@@ -4517,32 +4517,30 @@ fn clear_persisted_workspace_contexts(
             }
         }
 
-        if removed_contexts > 0
-            || persistence_snapshot_matches_scope(record_object, project_id, worktree_id)
-        {
-            if let Some(snapshot) = record_object
+        if (removed_contexts > 0
+            || persistence_snapshot_matches_scope(record_object, project_id, worktree_id))
+            && let Some(snapshot) = record_object
                 .get_mut("snapshot")
                 .and_then(Value::as_object_mut)
+        {
+            let (next_project_id, next_worktree_id) = next_active_scope
+                .map(|(project_id, worktree_id)| {
+                    (
+                        Value::String(project_id),
+                        worktree_id.map_or(Value::Null, Value::String),
+                    )
+                })
+                .unwrap_or((Value::Null, Value::Null));
+            snapshot.insert("activeProjectId".to_string(), next_project_id.clone());
+            snapshot.insert("activeWorktreeId".to_string(), next_worktree_id.clone());
+            if let Some(window_context) = snapshot
+                .get_mut("windowContext")
+                .and_then(Value::as_object_mut)
             {
-                let (next_project_id, next_worktree_id) = next_active_scope
-                    .map(|(project_id, worktree_id)| {
-                        (
-                            Value::String(project_id),
-                            worktree_id.map_or(Value::Null, Value::String),
-                        )
-                    })
-                    .unwrap_or((Value::Null, Value::Null));
-                snapshot.insert("activeProjectId".to_string(), next_project_id.clone());
-                snapshot.insert("activeWorktreeId".to_string(), next_worktree_id.clone());
-                if let Some(window_context) = snapshot
-                    .get_mut("windowContext")
-                    .and_then(Value::as_object_mut)
-                {
-                    window_context.insert("projectId".to_string(), next_project_id);
-                    window_context.insert("worktreeId".to_string(), next_worktree_id);
-                }
-                changed = true;
+                window_context.insert("projectId".to_string(), next_project_id);
+                window_context.insert("worktreeId".to_string(), next_worktree_id);
             }
+            changed = true;
         }
     }
 

--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -46,7 +46,7 @@ use comando_types::commands::{
 };
 use comando_types::error::{NativeError, NativeErrorCode};
 use comando_types::events::BACKEND_TEST_EVENT;
-use comando_types::ids::{RequestId, RuntimeId, SessionId, WindowId};
+use comando_types::ids::{ProjectId, RequestId, RuntimeId, SessionId, WindowId, WorktreeId};
 use comando_types::persistence::{
     NativePersistenceMode, NativePersistenceOpenStoreInput, NativePersistenceSnapshot,
 };
@@ -56,7 +56,7 @@ use comando_types::{
     projects as native_projects, terminal as native_terminal,
 };
 use rusqlite::{OptionalExtension, params};
-use serde::{Serialize, de::DeserializeOwned};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 
 use crate::protocol::{RpcOutput, RpcRequest, error_response, event, response_ok};
@@ -68,6 +68,24 @@ use crate::review::{
 
 const SETTINGS_SNAPSHOT_KEY: &str = "settings.snapshot";
 const PROJECT_SETTINGS_KEY: &str = "settings.projects";
+const PERSISTENCE_KEY: &str = "persistence.windows";
+const PENDING_WORKTREE_DATA_CLEANUP_KEY: &str = "persistence.pending_worktree_data_cleanup";
+
+#[derive(Debug, Default)]
+struct CurrentProjectDataCleanup {
+    chat_session_count: u64,
+    project_settings_count: u64,
+    workspace_layout_count: u64,
+    workspace_session_count: u64,
+    workspace_tab_count: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+struct PendingWorktreeDataCleanup {
+    project_id: ProjectId,
+    worktree_id: WorktreeId,
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CommandResult {
@@ -1180,7 +1198,7 @@ impl NativeBackend {
     }
 
     fn remove_project(&mut self, request: RpcRequest) -> CommandResult {
-        let Some(store) = self.persistence_store.as_mut() else {
+        let Some(store) = self.persistence_store.as_ref() else {
             return backend_not_ready(request.id);
         };
         if !matches!(store.mode(), NativePersistenceMode::Write) {
@@ -1197,8 +1215,21 @@ impl NativeBackend {
             Err(error) => return error_only(request.id, error),
         };
 
-        let mut registry = ProjectRegistry::new(store.connection_mut());
-        match registry.remove_project(&input.project_id) {
+        if let Err(error) = self.clear_current_project_data(&input.project_id, None) {
+            return error_only(request.id, error);
+        }
+        let result = {
+            let store = self
+                .persistence_store
+                .as_mut()
+                .expect("persistence store was checked above");
+            let mut registry = ProjectRegistry::new(store.connection_mut());
+            registry
+                .clear_project_app_data(&input.project_id)
+                .and_then(|_| registry.remove_project(&input.project_id))
+        };
+
+        match result {
             Ok(state) => {
                 self.fs_service.sync_state(state.clone());
                 CommandResult {
@@ -1306,26 +1337,70 @@ impl NativeBackend {
     }
 
     fn get_project_app_data_summary(&mut self, request: RpcRequest) -> CommandResult {
-        let Some(store) = self.persistence_store.as_mut() else {
+        if self.persistence_store.is_none() {
             return backend_not_ready(request.id);
-        };
+        }
         let input = match parse_args::<native_projects::NativeProjectIdInput>(&request) {
             Ok(input) => input,
             Err(error) => return error_only(request.id, error),
         };
 
-        let mut registry = ProjectRegistry::new(store.connection_mut());
-        match registry.get_project_app_data_summary(&input.project_id) {
-            Ok(summary) => response_only(
-                request.id,
-                serde_json::to_value(summary).expect("project app data summary serializes"),
-            ),
+        let summary = {
+            let store = self
+                .persistence_store
+                .as_mut()
+                .expect("persistence store was checked above");
+            let mut registry = ProjectRegistry::new(store.connection_mut());
+            registry.get_project_app_data_summary(&input.project_id)
+        };
+        match summary {
+            Ok(mut summary) => {
+                let history_count = self.ai_history_store().and_then(|history| {
+                    history
+                        .count_sessions_by_scope(&input.project_id, None)
+                        .map_err(|error| error.to_native_error())
+                });
+                let current = self
+                    .persistence_store
+                    .as_ref()
+                    .ok_or_else(|| {
+                        NativeError::new(
+                            NativeErrorCode::BackendNotReady,
+                            "Native persistence store has not been opened.",
+                        )
+                    })
+                    .and_then(|store| {
+                        inspect_current_persisted_project_data(store, &input.project_id, None)
+                    });
+                let (history_count, current) = match (history_count, current) {
+                    (Ok(history_count), Ok(current)) => (history_count, current),
+                    (Err(error), _) | (_, Err(error)) => return error_only(request.id, error),
+                };
+                summary.chat_session_count =
+                    summary.chat_session_count.saturating_add(history_count);
+                summary.project_settings_count = summary
+                    .project_settings_count
+                    .saturating_add(current.project_settings_count);
+                summary.workspace_layout_count = summary
+                    .workspace_layout_count
+                    .saturating_add(current.workspace_layout_count);
+                summary.workspace_session_count = summary
+                    .workspace_session_count
+                    .saturating_add(current.workspace_session_count);
+                summary.workspace_tab_count = summary
+                    .workspace_tab_count
+                    .saturating_add(current.workspace_tab_count);
+                response_only(
+                    request.id,
+                    serde_json::to_value(summary).expect("project app data summary serializes"),
+                )
+            }
             Err(error) => error_only(request.id, project_error(error)),
         }
     }
 
     fn clear_project_app_data(&mut self, request: RpcRequest) -> CommandResult {
-        let Some(store) = self.persistence_store.as_mut() else {
+        let Some(store) = self.persistence_store.as_ref() else {
             return backend_not_ready(request.id);
         };
         if !matches!(store.mode(), NativePersistenceMode::Write) {
@@ -1342,36 +1417,67 @@ impl NativeBackend {
             Err(error) => return error_only(request.id, error),
         };
 
-        let mut registry = ProjectRegistry::new(store.connection_mut());
-        match registry.clear_project_app_data(&input.project_id) {
-            Ok(result) => {
-                self.fs_service.sync_state(result.state.clone());
-                CommandResult {
-                    outputs: vec![
-                        response_ok(
-                            request.id,
-                            serde_json::to_value(&result)
-                                .expect("project clear app data output serializes"),
-                        ),
-                        event(
-                            "project://updated",
-                            json!({
-                                "projectId": input.project_id.0.as_str(),
-                                "worktreeId": Value::Null,
-                                "reason": "project_clear_app_data",
-                                "occurredAt": comando_persistence::store::now_rfc3339(),
-                            }),
-                        ),
-                    ],
-                    should_shutdown: false,
+        let result = {
+            let store = self
+                .persistence_store
+                .as_mut()
+                .expect("persistence store was checked above");
+            let mut registry = ProjectRegistry::new(store.connection_mut());
+            registry.clear_project_app_data(&input.project_id)
+        };
+
+        match result {
+            Ok(mut result) => match self.clear_current_project_data(&input.project_id, None) {
+                Ok(current) => {
+                    result.cleared.chat_session_count = result
+                        .cleared
+                        .chat_session_count
+                        .saturating_add(current.chat_session_count);
+                    result.cleared.project_settings_count = result
+                        .cleared
+                        .project_settings_count
+                        .saturating_add(current.project_settings_count);
+                    result.cleared.workspace_layout_count = result
+                        .cleared
+                        .workspace_layout_count
+                        .saturating_add(current.workspace_layout_count);
+                    result.cleared.workspace_session_count = result
+                        .cleared
+                        .workspace_session_count
+                        .saturating_add(current.workspace_session_count);
+                    result.cleared.workspace_tab_count = result
+                        .cleared
+                        .workspace_tab_count
+                        .saturating_add(current.workspace_tab_count);
+                    self.fs_service.sync_state(result.state.clone());
+                    CommandResult {
+                        outputs: vec![
+                            response_ok(
+                                request.id,
+                                serde_json::to_value(&result)
+                                    .expect("project clear app data output serializes"),
+                            ),
+                            event(
+                                "project://updated",
+                                json!({
+                                    "projectId": input.project_id.0.as_str(),
+                                    "worktreeId": Value::Null,
+                                    "reason": "project_clear_app_data",
+                                    "occurredAt": comando_persistence::store::now_rfc3339(),
+                                }),
+                            ),
+                        ],
+                        should_shutdown: false,
+                    }
                 }
-            }
+                Err(error) => error_only(request.id, error),
+            },
             Err(error) => error_only(request.id, project_error(error)),
         }
     }
 
     fn sync_project_worktrees(&mut self, request: RpcRequest) -> CommandResult {
-        let Some(store) = self.persistence_store.as_mut() else {
+        let Some(store) = self.persistence_store.as_ref() else {
             return backend_not_ready(request.id);
         };
         if !matches!(store.mode(), NativePersistenceMode::Write) {
@@ -1398,22 +1504,158 @@ impl NativeBackend {
             }
         };
 
-        let mut registry = ProjectRegistry::new(store.connection_mut());
-        match registry.sync_project_worktrees(&input.project_id, &input.worktrees) {
-            Ok(worktrees) => {
-                if let Ok(state) = registry.list_projects() {
-                    self.fs_service.sync_state(NativeProjectState {
-                        projects: state.projects,
-                        worktrees: state.worktrees,
-                    });
+        let pending_cleanup = match self.load_pending_worktree_data_cleanup() {
+            Ok(cleanup) => cleanup,
+            Err(error) => return error_only(request.id, error),
+        };
+        let sync_result = {
+            let store = self
+                .persistence_store
+                .as_mut()
+                .expect("persistence store was checked above");
+            let mut registry = ProjectRegistry::new(store.connection_mut());
+            let existing = registry.list_projects().map(|state| state.worktrees);
+            let worktrees = registry.sync_project_worktrees(&input.project_id, &input.worktrees);
+            let state = registry.list_projects();
+            (existing, worktrees, state)
+        };
+
+        let (existing, worktrees, state) = sync_result;
+        match (existing, worktrees, state) {
+            (Ok(existing), Ok(worktrees), Ok(state)) => {
+                let retained_ids = worktrees
+                    .iter()
+                    .map(|worktree| worktree.id.0.as_str())
+                    .collect::<std::collections::HashSet<_>>();
+                let removed_worktree_ids = existing
+                    .into_iter()
+                    .filter(|worktree| {
+                        worktree.project_id == input.project_id
+                            && !worktree.is_primary
+                            && !retained_ids.contains(worktree.id.0.as_str())
+                    })
+                    .map(|worktree| worktree.id)
+                    .collect::<Vec<_>>();
+                self.fs_service.sync_state(NativeProjectState {
+                    projects: state.projects,
+                    worktrees: state.worktrees,
+                });
+                let mut cleanup = pending_cleanup;
+                cleanup.extend(removed_worktree_ids.into_iter().map(|worktree_id| {
+                    PendingWorktreeDataCleanup {
+                        project_id: input.project_id.clone(),
+                        worktree_id,
+                    }
+                }));
+                if let Err(error) = self.retry_pending_worktree_data_cleanup(cleanup) {
+                    return error_only(request.id, error);
                 }
                 response_only(
                     request.id,
                     serde_json::to_value(worktrees).expect("project worktrees serialize"),
                 )
             }
-            Err(error) => error_only(request.id, project_error(error)),
+            (Err(error), _, _) | (_, Err(error), _) | (_, _, Err(error)) => {
+                error_only(request.id, project_error(error))
+            }
         }
+    }
+
+    fn clear_current_project_data(
+        &mut self,
+        project_id: &ProjectId,
+        worktree_id: Option<&WorktreeId>,
+    ) -> Result<CurrentProjectDataCleanup, NativeError> {
+        let history = self.ai_history_store()?;
+        let session_ids = history
+            .session_ids_by_scope(project_id, worktree_id)
+            .map_err(|error| error.to_native_error())?;
+        for session_id in &session_ids {
+            // Closing live runtimes first prevents them from writing a deleted session back to disk.
+            let _ = self
+                .ai_engine
+                .close_session(native_ai::NativeAiSessionIdInput {
+                    session_id: session_id.clone(),
+                    target_session_id: None,
+                    runtime_session_id: None,
+                });
+        }
+        let chat_session_count = history
+            .delete_sessions_by_scope(project_id, worktree_id)
+            .map_err(|error| error.to_native_error())?;
+
+        let store = self.persistence_store.as_mut().ok_or_else(|| {
+            NativeError::new(
+                NativeErrorCode::BackendNotReady,
+                "Native persistence store has not been opened.",
+            )
+        })?;
+        let mut cleanup = clear_current_persisted_project_data(store, project_id, worktree_id)?;
+        cleanup.chat_session_count = chat_session_count;
+        Ok(cleanup)
+    }
+
+    fn load_pending_worktree_data_cleanup(
+        &self,
+    ) -> Result<Vec<PendingWorktreeDataCleanup>, NativeError> {
+        let store = self.persistence_store.as_ref().ok_or_else(|| {
+            NativeError::new(
+                NativeErrorCode::BackendNotReady,
+                "Native persistence store has not been opened.",
+            )
+        })?;
+        let value = load_app_data_value(store, PENDING_WORKTREE_DATA_CLEANUP_KEY)?;
+        if value.is_null() {
+            return Ok(Vec::new());
+        }
+        serde_json::from_value(value).map_err(|error| {
+            NativeError::new(
+                NativeErrorCode::InvalidJson,
+                format!("Pending worktree cleanup data could not be parsed: {error}"),
+            )
+        })
+    }
+
+    fn retry_pending_worktree_data_cleanup(
+        &mut self,
+        mut cleanup: Vec<PendingWorktreeDataCleanup>,
+    ) -> Result<(), NativeError> {
+        cleanup.sort_by(|left, right| {
+            (&left.project_id.0, &left.worktree_id.0)
+                .cmp(&(&right.project_id.0, &right.worktree_id.0))
+        });
+        cleanup.dedup();
+        self.save_pending_worktree_data_cleanup(&cleanup)?;
+
+        let mut remaining = Vec::new();
+        for entry in cleanup {
+            if self
+                .clear_current_project_data(&entry.project_id, Some(&entry.worktree_id))
+                .is_err()
+            {
+                // Persist failed work so a later watcher refresh can finish it safely.
+                remaining.push(entry);
+            }
+        }
+        self.save_pending_worktree_data_cleanup(&remaining)
+    }
+
+    fn save_pending_worktree_data_cleanup(
+        &mut self,
+        cleanup: &[PendingWorktreeDataCleanup],
+    ) -> Result<(), NativeError> {
+        let store = self.persistence_store.as_mut().ok_or_else(|| {
+            NativeError::new(
+                NativeErrorCode::BackendNotReady,
+                "Native persistence store has not been opened.",
+            )
+        })?;
+        let value = if cleanup.is_empty() {
+            Value::Null
+        } else {
+            serde_json::to_value(cleanup).expect("pending worktree cleanup serializes")
+        };
+        save_app_data_value(store, PENDING_WORKTREE_DATA_CLEANUP_KEY, &value)
     }
 
     fn refresh_projects(&mut self, request: RpcRequest) -> CommandResult {
@@ -4122,6 +4364,216 @@ fn backend_not_ready(id: RequestId) -> CommandResult {
     )
 }
 
+fn clear_current_persisted_project_data(
+    store: &mut SqlitePersistenceStore,
+    project_id: &ProjectId,
+    worktree_id: Option<&WorktreeId>,
+) -> Result<CurrentProjectDataCleanup, NativeError> {
+    let mut cleanup = CurrentProjectDataCleanup::default();
+
+    if worktree_id.is_none() {
+        let mut project_settings = load_app_data_value(store, PROJECT_SETTINGS_KEY)?;
+        if let Some(settings) = project_settings.as_object_mut() {
+            if settings.remove(&project_id.0).is_some() {
+                cleanup.project_settings_count = 1;
+                save_app_data_value(store, PROJECT_SETTINGS_KEY, &project_settings)?;
+            }
+        }
+    }
+
+    let mut persistence = load_app_data_value(store, PERSISTENCE_KEY)?;
+    if clear_persisted_workspace_contexts(&mut persistence, project_id, worktree_id, &mut cleanup) {
+        save_app_data_value(store, PERSISTENCE_KEY, &persistence)?;
+    }
+
+    Ok(cleanup)
+}
+
+fn inspect_current_persisted_project_data(
+    store: &SqlitePersistenceStore,
+    project_id: &ProjectId,
+    worktree_id: Option<&WorktreeId>,
+) -> Result<CurrentProjectDataCleanup, NativeError> {
+    let mut cleanup = CurrentProjectDataCleanup::default();
+
+    if worktree_id.is_none()
+        && load_app_data_value(store, PROJECT_SETTINGS_KEY)?
+            .as_object()
+            .is_some_and(|settings| settings.contains_key(&project_id.0))
+    {
+        cleanup.project_settings_count = 1;
+    }
+
+    let mut persistence = load_app_data_value(store, PERSISTENCE_KEY)?;
+    clear_persisted_workspace_contexts(&mut persistence, project_id, worktree_id, &mut cleanup);
+    Ok(cleanup)
+}
+
+fn clear_persisted_workspace_contexts(
+    persistence: &mut Value,
+    project_id: &ProjectId,
+    worktree_id: Option<&WorktreeId>,
+    cleanup: &mut CurrentProjectDataCleanup,
+) -> bool {
+    let Some(records) = persistence.as_array_mut() else {
+        return false;
+    };
+    let mut changed = false;
+
+    for record in records {
+        let Some(record_object) = record.as_object_mut() else {
+            continue;
+        };
+        let mut removed_contexts = 0_u64;
+        let mut next_active_scope: Option<(String, Option<String>)> = None;
+        if let Some(navigation) = record_object
+            .get_mut("workspaceRestore")
+            .and_then(Value::as_object_mut)
+            .and_then(|restore| restore.get_mut("snapshot"))
+            .and_then(Value::as_object_mut)
+        {
+            let retained_context_keys = navigation
+                .get_mut("contexts")
+                .and_then(Value::as_array_mut)
+                .and_then(|contexts| {
+                    let before = contexts.len();
+                    for context in contexts.iter().filter(|context| {
+                        workspace_context_matches_scope(context, project_id, worktree_id)
+                    }) {
+                        removed_contexts = removed_contexts.saturating_add(1);
+                        cleanup.workspace_tab_count = cleanup.workspace_tab_count.saturating_add(
+                            context
+                                .pointer("/workspace/tabs")
+                                .and_then(Value::as_array)
+                                .map_or(0, |tabs| u64::try_from(tabs.len()).unwrap_or(0)),
+                        );
+                    }
+                    contexts.retain(|context| {
+                        !workspace_context_matches_scope(context, project_id, worktree_id)
+                    });
+                    (contexts.len() != before).then(|| {
+                        contexts
+                            .iter()
+                            .filter_map(|context| {
+                                context
+                                    .get("key")
+                                    .and_then(Value::as_str)
+                                    .map(str::to_string)
+                            })
+                            .collect::<std::collections::HashSet<_>>()
+                    })
+                });
+            if let Some(context_keys) = retained_context_keys {
+                changed = true;
+                cleanup.workspace_layout_count = cleanup.workspace_layout_count.saturating_add(1);
+                cleanup.workspace_session_count = cleanup.workspace_session_count.saturating_add(1);
+                if let Some(open_context_keys) = navigation
+                    .get_mut("openContextKeys")
+                    .and_then(Value::as_array_mut)
+                {
+                    open_context_keys
+                        .retain(|key| key.as_str().is_some_and(|key| context_keys.contains(key)));
+                }
+                let active_context_key = navigation
+                    .get("activeContextKey")
+                    .and_then(Value::as_str)
+                    .filter(|key| context_keys.contains(*key));
+                if active_context_key.is_none() {
+                    let next_active = navigation
+                        .get("openContextKeys")
+                        .and_then(Value::as_array)
+                        .and_then(|keys| keys.first())
+                        .cloned()
+                        .unwrap_or(Value::Null);
+                    navigation.insert("activeContextKey".to_string(), next_active);
+                }
+                next_active_scope = navigation
+                    .get("activeContextKey")
+                    .and_then(Value::as_str)
+                    .and_then(|active_key| {
+                        navigation
+                            .get("contexts")
+                            .and_then(Value::as_array)
+                            .and_then(|contexts| {
+                                contexts.iter().find(|context| {
+                                    context.get("key").and_then(Value::as_str) == Some(active_key)
+                                })
+                            })
+                    })
+                    .and_then(|context| {
+                        context
+                            .get("projectId")
+                            .and_then(Value::as_str)
+                            .map(|project_id| {
+                                (
+                                    project_id.to_string(),
+                                    context
+                                        .get("worktreeId")
+                                        .and_then(Value::as_str)
+                                        .map(str::to_string),
+                                )
+                            })
+                    });
+            }
+        }
+
+        if removed_contexts > 0
+            || persistence_snapshot_matches_scope(record_object, project_id, worktree_id)
+        {
+            if let Some(snapshot) = record_object
+                .get_mut("snapshot")
+                .and_then(Value::as_object_mut)
+            {
+                let (next_project_id, next_worktree_id) = next_active_scope
+                    .map(|(project_id, worktree_id)| {
+                        (
+                            Value::String(project_id),
+                            worktree_id.map_or(Value::Null, Value::String),
+                        )
+                    })
+                    .unwrap_or((Value::Null, Value::Null));
+                snapshot.insert("activeProjectId".to_string(), next_project_id.clone());
+                snapshot.insert("activeWorktreeId".to_string(), next_worktree_id.clone());
+                if let Some(window_context) = snapshot
+                    .get_mut("windowContext")
+                    .and_then(Value::as_object_mut)
+                {
+                    window_context.insert("projectId".to_string(), next_project_id);
+                    window_context.insert("worktreeId".to_string(), next_worktree_id);
+                }
+                changed = true;
+            }
+        }
+    }
+
+    changed
+}
+
+fn workspace_context_matches_scope(
+    context: &Value,
+    project_id: &ProjectId,
+    worktree_id: Option<&WorktreeId>,
+) -> bool {
+    context.get("projectId").and_then(Value::as_str) == Some(project_id.0.as_str())
+        && worktree_id.is_none_or(|worktree_id| {
+            context.get("worktreeId").and_then(Value::as_str) == Some(worktree_id.0.as_str())
+        })
+}
+
+fn persistence_snapshot_matches_scope(
+    record: &serde_json::Map<String, Value>,
+    project_id: &ProjectId,
+    worktree_id: Option<&WorktreeId>,
+) -> bool {
+    let Some(snapshot) = record.get("snapshot").and_then(Value::as_object) else {
+        return false;
+    };
+    snapshot.get("activeProjectId").and_then(Value::as_str) == Some(project_id.0.as_str())
+        && worktree_id.is_none_or(|worktree_id| {
+            snapshot.get("activeWorktreeId").and_then(Value::as_str) == Some(worktree_id.0.as_str())
+        })
+}
+
 fn load_app_data_value(store: &SqlitePersistenceStore, key: &str) -> Result<Value, NativeError> {
     let storage_key = app_data_storage_key(key)?;
     let raw_value = store
@@ -5934,6 +6386,170 @@ mod tests {
         assert!(rebuild_result.outputs.iter().any(|output| {
             matches!(output, RpcOutput::Event(event) if event.event_name == "index://stale")
         }));
+    }
+
+    #[test]
+    fn clearing_project_data_removes_current_settings_and_workspace_contexts() {
+        let (_temp_dir, mut backend, project_id) = backend_with_registered_project();
+        let other_project_id = "project-other";
+        let persistence = json!([
+            {
+                "snapshot": {
+                    "activeProjectId": project_id.as_str(),
+                    "activeWorktreeId": format!("{project_id}:primary"),
+                    "windowContext": {
+                        "projectId": project_id.as_str(),
+                        "worktreeId": format!("{project_id}:primary")
+                    }
+                },
+                "workspaceRestore": {
+                    "revision": 1,
+                    "schemaVersion": 1,
+                    "snapshot": {
+                        "activeContextKey": format!("{project_id}::__primary__"),
+                        "contexts": [
+                            {
+                                "key": format!("{project_id}::__primary__"),
+                                "lastActivatedAt": "2026-07-22T00:00:00.000Z",
+                                "projectId": project_id.as_str(),
+                                "worktreeId": null,
+                                "workspace": { "activePaneId": "pane-a", "rootNode": { "activeTabId": "tab-a", "id": "pane-a", "tabIds": ["tab-a"], "type": "pane" }, "tabs": [{ "id": "tab-a" }] }
+                            },
+                            {
+                                "key": format!("{other_project_id}::__primary__"),
+                                "lastActivatedAt": "2026-07-22T00:00:00.000Z",
+                                "projectId": other_project_id,
+                                "worktreeId": null,
+                                "workspace": { "activePaneId": "pane-b", "rootNode": { "activeTabId": "tab-b", "id": "pane-b", "tabIds": ["tab-b"], "type": "pane" }, "tabs": [{ "id": "tab-b" }] }
+                            }
+                        ],
+                        "openContextKeys": [format!("{project_id}::__primary__"), format!("{other_project_id}::__primary__")],
+                        "version": 3
+                    }
+                }
+            }
+        ]);
+        let mut settings = serde_json::Map::new();
+        settings.insert(
+            project_id.clone(),
+            json!({ "projectId": project_id.as_str(), "editor": { "fontSize": 14 } }),
+        );
+        settings.insert(
+            other_project_id.to_string(),
+            json!({ "projectId": other_project_id }),
+        );
+        let settings = Value::Object(settings);
+        assert!(
+            only_response(&backend.handle_request(request(
+                "app_data_set_json",
+                json!({ "key": PROJECT_SETTINGS_KEY, "value": settings }),
+            )))
+            .ok
+        );
+        assert!(
+            only_response(&backend.handle_request(request(
+                "app_data_set_json",
+                json!({ "key": PERSISTENCE_KEY, "value": persistence }),
+            )))
+            .ok
+        );
+
+        let cleared = backend.handle_request(request(
+            "project_clear_app_data",
+            json!({ "projectId": project_id }),
+        ));
+        let response = only_response(&cleared);
+        assert!(response.ok);
+        assert_eq!(
+            response.result.as_ref().unwrap()["cleared"]["projectSettingsCount"],
+            1
+        );
+        assert_eq!(
+            response.result.as_ref().unwrap()["cleared"]["workspaceLayoutCount"],
+            1
+        );
+        assert_eq!(
+            response.result.as_ref().unwrap()["cleared"]["workspaceTabCount"],
+            1
+        );
+
+        let settings = backend.handle_request(request(
+            "app_data_get_json",
+            json!({ "key": PROJECT_SETTINGS_KEY }),
+        ));
+        assert!(
+            only_response(&settings).result.as_ref().unwrap()["value"]
+                .get(&project_id)
+                .is_none()
+        );
+        assert!(
+            only_response(&settings).result.as_ref().unwrap()["value"]
+                .get(other_project_id)
+                .is_some()
+        );
+
+        let persistence = backend.handle_request(request(
+            "app_data_get_json",
+            json!({ "key": PERSISTENCE_KEY }),
+        ));
+        let snapshot = &only_response(&persistence).result.as_ref().unwrap()["value"][0]["workspaceRestore"]
+            ["snapshot"];
+        assert_eq!(snapshot["contexts"].as_array().unwrap().len(), 1);
+        assert_eq!(snapshot["contexts"][0]["projectId"], other_project_id);
+        assert_eq!(
+            snapshot["activeContextKey"],
+            format!("{other_project_id}::__primary__")
+        );
+    }
+
+    #[test]
+    fn retries_worktree_cleanup_after_current_persistence_recovers() {
+        let (_temp_dir, mut backend, project_id) = backend_with_registered_project();
+        let pending = PendingWorktreeDataCleanup {
+            project_id: ProjectId(project_id),
+            worktree_id: WorktreeId("removed-worktree".to_string()),
+        };
+        let store = backend
+            .persistence_store
+            .as_mut()
+            .expect("persistence store");
+        save_app_data_value(store, PERSISTENCE_KEY, &json!([])).expect("save persistence");
+        store
+            .connection_mut()
+            .execute(
+                "UPDATE app_settings SET value = 'not json' WHERE key = ?1",
+                [app_data_storage_key(PERSISTENCE_KEY).expect("storage key")],
+            )
+            .expect("corrupt persistence");
+
+        backend
+            .retry_pending_worktree_data_cleanup(vec![pending.clone()])
+            .expect("queue failed cleanup");
+        assert_eq!(
+            backend
+                .load_pending_worktree_data_cleanup()
+                .expect("load pending cleanup"),
+            vec![pending.clone()]
+        );
+
+        let store = backend
+            .persistence_store
+            .as_mut()
+            .expect("persistence store");
+        save_app_data_value(store, PERSISTENCE_KEY, &json!([])).expect("repair persistence");
+        backend
+            .retry_pending_worktree_data_cleanup(
+                backend
+                    .load_pending_worktree_data_cleanup()
+                    .expect("load queued cleanup"),
+            )
+            .expect("retry cleanup");
+        assert!(
+            backend
+                .load_pending_worktree_data_cleanup()
+                .expect("load empty cleanup")
+                .is_empty()
+        );
     }
 
     fn only_response(result: &CommandResult) -> &comando_types::protocol::NativeRpcResponse {

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -933,6 +933,73 @@ impl AiHistoryStore {
         Ok(summaries)
     }
 
+    pub fn count_sessions_by_scope(
+        &self,
+        project_id: &ProjectId,
+        worktree_id: Option<&WorktreeId>,
+    ) -> AiResult<u64> {
+        Ok(u64::try_from(self.session_ids_by_scope(project_id, worktree_id)?.len()).unwrap_or(0))
+    }
+
+    pub fn delete_sessions_by_scope(
+        &self,
+        project_id: &ProjectId,
+        worktree_id: Option<&WorktreeId>,
+    ) -> AiResult<u64> {
+        let session_ids = self.session_ids_by_scope(project_id, worktree_id)?;
+        for session_id in &session_ids {
+            let session_dir = self.session_dir(session_id);
+            if session_dir.exists() {
+                fs::remove_dir_all(&session_dir).map_err(|error| {
+                    history_io("delete scoped AI session dir", &session_dir, error)
+                })?;
+            }
+        }
+
+        Ok(u64::try_from(session_ids.len()).unwrap_or(0))
+    }
+
+    pub fn session_ids_by_scope(
+        &self,
+        project_id: &ProjectId,
+        worktree_id: Option<&WorktreeId>,
+    ) -> AiResult<Vec<SessionId>> {
+        let sessions_dir = self.sessions_dir();
+        if !sessions_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut session_ids = Vec::new();
+        for entry in fs::read_dir(&sessions_dir)
+            .map_err(|error| history_io("read AI sessions dir", &sessions_dir, error))?
+        {
+            let entry = entry
+                .map_err(|error| history_io("read AI session dir entry", &sessions_dir, error))?;
+            if !entry
+                .file_type()
+                .map_err(|error| history_io("read AI session file type", &entry.path(), error))?
+                .is_dir()
+            {
+                continue;
+            }
+
+            let metadata_path = entry.path().join(SESSION_META_FILE);
+            let Ok(metadata) = read_json_file::<AiHistorySessionMetadata>(&metadata_path) else {
+                continue;
+            };
+            if metadata.project_id.as_ref() != Some(project_id) {
+                continue;
+            }
+            // Cleanup must use the exact worktree id so primary compatibility does not delete another scope.
+            if worktree_id.is_some_and(|id| metadata.worktree_id.as_ref() != Some(id)) {
+                continue;
+            }
+            session_ids.push(metadata.session_id);
+        }
+
+        Ok(session_ids)
+    }
+
     pub fn list_runtime_mappings_for_parent(
         &self,
         parent_session_id: &SessionId,
@@ -3431,6 +3498,46 @@ mod tests {
         assert!(!store.has_session(&child.session_id));
         assert!(!store.has_session(&grandchild.session_id));
         assert!(store.has_session(&unrelated.session_id));
+    }
+
+    #[test]
+    fn deleting_worktree_scoped_sessions_preserves_other_scopes() {
+        let (_temp, store) = store();
+        let project_id = ProjectId("project_1".to_string());
+        let worktree_id = WorktreeId("worktree_1".to_string());
+
+        let target = metadata("target");
+        store.create_session(target.clone()).unwrap();
+
+        let mut target_child = metadata("target_child");
+        target_child.parent_session_id = Some(target.session_id.clone());
+        store.create_session(target_child.clone()).unwrap();
+
+        let mut other_worktree = metadata("other_worktree");
+        other_worktree.worktree_id = Some(WorktreeId("worktree_2".to_string()));
+        store.create_session(other_worktree.clone()).unwrap();
+
+        let mut other_project = metadata("other_project");
+        other_project.project_id = Some(ProjectId("project_2".to_string()));
+        store.create_session(other_project.clone()).unwrap();
+
+        assert_eq!(
+            store
+                .count_sessions_by_scope(&project_id, Some(&worktree_id))
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            store
+                .delete_sessions_by_scope(&project_id, Some(&worktree_id))
+                .unwrap(),
+            2
+        );
+
+        assert!(!store.has_session(&target.session_id));
+        assert!(!store.has_session(&target_child.session_id));
+        assert!(store.has_session(&other_worktree.session_id));
+        assert!(store.has_session(&other_project.session_id));
     }
 
     #[test]

--- a/crates/comando-persistence/src/sqlite.rs
+++ b/crates/comando-persistence/src/sqlite.rs
@@ -194,7 +194,7 @@ fn ensure_current_schema(connection: &Connection) -> Result<(), PersistenceError
             title TEXT NOT NULL,
             payload_json TEXT NOT NULL,
             created_at TEXT NOT NULL,
-            worktree_id TEXT REFERENCES project_worktrees(id) ON DELETE SET NULL,
+            worktree_id TEXT REFERENCES project_worktrees(id) ON DELETE CASCADE,
             position INTEGER NOT NULL
         );
 
@@ -229,7 +229,7 @@ fn ensure_current_schema(connection: &Connection) -> Result<(), PersistenceError
         CREATE TABLE IF NOT EXISTS chat_sessions (
             id TEXT PRIMARY KEY,
             project_id TEXT REFERENCES projects(id) ON DELETE SET NULL,
-            worktree_id TEXT REFERENCES project_worktrees(id) ON DELETE SET NULL,
+            worktree_id TEXT REFERENCES project_worktrees(id) ON DELETE CASCADE,
             parent_session_id TEXT REFERENCES chat_sessions(id) ON DELETE SET NULL,
             title TEXT NOT NULL,
             runtime TEXT NOT NULL DEFAULT 'pending',
@@ -388,8 +388,106 @@ fn ensure_current_schema(connection: &Connection) -> Result<(), PersistenceError
             ON workspace_sessions(window_id);
         ",
     )?;
+    migrate_worktree_owned_foreign_keys(connection)?;
 
     Ok(())
+}
+
+fn migrate_worktree_owned_foreign_keys(connection: &Connection) -> Result<(), PersistenceError> {
+    let workspace_tabs_are_cascaded =
+        foreign_key_uses_action(connection, "workspace_tabs", "worktree_id", "CASCADE")?;
+    let chat_sessions_are_cascaded =
+        foreign_key_uses_action(connection, "chat_sessions", "worktree_id", "CASCADE")?;
+    if workspace_tabs_are_cascaded && chat_sessions_are_cascaded {
+        return Ok(());
+    }
+
+    // SQLite cannot alter a foreign-key action in place, so rebuild only the owned tables.
+    connection.execute_batch("PRAGMA foreign_keys = OFF;")?;
+    let migration = connection.execute_batch(
+        "
+        BEGIN IMMEDIATE;
+
+        CREATE TABLE workspace_tabs_rebuilt (
+            id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL REFERENCES workspace_layouts(id) ON DELETE CASCADE,
+            kind TEXT NOT NULL,
+            title TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            worktree_id TEXT REFERENCES project_worktrees(id) ON DELETE CASCADE,
+            position INTEGER NOT NULL
+        );
+        INSERT INTO workspace_tabs_rebuilt
+        SELECT id, workspace_id, kind, title, payload_json, created_at, worktree_id, position
+        FROM workspace_tabs;
+        DROP TABLE workspace_tabs;
+        ALTER TABLE workspace_tabs_rebuilt RENAME TO workspace_tabs;
+
+        CREATE TABLE chat_sessions_rebuilt (
+            id TEXT PRIMARY KEY,
+            project_id TEXT REFERENCES projects(id) ON DELETE SET NULL,
+            worktree_id TEXT REFERENCES project_worktrees(id) ON DELETE CASCADE,
+            parent_session_id TEXT REFERENCES chat_sessions(id) ON DELETE SET NULL,
+            title TEXT NOT NULL,
+            runtime TEXT NOT NULL DEFAULT 'pending',
+            runtime_session_id TEXT,
+            status TEXT NOT NULL DEFAULT 'idle',
+            draft TEXT NOT NULL DEFAULT '',
+            pinned_at TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            last_opened_at TEXT NOT NULL
+        );
+        INSERT INTO chat_sessions_rebuilt
+        SELECT
+            id, project_id, worktree_id, parent_session_id, title, runtime, runtime_session_id,
+            status, draft, pinned_at, created_at, updated_at, last_opened_at
+        FROM chat_sessions;
+        DROP TABLE chat_sessions;
+        ALTER TABLE chat_sessions_rebuilt RENAME TO chat_sessions;
+
+        CREATE INDEX idx_workspace_tabs_worktree_id
+            ON workspace_tabs(worktree_id);
+        CREATE INDEX idx_chat_sessions_last_opened
+            ON chat_sessions(last_opened_at DESC);
+        CREATE INDEX idx_chat_sessions_project_worktree_updated_at
+            ON chat_sessions(project_id, worktree_id, updated_at DESC);
+        CREATE INDEX idx_chat_sessions_runtime_updated_at
+            ON chat_sessions(runtime, updated_at DESC);
+        CREATE INDEX idx_chat_sessions_project_worktree_pinned_at
+            ON chat_sessions(project_id, worktree_id, pinned_at DESC, updated_at DESC);
+        CREATE INDEX idx_chat_sessions_parent_session_id
+            ON chat_sessions(parent_session_id);
+
+        COMMIT;
+        ",
+    );
+    if let Err(error) = migration {
+        let _ = connection.execute_batch("ROLLBACK; PRAGMA foreign_keys = ON;");
+        return Err(error.into());
+    }
+    connection.execute_batch("PRAGMA foreign_keys = ON;")?;
+    Ok(())
+}
+
+fn foreign_key_uses_action(
+    connection: &Connection,
+    table: &'static str,
+    column: &'static str,
+    expected_action: &'static str,
+) -> Result<bool, PersistenceError> {
+    let mut statement = connection.prepare(&format!("PRAGMA foreign_key_list({table})"))?;
+    let rows = statement.query_map([], |row| {
+        Ok((row.get::<_, String>(3)?, row.get::<_, String>(6)?))
+    })?;
+    for row in rows {
+        let (from_column, on_delete) = row?;
+        if from_column == column {
+            return Ok(on_delete.eq_ignore_ascii_case(expected_action));
+        }
+    }
+    Ok(false)
 }
 
 fn ensure_column(
@@ -551,6 +649,79 @@ mod tests {
         assert_eq!(
             metadata_value(store.connection(), "native.schema_version"),
             "1"
+        );
+    }
+
+    #[test]
+    fn migrates_worktree_owned_foreign_keys_to_cascade() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let database_path = temp_dir.path().join("legacy.sqlite3");
+        create_current_schema(&database_path);
+        let connection = Connection::open(&database_path).expect("db");
+        connection
+            .execute_batch(
+                "
+                CREATE TABLE workspace_layouts (
+                    id TEXT PRIMARY KEY,
+                    root_node_json TEXT NOT NULL,
+                    active_pane_id TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                CREATE TABLE workspace_tabs (
+                    id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL REFERENCES workspace_layouts(id) ON DELETE CASCADE,
+                    kind TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    worktree_id TEXT REFERENCES project_worktrees(id) ON DELETE SET NULL,
+                    position INTEGER NOT NULL
+                );
+                CREATE TABLE chat_sessions (
+                    id TEXT PRIMARY KEY,
+                    project_id TEXT REFERENCES projects(id) ON DELETE SET NULL,
+                    worktree_id TEXT REFERENCES project_worktrees(id) ON DELETE SET NULL,
+                    parent_session_id TEXT REFERENCES chat_sessions(id) ON DELETE SET NULL,
+                    title TEXT NOT NULL,
+                    runtime TEXT NOT NULL DEFAULT 'pending',
+                    runtime_session_id TEXT,
+                    status TEXT NOT NULL DEFAULT 'idle',
+                    draft TEXT NOT NULL DEFAULT '',
+                    pinned_at TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    last_opened_at TEXT NOT NULL
+                );
+                ",
+            )
+            .expect("legacy owned tables");
+        drop(connection);
+
+        let (store, _) = SqlitePersistenceStore::open(NativeStorageConfig {
+            app_data_dir: temp_dir.path().to_path_buf(),
+            database_path,
+            mode: NativePersistenceMode::Write,
+        })
+        .expect("migrate store");
+
+        assert!(
+            foreign_key_uses_action(
+                store.connection(),
+                "workspace_tabs",
+                "worktree_id",
+                "CASCADE"
+            )
+            .expect("workspace tabs action")
+        );
+        assert!(
+            foreign_key_uses_action(
+                store.connection(),
+                "chat_sessions",
+                "worktree_id",
+                "CASCADE"
+            )
+            .expect("chat sessions action")
         );
     }
 

--- a/crates/comando-projects/src/registry.rs
+++ b/crates/comando-projects/src/registry.rs
@@ -426,6 +426,7 @@ impl<'a> ProjectRegistry<'a> {
             if existing.is_primary == 1 && !desired_worktrees.contains_key(&existing_root_key) {
                 continue;
             }
+            clear_worktree_app_data(&transaction, &existing.id)?;
             transaction.execute(
                 "DELETE FROM project_worktrees WHERE id = ?1",
                 [&existing.id],
@@ -1220,6 +1221,37 @@ fn normalize_worktree_key(path: &str) -> String {
     }
 }
 
+fn clear_worktree_app_data(
+    transaction: &Transaction<'_>,
+    worktree_id: &str,
+) -> Result<(), ProjectRegistryError> {
+    transaction.execute(
+        "DELETE FROM chat_sessions WHERE worktree_id = ?1",
+        [worktree_id],
+    )?;
+    transaction.execute(
+        "
+        DELETE FROM workspace_tabs
+        WHERE worktree_id = ?1
+           OR (
+                json_valid(payload_json)
+                AND json_extract(payload_json, '$.worktreeId') = ?1
+           )
+        ",
+        [worktree_id],
+    )?;
+    transaction.execute(
+        "
+        UPDATE workspace_sessions
+        SET active_worktree_id = NULL,
+            shell_state_json = NULL
+        WHERE active_worktree_id = ?1
+        ",
+        [worktree_id],
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use rusqlite::Connection;
@@ -1354,6 +1386,111 @@ mod tests {
     }
 
     #[test]
+    fn removing_a_worktree_clears_only_its_persisted_data() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let project_root = create_dir(temp_dir.path(), "worktree-cleanup-root");
+        let secondary_root = create_dir(temp_dir.path(), "worktree-cleanup-secondary");
+        let mut connection = create_current_schema();
+        let added = ProjectRegistry::new(&mut connection)
+            .add_project_paths(std::slice::from_ref(&project_root))
+            .expect("add project");
+        let project_id = added.project_ids_to_open[0].clone();
+
+        let worktrees = ProjectRegistry::new(&mut connection)
+            .sync_project_worktrees(
+                &project_id,
+                &[
+                    NativeProjectSyncWorktree {
+                        root_path: project_root.clone(),
+                        branch_name: Some("main".to_string()),
+                        head_sha: None,
+                    },
+                    NativeProjectSyncWorktree {
+                        root_path: secondary_root,
+                        branch_name: Some("feature/cleanup".to_string()),
+                        head_sha: None,
+                    },
+                ],
+            )
+            .expect("sync worktrees");
+        let primary_id = worktrees
+            .iter()
+            .find(|worktree| worktree.is_primary)
+            .expect("primary worktree")
+            .id
+            .0
+            .clone();
+        let removed_id = worktrees
+            .iter()
+            .find(|worktree| !worktree.is_primary)
+            .expect("secondary worktree")
+            .id
+            .0
+            .clone();
+
+        connection
+            .execute(
+                "INSERT INTO workspace_layouts VALUES ('layout', '{}', 'pane', 'now', 'now')",
+                [],
+            )
+            .expect("insert layout");
+        for (id, worktree_id) in [("removed-chat", &removed_id), ("kept-chat", &primary_id)] {
+            connection
+                .execute(
+                    "INSERT INTO chat_sessions (id, project_id, worktree_id) VALUES (?1, ?2, ?3)",
+                    params![id, project_id.0, worktree_id],
+                )
+                .expect("insert chat");
+        }
+        for (id, worktree_id) in [("removed-tab", &removed_id), ("kept-tab", &primary_id)] {
+            connection
+                .execute(
+                    "
+                    INSERT INTO workspace_tabs (
+                        id, workspace_id, kind, title, payload_json, created_at, worktree_id, position
+                    )
+                    VALUES (?1, 'layout', 'chat', 'Chat', json_object('worktreeId', ?2), 'now', ?2, 0)
+                    ",
+                    params![id, worktree_id],
+                )
+                .expect("insert tab");
+        }
+        connection
+            .execute(
+                "
+                INSERT INTO workspace_sessions (
+                    id, active_project_id, active_worktree_id, shell_state_json, last_opened_at
+                )
+                VALUES ('session', ?1, ?2, '{}', 'now')
+                ",
+                params![project_id.0, removed_id],
+            )
+            .expect("insert workspace session");
+
+        ProjectRegistry::new(&mut connection)
+            .sync_project_worktrees(
+                &project_id,
+                &[NativeProjectSyncWorktree {
+                    root_path: project_root,
+                    branch_name: Some("main".to_string()),
+                    head_sha: None,
+                }],
+            )
+            .expect("remove secondary worktree");
+
+        assert_eq!(count_rows(&connection, "chat_sessions"), 1);
+        assert_eq!(count_rows(&connection, "workspace_tabs"), 1);
+        let active_worktree_id: Option<String> = connection
+            .query_row(
+                "SELECT active_worktree_id FROM workspace_sessions WHERE id = 'session'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read workspace session");
+        assert_eq!(active_worktree_id, None);
+    }
+
+    #[test]
     fn reopens_hidden_project_and_reuses_id() {
         let temp_dir = TempDir::new().expect("temp dir");
         let project_root = create_dir(temp_dir.path(), "hidden-reopen");
@@ -1431,7 +1568,30 @@ mod tests {
                     id TEXT PRIMARY KEY,
                     active_project_id TEXT REFERENCES projects(id) ON DELETE SET NULL,
                     active_worktree_id TEXT REFERENCES project_worktrees(id) ON DELETE SET NULL,
+                    shell_state_json TEXT,
                     last_opened_at TEXT NOT NULL
+                );
+                CREATE TABLE workspace_layouts (
+                    id TEXT PRIMARY KEY,
+                    root_node_json TEXT NOT NULL,
+                    active_pane_id TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                CREATE TABLE workspace_tabs (
+                    id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL REFERENCES workspace_layouts(id) ON DELETE CASCADE,
+                    kind TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    worktree_id TEXT REFERENCES project_worktrees(id) ON DELETE CASCADE,
+                    position INTEGER NOT NULL
+                );
+                CREATE TABLE chat_sessions (
+                    id TEXT PRIMARY KEY,
+                    project_id TEXT REFERENCES projects(id) ON DELETE SET NULL,
+                    worktree_id TEXT REFERENCES project_worktrees(id) ON DELETE CASCADE
                 );
                 ",
             )

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1638,6 +1638,9 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     });
     ipcMain.handle(IPC_CHANNELS.removeProject, async (_event, projectId: string) => {
         await options.projectService.removeProject(projectId);
+        windowRegistry.forEachLiveWebContents((webContents) => {
+            webContents.send(IPC_EVENTS.projectAppDataCleared, projectId);
+        });
         broadcastProjectsUpdated();
     });
     ipcMain.handle(IPC_CHANNELS.touchProject, (_event, projectId: string) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -400,6 +400,9 @@ export function App() {
     const removeProjectTabs = useWorkspaceStore(
         (state) => state.removeProjectTabs,
     );
+    const removeUnavailableWorktreeTabs = useWorkspaceStore(
+        (state) => state.removeUnavailableWorktreeTabs,
+    );
     const closeWorkspaceTab = useWorkspaceStore((state) => state.closeTab);
     const requestCloseWorkspaceTab = useCallback(
         (tabId: string) =>
@@ -1161,8 +1164,18 @@ export function App() {
             useGitStore.getState().activeWorktreeIds[projectId] ??
             null;
         const projectRefreshScheduler = createGitProjectRefreshScheduler({
-            refreshProject: (projectId, worktreeId) => {
-                return refreshGitProject(projectId, worktreeId).then(() => undefined);
+            refreshProject: async (projectId, worktreeId) => {
+                const snapshot = await refreshGitProject(projectId, worktreeId);
+                if (!snapshot) {
+                    return;
+                }
+
+                // A watcher-driven removal has no sidebar action to close stale workspace contexts.
+                await removeUnavailableWorktreeTabs(
+                    projectId,
+                    snapshot.worktrees.map((worktree) => worktree.id),
+                );
+                await comandoApi.refreshAiProjectScopes(projectId);
             },
         });
 
@@ -1196,6 +1209,11 @@ export function App() {
                     snapshot.currentWorktreeId,
                 );
                 projectRefreshScheduler.cancel(snapshot.projectId, null);
+                // Snapshots cancel the deferred refresh, so they must also remove contexts for worktrees Git no longer reports.
+                void removeUnavailableWorktreeTabs(
+                    snapshot.projectId,
+                    snapshot.worktrees.map((worktree) => worktree.id),
+                );
                 ingestGitSnapshot(snapshot);
             },
         );
@@ -1211,7 +1229,12 @@ export function App() {
             unsubscribeWorktrees();
             projectRefreshScheduler.clear();
         };
-    }, [ingestGitSnapshot, refreshGitHistory, refreshGitProject]);
+    }, [
+        ingestGitSnapshot,
+        refreshGitHistory,
+        refreshGitProject,
+        removeUnavailableWorktreeTabs,
+    ]);
 
     useEffect(() => {
         const comandoApi = getComandoApi();

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -461,6 +461,55 @@ describe("workspace file opening", () => {
         expect(useWorkspaceStore.getState().activeContextKey).toBe(remainingContext.key);
     });
 
+    it("removes only contexts for unavailable worktrees", async () => {
+        const workspace = createDefaultWorkspaceState();
+        const primaryContext = {
+            key: "project-1::__primary__",
+            lastActivatedAt: "2026-04-15T00:00:00.000Z",
+            projectId: "project-1",
+            workspace,
+            worktreeId: null,
+        };
+        const availableContext = {
+            key: "project-1::worktree-available",
+            lastActivatedAt: "2026-04-16T00:00:00.000Z",
+            projectId: "project-1",
+            workspace,
+            worktreeId: "worktree-available",
+        };
+        const removedContext = {
+            key: "project-1::worktree-removed",
+            lastActivatedAt: "2026-04-17T00:00:00.000Z",
+            projectId: "project-1",
+            workspace,
+            worktreeId: "worktree-removed",
+        };
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            activeContextKey: removedContext.key,
+            contextsByKey: {
+                [primaryContext.key]: primaryContext,
+                [availableContext.key]: availableContext,
+                [removedContext.key]: removedContext,
+            },
+            openContextKeys: [
+                primaryContext.key,
+                availableContext.key,
+                removedContext.key,
+            ],
+        }));
+
+        await useWorkspaceStore
+            .getState()
+            .removeUnavailableWorktreeTabs("project-1", ["worktree-available"]);
+
+        expect(useWorkspaceStore.getState().contextsByKey).toEqual({
+            [primaryContext.key]: primaryContext,
+            [availableContext.key]: availableContext,
+        });
+        expect(useWorkspaceStore.getState().activeContextKey).toBe(primaryContext.key);
+    });
+
     it("reorders workspace contexts without changing the active context", async () => {
         await useWorkspaceStore
             .getState()

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -312,6 +312,10 @@ interface WorkspaceStore extends WorkspaceTreeState {
     reopenLastClosedTab: () => Promise<void>;
     removeProjectTabs: (projectId: string) => Promise<void>;
     removeWorktreeTabs: (projectId: string, worktreeId: string | null) => Promise<void>;
+    removeUnavailableWorktreeTabs: (
+        projectId: string,
+        availableWorktreeIds: readonly string[],
+    ) => Promise<void>;
     pinPaneTab: (paneId: string, tabId: string) => Promise<void>;
     reorderTab: (
         paneId: string,
@@ -2046,6 +2050,18 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                     context.worktreeId,
                     worktreeId,
                 ),
+        );
+    },
+
+    removeUnavailableWorktreeTabs: async (projectId, availableWorktreeIds) => {
+        const available = new Set(availableWorktreeIds);
+        await removeWorkspaceContexts(
+            get,
+            set,
+            (context) =>
+                context.projectId === projectId &&
+                context.worktreeId !== null &&
+                !available.has(context.worktreeId),
         );
     },
 

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -1186,7 +1186,7 @@ function ProjectSettingsRow({
                     onClick={() => {
                         if (
                             window.confirm(
-                                `Remove "${project.name}" from Comando?\n\nThis will hide the project from the app, but it will not delete project files or saved chat history.`,
+                                `Remove "${project.name}" from Comando?\n\nThis will delete all saved app data for this project, including chat history, transcripts, project settings, and restored workspace state. Project files on disk will not be deleted.`,
                             )
                         ) {
                             state.onRemoveProject?.(project.id);


### PR DESCRIPTION
## Summary
- remove modern and legacy data scoped to deleted worktrees and projects
- clear persisted project settings and workspace contexts without affecting other scopes
- migrate worktree-owned SQLite foreign keys to cascade on deletion

## Validation
- cargo test -p comando-persistence -p comando-projects -p comando-native-backend -p comando-ai
- pnpm run typecheck
- pnpm exec vitest run src/renderer/src/app/store/workspace-store.test.ts