### PR TITLE
Enable workspace switching and moves across windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,6 +28,7 @@ import {
     type WindowContextSnapshot,
     type WorkspaceNavigationSnapshot,
 } from "@shared/ipc";
+import { normalizeWorkspaceWorktreeId } from "@shared/workspace-context";
 import {
     nativeProjectTreeInvalidationToIpc,
     type NativeCapabilitySet,
@@ -404,16 +405,6 @@ if (!hasSingleInstanceLock) {
 
                     focusedWindow.close();
                 },
-                focusProjectWindow: (projectId) => {
-                    const existingWindow =
-                        windowRegistry.getMainWindowByProjectId(projectId);
-                    if (!existingWindow) {
-                        return false;
-                    }
-
-                    focusExistingWindow(existingWindow);
-                    return true;
-                },
                 getFocusedMainWindowContext: () => {
                     const mainWindow = windowRegistry.getFocusedMainWindow();
                     return mainWindow
@@ -779,13 +770,15 @@ async function openOrFocusProjectWindow(
         throw new Error("The persistence service is unavailable.");
     }
 
-    const existingWindow = input.forceNewWindow
+    // Snapshot-bearing requests are the legacy move path. They are replaced by
+    // live surface transfers later in this series and must remain functional
+    // until that path is removed.
+    const existingWindow = input.workspaceSnapshot
         ? null
-        : (windowRegistry.getMainWindowByProjectId(input.projectId) ??
-          workspaceSurfaceManager.activateProject(
+        : await activateExistingWorkspaceScope(
               input.projectId,
-              input.worktreeId,
-          ));
+              input.worktreeId ?? null,
+          );
     if (!existingWindow) {
         await openNewMainWindowWithOptions({
             forceNewWindow: input.forceNewWindow,
@@ -835,21 +828,18 @@ async function openNewMainWindowWithOptions(input: {
         throw new Error("The persistence service is unavailable.");
     }
 
-    if (input.projectId && !input.forceNewWindow) {
-        const existingWindow =
-            windowRegistry.getMainWindowByProjectId(input.projectId) ??
-            workspaceSurfaceManager.activateProject(
-                input.projectId,
-                input.worktreeId,
-            );
+    if (input.projectId && !input.workspaceSnapshot) {
+        const existingWindow = await activateExistingWorkspaceScope(
+            input.projectId,
+            input.worktreeId ?? null,
+        );
         if (existingWindow) {
-            focusExistingWindow(existingWindow);
             return;
         }
     }
 
     const closedProjectSnapshot =
-        input.projectId && !input.forceNewWindow
+        input.projectId && !input.workspaceSnapshot
             ? await persistenceService.findClosedMainWindowSnapshotForProject(
                   input.projectId,
                   input.worktreeId,
@@ -891,6 +881,74 @@ async function openNewMainWindowWithOptions(input: {
     }
 
     createTrackedMainWindow(snapshot);
+}
+
+async function activateExistingWorkspaceScope(
+    projectId: string,
+    worktreeId: string | null,
+): Promise<BrowserWindow | null> {
+    const location = workspaceSurfaceManager.findPreferredWorkspaceLocation({
+        projectId,
+        worktreeId,
+    });
+    if (location) {
+        const window = windowRegistry.getWindowByStableId(
+            location.hostWindowId,
+        );
+        const context = window
+            ? windowRegistry.getContextByBrowserWindow(window)
+            : null;
+        if (!window || context?.windowKind !== "main") {
+            return null;
+        }
+        workspaceSurfaceManager.activate(
+            location.hostWindowId,
+            location.contextKey,
+        );
+        const snapshot = workspaceSurfaceManager.getHostSnapshotForWindow(
+            location.hostWindowId,
+        );
+        if (snapshot) {
+            workspaceSurfaceManager
+                .getHostWebContents(location.hostWindowId)
+                ?.send(IPC_EVENTS.workspaceSurfaceSnapshotUpdated, snapshot);
+            if (workspaceService && context.workspaceId) {
+                await workspaceService.saveSnapshot(
+                    context.workspaceId,
+                    snapshot,
+                );
+            }
+        }
+        persistenceService?.saveActiveProjectId(
+            location.hostWindowId,
+            location.projectId,
+            location.worktreeId,
+        );
+        windowRegistry.updateMainWindowProjectId(
+            location.hostWindowId,
+            location.projectId,
+            location.worktreeId,
+        );
+        updateMainWindowTitle(window, location.projectId);
+        focusExistingWindow(window);
+        return window;
+    }
+
+    const pendingWindowContext = windowRegistry
+        .listMainWindowContexts()
+        .find(
+            (context) =>
+                context.projectId === projectId &&
+                normalizeWorkspaceWorktreeId(projectId, context.worktreeId) ===
+                    normalizeWorkspaceWorktreeId(projectId, worktreeId),
+        );
+    const pendingWindow = pendingWindowContext
+        ? windowRegistry.getWindowByStableId(pendingWindowContext.windowId)
+        : null;
+    if (pendingWindow) {
+        focusExistingWindow(pendingWindow);
+    }
+    return pendingWindow;
 }
 
 function createTrackedMainWindow(snapshot: PersistenceSnapshot): BrowserWindow {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,7 +30,6 @@ import {
     type WorkspaceNavigationSnapshot,
 } from "@shared/ipc";
 import {
-    areWorkspaceScopesEquivalent,
     normalizeWorkspaceWorktreeId,
 } from "@shared/workspace-context";
 import {
@@ -108,6 +107,7 @@ import {
 } from "./window";
 import { windowRegistry } from "./windows/registry";
 import { workspaceSurfaceManager } from "./workspace/surface-manager";
+import { moveWorkspaceBetweenWindows } from "./workspace/move-coordinator";
 import type { WorkspaceGateway } from "./workspace/service";
 
 import { initReviewEngine } from "@shared/ai-review-engine/reviewEngine";
@@ -775,20 +775,13 @@ async function openOrFocusProjectWindow(
         throw new Error("The persistence service is unavailable.");
     }
 
-    // Snapshot-bearing requests are the legacy move path. They are replaced by
-    // live surface transfers later in this series and must remain functional
-    // until that path is removed.
-    const existingWindow = input.workspaceSnapshot
-        ? null
-        : await activateExistingWorkspaceScope(
-              input.projectId,
-              input.worktreeId ?? null,
-          );
+    const existingWindow = await activateExistingWorkspaceScope(
+        input.projectId,
+        input.worktreeId ?? null,
+    );
     if (!existingWindow) {
         await openNewMainWindowWithOptions({
-            forceNewWindow: input.forceNewWindow,
             projectId: input.projectId,
-            workspaceSnapshot: input.workspaceSnapshot,
             worktreeId: input.worktreeId,
         });
         return;
@@ -824,16 +817,14 @@ async function openOrFocusProjectWindow(
 }
 
 async function openNewMainWindowWithOptions(input: {
-    readonly forceNewWindow?: boolean;
     readonly projectId: string | null;
-    readonly workspaceSnapshot?: WorkspaceNavigationSnapshot;
     readonly worktreeId?: string | null;
 }): Promise<void> {
     if (!persistenceService) {
         throw new Error("The persistence service is unavailable.");
     }
 
-    if (input.projectId && !input.workspaceSnapshot) {
+    if (input.projectId) {
         const existingWindow = await activateExistingWorkspaceScope(
             input.projectId,
             input.worktreeId ?? null,
@@ -844,7 +835,7 @@ async function openNewMainWindowWithOptions(input: {
     }
 
     const closedProjectSnapshot =
-        input.projectId && !input.workspaceSnapshot
+        input.projectId
             ? await persistenceService.findClosedMainWindowSnapshotForProject(
                   input.projectId,
                   input.worktreeId,
@@ -875,15 +866,6 @@ async function openNewMainWindowWithOptions(input: {
                   worktreeId: input.worktreeId,
               },
     );
-
-    const workspaceId = snapshot.windowContext?.workspaceId;
-    if (input.workspaceSnapshot) {
-        if (!workspaceService || !workspaceId) {
-            throw new Error("The workspace service is unavailable.");
-        }
-        // Persist before the renderer hydrates so it restores the transferred layout.
-        await workspaceService.saveSnapshot(workspaceId, input.workspaceSnapshot);
-    }
 
     createTrackedMainWindow(snapshot);
 }
@@ -995,132 +977,39 @@ async function moveWorkspaceContext(
     if (!persistenceService || !workspaceService) {
         throw new Error("The workspace service is unavailable.");
     }
-
-    const sourceLocation = workspaceSurfaceManager
-        .listOpenWorkspaceLocations()
-        .find(
-            (location) =>
-                location.hostWindowId === sourceWindowId &&
-                location.contextKey === input.contextKey,
-        );
-    if (
-        !sourceLocation ||
-        !areWorkspaceScopesEquivalent(sourceLocation, input)
-    ) {
-        throw new Error("The workspace is no longer open in this window.");
-    }
-
-    const sourceWindow = windowRegistry.getWindowByStableId(sourceWindowId);
-    const sourceContext = sourceWindow
-        ? windowRegistry.getContextByBrowserWindow(sourceWindow)
-        : null;
-    if (!sourceWindow || sourceContext?.windowKind !== "main") {
-        throw new Error("The source window is no longer available.");
-    }
-
-    const createdTarget = input.targetWindowId === null;
-    const targetContext = createdTarget
-        ? await createEmptyWorkspaceTransferWindow()
-        : windowRegistry
-              .listMainWindowContexts()
-              .find((context) => context.windowId === input.targetWindowId) ??
-          null;
-    const targetWindow = targetContext
-        ? windowRegistry.getWindowByStableId(targetContext.windowId)
-        : null;
-    if (
-        !targetContext ||
-        !targetWindow ||
-        targetContext.windowKind !== "main" ||
-        !targetContext.workspaceId
-    ) {
-        throw new Error("The destination window is no longer available.");
-    }
-    if (targetContext.windowId === sourceWindowId) {
-        throw new Error("The workspace is already in this window.");
-    }
-
-    const sourceWorkspaceId = sourceContext.workspaceId;
-    if (!sourceWorkspaceId) {
-        throw new Error("The source workspace is unavailable.");
-    }
-    const targetSnapshot =
-        workspaceSurfaceManager.getHostSnapshotForWindow(
-            targetContext.windowId,
-        );
-    if (!targetSnapshot) {
-        throw new Error("The destination window is still starting.");
-    }
-    if (
-        targetSnapshot.contexts.some((context) =>
-            areWorkspaceScopesEquivalent(context, input),
-        )
-    ) {
-        throw new Error("The destination already contains this workspace.");
-    }
-
-    await Promise.all([
-        requestWorkspaceFlushesForHost(sourceWindow, sourceWindowId),
-        ...(createdTarget
-            ? []
-            : [
-                  requestWorkspaceFlushesForHost(
-                      targetWindow,
-                      targetContext.windowId,
-                  ),
-              ]),
-    ]);
-    const capturedSourceSnapshot =
-        await requestWorkspaceSurfaceContextCapture(
-            sourceWindowId,
-            input.contextKey,
-        );
-    const latestTargetSnapshot =
-        workspaceSurfaceManager.getHostSnapshotForWindow(
-            targetContext.windowId,
-        );
-    if (!capturedSourceSnapshot || !latestTargetSnapshot) {
-        throw new Error("Could not capture the workspace before moving it.");
-    }
-
-    await workspaceService.saveSnapshot(
-        sourceWorkspaceId,
-        capturedSourceSnapshot,
-    );
-    await workspaceService.saveSnapshot(
-        targetContext.workspaceId,
-        latestTargetSnapshot,
-    );
-    const [sourceRestore, targetRestore] = await Promise.all([
-        workspaceService.loadSnapshot(sourceWorkspaceId),
-        workspaceService.loadSnapshot(targetContext.workspaceId),
-    ]);
-
-    const transfer = await workspaceSurfaceManager.transferSurface({
-        commit: () =>
-            Promise.resolve(
-                workspaceService!.transferContext({
-                    contextKey: input.contextKey,
-                    sourceRevision: sourceRestore.revision,
-                    sourceWorkspaceId,
-                    targetRevision: targetRestore.revision,
-                    targetWorkspaceId: targetContext.workspaceId!,
-                }),
-            ),
-        contextKey: input.contextKey,
-        sourceHostWindowId: sourceWindowId,
-        targetHostWindowId: targetContext.windowId,
+    await moveWorkspaceBetweenWindows(sourceWindowId, input, {
+        captureContext: requestWorkspaceSurfaceContextCapture,
+        createEmptyTarget: createEmptyWorkspaceTransferWindow,
+        flushHost: async (windowId) => {
+            const window = windowRegistry.getWindowByStableId(windowId);
+            if (!window) {
+                throw new Error("A workspace window is no longer available.");
+            }
+            await requestWorkspaceFlushesForHost(window, windowId);
+        },
+        getWindowContext: (windowId) =>
+            windowRegistry
+                .listMainWindowContexts()
+                .find((context) => context.windowId === windowId) ?? null,
+        isWindowAvailable: (windowId) =>
+            Boolean(windowRegistry.getWindowByStableId(windowId)),
+        manager: workspaceSurfaceManager,
+        onTransferred: (sourceId, targetId, transfer) => {
+            applyTransferredWorkspaceWindowState(
+                sourceId,
+                transfer.sourceSnapshot,
+            );
+            applyTransferredWorkspaceWindowState(
+                targetId,
+                transfer.targetSnapshot,
+            );
+            const targetWindow = windowRegistry.getWindowByStableId(targetId);
+            if (targetWindow) {
+                focusExistingWindow(targetWindow);
+            }
+        },
+        workspaceService,
     });
-
-    applyTransferredWorkspaceWindowState(
-        sourceWindowId,
-        transfer.sourceSnapshot,
-    );
-    applyTransferredWorkspaceWindowState(
-        targetContext.windowId,
-        transfer.targetSnapshot,
-    );
-    focusExistingWindow(targetWindow);
 }
 
 async function createEmptyWorkspaceTransferWindow(): Promise<WindowContextSnapshot> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -423,6 +423,12 @@ if (!hasSingleInstanceLock) {
                 openNewMainWindow: (projectId) => {
                     void openNewMainWindow(projectId ?? null);
                 },
+                openWorkspaceSwitcher: () => {
+                    const focusedWindow = windowRegistry.getFocusedMainWindow();
+                    focusedWindow?.webContents.send(
+                        IPC_EVENTS.workspaceSwitcherRequested,
+                    );
+                },
                 reopenLastClosedTab: () => {
                     const focusedWindow = windowRegistry.getFocusedMainWindow();
                     if (!focusedWindow) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,7 @@ import {
     type AppBootstrapSnapshot,
     type GitRepositoryInvalidation,
     type GitRepositorySnapshot,
+    type MoveWorkspaceContextInput,
     type OpenProjectWindowInput,
     type PersistenceSnapshot,
     type ProjectTreeInvalidation,
@@ -28,7 +29,10 @@ import {
     type WindowContextSnapshot,
     type WorkspaceNavigationSnapshot,
 } from "@shared/ipc";
-import { normalizeWorkspaceWorktreeId } from "@shared/workspace-context";
+import {
+    areWorkspaceScopesEquivalent,
+    normalizeWorkspaceWorktreeId,
+} from "@shared/workspace-context";
 import {
     nativeProjectTreeInvalidationToIpc,
     type NativeCapabilitySet,
@@ -374,6 +378,7 @@ if (!hasSingleInstanceLock) {
                 gitService,
                 githubService,
                 openProjectWindow: openOrFocusProjectWindow,
+                moveWorkspaceContext,
                 projectService,
                 settingsService,
                 terminalService,
@@ -981,6 +986,200 @@ function createTrackedMainWindow(snapshot: PersistenceSnapshot): BrowserWindow {
     updateMainWindowTitle(window, context.projectId);
 
     return window;
+}
+
+async function moveWorkspaceContext(
+    sourceWindowId: string,
+    input: MoveWorkspaceContextInput,
+): Promise<void> {
+    if (!persistenceService || !workspaceService) {
+        throw new Error("The workspace service is unavailable.");
+    }
+
+    const sourceLocation = workspaceSurfaceManager
+        .listOpenWorkspaceLocations()
+        .find(
+            (location) =>
+                location.hostWindowId === sourceWindowId &&
+                location.contextKey === input.contextKey,
+        );
+    if (
+        !sourceLocation ||
+        !areWorkspaceScopesEquivalent(sourceLocation, input)
+    ) {
+        throw new Error("The workspace is no longer open in this window.");
+    }
+
+    const sourceWindow = windowRegistry.getWindowByStableId(sourceWindowId);
+    const sourceContext = sourceWindow
+        ? windowRegistry.getContextByBrowserWindow(sourceWindow)
+        : null;
+    if (!sourceWindow || sourceContext?.windowKind !== "main") {
+        throw new Error("The source window is no longer available.");
+    }
+
+    const createdTarget = input.targetWindowId === null;
+    const targetContext = createdTarget
+        ? await createEmptyWorkspaceTransferWindow()
+        : windowRegistry
+              .listMainWindowContexts()
+              .find((context) => context.windowId === input.targetWindowId) ??
+          null;
+    const targetWindow = targetContext
+        ? windowRegistry.getWindowByStableId(targetContext.windowId)
+        : null;
+    if (
+        !targetContext ||
+        !targetWindow ||
+        targetContext.windowKind !== "main" ||
+        !targetContext.workspaceId
+    ) {
+        throw new Error("The destination window is no longer available.");
+    }
+    if (targetContext.windowId === sourceWindowId) {
+        throw new Error("The workspace is already in this window.");
+    }
+
+    const sourceWorkspaceId = sourceContext.workspaceId;
+    if (!sourceWorkspaceId) {
+        throw new Error("The source workspace is unavailable.");
+    }
+    const targetSnapshot =
+        workspaceSurfaceManager.getHostSnapshotForWindow(
+            targetContext.windowId,
+        );
+    if (!targetSnapshot) {
+        throw new Error("The destination window is still starting.");
+    }
+    if (
+        targetSnapshot.contexts.some((context) =>
+            areWorkspaceScopesEquivalent(context, input),
+        )
+    ) {
+        throw new Error("The destination already contains this workspace.");
+    }
+
+    await Promise.all([
+        requestWorkspaceFlushesForHost(sourceWindow, sourceWindowId),
+        ...(createdTarget
+            ? []
+            : [
+                  requestWorkspaceFlushesForHost(
+                      targetWindow,
+                      targetContext.windowId,
+                  ),
+              ]),
+    ]);
+    const capturedSourceSnapshot =
+        await requestWorkspaceSurfaceContextCapture(
+            sourceWindowId,
+            input.contextKey,
+        );
+    const latestTargetSnapshot =
+        workspaceSurfaceManager.getHostSnapshotForWindow(
+            targetContext.windowId,
+        );
+    if (!capturedSourceSnapshot || !latestTargetSnapshot) {
+        throw new Error("Could not capture the workspace before moving it.");
+    }
+
+    await workspaceService.saveSnapshot(
+        sourceWorkspaceId,
+        capturedSourceSnapshot,
+    );
+    await workspaceService.saveSnapshot(
+        targetContext.workspaceId,
+        latestTargetSnapshot,
+    );
+    const [sourceRestore, targetRestore] = await Promise.all([
+        workspaceService.loadSnapshot(sourceWorkspaceId),
+        workspaceService.loadSnapshot(targetContext.workspaceId),
+    ]);
+
+    const transfer = await workspaceSurfaceManager.transferSurface({
+        commit: () =>
+            Promise.resolve(
+                workspaceService!.transferContext({
+                    contextKey: input.contextKey,
+                    sourceRevision: sourceRestore.revision,
+                    sourceWorkspaceId,
+                    targetRevision: targetRestore.revision,
+                    targetWorkspaceId: targetContext.workspaceId!,
+                }),
+            ),
+        contextKey: input.contextKey,
+        sourceHostWindowId: sourceWindowId,
+        targetHostWindowId: targetContext.windowId,
+    });
+
+    applyTransferredWorkspaceWindowState(
+        sourceWindowId,
+        transfer.sourceSnapshot,
+    );
+    applyTransferredWorkspaceWindowState(
+        targetContext.windowId,
+        transfer.targetSnapshot,
+    );
+    focusExistingWindow(targetWindow);
+}
+
+async function createEmptyWorkspaceTransferWindow(): Promise<WindowContextSnapshot> {
+    if (!persistenceService || !workspaceService) {
+        throw new Error("The workspace service is unavailable.");
+    }
+    const focusedMainWindow = windowRegistry.getFocusedMainWindow();
+    const focusedContext = focusedMainWindow
+        ? windowRegistry.getContextByBrowserWindow(focusedMainWindow)
+        : null;
+    const shellState =
+        focusedContext?.windowKind === "main"
+            ? persistenceService.loadSnapshot(focusedContext.windowId).shellState
+            : null;
+    const persistenceSnapshot = await persistenceService.createMainWindowSession({
+        projectId: null,
+        shellState,
+        worktreeId: null,
+    });
+    const context = persistenceSnapshot.windowContext;
+    if (context?.windowKind !== "main" || !context.workspaceId) {
+        throw new Error("Could not create the destination window.");
+    }
+    const emptySnapshot: WorkspaceNavigationSnapshot = {
+        activeContextKey: null,
+        contexts: [],
+        openContextKeys: [],
+        version: 3,
+    };
+    await workspaceService.saveSnapshot(context.workspaceId, emptySnapshot);
+    createTrackedMainWindow(persistenceSnapshot);
+    // The live surface can only be attached after the new host renderer has
+    // hydrated its empty navigation and registered its content view owner.
+    if (!(await workspaceSurfaceManager.waitForHost(context.windowId))) {
+        throw new Error("The destination window did not finish starting.");
+    }
+    return context;
+}
+
+function applyTransferredWorkspaceWindowState(
+    windowId: string,
+    snapshot: WorkspaceNavigationSnapshot,
+): void {
+    const activeContext = snapshot.activeContextKey
+        ? snapshot.contexts.find(
+              (context) => context.key === snapshot.activeContextKey,
+          ) ?? null
+        : null;
+    const projectId = activeContext?.projectId ?? null;
+    const worktreeId = activeContext?.worktreeId ?? null;
+    workspaceSurfaceManager
+        .getHostWebContents(windowId)
+        ?.send(IPC_EVENTS.workspaceSurfaceSnapshotUpdated, snapshot);
+    persistenceService?.saveActiveProjectId(windowId, projectId, worktreeId);
+    windowRegistry.updateMainWindowProjectId(windowId, projectId, worktreeId);
+    const window = windowRegistry.getWindowByStableId(windowId);
+    if (window) {
+        updateMainWindowTitle(window, projectId);
+    }
 }
 
 function loadCurrentAppZoomFactor(): number {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -40,6 +40,7 @@ import {
     type DeleteProjectEntryInput,
     type FileBufferNotificationInput,
     type NativeContextMenuInput,
+    type MoveWorkspaceContextInput,
     type EnqueueAiPromptInput,
     type GitBranchListInput,
     type GitBranchSummary as SharedGitBranchSummary,
@@ -234,6 +235,7 @@ import {
 import type { WorkspaceGateway } from "@main/workspace/service";
 import { windowRegistry } from "@main/windows/registry";
 import { workspaceSurfaceManager } from "@main/workspace/surface-manager";
+import { buildWorkspaceMoveDestinations } from "@main/workspace/move-destinations";
 import { activateOpenWorkspaceLocation } from "@main/workspace/location-navigation";
 import {
     activateWorkspaceSurfaceAndNotifyHost,
@@ -255,6 +257,10 @@ interface RegisterIpcHandlersOptions {
         contextKey: string,
     ) => Promise<WorkspaceNavigationSnapshot | null>;
     readonly openProjectWindow: (input: OpenProjectWindowInput) => Promise<void>;
+    readonly moveWorkspaceContext: (
+        sourceWindowId: string,
+        input: MoveWorkspaceContextInput,
+    ) => Promise<void>;
     readonly persistenceService: PersistenceGateway;
     readonly projectService: ProjectService;
     readonly settingsService: SettingsGateway;
@@ -388,6 +394,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceGitScopeMenu);
     ipcMain.removeHandler(IPC_CHANNELS.openWorkspaceSurfaceProjectMenu);
     ipcMain.removeHandler(IPC_CHANNELS.showWorkspaceContextMenu);
+    ipcMain.removeHandler(IPC_CHANNELS.moveWorkspaceContext);
     ipcMain.removeHandler(IPC_CHANNELS.showNativeContextMenu);
     ipcMain.removeHandler(IPC_CHANNELS.setWorkspaceSurfaceContentInset);
     ipcMain.removeHandler(IPC_CHANNELS.setWorkspaceSurfaceContentLeftInset);
@@ -2197,11 +2204,38 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.handle(
         IPC_CHANNELS.showWorkspaceContextMenu,
         (event, input: WorkspaceContextMenuInput) => {
-            requireWindowContext(event.sender, "main");
+            const sourceContext = requireWindowContext(event.sender, "main");
             const window = BrowserWindow.fromWebContents(event.sender);
             if (!window || workspaceSurfaceManager.isSurface(event.sender)) {
                 return null;
             }
+
+            const destinations = buildWorkspaceMoveDestinations({
+                candidates: windowRegistry
+                    .listMainWindowContexts()
+                    .flatMap((context) => {
+                        const candidateWindow =
+                            windowRegistry.getWindowByStableId(context.windowId);
+                        const snapshot =
+                            workspaceSurfaceManager.getHostSnapshotForWindow(
+                                context.windowId,
+                            );
+                        return candidateWindow && snapshot
+                            ? [
+                                  {
+                                      snapshot,
+                                      windowId: context.windowId,
+                                      windowTitle: candidateWindow.getTitle(),
+                                  },
+                              ]
+                            : [];
+                    }),
+                scope: {
+                    projectId: input.projectId,
+                    worktreeId: input.worktreeId,
+                },
+                sourceWindowId: sourceContext.windowId,
+            });
 
             return new Promise<WorkspaceContextMenuAction | null>((resolve) => {
                 let selected = false;
@@ -2211,18 +2245,40 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
                 };
                 const menu = Menu.buildFromTemplate([
                     {
-                        click: () => select("copy_full_path"),
+                        click: () => select({ type: "copy_full_path" }),
                         enabled: input.canCopyFullPath,
                         label: "Copy Full Path",
                     },
                     { type: "separator" },
                     {
-                        click: () => select("move_to_new_window"),
-                        label: "Move to New Window",
+                        label: "Move to Window",
+                        submenu: [
+                            ...destinations.map((destination) => ({
+                                click: () =>
+                                    select({
+                                        targetWindowId:
+                                            destination.targetWindowId,
+                                        type: "move",
+                                    }),
+                                enabled: destination.enabled,
+                                label: destination.label,
+                            })),
+                            ...(destinations.length > 0
+                                ? ([{ type: "separator" }] as const)
+                                : []),
+                            {
+                                click: () =>
+                                    select({
+                                        targetWindowId: null,
+                                        type: "move",
+                                    }),
+                                label: "New Window",
+                            },
+                        ],
                     },
                     { type: "separator" },
                     {
-                        click: () => select("close"),
+                        click: () => select({ type: "close" }),
                         label: "Close",
                     },
                 ]);
@@ -2235,6 +2291,27 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
                     y: Math.max(0, Math.round(input.y)),
                 });
             });
+        },
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.moveWorkspaceContext,
+        async (event, input: MoveWorkspaceContextInput): Promise<void> => {
+            const sourceContext = requireWindowContext(event.sender, "main");
+            if (workspaceSurfaceManager.isSurface(event.sender)) {
+                throw new Error("Workspace moves must start from a host window.");
+            }
+            if (
+                !input ||
+                typeof input.contextKey !== "string" ||
+                typeof input.projectId !== "string" ||
+                (input.worktreeId !== null &&
+                    typeof input.worktreeId !== "string") ||
+                (input.targetWindowId !== null &&
+                    typeof input.targetWindowId !== "string")
+            ) {
+                throw new Error("The workspace move request is invalid.");
+            }
+            await options.moveWorkspaceContext(sourceContext.windowId, input);
         },
     );
     ipcMain.handle(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -133,6 +133,7 @@ import {
     type GitWorktreeDiffSection,
     type GitWorktreeListInput,
     type GitWorktreeSummary as SharedGitWorktreeSummary,
+    type ActivateWorkspaceLocationInput,
     type ListAiSessionHistoryInput,
     type ListProjectEntriesInput,
     type ListProjectTreeInput,
@@ -140,6 +141,7 @@ import {
     type OpenProjectFileInput,
     type OpenProjectWindowInput,
     type OpenSettingsWindowInput,
+    type OpenWorkspaceLocationSummary,
     type PrepareAiSessionInput,
     type PersistedShellState,
     type PersistenceSnapshot,
@@ -232,6 +234,7 @@ import {
 import type { WorkspaceGateway } from "@main/workspace/service";
 import { windowRegistry } from "@main/windows/registry";
 import { workspaceSurfaceManager } from "@main/workspace/surface-manager";
+import { activateOpenWorkspaceLocation } from "@main/workspace/location-navigation";
 import {
     activateWorkspaceSurfaceAndNotifyHost,
     persistWorkspaceSurfaceSnapshot,
@@ -373,6 +376,8 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.saveWorkspaceSnapshot);
     ipcMain.removeHandler(IPC_CHANNELS.initializeWorkspaceSurfaces);
     ipcMain.removeHandler(IPC_CHANNELS.activateWorkspaceSurface);
+    ipcMain.removeHandler(IPC_CHANNELS.listOpenWorkspaceLocations);
+    ipcMain.removeHandler(IPC_CHANNELS.activateWorkspaceLocation);
     ipcMain.removeHandler(IPC_CHANNELS.captureWorkspaceSurfaceContext);
     ipcMain.removeHandler(IPC_CHANNELS.dispatchWorkspaceSurfaceDrag);
     ipcMain.removeHandler(IPC_CHANNELS.dispatchWorkspaceSurfaceAction);
@@ -2056,6 +2061,90 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             }
         },
     );
+    ipcMain.handle(IPC_CHANNELS.listOpenWorkspaceLocations, (event) => {
+        const sourceContext = requireWindowContext(event.sender, "main");
+        if (workspaceSurfaceManager.isSurface(event.sender)) {
+            return [];
+        }
+        return workspaceSurfaceManager.listOpenWorkspaceLocations().map(
+            (location): OpenWorkspaceLocationSummary => ({
+                ...location,
+                isCurrentWindow:
+                    location.hostWindowId === sourceContext.windowId,
+                windowTitle:
+                    windowRegistry
+                        .getWindowByStableId(location.hostWindowId)
+                        ?.getTitle() ?? "Comando",
+            }),
+        );
+    });
+    ipcMain.handle(
+        IPC_CHANNELS.activateWorkspaceLocation,
+        async (event, input: ActivateWorkspaceLocationInput) => {
+            requireWindowContext(event.sender, "main");
+            if (
+                workspaceSurfaceManager.isSurface(event.sender) ||
+                !isActivateWorkspaceLocationInput(input)
+            ) {
+                return false;
+            }
+            return activateOpenWorkspaceLocation({
+                focusWindow: focusWorkspaceWindow,
+                location: input,
+                manager: workspaceSurfaceManager,
+                notifyChannel: IPC_EVENTS.workspaceSurfaceSnapshotUpdated,
+                onActivated: async (location, snapshot) => {
+                    const targetContext = windowRegistry
+                        .listMainWindowContexts()
+                        .find(
+                            (candidate) =>
+                                candidate.windowId === location.hostWindowId,
+                        );
+                    if (!targetContext?.workspaceId) {
+                        throw new Error(
+                            "The target workspace window is unavailable.",
+                        );
+                    }
+                    await options.workspaceService.saveSnapshot(
+                        targetContext.workspaceId,
+                        snapshot,
+                    );
+                    const latestSnapshot =
+                        workspaceSurfaceManager.getHostSnapshotForWindow(
+                            location.hostWindowId,
+                        );
+                    if (
+                        latestSnapshot &&
+                        latestSnapshot.activeContextKey !==
+                            snapshot.activeContextKey
+                    ) {
+                        await options.workspaceService.saveSnapshot(
+                            targetContext.workspaceId,
+                            latestSnapshot,
+                        );
+                    }
+                    options.persistenceService.saveActiveProjectId(
+                        location.hostWindowId,
+                        location.projectId,
+                        location.worktreeId,
+                    );
+                    windowRegistry.updateMainWindowProjectId(
+                        location.hostWindowId,
+                        location.projectId,
+                        location.worktreeId,
+                    );
+                    windowRegistry
+                        .getWindowByStableId(location.hostWindowId)
+                        ?.setTitle(
+                            buildMainWindowTitle(
+                                options.projectService,
+                                location.projectId,
+                            ),
+                        );
+                },
+            });
+        },
+    );
     ipcMain.handle(
         IPC_CHANNELS.requestWorkspaceSurfaceContext,
         (event, input: WorkspaceSurfaceContextRequest) => {
@@ -2645,6 +2734,33 @@ function requireWindowContext(
 
 function getPersistenceOwnerId(context: WindowContextSnapshot): string {
     return context.hostWindowId ?? context.windowId;
+}
+
+function isActivateWorkspaceLocationInput(
+    input: ActivateWorkspaceLocationInput,
+): input is ActivateWorkspaceLocationInput {
+    return (
+        Boolean(input) &&
+        typeof input.contextKey === "string" &&
+        input.contextKey.length > 0 &&
+        typeof input.hostWindowId === "string" &&
+        input.hostWindowId.length > 0 &&
+        typeof input.projectId === "string" &&
+        input.projectId.length > 0 &&
+        (input.worktreeId === null || typeof input.worktreeId === "string")
+    );
+}
+
+function focusWorkspaceWindow(windowId: string): void {
+    const window = windowRegistry.getWindowByStableId(windowId);
+    if (!window || window.isDestroyed()) {
+        return;
+    }
+    if (window.isMinimized()) {
+        window.restore();
+    }
+    window.show();
+    window.focus();
 }
 
 function buildMainWindowTitle(

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -14,6 +14,7 @@ interface InstallApplicationMenuOptions {
     readonly openNewMainWindow: (
         projectId?: string | null,
     ) => Promise<void> | void;
+    readonly openWorkspaceSwitcher: () => void;
     readonly reopenLastClosedTab: () => void;
     readonly toggleSidebar: () => void;
     readonly openSettingsWindow: (
@@ -80,6 +81,13 @@ function buildMenuTemplate(
                     }
                 },
                 label: "Open Current Project In New Window",
+            },
+            {
+                accelerator: "CmdOrCtrl+Shift+O",
+                click: () => {
+                    options.openWorkspaceSwitcher();
+                },
+                label: "Switch Workspace…",
             },
             { type: "separator" },
             {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -9,7 +9,6 @@ interface InstallApplicationMenuOptions {
         direction: "decrease" | "increase" | "reset",
     ) => void;
     readonly closeFocusedWindowSurface: () => void;
-    readonly focusProjectWindow: (projectId: string) => boolean;
     readonly getFocusedMainWindowContext: () => WindowContextSnapshot | null;
     readonly openNewMainWindow: (
         projectId?: string | null,
@@ -65,22 +64,6 @@ function buildMenuTemplate(
                     void options.openNewMainWindow(null);
                 },
                 label: "New Window",
-            },
-            {
-                accelerator: "CmdOrCtrl+Alt+N",
-                click: () => {
-                    const context = options.getFocusedMainWindowContext();
-                    const projectId = context?.projectId ?? null;
-                    if (!projectId) {
-                        void options.openNewMainWindow(null);
-                        return;
-                    }
-
-                    if (!options.focusProjectWindow(projectId)) {
-                        void options.openNewMainWindow(projectId);
-                    }
-                },
-                label: "Open Current Project In New Window",
             },
             {
                 accelerator: "CmdOrCtrl+Shift+O",

--- a/src/main/native-backend/app-data.test.ts
+++ b/src/main/native-backend/app-data.test.ts
@@ -124,6 +124,94 @@ describe("createNativeAppDataClient", () => {
         await secondClient.close();
     });
 
+    it("atomically transfers a context between window snapshots", async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "comando-app-data-"));
+        tempDirs.push(tempDir);
+        const databaseFile = path.join(tempDir, "comando.sqlite");
+        new DatabaseSync(databaseFile).close();
+        const native = createFakeNativeRequester();
+        const { createNativeAppDataClient } = await import("./app-data");
+        const client = await createNativeAppDataClient({
+            client: native.requester,
+            databaseFile,
+        });
+        const sourceWindow = await client.persistence.createMainWindowSession({
+            projectId: "project-1",
+        });
+        const targetWindow = await client.persistence.createMainWindowSession({
+            projectId: "project-2",
+        });
+        const sourceWorkspaceId = sourceWindow.windowContext?.workspaceId;
+        const targetWorkspaceId = targetWindow.windowContext?.workspaceId;
+        if (!sourceWorkspaceId || !targetWorkspaceId) {
+            throw new Error("Expected transfer workspace ids.");
+        }
+        await client.workspace.saveSnapshot(
+            sourceWorkspaceId,
+            workspaceNavigation("project-1", null, "pane-source"),
+        );
+        await client.workspace.saveSnapshot(
+            targetWorkspaceId,
+            workspaceNavigation("project-2", null, "pane-target"),
+        );
+        const sourceBefore = await client.workspace.loadSnapshot(
+            sourceWorkspaceId,
+        );
+        const targetBefore = await client.workspace.loadSnapshot(
+            targetWorkspaceId,
+        );
+
+        const transfer = await client.workspace.transferContext({
+            contextKey: "project-1::__primary__",
+            sourceRevision: sourceBefore.revision,
+            sourceWorkspaceId,
+            targetRevision: targetBefore.revision,
+            targetWorkspaceId,
+        });
+
+        expect(transfer.source).toMatchObject({
+            revision: sourceBefore.revision + 1,
+            snapshot: { activeContextKey: null, openContextKeys: [] },
+        });
+        expect(transfer.target).toMatchObject({
+            revision: targetBefore.revision + 1,
+            snapshot: {
+                activeContextKey: "project-1::__primary__",
+                openContextKeys: [
+                    "project-2::__primary__",
+                    "project-1::__primary__",
+                ],
+            },
+        });
+        await expect(
+            client.workspace.transferContext({
+                contextKey: "project-2::__primary__",
+                sourceRevision: targetBefore.revision,
+                sourceWorkspaceId: targetWorkspaceId,
+                targetRevision: sourceBefore.revision,
+                targetWorkspaceId: sourceWorkspaceId,
+            }),
+        ).rejects.toThrow("changed before it could be moved");
+        await client.close();
+
+        const restored = await createNativeAppDataClient({
+            client: native.requester,
+            databaseFile,
+        });
+        expect(
+            (await restored.workspace.loadSnapshot(sourceWorkspaceId)).snapshot
+                .openContextKeys,
+        ).toEqual([]);
+        expect(
+            (await restored.workspace.loadSnapshot(targetWorkspaceId)).snapshot
+                .openContextKeys,
+        ).toEqual([
+            "project-2::__primary__",
+            "project-1::__primary__",
+        ]);
+        await restored.close();
+    });
+
     it("migrates legacy SQLite app data into native app-data and keyring", async () => {
         const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "comando-app-data-"));
         tempDirs.push(tempDir);

--- a/src/main/native-backend/app-data.ts
+++ b/src/main/native-backend/app-data.ts
@@ -55,6 +55,7 @@ import {
     createWindowWorkspaceRestoreRecord,
     normalizeWindowWorkspaceRestoreRecord,
 } from "@shared/workspace-restore";
+import { areWorkspaceScopesEquivalent } from "@shared/workspace-context";
 
 import type {
     AiPersistenceGateway,
@@ -72,7 +73,11 @@ import type {
     PersistenceGateway,
 } from "@main/persistence/service";
 import type { SettingsGateway } from "@main/settings/service";
-import type { WorkspaceGateway } from "@main/workspace/service";
+import type {
+    WorkspaceContextTransferInput,
+    WorkspaceContextTransferResult,
+    WorkspaceGateway,
+} from "@main/workspace/service";
 
 import { debugBenignError } from "@main/observability/logging";
 
@@ -436,6 +441,133 @@ class NativePersistenceClient implements PersistenceGateway {
         await commit;
     }
 
+    async transferWorkspaceContext(
+        input: WorkspaceContextTransferInput,
+    ): Promise<WorkspaceContextTransferResult> {
+        const commit = this.#workspaceCommitChain.then(() =>
+            this.#transferWorkspaceContextNow(input),
+        );
+        this.#workspaceCommitChain = commit.then(
+            () => undefined,
+            () => undefined,
+        );
+        return await commit;
+    }
+
+    async #transferWorkspaceContextNow(
+        input: WorkspaceContextTransferInput,
+    ): Promise<WorkspaceContextTransferResult> {
+        if (input.sourceWorkspaceId === input.targetWorkspaceId) {
+            throw new Error("Workspace transfers require two different windows.");
+        }
+        const sourceEntry = this.#findWindowEntryByWorkspaceId(
+            input.sourceWorkspaceId,
+        );
+        const targetEntry = this.#findWindowEntryByWorkspaceId(
+            input.targetWorkspaceId,
+        );
+        if (!sourceEntry || !targetEntry) {
+            throw new Error("A workspace transfer window was not found.");
+        }
+        const [sourceWindowId, sourceRecord] = sourceEntry;
+        const [targetWindowId, targetRecord] = targetEntry;
+        const sourceRestore = sourceRecord.workspaceRestore ??
+            createWindowWorkspaceRestoreRecord(emptyWorkspaceNavigation());
+        const targetRestore = targetRecord.workspaceRestore ??
+            createWindowWorkspaceRestoreRecord(emptyWorkspaceNavigation());
+        if (
+            sourceRestore.revision !== input.sourceRevision ||
+            targetRestore.revision !== input.targetRevision
+        ) {
+            throw new Error("A workspace changed before it could be moved.");
+        }
+        const context = sourceRestore.snapshot.contexts.find(
+            (candidate) => candidate.key === input.contextKey,
+        );
+        if (
+            !context ||
+            !sourceRestore.snapshot.openContextKeys.includes(input.contextKey)
+        ) {
+            throw new Error("The workspace to move is no longer open.");
+        }
+        if (
+            targetRestore.snapshot.contexts.some((candidate) =>
+                areWorkspaceScopesEquivalent(candidate, context),
+            )
+        ) {
+            throw new Error("The destination already contains this workspace.");
+        }
+
+        const sourceOpenContextKeys =
+            sourceRestore.snapshot.openContextKeys.filter(
+                (key) => key !== input.contextKey,
+            );
+        const sourceIndex = sourceRestore.snapshot.openContextKeys.indexOf(
+            input.contextKey,
+        );
+        const sourceActiveContextKey =
+            sourceRestore.snapshot.activeContextKey === input.contextKey
+                ? (sourceOpenContextKeys[
+                      Math.min(sourceIndex, sourceOpenContextKeys.length - 1)
+                  ] ?? null)
+                : sourceRestore.snapshot.activeContextKey;
+        const targetIndex = Math.max(
+            0,
+            Math.min(
+                input.targetIndex ?? targetRestore.snapshot.openContextKeys.length,
+                targetRestore.snapshot.openContextKeys.length,
+            ),
+        );
+        const targetOpenContextKeys = [
+            ...targetRestore.snapshot.openContextKeys.slice(0, targetIndex),
+            context.key,
+            ...targetRestore.snapshot.openContextKeys.slice(targetIndex),
+        ];
+        const updatedContext = {
+            ...context,
+            lastActivatedAt: new Date().toISOString(),
+        };
+        const source = createWindowWorkspaceRestoreRecord(
+            {
+                ...sourceRestore.snapshot,
+                activeContextKey: sourceActiveContextKey,
+                contexts: sourceRestore.snapshot.contexts.filter(
+                    (candidate) => candidate.key !== input.contextKey,
+                ),
+                openContextKeys: sourceOpenContextKeys,
+            },
+            sourceRestore.revision + 1,
+        );
+        const target = createWindowWorkspaceRestoreRecord(
+            {
+                ...targetRestore.snapshot,
+                activeContextKey: context.key,
+                contexts: [...targetRestore.snapshot.contexts, updatedContext],
+                openContextKeys: targetOpenContextKeys,
+            },
+            targetRestore.revision + 1,
+        );
+
+        this.#recordsByWindowId.set(
+            sourceWindowId,
+            withWorkspaceRestore(sourceRecord, source),
+        );
+        this.#recordsByWindowId.set(
+            targetWindowId,
+            withWorkspaceRestore(targetRecord, target),
+        );
+        try {
+            await this.#persist();
+        } catch (error) {
+            // Restore both records together so a failed durable write cannot
+            // leak a half-applied move into later in-memory reads.
+            this.#recordsByWindowId.set(sourceWindowId, sourceRecord);
+            this.#recordsByWindowId.set(targetWindowId, targetRecord);
+            throw error;
+        }
+        return { source, target };
+    }
+
     async #commitWorkspaceRestoreNow(
         workspaceId: string,
         snapshot: WorkspaceNavigationSnapshot,
@@ -473,6 +605,17 @@ class NativePersistenceClient implements PersistenceGateway {
             workspaceRestore: restore,
         });
         await this.#persist();
+    }
+
+    #findWindowEntryByWorkspaceId(
+        workspaceId: string,
+    ): [string, PersistedWindowRecord] | null {
+        return (
+            [...this.#recordsByWindowId.entries()].find(
+                ([, record]) =>
+                    record.snapshot.windowContext?.workspaceId === workspaceId,
+            ) ?? null
+        );
     }
 
     #rehydrate(records: readonly PersistedWindowRecord[]): void {
@@ -535,6 +678,40 @@ class NativePersistenceClient implements PersistenceGateway {
             [...this.#recordsByWindowId.values()],
         );
     }
+}
+
+function emptyWorkspaceNavigation(): WorkspaceNavigationSnapshot {
+    return {
+        activeContextKey: null,
+        contexts: [],
+        openContextKeys: [],
+        version: 3,
+    };
+}
+
+function withWorkspaceRestore(
+    record: PersistedWindowRecord,
+    workspaceRestore: WindowWorkspaceRestoreRecord,
+): PersistedWindowRecord {
+    const activeContext = workspaceRestore.snapshot.contexts.find(
+        (context) => context.key === workspaceRestore.snapshot.activeContextKey,
+    );
+    return {
+        ...record,
+        snapshot: {
+            ...record.snapshot,
+            activeProjectId: activeContext?.projectId ?? null,
+            activeWorktreeId: activeContext?.worktreeId ?? null,
+            windowContext: record.snapshot.windowContext
+                ? {
+                      ...record.snapshot.windowContext,
+                      projectId: activeContext?.projectId ?? null,
+                      worktreeId: activeContext?.worktreeId ?? null,
+                  }
+                : null,
+        },
+        workspaceRestore,
+    };
 }
 
 class NativeSettingsClient implements SettingsGateway {
@@ -870,6 +1047,12 @@ class NativeWorkspaceClient implements WorkspaceGateway {
             workspaceId,
             normalizedSnapshot,
         );
+    }
+
+    transferContext(
+        input: WorkspaceContextTransferInput,
+    ): Promise<WorkspaceContextTransferResult> {
+        return this.#persistence.transferWorkspaceContext(input);
     }
 
     loadChatSessionState(

--- a/src/main/windows/registry.ts
+++ b/src/main/windows/registry.ts
@@ -137,6 +137,10 @@ class WindowRegistry {
         return this.#getMostRecentMainWindowEntry()?.window ?? null;
     }
 
+    getLastFocusedMainWindowId(): string | null {
+        return this.#lastFocusedMainWindowId;
+    }
+
     getFocusedMainWindow(): BrowserWindow | null {
         const focusedWindow = BrowserWindow.getFocusedWindow();
         if (!focusedWindow) {

--- a/src/main/workspace/location-navigation.test.ts
+++ b/src/main/workspace/location-navigation.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { IPC_EVENTS } from "@shared/ipc";
+import type {
+    OpenWorkspaceLocationSummary,
+    WorkspaceNavigationSnapshot,
+} from "@shared/ipc";
+
+import { activateOpenWorkspaceLocation } from "./location-navigation";
+
+describe("activateOpenWorkspaceLocation", () => {
+    it("activates and focuses only the exact target host", async () => {
+        const snapshot = createSnapshot("project-b::__primary__");
+        const targetSend = vi.fn();
+        const sourceSend = vi.fn();
+        const manager = {
+            activate: vi.fn(() => true),
+            getHostSnapshotForWindow: vi.fn(() => snapshot),
+            getHostWebContents: vi.fn((hostWindowId: string) => ({
+                send: hostWindowId === "window-2" ? targetSend : sourceSend,
+            })),
+            listOpenWorkspaceLocations: vi.fn(() => createLocations()),
+        };
+        const focusWindow = vi.fn();
+        const onActivated = vi.fn();
+
+        await expect(
+            activateOpenWorkspaceLocation({
+                focusWindow,
+                location: {
+                    contextKey: "project-b::__primary__",
+                    hostWindowId: "window-2",
+                    projectId: "project-b",
+                    worktreeId: null,
+                },
+                manager,
+                notifyChannel: IPC_EVENTS.workspaceSurfaceSnapshotUpdated,
+                onActivated,
+            }),
+        ).resolves.toBe(true);
+
+        expect(manager.activate).toHaveBeenCalledWith(
+            "window-2",
+            "project-b::__primary__",
+        );
+        expect(targetSend).toHaveBeenCalledWith(
+            IPC_EVENTS.workspaceSurfaceSnapshotUpdated,
+            snapshot,
+        );
+        expect(sourceSend).not.toHaveBeenCalled();
+        expect(focusWindow).toHaveBeenCalledWith("window-2");
+        expect(onActivated).toHaveBeenCalledWith(
+            expect.objectContaining({ hostWindowId: "window-2" }),
+            snapshot,
+        );
+    });
+
+    it("rejects a stale location without changing any host", async () => {
+        const manager = {
+            activate: vi.fn(() => true),
+            getHostSnapshotForWindow: vi.fn(),
+            getHostWebContents: vi.fn(),
+            listOpenWorkspaceLocations: vi.fn(() => createLocations()),
+        };
+        const focusWindow = vi.fn();
+
+        await expect(
+            activateOpenWorkspaceLocation({
+                focusWindow,
+                location: {
+                    contextKey: "project-b::__primary__",
+                    hostWindowId: "window-2",
+                    projectId: "project-b",
+                    worktreeId: "stale-worktree",
+                },
+                manager,
+                notifyChannel: IPC_EVENTS.workspaceSurfaceSnapshotUpdated,
+                onActivated: vi.fn(),
+            }),
+        ).resolves.toBe(false);
+
+        expect(manager.activate).not.toHaveBeenCalled();
+        expect(focusWindow).not.toHaveBeenCalled();
+    });
+});
+
+function createLocations(): OpenWorkspaceLocationSummary[] {
+    return [
+        {
+            contextKey: "project-a::__primary__",
+            hostWindowId: "window-1",
+            isActive: true,
+            isCurrentWindow: true,
+            lastActivatedAt: "2026-07-20T00:00:00.000Z",
+            projectId: "project-a",
+            windowTitle: "Comando · project-a",
+            worktreeId: null,
+        },
+        {
+            contextKey: "project-b::__primary__",
+            hostWindowId: "window-2",
+            isActive: true,
+            isCurrentWindow: false,
+            lastActivatedAt: "2026-07-21T00:00:00.000Z",
+            projectId: "project-b",
+            windowTitle: "Comando · project-b",
+            worktreeId: null,
+        },
+    ];
+}
+
+function createSnapshot(activeContextKey: string): WorkspaceNavigationSnapshot {
+    return {
+        activeContextKey,
+        contexts: [],
+        openContextKeys: [],
+        version: 3,
+    };
+}

--- a/src/main/workspace/location-navigation.ts
+++ b/src/main/workspace/location-navigation.ts
@@ -1,0 +1,53 @@
+import type { WorkspaceNavigationSnapshot } from "@shared/ipc";
+import type { ActivateWorkspaceLocationInput } from "@shared/ipc";
+import { areWorkspaceScopesEquivalent } from "@shared/workspace-context";
+import type { WorkspaceLocation } from "@shared/workspace-context";
+
+interface WorkspaceLocationNavigationManager {
+    activate(hostWindowId: string, contextKey: string): boolean;
+    getHostSnapshotForWindow(
+        hostWindowId: string,
+    ): WorkspaceNavigationSnapshot | null;
+    getHostWebContents(
+        hostWindowId: string,
+    ): { send(channel: string, snapshot: WorkspaceNavigationSnapshot): void } | null;
+    listOpenWorkspaceLocations(): readonly WorkspaceLocation[];
+}
+
+export async function activateOpenWorkspaceLocation(input: {
+    readonly focusWindow: (hostWindowId: string) => void;
+    readonly location: ActivateWorkspaceLocationInput;
+    readonly manager: WorkspaceLocationNavigationManager;
+    readonly notifyChannel: string;
+    readonly onActivated: (
+        location: WorkspaceLocation,
+        snapshot: WorkspaceNavigationSnapshot,
+    ) => Promise<void> | void;
+}): Promise<boolean> {
+    const location = input.manager
+        .listOpenWorkspaceLocations()
+        .find(
+            (candidate) =>
+                candidate.hostWindowId === input.location.hostWindowId &&
+                candidate.contextKey === input.location.contextKey,
+        );
+    if (!location || !areWorkspaceScopesEquivalent(location, input.location)) {
+        return false;
+    }
+    if (!input.manager.activate(location.hostWindowId, location.contextKey)) {
+        return false;
+    }
+    const snapshot = input.manager.getHostSnapshotForWindow(
+        location.hostWindowId,
+    );
+    if (!snapshot) {
+        return false;
+    }
+
+    input.manager
+        .getHostWebContents(location.hostWindowId)
+        ?.send(input.notifyChannel, snapshot);
+    input.focusWindow(location.hostWindowId);
+    await input.onActivated(location, snapshot);
+    return true;
+}

--- a/src/main/workspace/move-coordinator.test.ts
+++ b/src/main/workspace/move-coordinator.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+    PersistedWorkspaceContext,
+    WindowContextSnapshot,
+    WorkspaceNavigationSnapshot,
+} from "@shared/ipc";
+import { createWindowWorkspaceRestoreRecord } from "@shared/workspace-restore";
+
+import type { WorkspaceGateway } from "./service";
+import { moveWorkspaceBetweenWindows } from "./move-coordinator";
+import type { WorkspaceSurfaceManager } from "./surface-manager";
+
+type TransferSurfaceInput = Parameters<
+    WorkspaceSurfaceManager["transferSurface"]
+>[0];
+
+describe("moveWorkspaceBetweenWindows", () => {
+    it("moves a primary scope beside distinct worktrees without recreating it", async () => {
+        const primary = createContext("project-a::__primary__", null);
+        const worktreeOne = createContext("project-a::worktree-1", "worktree-1");
+        const worktreeTwo = createContext("project-a::worktree-2", "worktree-2");
+        const sourceSnapshot = createSnapshot(primary.key, [primary, worktreeOne]);
+        const targetSnapshot = createSnapshot(worktreeTwo.key, [worktreeTwo]);
+        const committedSource = createSnapshot(worktreeOne.key, [worktreeOne]);
+        const committedTarget = createSnapshot(primary.key, [worktreeTwo, primary]);
+        const transferContext = vi.fn(() =>
+            Promise.resolve({
+                source: createWindowWorkspaceRestoreRecord(committedSource, 4),
+                target: createWindowWorkspaceRestoreRecord(committedTarget, 7),
+            }),
+        );
+        const saveSnapshot = vi.fn(() => Promise.resolve());
+        const flushHost = vi.fn(() => Promise.resolve());
+        const onTransferred = vi.fn();
+        const transferSurface = vi.fn(async (input: TransferSurfaceInput) => {
+            const committed = await input.commit();
+            return {
+                sourceSnapshot: committed.source.snapshot,
+                surfaceId: "surface-primary",
+                targetSnapshot: committed.target.snapshot,
+            };
+        });
+
+        await moveWorkspaceBetweenWindows(
+            "window-1",
+            {
+                contextKey: primary.key,
+                projectId: "project-a",
+                targetWindowId: "window-2",
+                worktreeId: null,
+            },
+            {
+                captureContext: vi.fn(() => Promise.resolve(sourceSnapshot)),
+                createEmptyTarget: vi.fn(),
+                flushHost,
+                getWindowContext: (windowId) => createWindowContext(windowId),
+                isWindowAvailable: () => true,
+                manager: {
+                    getHostSnapshotForWindow: (windowId) =>
+                        windowId === "window-1" ? sourceSnapshot : targetSnapshot,
+                    listOpenWorkspaceLocations: () => [
+                        {
+                            contextKey: primary.key,
+                            hostWindowId: "window-1",
+                            isActive: true,
+                            lastActivatedAt: primary.lastActivatedAt,
+                            projectId: primary.projectId,
+                            worktreeId: primary.worktreeId,
+                        },
+                    ],
+                    transferSurface,
+                },
+                onTransferred,
+                workspaceService: createWorkspaceService({
+                    saveSnapshot,
+                    sourceSnapshot,
+                    targetSnapshot,
+                    transferContext,
+                }),
+            },
+        );
+
+        expect(flushHost).toHaveBeenCalledWith("window-1");
+        expect(flushHost).toHaveBeenCalledWith("window-2");
+        expect(transferSurface).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contextKey: primary.key,
+                sourceHostWindowId: "window-1",
+                targetHostWindowId: "window-2",
+            }),
+        );
+        expect(transferContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contextKey: primary.key,
+                sourceWorkspaceId: "workspace-window-1",
+                targetWorkspaceId: "workspace-window-2",
+            }),
+        );
+        expect(onTransferred).toHaveBeenCalledWith(
+            "window-1",
+            "window-2",
+            expect.objectContaining({ surfaceId: "surface-primary" }),
+        );
+    });
+
+    it("creates an empty target and does not flush its renderer before moving", async () => {
+        const primary = createContext("project-a::__primary__", null);
+        const sourceSnapshot = createSnapshot(primary.key, [primary]);
+        const emptySnapshot = createSnapshot(null, []);
+        const flushHost = vi.fn(() => Promise.resolve());
+        const targetContext = createWindowContext("window-new");
+        const transferSurface = vi.fn(async (input: TransferSurfaceInput) => {
+            const committed = await input.commit();
+            return {
+                sourceSnapshot: committed.source.snapshot,
+                surfaceId: "surface-primary",
+                targetSnapshot: committed.target.snapshot,
+            };
+        });
+
+        await moveWorkspaceBetweenWindows(
+            "window-1",
+            {
+                contextKey: primary.key,
+                projectId: primary.projectId,
+                targetWindowId: null,
+                worktreeId: null,
+            },
+            {
+                captureContext: vi.fn(() => Promise.resolve(sourceSnapshot)),
+                createEmptyTarget: vi.fn(() => Promise.resolve(targetContext)),
+                flushHost,
+                getWindowContext: (windowId) => createWindowContext(windowId),
+                isWindowAvailable: () => true,
+                manager: {
+                    getHostSnapshotForWindow: (windowId) =>
+                        windowId === "window-new" ? emptySnapshot : sourceSnapshot,
+                    listOpenWorkspaceLocations: () => [
+                        {
+                            contextKey: primary.key,
+                            hostWindowId: "window-1",
+                            isActive: true,
+                            lastActivatedAt: primary.lastActivatedAt,
+                            projectId: primary.projectId,
+                            worktreeId: null,
+                        },
+                    ],
+                    transferSurface,
+                },
+                onTransferred: vi.fn(),
+                workspaceService: createWorkspaceService({
+                    saveSnapshot: vi.fn(() => Promise.resolve()),
+                    sourceSnapshot,
+                    targetSnapshot: emptySnapshot,
+                    transferContext: vi.fn(() =>
+                        Promise.resolve({
+                            source: createWindowWorkspaceRestoreRecord(
+                                emptySnapshot,
+                                2,
+                            ),
+                            target: createWindowWorkspaceRestoreRecord(
+                                sourceSnapshot,
+                                2,
+                            ),
+                        }),
+                    ),
+                }),
+            },
+        );
+
+        expect(flushHost).toHaveBeenCalledTimes(1);
+        expect(flushHost).toHaveBeenCalledWith("window-1");
+        expect(transferSurface).toHaveBeenCalledWith(
+            expect.objectContaining({ targetHostWindowId: "window-new" }),
+        );
+    });
+
+    it("leaves the source untouched when a selected target has closed", async () => {
+        const primary = createContext("project-a::__primary__", null);
+        const sourceSnapshot = createSnapshot(primary.key, [primary]);
+        const transferSurface = vi.fn();
+        const saveSnapshot = vi.fn();
+
+        await expect(
+            moveWorkspaceBetweenWindows(
+                "window-1",
+                {
+                    contextKey: primary.key,
+                    projectId: primary.projectId,
+                    targetWindowId: "window-closed",
+                    worktreeId: null,
+                },
+                {
+                    captureContext: vi.fn(),
+                    createEmptyTarget: vi.fn(),
+                    flushHost: vi.fn(),
+                    getWindowContext: (windowId) => createWindowContext(windowId),
+                    isWindowAvailable: (windowId) =>
+                        windowId !== "window-closed",
+                    manager: {
+                        getHostSnapshotForWindow: () => sourceSnapshot,
+                        listOpenWorkspaceLocations: () => [
+                            {
+                                contextKey: primary.key,
+                                hostWindowId: "window-1",
+                                isActive: true,
+                                lastActivatedAt: primary.lastActivatedAt,
+                                projectId: primary.projectId,
+                                worktreeId: null,
+                            },
+                        ],
+                        transferSurface,
+                    },
+                    onTransferred: vi.fn(),
+                    workspaceService: createWorkspaceService({
+                        saveSnapshot,
+                        sourceSnapshot,
+                        targetSnapshot: sourceSnapshot,
+                        transferContext: vi.fn(),
+                    }),
+                },
+            ),
+        ).rejects.toThrow("destination window is no longer available");
+
+        expect(saveSnapshot).not.toHaveBeenCalled();
+        expect(transferSurface).not.toHaveBeenCalled();
+    });
+});
+
+function createWorkspaceService(input: {
+    readonly saveSnapshot: WorkspaceGateway["saveSnapshot"];
+    readonly sourceSnapshot: WorkspaceNavigationSnapshot;
+    readonly targetSnapshot: WorkspaceNavigationSnapshot;
+    readonly transferContext: WorkspaceGateway["transferContext"];
+}): WorkspaceGateway {
+    return {
+        loadChatSessionState: vi.fn(() => Promise.resolve(null)),
+        loadSnapshot: vi.fn((workspaceId: string) =>
+            Promise.resolve(
+                createWindowWorkspaceRestoreRecord(
+                    workspaceId === "workspace-window-1"
+                        ? input.sourceSnapshot
+                        : input.targetSnapshot,
+                    workspaceId === "workspace-window-1" ? 3 : 6,
+                ),
+            ),
+        ),
+        saveSnapshot: input.saveSnapshot,
+        transferContext: input.transferContext,
+    };
+}
+
+function createWindowContext(windowId: string): WindowContextSnapshot {
+    return {
+        projectId: null,
+        windowId,
+        windowKind: "main",
+        workspaceId: `workspace-${windowId}`,
+        workspaceSessionId: `session-${windowId}`,
+        worktreeId: null,
+    };
+}
+
+function createContext(
+    key: string,
+    worktreeId: string | null,
+): PersistedWorkspaceContext {
+    return {
+        key,
+        lastActivatedAt: "2026-07-22T12:00:00.000Z",
+        projectId: "project-a",
+        workspace: {
+            activePaneId: `pane-${key}`,
+            rootNode: {
+                activeTabId: null,
+                id: `pane-${key}`,
+                tabIds: [],
+                type: "pane",
+            },
+            tabs: [],
+        },
+        worktreeId,
+    };
+}
+
+function createSnapshot(
+    activeContextKey: string | null,
+    contexts: readonly PersistedWorkspaceContext[],
+): WorkspaceNavigationSnapshot {
+    return {
+        activeContextKey,
+        contexts,
+        openContextKeys: contexts.map((context) => context.key),
+        version: 3,
+    };
+}

--- a/src/main/workspace/move-coordinator.ts
+++ b/src/main/workspace/move-coordinator.ts
@@ -1,0 +1,151 @@
+import type {
+    MoveWorkspaceContextInput,
+    WindowContextSnapshot,
+    WorkspaceNavigationSnapshot,
+} from "@shared/ipc";
+import { areWorkspaceScopesEquivalent } from "@shared/workspace-context";
+
+import type { WorkspaceGateway } from "./service";
+import type {
+    OpenWorkspaceSurfaceLocation,
+    WorkspaceSurfaceManager,
+    WorkspaceSurfaceTransferResult,
+} from "./surface-manager";
+
+interface WorkspaceMoveManager {
+    getHostSnapshotForWindow(
+        hostWindowId: string,
+    ): WorkspaceNavigationSnapshot | null;
+    listOpenWorkspaceLocations(): readonly OpenWorkspaceSurfaceLocation[];
+    transferSurface(
+        input: Parameters<WorkspaceSurfaceManager["transferSurface"]>[0],
+    ): Promise<WorkspaceSurfaceTransferResult>;
+}
+
+export interface WorkspaceMoveCoordinatorDependencies {
+    readonly captureContext: (
+        hostWindowId: string,
+        contextKey: string,
+    ) => Promise<WorkspaceNavigationSnapshot | null>;
+    readonly createEmptyTarget: () => Promise<WindowContextSnapshot>;
+    readonly flushHost: (hostWindowId: string) => Promise<void>;
+    readonly getWindowContext: (
+        hostWindowId: string,
+    ) => WindowContextSnapshot | null;
+    readonly isWindowAvailable: (hostWindowId: string) => boolean;
+    readonly manager: WorkspaceMoveManager;
+    readonly onTransferred: (
+        sourceWindowId: string,
+        targetWindowId: string,
+        transfer: WorkspaceSurfaceTransferResult,
+    ) => void;
+    readonly workspaceService: WorkspaceGateway;
+}
+
+export async function moveWorkspaceBetweenWindows(
+    sourceWindowId: string,
+    input: MoveWorkspaceContextInput,
+    dependencies: WorkspaceMoveCoordinatorDependencies,
+): Promise<void> {
+    // Global identity is the project/worktree scope plus its current host;
+    // uniqueness applies to the scope, never to every worktree in a project.
+    const sourceLocation = dependencies.manager
+        .listOpenWorkspaceLocations()
+        .find(
+            (location) =>
+                location.hostWindowId === sourceWindowId &&
+                location.contextKey === input.contextKey,
+        );
+    if (
+        !sourceLocation ||
+        !areWorkspaceScopesEquivalent(sourceLocation, input)
+    ) {
+        throw new Error("The workspace is no longer open in this window.");
+    }
+
+    const sourceContext = dependencies.getWindowContext(sourceWindowId);
+    if (
+        !sourceContext?.workspaceId ||
+        !dependencies.isWindowAvailable(sourceWindowId)
+    ) {
+        throw new Error("The source window is no longer available.");
+    }
+
+    const createdTarget = input.targetWindowId === null;
+    const targetContext = createdTarget
+        ? await dependencies.createEmptyTarget()
+        : dependencies.getWindowContext(input.targetWindowId);
+    if (
+        !targetContext?.workspaceId ||
+        targetContext.windowKind !== "main" ||
+        !dependencies.isWindowAvailable(targetContext.windowId)
+    ) {
+        throw new Error("The destination window is no longer available.");
+    }
+    if (targetContext.windowId === sourceWindowId) {
+        throw new Error("The workspace is already in this window.");
+    }
+
+    const targetSnapshot = dependencies.manager.getHostSnapshotForWindow(
+        targetContext.windowId,
+    );
+    if (!targetSnapshot) {
+        throw new Error("The destination window is still starting.");
+    }
+    if (
+        targetSnapshot.contexts.some((context) =>
+            areWorkspaceScopesEquivalent(context, input),
+        )
+    ) {
+        throw new Error("The destination already contains this workspace.");
+    }
+
+    await Promise.all([
+        dependencies.flushHost(sourceWindowId),
+        ...(createdTarget
+            ? []
+            : [dependencies.flushHost(targetContext.windowId)]),
+    ]);
+    const capturedSourceSnapshot = await dependencies.captureContext(
+        sourceWindowId,
+        input.contextKey,
+    );
+    const latestTargetSnapshot =
+        dependencies.manager.getHostSnapshotForWindow(targetContext.windowId);
+    if (!capturedSourceSnapshot || !latestTargetSnapshot) {
+        throw new Error("Could not capture the workspace before moving it.");
+    }
+
+    await dependencies.workspaceService.saveSnapshot(
+        sourceContext.workspaceId,
+        capturedSourceSnapshot,
+    );
+    await dependencies.workspaceService.saveSnapshot(
+        targetContext.workspaceId,
+        latestTargetSnapshot,
+    );
+    const [sourceRestore, targetRestore] = await Promise.all([
+        dependencies.workspaceService.loadSnapshot(sourceContext.workspaceId),
+        dependencies.workspaceService.loadSnapshot(targetContext.workspaceId),
+    ]);
+    const transfer = await dependencies.manager.transferSurface({
+        commit: () =>
+            Promise.resolve(
+                dependencies.workspaceService.transferContext({
+                    contextKey: input.contextKey,
+                    sourceRevision: sourceRestore.revision,
+                    sourceWorkspaceId: sourceContext.workspaceId!,
+                    targetRevision: targetRestore.revision,
+                    targetWorkspaceId: targetContext.workspaceId!,
+                }),
+            ),
+        contextKey: input.contextKey,
+        sourceHostWindowId: sourceWindowId,
+        targetHostWindowId: targetContext.windowId,
+    });
+    dependencies.onTransferred(
+        sourceWindowId,
+        targetContext.windowId,
+        transfer,
+    );
+}

--- a/src/main/workspace/move-destinations.test.ts
+++ b/src/main/workspace/move-destinations.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { buildWorkspaceMoveDestinations } from "./move-destinations";
+
+const emptySnapshot = {
+    activeContextKey: null,
+    contexts: [],
+    openContextKeys: [],
+    version: 3,
+} as const;
+
+describe("buildWorkspaceMoveDestinations", () => {
+    it("omits the source and preserves exact destination window IDs", () => {
+        expect(
+            buildWorkspaceMoveDestinations({
+                candidates: [
+                    {
+                        snapshot: emptySnapshot,
+                        windowId: "source",
+                        windowTitle: "Comando",
+                    },
+                    {
+                        snapshot: emptySnapshot,
+                        windowId: "target",
+                        windowTitle: "Comando",
+                    },
+                ],
+                scope: { projectId: "project-a", worktreeId: null },
+                sourceWindowId: "source",
+            }),
+        ).toEqual([
+            {
+                enabled: true,
+                label: "Window 1",
+                targetWindowId: "target",
+            },
+        ]);
+    });
+
+    it("disables legacy duplicate scopes and labels active destinations", () => {
+        const context = {
+            key: "project-a::__primary__",
+            lastActivatedAt: "2026-07-22T12:00:00.000Z",
+            projectId: "project-a",
+            workspace: {
+                activePaneId: "pane-root",
+                rootNode: {
+                    activeTabId: null,
+                    id: "pane-root",
+                    tabIds: [],
+                    type: "pane" as const,
+                },
+                tabs: [],
+            },
+            worktreeId: null,
+        };
+        const destinations = buildWorkspaceMoveDestinations({
+            candidates: [
+                {
+                    snapshot: {
+                        activeContextKey: context.key,
+                        contexts: [context],
+                        openContextKeys: [context.key],
+                        version: 3,
+                    },
+                    windowId: "duplicate",
+                    windowTitle: "Comando · Comando",
+                },
+            ],
+            scope: { projectId: "project-a", worktreeId: null },
+            sourceWindowId: "source",
+        });
+
+        expect(destinations).toEqual([
+            {
+                enabled: false,
+                label: "Comando",
+                targetWindowId: "duplicate",
+            },
+        ]);
+    });
+});

--- a/src/main/workspace/move-destinations.ts
+++ b/src/main/workspace/move-destinations.ts
@@ -1,0 +1,61 @@
+import type { WorkspaceNavigationSnapshot } from "@shared/ipc";
+import {
+    areWorkspaceScopesEquivalent,
+    type WorkspaceScope,
+} from "@shared/workspace-context";
+
+export interface WorkspaceMoveWindowCandidate {
+    readonly snapshot: WorkspaceNavigationSnapshot;
+    readonly windowId: string;
+    readonly windowTitle: string;
+}
+
+export interface WorkspaceMoveDestination {
+    readonly enabled: boolean;
+    readonly label: string;
+    readonly targetWindowId: string;
+}
+
+export function buildWorkspaceMoveDestinations(input: {
+    readonly candidates: readonly WorkspaceMoveWindowCandidate[];
+    readonly scope: WorkspaceScope;
+    readonly sourceWindowId: string;
+}): readonly WorkspaceMoveDestination[] {
+    const candidates = input.candidates.filter(
+        (candidate) => candidate.windowId !== input.sourceWindowId,
+    );
+    const baseLabels = candidates.map((candidate, index) =>
+        getBaseWindowLabel(candidate, index + 1),
+    );
+    const labelCounts = new Map<string, number>();
+    for (const label of baseLabels) {
+        labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+    }
+
+    return candidates.map((candidate, index) => ({
+        enabled: !candidate.snapshot.contexts.some((context) =>
+            areWorkspaceScopesEquivalent(context, input.scope),
+        ),
+        label:
+            (labelCounts.get(baseLabels[index]) ?? 0) > 1
+                ? `${baseLabels[index]} — Window ${index + 1}`
+                : baseLabels[index],
+        targetWindowId: candidate.windowId,
+    }));
+}
+
+function getBaseWindowLabel(
+    candidate: WorkspaceMoveWindowCandidate,
+    ordinal: number,
+): string {
+    if (!candidate.snapshot.activeContextKey) {
+        return `Window ${ordinal}`;
+    }
+    const title = candidate.windowTitle.trim();
+    const separatorIndex = title.indexOf(" · ");
+    const projectLabel =
+        separatorIndex >= 0 ? title.slice(separatorIndex + 3).trim() : title;
+    return projectLabel.length > 0 && title !== "Comando"
+        ? projectLabel
+        : `Window ${ordinal}`;
+}

--- a/src/main/workspace/service.ts
+++ b/src/main/workspace/service.ts
@@ -6,12 +6,29 @@ import type {
 
 type Awaitable<T> = T | Promise<T>;
 
+export interface WorkspaceContextTransferInput {
+    readonly contextKey: string;
+    readonly sourceRevision: number;
+    readonly sourceWorkspaceId: string;
+    readonly targetIndex?: number;
+    readonly targetRevision: number;
+    readonly targetWorkspaceId: string;
+}
+
+export interface WorkspaceContextTransferResult {
+    readonly source: WindowWorkspaceRestoreRecord;
+    readonly target: WindowWorkspaceRestoreRecord;
+}
+
 export interface WorkspaceGateway {
     loadSnapshot(workspaceId: string): Awaitable<WindowWorkspaceRestoreRecord>;
     saveSnapshot(
         workspaceId: string,
         snapshot: WorkspaceNavigationSnapshot,
     ): Awaitable<void>;
+    transferContext(
+        input: WorkspaceContextTransferInput,
+    ): Awaitable<WorkspaceContextTransferResult>;
     loadChatSessionState(
         sessionId: string,
     ): Awaitable<PersistedChatSessionState | null>;

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -8,6 +8,7 @@ import type {
     WorkspaceSurfaceActionRequest,
     WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
+import { createWindowWorkspaceRestoreRecord } from "@shared/workspace-restore";
 
 const electronMocks = vi.hoisted(() => {
     let nextWebContentsId = 100;
@@ -380,6 +381,141 @@ describe("WorkspaceSurfaceManager action routing", () => {
             )?.hostWindowId,
         ).toBe("host-2");
     });
+
+    it("moves a live surface without changing its owner identity", async () => {
+        const manager = new WorkspaceSurfaceManager();
+        const onSurfaceDestroyed = vi.fn();
+        manager.setLifecycleHandlers({ onSurfaceDestroyed });
+        const sourceHost = createHostWindow();
+        const targetHost = createHostWindow();
+        const sourceSnapshot = createSnapshot();
+        const targetSnapshot = singleContextSnapshot(
+            "project-c::__primary__",
+            "project-c",
+        );
+        manager.syncHost(
+            sourceHost.window,
+            createHostContext(),
+            sourceSnapshot,
+        );
+        manager.syncHost(
+            targetHost.window,
+            {
+                ...createHostContext(),
+                projectId: "project-c",
+                windowId: "host-2",
+                workspaceId: "workspace-2",
+                workspaceSessionId: "workspace-session-2",
+            },
+            targetSnapshot,
+        );
+        const originalWebContents = manager.getSurfaceWebContents(
+            "host-1",
+            "project-a::__primary__",
+        );
+        const committedSource = singleContextSnapshot(
+            "project-b::__primary__",
+            "project-b",
+        );
+        const movedContext = sourceSnapshot.contexts[0];
+        if (!originalWebContents || !movedContext) {
+            throw new Error("Expected a live source surface.");
+        }
+        const committedTarget: WorkspaceNavigationSnapshot = {
+            activeContextKey: movedContext.key,
+            contexts: [...targetSnapshot.contexts, movedContext],
+            openContextKeys: [
+                ...targetSnapshot.openContextKeys,
+                movedContext.key,
+            ],
+            version: 3,
+        };
+
+        const result = await manager.transferSurface({
+            commit: vi.fn(() =>
+                Promise.resolve({
+                    source: createWindowWorkspaceRestoreRecord(
+                        committedSource,
+                        2,
+                    ),
+                    target: createWindowWorkspaceRestoreRecord(
+                        committedTarget,
+                        2,
+                    ),
+                }),
+            ),
+            contextKey: movedContext.key,
+            sourceHostWindowId: "host-1",
+            targetHostWindowId: "host-2",
+        });
+
+        expect(
+            manager.getSurfaceWebContents("host-1", movedContext.key),
+        ).toBeNull();
+        expect(
+            manager.getSurfaceWebContents("host-2", movedContext.key),
+        ).toBe(originalWebContents);
+        expect(manager.getSurfaceContext(originalWebContents)).toMatchObject({
+            hostWindowId: "host-2",
+            windowId: result.surfaceId,
+            workspaceId: "workspace-2",
+            workspaceSessionId: "workspace-session-2",
+        });
+        expect(result.sourceSnapshot.activeContextKey).toBe(
+            "project-b::__primary__",
+        );
+        expect(result.targetSnapshot.activeContextKey).toBe(movedContext.key);
+        expect(onSurfaceDestroyed).not.toHaveBeenCalled();
+    });
+
+    it("rolls a live surface back when persistence fails", async () => {
+        const manager = new WorkspaceSurfaceManager();
+        const sourceHost = createHostWindow();
+        const targetHost = createHostWindow();
+        manager.syncHost(sourceHost.window, createHostContext(), createSnapshot());
+        manager.syncHost(
+            targetHost.window,
+            {
+                ...createHostContext(),
+                projectId: "project-c",
+                windowId: "host-2",
+                workspaceId: "workspace-2",
+                workspaceSessionId: "workspace-session-2",
+            },
+            singleContextSnapshot("project-c::__primary__", "project-c"),
+        );
+        const originalWebContents = manager.getSurfaceWebContents(
+            "host-1",
+            "project-a::__primary__",
+        );
+
+        await expect(
+            manager.transferSurface({
+                commit: vi.fn(() => Promise.reject(new Error("write failed"))),
+                contextKey: "project-a::__primary__",
+                sourceHostWindowId: "host-1",
+                targetHostWindowId: "host-2",
+            }),
+        ).rejects.toThrow("write failed");
+
+        expect(
+            manager.getSurfaceWebContents(
+                "host-1",
+                "project-a::__primary__",
+            ),
+        ).toBe(originalWebContents);
+        expect(
+            manager.getSurfaceWebContents(
+                "host-2",
+                "project-a::__primary__",
+            ),
+        ).toBeNull();
+        expect(
+            originalWebContents
+                ? manager.getSurfaceContext(originalWebContents)
+                : null,
+        ).toMatchObject({ hostWindowId: "host-1", workspaceId: "workspace-1" });
+    });
 });
 
 function createHostWindow(): {
@@ -427,6 +563,18 @@ function createSnapshot(): WorkspaceNavigationSnapshot {
             "project-a::__primary__",
             "project-b::__primary__",
         ],
+        version: 3,
+    };
+}
+
+function singleContextSnapshot(
+    contextKey: string,
+    projectId: string,
+): WorkspaceNavigationSnapshot {
+    return {
+        activeContextKey: contextKey,
+        contexts: [createPersistedContext(contextKey, projectId)],
+        openContextKeys: [contextKey],
         version: 3,
     };
 }

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -83,6 +83,20 @@ describe("WorkspaceSurfaceManager action routing", () => {
         electronMocks.reset();
     });
 
+    it("waits until a new host renderer registers its surface container", async () => {
+        const manager = new WorkspaceSurfaceManager();
+        const ready = manager.waitForHost("host-1", 100);
+
+        manager.syncHost(
+            createHostWindow().window,
+            createHostContext(),
+            createSnapshot(),
+        );
+
+        await expect(ready).resolves.toBe(true);
+        await expect(manager.waitForHost("host-1", 100)).resolves.toBe(true);
+    });
+
     it("delivers only to the active surface and rejects stale scopes", () => {
         const manager = new WorkspaceSurfaceManager();
         const host = createHostWindow();

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -272,6 +272,114 @@ describe("WorkspaceSurfaceManager action routing", () => {
             ),
         ).toEqual({ delivered: true });
     });
+
+    it("indexes open workspaces without changing host activation", () => {
+        const manager = new WorkspaceSurfaceManager();
+        const firstHost = createHostWindow();
+        const secondHost = createHostWindow();
+        const firstSnapshot = createSnapshot();
+        const secondSnapshot: WorkspaceNavigationSnapshot = {
+            activeContextKey: "project-a::worktree-feature",
+            contexts: [
+                {
+                    ...createPersistedContext(
+                        "project-a::worktree-feature",
+                        "project-a",
+                    ),
+                    lastActivatedAt: "2026-07-20T00:00:00.000Z",
+                    worktreeId: "worktree-feature",
+                },
+            ],
+            openContextKeys: ["project-a::worktree-feature"],
+            version: 3,
+        };
+        manager.syncHost(firstHost.window, createHostContext(), firstSnapshot);
+        manager.syncHost(
+            secondHost.window,
+            {
+                ...createHostContext(),
+                windowId: "host-2",
+                workspaceId: "workspace-2",
+                workspaceSessionId: "workspace-session-2",
+            },
+            secondSnapshot,
+        );
+
+        expect(manager.listOpenWorkspaceLocations()).toEqual([
+            expect.objectContaining({
+                contextKey: "project-a::__primary__",
+                hostWindowId: "host-1",
+                isActive: true,
+            }),
+            expect.objectContaining({
+                contextKey: "project-b::__primary__",
+                hostWindowId: "host-1",
+                isActive: false,
+            }),
+            expect.objectContaining({
+                contextKey: "project-a::worktree-feature",
+                hostWindowId: "host-2",
+                isActive: true,
+            }),
+        ]);
+        expect(manager.getActiveContext("host-1")?.key).toBe(
+            "project-a::__primary__",
+        );
+        expect(manager.getActiveContext("host-2")?.key).toBe(
+            "project-a::worktree-feature",
+        );
+    });
+
+    it("resolves historical duplicates deterministically", () => {
+        const manager = new WorkspaceSurfaceManager();
+        const firstHost = createHostWindow();
+        const secondHost = createHostWindow();
+        const firstSnapshot = createSnapshot();
+        const duplicateContext = {
+            ...createPersistedContext(
+                "project-a::project-a:primary",
+                "project-a",
+            ),
+            lastActivatedAt: "2026-07-21T00:00:00.000Z",
+            worktreeId: "project-a:primary",
+        };
+        manager.syncHost(firstHost.window, createHostContext(), firstSnapshot);
+        manager.syncHost(
+            secondHost.window,
+            {
+                ...createHostContext(),
+                windowId: "host-2",
+                workspaceId: "workspace-2",
+                workspaceSessionId: "workspace-session-2",
+            },
+            {
+                activeContextKey: duplicateContext.key,
+                contexts: [duplicateContext],
+                openContextKeys: [duplicateContext.key],
+                version: 3,
+            },
+        );
+
+        const locations = manager.findWorkspaceLocations({
+            projectId: "project-a",
+            worktreeId: null,
+        });
+        expect(locations).toHaveLength(2);
+        expect(
+            manager.findPreferredWorkspaceLocation(
+                { projectId: "project-a", worktreeId: null },
+                "host-2",
+            )?.hostWindowId,
+        ).toBe("host-2");
+
+        manager.activate("host-1", "project-b::__primary__");
+        expect(
+            manager.findPreferredWorkspaceLocation(
+                { projectId: "project-a", worktreeId: null },
+                "host-1",
+            )?.hostWindowId,
+        ).toBe("host-2");
+    });
 });
 
 function createHostWindow(): {

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -7,7 +7,12 @@ import {
 } from "electron";
 
 import { IPC_EVENTS } from "@shared/ipc";
-import { areWorkspaceWorktreeIdsEquivalent } from "@shared/workspace-context";
+import {
+    areWorkspaceScopesEquivalent,
+    areWorkspaceWorktreeIdsEquivalent,
+    type WorkspaceLocation,
+    type WorkspaceScope,
+} from "@shared/workspace-context";
 import type {
     WindowContextSnapshot,
     WorkspaceNavigationSnapshot,
@@ -78,6 +83,11 @@ interface WorkspaceSurfaceLifecycleHandlers {
         ownerId: string,
     ) => void;
     readonly onSurfaceDestroyed?: (ownerId: string) => void;
+}
+
+export interface OpenWorkspaceSurfaceLocation extends WorkspaceLocation {
+    readonly isActive: boolean;
+    readonly lastActivatedAt: string;
 }
 
 /**
@@ -529,6 +539,62 @@ export class WorkspaceSurfaceManager {
         return surface
             ? this.getHostWebContents(surface.hostWindowId)
             : null;
+    }
+
+    listOpenWorkspaceLocations(): readonly OpenWorkspaceSurfaceLocation[] {
+        return [...this.#hostsByWindowId.values()].flatMap((host) =>
+            host.snapshot.openContextKeys.flatMap((contextKey) => {
+                const context = host.snapshot.contexts.find(
+                    (candidate) => candidate.key === contextKey,
+                );
+                if (!context || !host.surfaceIdsByContextKey.has(contextKey)) {
+                    return [];
+                }
+                return [
+                    {
+                        contextKey,
+                        hostWindowId: host.hostWindowId,
+                        isActive: host.activeContextKey === contextKey,
+                        lastActivatedAt: context.lastActivatedAt,
+                        projectId: context.projectId,
+                        worktreeId: context.worktreeId,
+                    },
+                ];
+            }),
+        );
+    }
+
+    findWorkspaceLocations(
+        scope: WorkspaceScope,
+    ): readonly OpenWorkspaceSurfaceLocation[] {
+        return this.listOpenWorkspaceLocations().filter((location) =>
+            areWorkspaceScopesEquivalent(location, scope),
+        );
+    }
+
+    findPreferredWorkspaceLocation(
+        scope: WorkspaceScope,
+        preferredHostWindowId = windowRegistry.getLastFocusedMainWindowId(),
+    ): OpenWorkspaceSurfaceLocation | null {
+        return (
+            [...this.findWorkspaceLocations(scope)].sort((left, right) => {
+                if (left.isActive !== right.isActive) {
+                    return left.isActive ? -1 : 1;
+                }
+                const leftIsPreferred =
+                    left.hostWindowId === preferredHostWindowId;
+                const rightIsPreferred =
+                    right.hostWindowId === preferredHostWindowId;
+                if (leftIsPreferred !== rightIsPreferred) {
+                    return leftIsPreferred ? -1 : 1;
+                }
+                const activationOrder =
+                    Date.parse(right.lastActivatedAt) -
+                    Date.parse(left.lastActivatedAt);
+                return activationOrder ||
+                    left.hostWindowId.localeCompare(right.hostWindowId);
+            })[0] ?? null
+        );
     }
 
     activateProject(

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -7,6 +7,7 @@ import {
 } from "electron";
 
 import { IPC_EVENTS } from "@shared/ipc";
+import { areWorkspaceWorktreeIdsEquivalent } from "@shared/workspace-context";
 import type {
     WindowContextSnapshot,
     WorkspaceNavigationSnapshot,
@@ -539,7 +540,11 @@ export class WorkspaceSurfaceManager {
                 (candidate) =>
                     candidate.projectId === projectId &&
                     (worktreeId === undefined ||
-                        candidate.worktreeId === worktreeId),
+                        areWorkspaceWorktreeIdsEquivalent(
+                            projectId,
+                            candidate.worktreeId,
+                            worktreeId,
+                        )),
             );
             if (!context) {
                 continue;

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -104,6 +104,10 @@ export interface WorkspaceSurfaceTransferResult {
  */
 export class WorkspaceSurfaceManager {
     readonly #hostsByWindowId = new Map<string, WorkspaceSurfaceHostRecord>();
+    readonly #hostReadyWaitersByWindowId = new Map<
+        string,
+        Set<(ready: boolean) => void>
+    >();
     readonly #surfaceIdsByWebContentsId = new Map<number, string>();
     readonly #surfacesById = new Map<string, WorkspaceSurfaceRecord>();
     readonly #actionsById = new Map<
@@ -135,6 +139,7 @@ export class WorkspaceSurfaceManager {
                 surfaceIdsByContextKey: new Map(),
             };
             this.#hostsByWindowId.set(host.hostWindowId, host);
+            this.#resolveHostReadyWaiters(host.hostWindowId, true);
             const createdHost = host;
             hostWindow.on("resize", () => {
                 this.#scheduleActiveSurfaceLayout(createdHost);
@@ -174,6 +179,30 @@ export class WorkspaceSurfaceManager {
         this.#rejectInactiveActions(host);
         this.#applyVisibility(host, { focusActive: activeContextChanged });
         return host.snapshot;
+    }
+
+    waitForHost(hostWindowId: string, timeoutMs = 10_000): Promise<boolean> {
+        if (this.#hostsByWindowId.has(hostWindowId)) {
+            return Promise.resolve(true);
+        }
+        return new Promise<boolean>((resolve) => {
+            const finish = (ready: boolean) => {
+                clearTimeout(timer);
+                const waiters = this.#hostReadyWaitersByWindowId.get(hostWindowId);
+                waiters?.delete(finish);
+                if (waiters?.size === 0) {
+                    this.#hostReadyWaitersByWindowId.delete(hostWindowId);
+                }
+                resolve(ready);
+            };
+            const timer = setTimeout(() => {
+                finish(false);
+            }, timeoutMs);
+            const waiters =
+                this.#hostReadyWaitersByWindowId.get(hostWindowId) ?? new Set();
+            waiters.add(finish);
+            this.#hostReadyWaitersByWindowId.set(hostWindowId, waiters);
+        });
     }
 
     activate(hostWindowId: string, contextKey: string): boolean {
@@ -758,6 +787,7 @@ export class WorkspaceSurfaceManager {
     }
 
     disposeHost(hostWindowId: string): void {
+        this.#resolveHostReadyWaiters(hostWindowId, false);
         const host = this.#hostsByWindowId.get(hostWindowId);
         if (!host) {
             return;
@@ -769,6 +799,17 @@ export class WorkspaceSurfaceManager {
             this.#destroySurface(host, surfaceId);
         }
         this.#hostsByWindowId.delete(hostWindowId);
+    }
+
+    #resolveHostReadyWaiters(hostWindowId: string, ready: boolean): void {
+        const waiters = this.#hostReadyWaitersByWindowId.get(hostWindowId);
+        if (!waiters) {
+            return;
+        }
+        this.#hostReadyWaitersByWindowId.delete(hostWindowId);
+        for (const resolve of waiters) {
+            resolve(ready);
+        }
     }
 
     #createSurface(

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -16,6 +16,7 @@ import {
 import type {
     WindowContextSnapshot,
     WorkspaceNavigationSnapshot,
+    WindowWorkspaceRestoreRecord,
     WorkspaceSurfaceActionCompletion,
     WorkspaceSurfaceActionDeliveryFailureReason,
     WorkspaceSurfaceActionDeliveryResult,
@@ -39,9 +40,9 @@ import {
 
 interface WorkspaceSurfaceRecord {
     bounds: WorkspaceSurfaceBounds | null;
-    readonly context: WindowContextSnapshot;
+    context: WindowContextSnapshot;
     readonly contextKey: string;
-    readonly hostWindowId: string;
+    hostWindowId: string;
     readonly id: string;
     isVisible: boolean;
     isReady: boolean;
@@ -65,6 +66,7 @@ interface WorkspaceSurfaceHostRecord {
     contentLeftInset: number;
     readonly hostWindow: BrowserWindow;
     readonly hostWindowId: string;
+    context: WindowContextSnapshot;
     pendingLayoutTimer: NodeJS.Timeout | null;
     snapshot: WorkspaceNavigationSnapshot;
     readonly surfaceIdsByContextKey: Map<string, string>;
@@ -73,7 +75,7 @@ interface WorkspaceSurfaceHostRecord {
 interface DispatchedWorkspaceSurfaceAction {
     claimed: boolean;
     readonly envelope: WorkspaceSurfaceActionEnvelope;
-    readonly hostWindowId: string;
+    hostWindowId: string;
     readonly surfaceId: string;
 }
 
@@ -88,6 +90,12 @@ interface WorkspaceSurfaceLifecycleHandlers {
 export interface OpenWorkspaceSurfaceLocation extends WorkspaceLocation {
     readonly isActive: boolean;
     readonly lastActivatedAt: string;
+}
+
+export interface WorkspaceSurfaceTransferResult {
+    readonly sourceSnapshot: WorkspaceNavigationSnapshot;
+    readonly surfaceId: string;
+    readonly targetSnapshot: WorkspaceNavigationSnapshot;
 }
 
 /**
@@ -121,6 +129,7 @@ export class WorkspaceSurfaceManager {
                 contentLeftInset: 0,
                 hostWindow,
                 hostWindowId: hostContext.windowId,
+                context: hostContext,
                 pendingLayoutTimer: null,
                 snapshot,
                 surfaceIdsByContextKey: new Map(),
@@ -131,6 +140,7 @@ export class WorkspaceSurfaceManager {
                 this.#scheduleActiveSurfaceLayout(createdHost);
             });
         }
+        host.context = hostContext;
 
         const openContextKeys = new Set(snapshot.openContextKeys);
         for (const [contextKey, surfaceId] of host.surfaceIdsByContextKey) {
@@ -597,6 +607,132 @@ export class WorkspaceSurfaceManager {
         );
     }
 
+    async transferSurface(input: {
+        readonly commit: () => Promise<{
+            readonly source: WindowWorkspaceRestoreRecord;
+            readonly target: WindowWorkspaceRestoreRecord;
+        }>;
+        readonly contextKey: string;
+        readonly sourceHostWindowId: string;
+        readonly targetHostWindowId: string;
+    }): Promise<WorkspaceSurfaceTransferResult> {
+        if (input.sourceHostWindowId === input.targetHostWindowId) {
+            throw new Error("The workspace is already in the target window.");
+        }
+        const sourceHost = this.#hostsByWindowId.get(
+            input.sourceHostWindowId,
+        );
+        const targetHost = this.#hostsByWindowId.get(
+            input.targetHostWindowId,
+        );
+        const surfaceId = sourceHost?.surfaceIdsByContextKey.get(
+            input.contextKey,
+        );
+        const surface = surfaceId ? this.#surfacesById.get(surfaceId) : null;
+        if (!sourceHost || !targetHost || !surface) {
+            throw new Error("The workspace surface is no longer available.");
+        }
+        if (
+            sourceHost.hostWindow.isDestroyed() ||
+            targetHost.hostWindow.isDestroyed()
+        ) {
+            throw new Error("A workspace transfer window is no longer available.");
+        }
+        const movingContext = sourceHost.snapshot.contexts.find(
+            (context) => context.key === input.contextKey,
+        );
+        if (!movingContext) {
+            throw new Error("The workspace context is no longer available.");
+        }
+        if (
+            targetHost.snapshot.contexts.some((context) =>
+                areWorkspaceScopesEquivalent(context, movingContext),
+            ) ||
+            targetHost.surfaceIdsByContextKey.has(input.contextKey)
+        ) {
+            throw new Error("The destination already contains this workspace.");
+        }
+
+        const previousContext = surface.context;
+        const previousActionHostIds = new Map<string, string>();
+        let attachedToTarget = false;
+        surface.view.setVisible(false);
+        surface.isVisible = false;
+        surface.bounds = null;
+        try {
+            sourceHost.hostWindow.contentView.removeChildView(surface.view);
+            targetHost.hostWindow.contentView.addChildView(surface.view);
+            attachedToTarget = true;
+            sourceHost.surfaceIdsByContextKey.delete(input.contextKey);
+            targetHost.surfaceIdsByContextKey.set(input.contextKey, surface.id);
+            surface.hostWindowId = targetHost.hostWindowId;
+            surface.context = {
+                ...surface.context,
+                hostWindowId: targetHost.hostWindowId,
+                workspaceId: targetHost.context.workspaceId,
+                workspaceSessionId: targetHost.context.workspaceSessionId,
+            };
+            windowRegistry.registerEmbeddedRenderer(
+                surface.webContents,
+                surface.context,
+            );
+            for (const [actionId, action] of this.#actionsById) {
+                if (action.surfaceId !== surface.id) {
+                    continue;
+                }
+                previousActionHostIds.set(actionId, action.hostWindowId);
+                action.hostWindowId = targetHost.hostWindowId;
+            }
+
+            const committed = await input.commit();
+            sourceHost.snapshot = committed.source.snapshot;
+            sourceHost.activeContextKey =
+                committed.source.snapshot.activeContextKey;
+            targetHost.snapshot = committed.target.snapshot;
+            targetHost.activeContextKey =
+                committed.target.snapshot.activeContextKey;
+            surface.snapshot = toSurfaceSnapshot(
+                committed.target.snapshot,
+                input.contextKey,
+            );
+            this.#rejectInactiveActions(sourceHost);
+            this.#rejectInactiveActions(targetHost);
+            this.#applyVisibility(sourceHost);
+            this.#applyVisibility(targetHost, { focusActive: true });
+            return {
+                sourceSnapshot: sourceHost.snapshot,
+                surfaceId: surface.id,
+                targetSnapshot: targetHost.snapshot,
+            };
+        } catch (error) {
+            if (attachedToTarget && !targetHost.hostWindow.isDestroyed()) {
+                targetHost.hostWindow.contentView.removeChildView(surface.view);
+            }
+            if (!sourceHost.hostWindow.isDestroyed()) {
+                sourceHost.hostWindow.contentView.addChildView(surface.view);
+            }
+            targetHost.surfaceIdsByContextKey.delete(input.contextKey);
+            sourceHost.surfaceIdsByContextKey.set(input.contextKey, surface.id);
+            surface.hostWindowId = sourceHost.hostWindowId;
+            surface.context = previousContext;
+            windowRegistry.registerEmbeddedRenderer(
+                surface.webContents,
+                previousContext,
+            );
+            for (const [actionId, previousHostWindowId] of previousActionHostIds) {
+                const action = this.#actionsById.get(actionId);
+                if (action) {
+                    action.hostWindowId = previousHostWindowId;
+                }
+            }
+            this.#applyVisibility(sourceHost, {
+                focusActive:
+                    sourceHost.activeContextKey === input.contextKey,
+            });
+            throw error;
+        }
+    }
+
     activateProject(
         projectId: string,
         worktreeId: string | null | undefined,
@@ -700,9 +836,15 @@ export class WorkspaceSurfaceManager {
                 return;
             }
 
+            const currentHost = this.#hostsByWindowId.get(
+                surface.hostWindowId,
+            );
+            if (!currentHost) {
+                return;
+            }
             const nextContextKey = getAdjacentContextKey(
-                host.snapshot.openContextKeys,
-                host.activeContextKey,
+                currentHost.snapshot.openContextKeys,
+                currentHost.activeContextKey,
                 direction,
             );
             if (!nextContextKey) {
@@ -710,16 +852,21 @@ export class WorkspaceSurfaceManager {
             }
 
             event.preventDefault();
-            this.activate(host.hostWindowId, nextContextKey);
-            host.hostWindow.webContents.send(
+            this.activate(currentHost.hostWindowId, nextContextKey);
+            currentHost.hostWindow.webContents.send(
                 IPC_EVENTS.workspaceSurfaceSnapshotUpdated,
-                host.snapshot,
+                currentHost.snapshot,
             );
         });
         webContents.once("did-finish-load", () => {
             if (!webContents.isDestroyed()) {
                 this.#lifecycleHandlers.onSurfaceCreated?.(webContents, id);
-                this.#applyVisibility(host);
+                const currentHost = this.#hostsByWindowId.get(
+                    surface.hostWindowId,
+                );
+                if (currentHost) {
+                    this.#applyVisibility(currentHost);
+                }
             }
         });
         webContents.once("destroyed", () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -43,6 +43,7 @@ import {
     type AiTrackedFileHunkMutationInput,
     type AiTrackedFileMutationInput,
     type AiUserInputResponseInput,
+    type ActivateWorkspaceLocationInput,
     type ClaudeRuntimeSettingsInput,
     type ClearProjectAppDataInput,
     type ClearProjectAppDataResult,
@@ -66,6 +67,7 @@ import {
     type ListAiSessionHistoryInput,
     type ListProjectTreeInput,
     type OpenProjectWindowInput,
+    type OpenWorkspaceLocationSummary,
     type OpenProjectEntryExternallyInput,
     type OpenProjectFileInput,
     type OpenSettingsWindowInput,
@@ -1123,6 +1125,13 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.initializeWorkspaceSurfaces, snapshot),
     activateWorkspaceSurface: (contextKey: string) =>
         ipcRenderer.invoke(IPC_CHANNELS.activateWorkspaceSurface, contextKey),
+    listOpenWorkspaceLocations: async () =>
+        assertIpcArray<OpenWorkspaceLocationSummary>(
+            IPC_CHANNELS.listOpenWorkspaceLocations,
+            await ipcRenderer.invoke(IPC_CHANNELS.listOpenWorkspaceLocations),
+        ),
+    activateWorkspaceLocation: (input: ActivateWorkspaceLocationInput) =>
+        ipcRenderer.invoke(IPC_CHANNELS.activateWorkspaceLocation, input),
     captureWorkspaceSurfaceContext: (contextKey: string) =>
         ipcRenderer.invoke(
             IPC_CHANNELS.captureWorkspaceSurfaceContext,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1178,6 +1178,8 @@ const comandoApi: ComandoApi = {
         ipcRenderer.invoke(IPC_CHANNELS.openWorkspaceSurfaceProjectMenu),
     showWorkspaceContextMenu: (input) =>
         ipcRenderer.invoke(IPC_CHANNELS.showWorkspaceContextMenu, input),
+    moveWorkspaceContext: (input) =>
+        ipcRenderer.invoke(IPC_CHANNELS.moveWorkspaceContext, input),
     showNativeContextMenu: (input) =>
         ipcRenderer.invoke(IPC_CHANNELS.showNativeContextMenu, input),
     setWorkspaceSurfaceContentInset: (height: number) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -868,6 +868,16 @@ const comandoApi: ComandoApi = {
             );
         };
     },
+    onWorkspaceSwitcherRequested: (listener) => {
+        const handler = () => listener();
+        ipcRenderer.on(IPC_EVENTS.workspaceSwitcherRequested, handler);
+        return () => {
+            ipcRenderer.removeListener(
+                IPC_EVENTS.workspaceSwitcherRequested,
+                handler,
+            );
+        };
+    },
     onWorkspaceFlushRequested: (listener) => {
         const handleEvent = (
             _event: Electron.IpcRendererEvent,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -475,38 +475,28 @@ export function App() {
         },
         [],
     );
-    const requestMoveWorkspaceContextToNewWindow = useCallback(
-        (contextKey: string) => {
+    const requestMoveWorkspaceContext = useCallback(
+        (contextKey: string, targetWindowId: string | null) => {
             const workspaceState = useWorkspaceStore.getState();
             const context = workspaceState.contextsByKey[contextKey];
-            const workspaceSnapshot =
-                workspaceState.getContextNavigationSnapshot(contextKey);
-            if (!context || !workspaceSnapshot) {
+            if (!context) {
                 return Promise.resolve();
             }
 
-            const tabsById =
-                workspaceState.activeContextKey === contextKey
-                    ? workspaceState.tabsById
-                    : context.workspace.tabsById;
-            return closeWorkspaceTabsWithConfirmation(
-                Object.keys(tabsById),
-                async () => {
-                    const comandoApi = getComandoApi();
-                    if (!comandoApi) {
-                        throw new Error("The desktop bridge is unavailable.");
-                    }
+            const comandoApi = getComandoApi();
+            if (!comandoApi) {
+                return Promise.reject(
+                    new Error("The desktop bridge is unavailable."),
+                );
+            }
 
-                    await comandoApi.openProjectWindow({
-                        forceNewWindow: true,
-                        projectId: context.projectId,
-                        workspaceSnapshot,
-                        worktreeId: context.worktreeId,
-                    });
-                    await useWorkspaceStore.getState().closeContext(contextKey);
-                },
-                { tabsById },
-            );
+            // The main process owns the atomic persistence and live surface move.
+            return comandoApi.moveWorkspaceContext({
+                contextKey,
+                projectId: context.projectId,
+                targetWindowId,
+                worktreeId: context.worktreeId,
+            });
         },
         [],
     );
@@ -4943,9 +4933,7 @@ export function App() {
             onCloseContext={(contextKey) => {
                 void requestCloseWorkspaceContext(contextKey);
             }}
-            onMoveContextToNewWindow={(contextKey) => {
-                void requestMoveWorkspaceContextToNewWindow(contextKey);
-            }}
+            onMoveContext={requestMoveWorkspaceContext}
             onOpenProject={handleOpenProject}
             onOpenProjects={handleOpenProjects}
             onOpenSettings={(initialCategory) =>

--- a/src/renderer/src/app/projects/context-key.ts
+++ b/src/renderer/src/app/projects/context-key.ts
@@ -1,20 +1,13 @@
-// Shared helpers for building the per-(project, worktree) cache key used by the
-// project tree, the file index, and any other context-scoped renderer caches.
-// Centralizing this keeps the key format identical across every consumer.
+import {
+    getWorkspaceContextKey,
+    WORKSPACE_PRIMARY_CONTEXT,
+} from "@shared/workspace-context";
 
-export const PROJECT_TREE_PRIMARY_CONTEXT = "__primary__";
-
-const NO_PROJECT_CONTEXT = "__none__";
+export const PROJECT_TREE_PRIMARY_CONTEXT = WORKSPACE_PRIMARY_CONTEXT;
 
 export function getProjectContextKey(
     projectId: string | null,
     worktreeId: string | null,
 ): string {
-    const normalizedWorktreeId =
-        projectId && worktreeId === `${projectId}:primary`
-            ? PROJECT_TREE_PRIMARY_CONTEXT
-            : (worktreeId ?? PROJECT_TREE_PRIMARY_CONTEXT);
-    return `${projectId ?? NO_PROJECT_CONTEXT}::${
-        normalizedWorktreeId
-    }`;
+    return getWorkspaceContextKey(projectId, worktreeId);
 }

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -25,6 +25,10 @@ import {
     type ActiveAiRuntimeId,
 } from "@shared/ai-runtimes";
 import { normalizeWorkspaceNavigationSnapshot } from "@shared/workspace-restore";
+import {
+    areWorkspaceWorktreeIdsEquivalent,
+    normalizeWorkspaceWorktreeId,
+} from "@shared/workspace-context";
 
 import {
     activatePane,
@@ -1280,8 +1284,10 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             });
             return;
         }
-        const normalizedWorktreeId =
-            worktreeId === `${projectId}:primary` ? null : worktreeId;
+        const normalizedWorktreeId = normalizeWorkspaceWorktreeId(
+            projectId,
+            worktreeId,
+        );
         const contextKey = getProjectContextKey(
             projectId,
             normalizedWorktreeId,
@@ -4411,23 +4417,11 @@ function getComandoApi() {
     return comandoWindow.comando;
 }
 
-function areWorkspaceWorktreeIdsEquivalent(
-    projectId: string | null,
-    left: string | null | undefined,
-    right: string | null | undefined,
-): boolean {
-    return projectId
-        ? areGitWorktreeIdsEquivalent(projectId, left ?? null, right ?? null)
-        : (left ?? null) === (right ?? null);
-}
-
 function getWorkspaceWorktreeScopeKey(
     projectId: string,
     worktreeId: string | null | undefined,
 ): string {
-    return areGitWorktreeIdsEquivalent(projectId, worktreeId ?? null, null)
-        ? "__primary__"
-        : (worktreeId ?? "__primary__");
+    return normalizeWorkspaceWorktreeId(projectId, worktreeId) ?? "__primary__";
 }
 
 function isFileTabAffectedByProjectInvalidation(

--- a/src/renderer/src/components/DesktopTopBar.context-menu.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.context-menu.test.tsx
@@ -27,7 +27,7 @@ function renderTopBar() {
     mountedContainers.push(container);
 
     const onCloseContext = vi.fn();
-    const onMoveContextToNewWindow = vi.fn();
+    const onMoveContext = vi.fn();
     const onOpenProject = vi.fn();
     const root = createRoot(container);
     mountedRoots.push(root);
@@ -66,7 +66,7 @@ function renderTopBar() {
                 onActivateContext: vi.fn(),
                 onCloneRepository: vi.fn(() => Promise.resolve(true)),
                 onCloseContext,
-                onMoveContextToNewWindow,
+                onMoveContext,
                 onOpenProject,
                 onOpenProjects: vi.fn(),
                 onOpenSettings: vi.fn(),
@@ -82,7 +82,7 @@ function renderTopBar() {
     return {
         container,
         onCloseContext,
-        onMoveContextToNewWindow,
+        onMoveContext,
         onOpenProject,
     };
 }
@@ -93,9 +93,16 @@ describe("DesktopTopBar context menu", () => {
         const writeText = vi.fn(() => Promise.resolve());
         const showWorkspaceContextMenu = vi
             .fn()
-            .mockResolvedValueOnce("copy_full_path")
-            .mockResolvedValueOnce("move_to_new_window")
-            .mockResolvedValueOnce("close");
+            .mockResolvedValueOnce({ type: "copy_full_path" })
+            .mockResolvedValueOnce({
+                targetWindowId: "target-window",
+                type: "move",
+            })
+            .mockResolvedValueOnce({
+                targetWindowId: null,
+                type: "move",
+            })
+            .mockResolvedValueOnce({ type: "close" });
         vi.stubGlobal("navigator", {
             ...navigator,
             clipboard: { writeText },
@@ -104,7 +111,7 @@ describe("DesktopTopBar context menu", () => {
             showWorkspaceContextMenu,
             writeClipboardText,
         });
-        const { container, onCloseContext, onMoveContextToNewWindow } =
+        const { container, onCloseContext, onMoveContext } =
             renderTopBar();
         const tab = container.querySelector<HTMLElement>(
             '[data-project-context-tab-key="project-2::__primary__"]',
@@ -125,6 +132,9 @@ describe("DesktopTopBar context menu", () => {
 
         expect(showWorkspaceContextMenu).toHaveBeenLastCalledWith({
             canCopyFullPath: true,
+            contextKey: "project-2::__primary__",
+            projectId: "project-2",
+            worktreeId: null,
             x: 120,
             y: 40,
         });
@@ -142,8 +152,26 @@ describe("DesktopTopBar context menu", () => {
             );
             await Promise.resolve();
         });
-        expect(onMoveContextToNewWindow).toHaveBeenCalledWith(
+        expect(onMoveContext).toHaveBeenCalledWith(
             "project-2::__primary__",
+            "target-window",
+        );
+        expect(onCloseContext).not.toHaveBeenCalled();
+
+        await act(async () => {
+            tab?.dispatchEvent(
+                new MouseEvent("contextmenu", {
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: 120,
+                    clientY: 40,
+                }),
+            );
+            await Promise.resolve();
+        });
+        expect(onMoveContext).toHaveBeenLastCalledWith(
+            "project-2::__primary__",
+            null,
         );
         expect(onCloseContext).not.toHaveBeenCalled();
 
@@ -161,6 +189,20 @@ describe("DesktopTopBar context menu", () => {
         expect(onCloseContext).toHaveBeenCalledWith(
             "project-2::__primary__",
         );
+
+        await act(async () => {
+            tab?.dispatchEvent(
+                new MouseEvent("contextmenu", {
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: 120,
+                    clientY: 40,
+                }),
+            );
+            await Promise.resolve();
+        });
+        expect(onMoveContext).toHaveBeenCalledTimes(2);
+        expect(onCloseContext).toHaveBeenCalledTimes(1);
     });
 
     it("opens a project from the portaled project menu", async () => {

--- a/src/renderer/src/components/DesktopTopBar.test.tsx
+++ b/src/renderer/src/components/DesktopTopBar.test.tsx
@@ -31,7 +31,7 @@ describe("DesktopTopBar", () => {
                 onActivateContext={vi.fn()}
                 onCloneRepository={vi.fn(() => Promise.resolve(true))}
                 onCloseContext={vi.fn()}
-                onMoveContextToNewWindow={vi.fn()}
+                onMoveContext={vi.fn()}
                 onOpenProject={vi.fn()}
                 onOpenProjects={vi.fn()}
                 onOpenSettings={vi.fn()}

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -16,6 +16,7 @@ import {
 import { writeClipboardText } from "../app/utils/clipboard";
 import { SidebarGitScopePicker } from "./sidebar/SidebarGitScopePicker";
 import { useProjectContextTabDrag } from "./useProjectContextTabDrag";
+import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 
 export type { ProjectContextMenuProject } from "./ProjectContextMenu";
 
@@ -76,6 +77,7 @@ export function DesktopTopBar({
     settingsLabel,
 }: DesktopTopBarProps) {
     const [menuOpen, setMenuOpen] = useState(false);
+    const [workspaceSwitcherOpen, setWorkspaceSwitcherOpen] = useState(false);
     const menuRootRef = useRef<HTMLDivElement | null>(null);
     const tabsRef = useRef<HTMLDivElement | null>(null);
     const contextTabDrag = useProjectContextTabDrag({
@@ -107,6 +109,13 @@ export function DesktopTopBar({
             window.removeEventListener("keydown", handleKeyDown);
         };
     }, [menuOpen]);
+
+    useEffect(() => {
+        return window.comando?.onWorkspaceSwitcherRequested?.(() => {
+            setMenuOpen(false);
+            setWorkspaceSwitcherOpen(true);
+        });
+    }, []);
 
     useEffect(() => {
         const tabs = tabsRef.current;
@@ -156,6 +165,7 @@ export function DesktopTopBar({
     };
 
     return (
+        <>
         <header
             className="app-drag desktop-titlebar project-context-titlebar relative flex shrink-0 items-center select-none"
             style={{
@@ -331,6 +341,33 @@ export function DesktopTopBar({
 
             <div className="app-no-drag project-context-menu-root" ref={menuRootRef}>
                 <button
+                    aria-expanded={workspaceSwitcherOpen}
+                    aria-haspopup="dialog"
+                    aria-label="Switch workspace"
+                    className="project-context-add"
+                    onClick={() => {
+                        setMenuOpen(false);
+                        setWorkspaceSwitcherOpen(true);
+                    }}
+                    title="Switch workspace"
+                    type="button"
+                >
+                    <svg
+                        aria-hidden="true"
+                        fill="none"
+                        height="12"
+                        viewBox="0 0 14 14"
+                        width="12"
+                    >
+                        <path
+                            d="M3 3.25h8M3 7h8M3 10.75h8"
+                            stroke="currentColor"
+                            strokeLinecap="round"
+                            strokeWidth="1.35"
+                        />
+                    </svg>
+                </button>
+                <button
                     aria-expanded={menuOpen}
                     aria-haspopup="dialog"
                     aria-label="Open project or worktree"
@@ -375,6 +412,12 @@ export function DesktopTopBar({
                 )}
             </div>
         </header>
+        <WorkspaceSwitcher
+            onClose={() => setWorkspaceSwitcherOpen(false)}
+            open={workspaceSwitcherOpen}
+            projects={menuProjects}
+        />
+        </>
     );
 }
 

--- a/src/renderer/src/components/DesktopTopBar.tsx
+++ b/src/renderer/src/components/DesktopTopBar.tsx
@@ -42,7 +42,10 @@ interface DesktopTopBarProps {
     readonly onActivateContext: (contextKey: string) => void;
     readonly onCloneRepository: (repositoryUrl: string) => Promise<boolean>;
     readonly onCloseContext: (contextKey: string) => void;
-    readonly onMoveContextToNewWindow: (contextKey: string) => void;
+    readonly onMoveContext: (
+        contextKey: string,
+        targetWindowId: string | null,
+    ) => Promise<void> | void;
     readonly onOpenProject: (projectId: string) => void;
     readonly onOpenProjects: () => void;
     readonly onOpenSettings: (initialCategory?: "updates") => void;
@@ -66,7 +69,7 @@ export function DesktopTopBar({
     onActivateContext,
     onCloneRepository,
     onCloseContext,
-    onMoveContextToNewWindow,
+    onMoveContext,
     onOpenProject,
     onOpenProjects,
     onOpenSettings,
@@ -242,7 +245,7 @@ export function DesktopTopBar({
                                 void openWorkspaceContextMenu({
                                     context,
                                     onCloseContext,
-                                    onMoveContextToNewWindow,
+                                    onMoveContext,
                                     x: event.clientX,
                                     y: event.clientY,
                                 });
@@ -424,17 +427,23 @@ export function DesktopTopBar({
 async function openWorkspaceContextMenu(input: {
     readonly context: ProjectContextTabItem;
     readonly onCloseContext: (contextKey: string) => void;
-    readonly onMoveContextToNewWindow: (contextKey: string) => void;
+    readonly onMoveContext: (
+        contextKey: string,
+        targetWindowId: string | null,
+    ) => Promise<void> | void;
     readonly x: number;
     readonly y: number;
 }): Promise<void> {
     // Native menus render above the workspace WebContentsView boundary.
     const action = await window.comando?.showWorkspaceContextMenu({
         canCopyFullPath: Boolean(input.context.fullPath),
+        contextKey: input.context.key,
+        projectId: input.context.projectId,
+        worktreeId: input.context.worktreeId,
         x: input.x,
         y: input.y,
     });
-    if (action === "copy_full_path" && input.context.fullPath) {
+    if (action?.type === "copy_full_path" && input.context.fullPath) {
         try {
             await writeClipboardText(input.context.fullPath);
         } catch {
@@ -442,11 +451,22 @@ async function openWorkspaceContextMenu(input: {
         }
         return;
     }
-    if (action === "move_to_new_window") {
-        input.onMoveContextToNewWindow(input.context.key);
+    if (action?.type === "move") {
+        try {
+            await input.onMoveContext(
+                input.context.key,
+                action.targetWindowId,
+            );
+        } catch (error) {
+            window.alert(
+                error instanceof Error
+                    ? error.message
+                    : "Could not move the workspace.",
+            );
+        }
         return;
     }
-    if (action === "close") {
+    if (action?.type === "close") {
         input.onCloseContext(input.context.key);
     }
 }

--- a/src/renderer/src/components/WorkspaceSwitcher.test.tsx
+++ b/src/renderer/src/components/WorkspaceSwitcher.test.tsx
@@ -1,0 +1,131 @@
+/** @vitest-environment jsdom */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+    act(() => root?.unmount());
+    container?.remove();
+    root = null;
+    container = null;
+    vi.unstubAllGlobals();
+});
+
+describe("WorkspaceSwitcher", () => {
+    it("groups, filters, and activates remote workspaces", async () => {
+        const activateWorkspaceLocation = vi.fn(() => Promise.resolve(true));
+        vi.stubGlobal("comando", {
+            activateWorkspaceLocation,
+            listOpenWorkspaceLocations: vi.fn(() =>
+                Promise.resolve([
+                    createLocation("window-1", "project-1", true),
+                    createLocation("window-2", "project-2", false),
+                ]),
+            ),
+        });
+        const onClose = vi.fn();
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        root = createRoot(container);
+
+        await act(async () => {
+            root?.render(
+                <WorkspaceSwitcher
+                    onClose={onClose}
+                    open={true}
+                    projects={[
+                        { id: "project-1", name: "Comando", worktrees: [] },
+                        { id: "project-2", name: "Sandbox", worktrees: [] },
+                    ]}
+                />,
+            );
+            await Promise.resolve();
+        });
+
+        expect(document.body.textContent).toContain("Current Window");
+        expect(document.body.textContent).toContain("Other Windows");
+        const input = document.body.querySelector<HTMLInputElement>(
+            '[aria-label="Search open workspaces"]',
+        );
+        expect(input).toBeTruthy();
+        act(() => {
+            if (!input) {
+                return;
+            }
+            Object.getOwnPropertyDescriptor(
+                HTMLInputElement.prototype,
+                "value",
+            )?.set?.call(input, "Sandbox");
+            input.dispatchEvent(new Event("input", { bubbles: true }));
+        });
+        expect(document.body.textContent).not.toContain("Current Window");
+        const option = document.body.querySelector<HTMLButtonElement>(
+            ".workspace-switcher-item",
+        );
+        await act(async () => {
+            option?.click();
+            await Promise.resolve();
+        });
+        expect(activateWorkspaceLocation).toHaveBeenCalledWith(
+            expect.objectContaining({ hostWindowId: "window-2" }),
+        );
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("closes with Escape without activating", async () => {
+        const activateWorkspaceLocation = vi.fn();
+        vi.stubGlobal("comando", {
+            activateWorkspaceLocation,
+            listOpenWorkspaceLocations: vi.fn(() => Promise.resolve([])),
+        });
+        const onClose = vi.fn();
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        root = createRoot(container);
+        await act(async () => {
+            root?.render(
+                <WorkspaceSwitcher
+                    onClose={onClose}
+                    open={true}
+                    projects={[]}
+                />,
+            );
+            await Promise.resolve();
+        });
+        const input = document.body.querySelector<HTMLInputElement>(
+            '[aria-label="Search open workspaces"]',
+        );
+        act(() => {
+            input?.dispatchEvent(
+                new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }),
+            );
+        });
+        expect(onClose).toHaveBeenCalledOnce();
+        expect(activateWorkspaceLocation).not.toHaveBeenCalled();
+    });
+});
+
+function createLocation(
+    hostWindowId: string,
+    projectId: string,
+    isCurrentWindow: boolean,
+) {
+    return {
+        contextKey: `${projectId}::__primary__`,
+        hostWindowId,
+        isActive: true,
+        isCurrentWindow,
+        lastActivatedAt: "2026-07-22T00:00:00.000Z",
+        projectId,
+        windowTitle: `Comando · ${projectId}`,
+        worktreeId: null,
+    };
+}

--- a/src/renderer/src/components/WorkspaceSwitcher.tsx
+++ b/src/renderer/src/components/WorkspaceSwitcher.tsx
@@ -1,0 +1,267 @@
+import {
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type KeyboardEvent,
+} from "react";
+import { createPortal } from "react-dom";
+
+import type { OpenWorkspaceLocationSummary } from "@shared/ipc";
+
+export interface WorkspaceSwitcherProject {
+    readonly id: string;
+    readonly name: string;
+    readonly worktrees: readonly {
+        readonly id: string;
+        readonly label: string;
+    }[];
+}
+
+interface WorkspaceSwitcherProps {
+    readonly onClose: () => void;
+    readonly open: boolean;
+    readonly projects: readonly WorkspaceSwitcherProject[];
+}
+
+interface DisplayWorkspaceLocation {
+    readonly location: OpenWorkspaceLocationSummary;
+    readonly projectName: string;
+    readonly searchText: string;
+    readonly worktreeLabel: string;
+}
+
+export function WorkspaceSwitcher({
+    onClose,
+    open,
+    projects,
+}: WorkspaceSwitcherProps) {
+    const [locations, setLocations] = useState<
+        readonly OpenWorkspaceLocationSummary[]
+    >([]);
+    const [query, setQuery] = useState("");
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const [error, setError] = useState<string | null>(null);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+        let cancelled = false;
+        setQuery("");
+        setSelectedIndex(0);
+        setError(null);
+        void window.comando
+            ?.listOpenWorkspaceLocations()
+            .then((nextLocations) => {
+                if (!cancelled) {
+                    setLocations(nextLocations);
+                    requestAnimationFrame(() => inputRef.current?.focus());
+                }
+            })
+            .catch((cause: unknown) => {
+                if (!cancelled) {
+                    setError(
+                        cause instanceof Error
+                            ? cause.message
+                            : "Could not load open workspaces.",
+                    );
+                }
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [open]);
+
+    const displayLocations = useMemo(
+        () =>
+            locations.map((location): DisplayWorkspaceLocation => {
+                const project = projects.find(
+                    (candidate) => candidate.id === location.projectId,
+                );
+                const projectName = project?.name ?? location.projectId;
+                const worktreeLabel = location.worktreeId
+                    ? (project?.worktrees.find(
+                          (worktree) => worktree.id === location.worktreeId,
+                      )?.label ?? location.worktreeId)
+                    : "Primary worktree";
+                return {
+                    location,
+                    projectName,
+                    searchText: [
+                        projectName,
+                        worktreeLabel,
+                        location.windowTitle,
+                    ]
+                        .join(" ")
+                        .toLowerCase(),
+                    worktreeLabel,
+                };
+            }),
+        [locations, projects],
+    );
+    const normalizedQuery = query.trim().toLowerCase();
+    const filteredLocations = useMemo(
+        () =>
+            displayLocations.filter(
+                (entry) =>
+                    !normalizedQuery ||
+                    entry.searchText.includes(normalizedQuery),
+            ),
+        [displayLocations, normalizedQuery],
+    );
+
+    useEffect(() => {
+        setSelectedIndex((current) =>
+            filteredLocations.length === 0
+                ? 0
+                : Math.min(current, filteredLocations.length - 1),
+        );
+    }, [filteredLocations.length]);
+
+    if (!open || typeof document === "undefined") {
+        return null;
+    }
+
+    const activate = async (entry: DisplayWorkspaceLocation) => {
+        setError(null);
+        try {
+            const activated = await window.comando?.activateWorkspaceLocation(
+                entry.location,
+            );
+            if (!activated) {
+                setError("This workspace is no longer open.");
+                return;
+            }
+            onClose();
+        } catch (cause) {
+            setError(
+                cause instanceof Error
+                    ? cause.message
+                    : "Could not switch workspaces.",
+            );
+        }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Escape") {
+            event.preventDefault();
+            onClose();
+            return;
+        }
+        if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            if (filteredLocations.length === 0) {
+                return;
+            }
+            const direction = event.key === "ArrowDown" ? 1 : -1;
+            setSelectedIndex(
+                (current) =>
+                    (current + direction + filteredLocations.length) %
+                    filteredLocations.length,
+            );
+            return;
+        }
+        if (event.key === "Enter") {
+            const selected = filteredLocations[selectedIndex];
+            if (selected) {
+                event.preventDefault();
+                void activate(selected);
+            }
+        }
+    };
+
+    const currentWindow = filteredLocations.filter(
+        (entry) => entry.location.isCurrentWindow,
+    );
+    const otherWindows = filteredLocations.filter(
+        (entry) => !entry.location.isCurrentWindow,
+    );
+    let displayIndex = 0;
+
+    return createPortal(
+        <div
+            className="project-context-menu-backdrop"
+            onMouseDown={(event) => {
+                if (event.currentTarget === event.target) {
+                    onClose();
+                }
+            }}
+        >
+            <div
+                aria-label="Switch workspace"
+                aria-modal="true"
+                className="project-context-menu workspace-switcher"
+                role="dialog"
+            >
+                <label className="project-context-search-shell">
+                    <span aria-hidden="true">⌕</span>
+                    <input
+                        aria-label="Search open workspaces"
+                        onChange={(event) => setQuery(event.target.value)}
+                        onKeyDown={handleKeyDown}
+                        placeholder="Search projects, worktrees, or windows"
+                        ref={inputRef}
+                        value={query}
+                    />
+                    <span>{filteredLocations.length}</span>
+                </label>
+                <div className="workspace-switcher-list" role="listbox">
+                    {renderGroup("Current Window", currentWindow)}
+                    {renderGroup("Other Windows", otherWindows)}
+                    {filteredLocations.length === 0 && !error && (
+                        <div className="workspace-switcher-empty">
+                            No open workspaces match your search.
+                        </div>
+                    )}
+                    {error && (
+                        <div className="workspace-switcher-error" role="alert">
+                            {error}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>,
+        document.body,
+    );
+
+    function renderGroup(
+        label: string,
+        entries: readonly DisplayWorkspaceLocation[],
+    ) {
+        if (entries.length === 0) {
+            return null;
+        }
+        return (
+            <section aria-label={label} className="workspace-switcher-group">
+                <h2>{label}</h2>
+                {entries.map((entry) => {
+                    const itemIndex = displayIndex++;
+                    const selected = itemIndex === selectedIndex;
+                    return (
+                        <button
+                            aria-selected={selected}
+                            className="workspace-switcher-item"
+                            data-selected={selected || undefined}
+                            key={`${entry.location.hostWindowId}:${entry.location.contextKey}`}
+                            onClick={() => void activate(entry)}
+                            onMouseEnter={() => setSelectedIndex(itemIndex)}
+                            role="option"
+                            type="button"
+                        >
+                            <span className="workspace-switcher-item-copy">
+                                <strong>{entry.projectName}</strong>
+                                <span>{entry.worktreeLabel}</span>
+                            </span>
+                            <span className="workspace-switcher-window">
+                                {entry.location.isActive ? "Active · " : ""}
+                                {entry.location.windowTitle}
+                            </span>
+                        </button>
+                    );
+                })}
+            </section>
+        );
+    }
+}

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -1595,7 +1595,6 @@ export function SidebarGitScopePicker({
 
             try {
                 await getComandoApi().openProjectWindow({
-                    forceNewWindow: true,
                     projectId,
                     worktreeId: targetWorktree.id,
                 });

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -592,7 +592,10 @@
 }
 
 .project-context-menu-root {
-    flex: 0 0 auto;
+display: flex;
+flex: 0 0 auto;
+align-items: center;
+gap: 2px;
 }
 
 .project-context-add {
@@ -644,7 +647,91 @@
 }
 
 :root[data-transparency-enabled="false"] .project-context-menu-backdrop {
-    backdrop-filter: none;
+backdrop-filter: none;
+}
+
+.workspace-switcher {
+width: min(560px, 100%);
+}
+
+.workspace-switcher-list {
+max-height: min(460px, calc(100vh - 180px));
+overflow-y: auto;
+padding: 8px;
+}
+
+.workspace-switcher-group + .workspace-switcher-group {
+margin-top: 8px;
+}
+
+.workspace-switcher-group h2 {
+margin: 0;
+padding: 6px 8px 4px;
+color: var(--color-text-tertiary);
+font-size: 10px;
+font-weight: 650;
+letter-spacing: 0.06em;
+text-transform: uppercase;
+}
+
+.workspace-switcher-item {
+display: flex;
+width: 100%;
+min-height: 44px;
+align-items: center;
+justify-content: space-between;
+gap: 12px;
+border: 0;
+border-radius: 7px;
+background: transparent;
+color: var(--color-text-primary);
+padding: 7px 9px;
+text-align: left;
+}
+
+.workspace-switcher-item:hover,
+.workspace-switcher-item[data-selected] {
+background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+}
+
+.workspace-switcher-item-copy {
+display: flex;
+min-width: 0;
+flex-direction: column;
+gap: 2px;
+}
+
+.workspace-switcher-item-copy strong {
+overflow: hidden;
+font-size: 12px;
+font-weight: 600;
+text-overflow: ellipsis;
+white-space: nowrap;
+}
+
+.workspace-switcher-item-copy span,
+.workspace-switcher-window {
+color: var(--color-text-secondary);
+font-size: 10px;
+}
+
+.workspace-switcher-window {
+max-width: 45%;
+overflow: hidden;
+text-overflow: ellipsis;
+white-space: nowrap;
+}
+
+.workspace-switcher-empty,
+.workspace-switcher-error {
+padding: 28px 12px;
+color: var(--color-text-secondary);
+font-size: 12px;
+text-align: center;
+}
+
+.workspace-switcher-error {
+color: var(--color-danger);
 }
 
 .project-context-search-shell {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -145,6 +145,7 @@ export const IPC_CHANNELS = {
     openWorkspaceSurfaceGitScopeMenu: "workspace:open-surface-git-scope-menu",
     openWorkspaceSurfaceProjectMenu: "workspace:open-surface-project-menu",
     showWorkspaceContextMenu: "workspace:show-context-menu",
+    moveWorkspaceContext: "workspace:move-context",
     showNativeContextMenu: "app:show-native-context-menu",
     setWorkspaceSurfaceContentInset: "workspace:set-surface-content-inset",
     setWorkspaceSurfaceContentLeftInset: "workspace:set-surface-content-left-inset",
@@ -2324,14 +2325,28 @@ export type WorkspaceSurfaceActionDispatchResult =
 
 export interface WorkspaceContextMenuInput {
     readonly canCopyFullPath: boolean;
+    readonly contextKey: string;
+    readonly projectId: string;
+    readonly worktreeId: string | null;
     readonly x: number;
     readonly y: number;
 }
 
 export type WorkspaceContextMenuAction =
-    | "copy_full_path"
-    | "move_to_new_window"
-    | "close";
+    | { readonly type: "copy_full_path" }
+    | {
+          readonly type: "move";
+          /** A null destination asks the main process to create an empty window. */
+          readonly targetWindowId: string | null;
+      }
+    | { readonly type: "close" };
+
+export interface MoveWorkspaceContextInput {
+    readonly contextKey: string;
+    readonly projectId: string;
+    readonly targetWindowId: string | null;
+    readonly worktreeId: string | null;
+}
 
 export type NativeContextMenuEntry =
     | {
@@ -3464,6 +3479,7 @@ export interface ComandoApi {
     showWorkspaceContextMenu: (
         input: WorkspaceContextMenuInput,
     ) => Promise<WorkspaceContextMenuAction | null>;
+    moveWorkspaceContext: (input: MoveWorkspaceContextInput) => Promise<void>;
     showNativeContextMenu: (
         input: NativeContextMenuInput,
     ) => Promise<string | null>;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -730,9 +730,7 @@ export interface OpenSettingsWindowInput {
 
 export interface OpenProjectWindowInput {
     readonly branchName?: string | null;
-    readonly forceNewWindow?: boolean;
     readonly projectId: string;
-    readonly workspaceSnapshot?: WorkspaceNavigationSnapshot;
     readonly worktreeId?: string | null;
 }
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -213,6 +213,7 @@ export const IPC_EVENTS = {
     sidebarToggleRequested: "shell:sidebar-toggle-requested",
     workspaceCloseActiveTab: "workspace:close-active-tab",
     workspaceReopenLastClosedTab: "workspace:reopen-last-closed-tab",
+    workspaceSwitcherRequested: "workspace:switcher-requested",
     workspaceFlushRequested: "workspace:flush-requested",
     workspaceFlushAcknowledged: "workspace:flush-acknowledged",
     workspaceSurfaceSnapshotRequested: "workspace:surface-snapshot-requested",
@@ -3868,6 +3869,7 @@ export interface ComandoApi {
     onSidebarToggleRequested: (listener: () => void) => () => void;
     onWorkspaceCloseActiveTab: (listener: () => void) => () => void;
     onWorkspaceReopenLastClosedTab: (listener: () => void) => () => void;
+    onWorkspaceSwitcherRequested: (listener: () => void) => () => void;
     onWorkspaceFlushRequested: (
         listener: () => Promise<void> | void,
     ) => () => void;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -2,6 +2,7 @@ import type { AppIdentity } from "@shared/app-identity";
 import type { AiReviewActionLogState } from "./ai-review-action-log";
 import type { AppTerminalSettings } from "./terminal-settings";
 import type { ChatFontFamily, EditorFontFamily } from "./typography";
+import type { WorkspaceLocation } from "./workspace-context";
 
 export type { AppTerminalSettings } from "./terminal-settings";
 export type { ChatFontFamily, EditorFontFamily } from "./typography";
@@ -129,6 +130,8 @@ export const IPC_CHANNELS = {
     saveWorkspaceSnapshot: "workspace:save-snapshot",
     initializeWorkspaceSurfaces: "workspace:initialize-surfaces",
     activateWorkspaceSurface: "workspace:activate-surface",
+    listOpenWorkspaceLocations: "workspace:list-open-locations",
+    activateWorkspaceLocation: "workspace:activate-location",
     captureWorkspaceSurfaceContext: "workspace:capture-surface-context",
     dispatchWorkspaceSurfaceDrag: "workspace:dispatch-surface-drag",
     dispatchWorkspaceSurfaceAction: "workspace:dispatch-surface-action",
@@ -2188,6 +2191,15 @@ export interface WorkspaceNavigationSnapshot {
     readonly version: 3;
 }
 
+export interface OpenWorkspaceLocationSummary extends WorkspaceLocation {
+    readonly isActive: boolean;
+    readonly isCurrentWindow: boolean;
+    readonly lastActivatedAt: string;
+    readonly windowTitle: string;
+}
+
+export type ActivateWorkspaceLocationInput = WorkspaceLocation;
+
 export interface WorkspaceSurfaceContextRequest {
     readonly emptyLayout?: boolean;
     readonly projectId: string;
@@ -3434,6 +3446,12 @@ export interface ComandoApi {
         snapshot: WorkspaceNavigationSnapshot,
     ) => Promise<void>;
     activateWorkspaceSurface: (contextKey: string) => Promise<void>;
+    listOpenWorkspaceLocations: () => Promise<
+        readonly OpenWorkspaceLocationSummary[]
+    >;
+    activateWorkspaceLocation: (
+        input: ActivateWorkspaceLocationInput,
+    ) => Promise<boolean>;
     requestWorkspaceSurfaceContext: (
         input: WorkspaceSurfaceContextRequest,
     ) => Promise<void>;

--- a/src/shared/workspace-context.test.ts
+++ b/src/shared/workspace-context.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    areWorkspaceScopesEquivalent,
+    getWorkspaceContextKey,
+    normalizeWorkspaceWorktreeId,
+    type WorkspaceLocation,
+} from "./workspace-context";
+
+describe("workspace context identity", () => {
+    it("normalizes both primary worktree representations", () => {
+        expect(normalizeWorkspaceWorktreeId("project-1", null)).toBeNull();
+        expect(
+            normalizeWorkspaceWorktreeId("project-1", "project-1:primary"),
+        ).toBeNull();
+        expect(getWorkspaceContextKey("project-1", null)).toBe(
+            "project-1::__primary__",
+        );
+        expect(
+            getWorkspaceContextKey("project-1", "project-1:primary"),
+        ).toBe("project-1::__primary__");
+    });
+
+    it("keeps distinct worktrees and projects isolated", () => {
+        expect(
+            areWorkspaceScopesEquivalent(
+                { projectId: "project-1", worktreeId: "worktree-a" },
+                { projectId: "project-1", worktreeId: "worktree-b" },
+            ),
+        ).toBe(false);
+        expect(
+            areWorkspaceScopesEquivalent(
+                { projectId: "project-1", worktreeId: "shared-id" },
+                { projectId: "project-2", worktreeId: "shared-id" },
+            ),
+        ).toBe(false);
+    });
+
+    it("requires a host and context to locate a workspace globally", () => {
+        const location: WorkspaceLocation = {
+            contextKey: "project-1::__primary__",
+            hostWindowId: "window-1",
+            projectId: "project-1",
+            worktreeId: null,
+        };
+
+        expect(location).toMatchObject({
+            contextKey: "project-1::__primary__",
+            hostWindowId: "window-1",
+        });
+    });
+});

--- a/src/shared/workspace-context.ts
+++ b/src/shared/workspace-context.ts
@@ -1,0 +1,62 @@
+export const WORKSPACE_PRIMARY_CONTEXT = "__primary__";
+
+const NO_PROJECT_CONTEXT = "__none__";
+
+export interface WorkspaceScope {
+    readonly projectId: string;
+    readonly worktreeId: string | null;
+}
+
+export interface WorkspaceLocation extends WorkspaceScope {
+    readonly contextKey: string;
+    readonly hostWindowId: string;
+}
+
+export function normalizeWorkspaceWorktreeId(
+    projectId: string,
+    worktreeId: string | null | undefined,
+): string | null {
+    return worktreeId === null ||
+        worktreeId === undefined ||
+        worktreeId === `${projectId}:primary`
+        ? null
+        : worktreeId;
+}
+
+export function getWorkspaceContextKey(
+    projectId: string | null,
+    worktreeId: string | null | undefined,
+): string {
+    if (!projectId) {
+        return `${NO_PROJECT_CONTEXT}::${worktreeId ?? WORKSPACE_PRIMARY_CONTEXT}`;
+    }
+    return `${projectId}::${normalizeWorkspaceWorktreeId(projectId, worktreeId) ?? WORKSPACE_PRIMARY_CONTEXT}`;
+}
+
+export function areWorkspaceWorktreeIdsEquivalent(
+    projectId: string | null,
+    left: string | null | undefined,
+    right: string | null | undefined,
+): boolean {
+    if (!projectId) {
+        return (left ?? null) === (right ?? null);
+    }
+    return (
+        normalizeWorkspaceWorktreeId(projectId, left) ===
+        normalizeWorkspaceWorktreeId(projectId, right)
+    );
+}
+
+export function areWorkspaceScopesEquivalent(
+    left: WorkspaceScope,
+    right: WorkspaceScope,
+): boolean {
+    return (
+        left.projectId === right.projectId &&
+        areWorkspaceWorktreeIdsEquivalent(
+            left.projectId,
+            left.worktreeId,
+            right.worktreeId,
+        )
+    );
+}

--- a/src/shared/workspace-restore.ts
+++ b/src/shared/workspace-restore.ts
@@ -7,6 +7,10 @@ import type {
     WorkspacePaneNode,
     WorkspaceTab,
 } from "./ipc";
+import {
+    getWorkspaceContextKey,
+    normalizeWorkspaceWorktreeId,
+} from "./workspace-context";
 
 export const WINDOW_WORKSPACE_RESTORE_SCHEMA_VERSION = 1 as const;
 
@@ -42,7 +46,7 @@ export function normalizeWorkspaceNavigationSnapshot(
         if (!legacy || !projectId) {
             return { droppedContextCount: 0, repaired: true, snapshot: emptyNavigation() };
         }
-        const worktreeId = normalizePrimaryWorktree(
+        const worktreeId = normalizeWorkspaceWorktreeId(
             projectId,
             fallbackScope.worktreeId ?? firstTabWorktreeId(legacy),
         );
@@ -116,7 +120,7 @@ export function normalizeWindowWorkspaceRestoreRecord(
 function normalizeContext(value: unknown): PersistedWorkspaceContext | null {
     if (!isRecord(value) || typeof value.projectId !== "string" || value.projectId.length === 0) return null;
     const rawWorktreeId = typeof value.worktreeId === "string" ? value.worktreeId : null;
-    const worktreeId = normalizePrimaryWorktree(value.projectId, rawWorktreeId);
+    const worktreeId = normalizeWorkspaceWorktreeId(value.projectId, rawWorktreeId);
     const workspace = normalizeLayout(value.workspace);
     if (!workspace) return null;
     const scopedWorkspace: WorkspaceLayoutSnapshot = {
@@ -229,11 +233,7 @@ function firstTabWorktreeId(layout: WorkspaceLayoutSnapshot | null): string | nu
 }
 
 function workspaceContextKey(projectId: string, worktreeId: string | null): string {
-    return `${projectId}::${worktreeId ?? "__primary__"}`;
-}
-
-function normalizePrimaryWorktree(projectId: string, worktreeId: string | null): string | null {
-    return worktreeId === `${projectId}:primary` ? null : worktreeId;
+    return getWorkspaceContextKey(projectId, worktreeId);
 }
 
 function emptyNavigation(): WorkspaceNavigationSnapshot {


### PR DESCRIPTION
## Summary

- introduce canonical project/worktree workspace identity and a global inventory of open workspace locations
- add a searchable workspace switcher that can activate workspaces in the current window or focus another window
- enforce one live workspace per project/worktree scope while preserving distinct worktrees and legacy duplicates
- move workspace tabs to an existing or new window by reparenting the live `WebContentsView`, preserving agents, terminals, dirty buffers, tabs, and surface ownership
- persist source and destination snapshots atomically with revision checks and full in-memory rollback on failure
- replace the old snapshot-copy/close flow with structured context-menu destinations owned by the main process

## Safety and behavior

- switching only activates and focuses the selected location
- moving preserves the existing surface and runtime owner identity
- unrelated windows and surfaces are not mutated
- a source window remains open if its last workspace is moved
- stale or closed destinations fail without removing the workspace from its source
- legacy duplicate scopes are preserved but normal opening flows cannot create additional duplicates

## Testing

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test` — 2,512 passed, 1 skipped
- `pnpm run build`
- `pnpm exec playwright test --config e2e/playwright.config.ts` — 3 passed
- `git diff --check`

## Manual validation

The automated suite covers surface identity, lifecycle preservation, agent/action routing, rollback, atomic persistence, restart restoration, multiple worktrees, existing-window moves, new-window moves, and closed destinations. Manual compositor validation of live `WebContentsView` reparenting on Windows and Linux is still recommended before merge.
