### PR TITLE
Fix agent session titles and sidebar visibility

### DIFF
--- a/crates/comando-ai/src/engine.rs
+++ b/crates/comando-ai/src/engine.rs
@@ -510,12 +510,6 @@ impl AiEngine {
         &self,
         input: comando_types::ai::NativeAiRenameSessionInput,
     ) -> AiResult<()> {
-        if let Ok(mut sessions) = self.lock_sessions()
-            && let Ok(session) = sessions.get_mut(&input.session_id)
-        {
-            session.session.title = input.title.clone();
-            session.session.updated_at = now_iso8601();
-        }
         if let Some(store) = self.history_store()?
             && store.has_session(&input.session_id)
         {
@@ -1828,17 +1822,19 @@ fn is_reasoning_effort_config_option(option: &Value) -> bool {
 }
 
 fn preferred_status_title(metadata: &AiHistorySessionMetadata, incoming_title: &str) -> String {
-    metadata
-        .custom_title
-        .as_deref()
-        .or_else(|| {
-            metadata
-                .subagent
-                .as_ref()
-                .and_then(|subagent| subagent.nickname.as_deref())
-        })
-        .unwrap_or(incoming_title)
-        .to_string()
+    if let Some(nickname) = metadata
+        .subagent
+        .as_ref()
+        .and_then(|subagent| subagent.nickname.as_deref())
+    {
+        return nickname.to_string();
+    }
+    let incoming_title = incoming_title.trim();
+    if incoming_title.is_empty() {
+        metadata.title.clone()
+    } else {
+        incoming_title.to_string()
+    }
 }
 
 fn native_status_from_event(status: &str) -> NativeAiSessionStatus {

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -163,15 +163,17 @@ impl AiHistorySessionMetadata {
         }
     }
 
+    pub fn runtime_title(&self) -> &str {
+        self.subagent
+            .as_ref()
+            .and_then(|subagent| subagent.nickname.as_deref())
+            .unwrap_or(&self.title)
+    }
+
     pub fn display_title(&self) -> &str {
         self.custom_title
             .as_deref()
-            .or_else(|| {
-                self.subagent
-                    .as_ref()
-                    .and_then(|subagent| subagent.nickname.as_deref())
-            })
-            .unwrap_or(&self.title)
+            .unwrap_or_else(|| self.runtime_title())
     }
 }
 
@@ -847,8 +849,8 @@ impl AiHistoryStore {
             let index = self.load_or_repair_index(session_id)?;
             self.read_payloads_by_index(session_id, &index, 0, index.len())?
         };
-        let title = metadata.display_title().to_string();
-
+        let title = metadata.runtime_title().to_string();
+        let manual_title = metadata.custom_title.clone();
         Ok(Some(NativeAiSessionSnapshot {
             session_id: metadata.session_id,
             parent_session_id: metadata.parent_session_id,
@@ -857,6 +859,7 @@ impl AiHistoryStore {
             project_id: metadata.project_id,
             worktree_id: metadata.worktree_id,
             title,
+            manual_title,
             status: metadata.status,
             updated_at: metadata.updated_at,
             active_turn_started_at: state.active_turn_started_at,
@@ -1006,7 +1009,6 @@ impl AiHistoryStore {
 
     pub fn rename_session(&self, session_id: &SessionId, title: String) -> AiResult<()> {
         let mut metadata = self.load_metadata(session_id)?;
-        metadata.title = normalize_title(title.clone());
         metadata.custom_title = Some(normalize_title(title));
         metadata.updated_at = now_iso8601();
         self.save_metadata(&metadata)
@@ -1771,6 +1773,7 @@ impl<'a> LegacyAiHistoryReader<'a> {
                 .and_then(Value::as_str)
                 .unwrap_or(&row.title)
                 .to_string(),
+            manual_title: string_field(&state, "manualTitle"),
             status: native_status_from_legacy(
                 state
                     .get("status")
@@ -3362,7 +3365,11 @@ mod tests {
             .load_session_snapshot(&child.session_id)
             .unwrap()
             .unwrap();
-        assert_eq!(renamed_snapshot.title, "Custom child title");
+        assert_eq!(renamed_snapshot.title, "Kierkegaard");
+        assert_eq!(
+            renamed_snapshot.manual_title.as_deref(),
+            Some("Custom child title")
+        );
     }
 
     #[test]
@@ -3384,7 +3391,8 @@ mod tests {
             .load_session_snapshot(&metadata.session_id)
             .unwrap()
             .unwrap();
-        assert_eq!(snapshot.title, "Renamed");
+        assert_eq!(snapshot.title, metadata.title);
+        assert_eq!(snapshot.manual_title.as_deref(), Some("Renamed"));
         assert_eq!(snapshot.messages, vec![message("message_1", "hello")]);
         assert!(
             store

--- a/crates/comando-types/src/ai.rs
+++ b/crates/comando-types/src/ai.rs
@@ -769,6 +769,8 @@ pub struct NativeAiSessionSnapshot {
     pub project_id: Option<ProjectId>,
     pub worktree_id: Option<WorktreeId>,
     pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manual_title: Option<String>,
     pub status: NativeAiSessionStatus,
     pub updated_at: String,
     pub active_turn_started_at: Option<String>,

--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -78,6 +78,7 @@ describe("AiService prepareSession", () => {
             runtimeSessionId: "runtime-session-1",
             sessionId: "session-1",
             status: "error",
+            manualTitle: "Manual title",
             title: "Codex 1",
             tokenUsage: null,
             toolActivity: [],
@@ -160,7 +161,7 @@ describe("AiService prepareSession", () => {
                 projectId: null,
                 runtimeId: "codex",
                 sessionId: "session-1",
-                title: "Codex 1",
+                title: "Manual title",
                 worktreeId: null,
             },
             "window-1",
@@ -1233,7 +1234,6 @@ describe("AiService prepareSession", () => {
             patch: {
                 changes: {
                     manualTitle: "Manual title",
-                    title: "Manual title",
                 },
                 sessionId: "session-1",
             },
@@ -1241,7 +1241,7 @@ describe("AiService prepareSession", () => {
         expect(await service.getSessionSnapshot("session-1")).toMatchObject({
             manualTitle: "Manual title",
             sessionId: "session-1",
-            title: "Manual title",
+            title: "Codex 1",
         });
     });
 
@@ -1290,14 +1290,14 @@ describe("AiService prepareSession", () => {
 
         expect(await service.getSessionSnapshot("session-1")).toMatchObject({
             manualTitle: "Manual title",
-            title: "Manual title",
+            title: "Late runtime title",
             updatedAt: "2026-04-15T22:24:00.000Z",
         });
         const update = onSessionSnapshot.mock.lastCall?.[1] as
             | AiSessionUpdate
             | undefined;
         expect(update?.kind).toBe("patch");
-        expect(update?.kind === "patch" ? update.patch.changes.title : null).not.toBe(
+        expect(update?.kind === "patch" ? update.patch.changes.title : null).toBe(
             "Late runtime title",
         );
     });
@@ -1341,7 +1341,7 @@ describe("AiService prepareSession", () => {
 
         expect(await service.getSessionSnapshot("session-1")).toMatchObject({
             manualTitle: "Manual title",
-            title: "Manual title",
+            title: "Late runtime title",
             updatedAt: "2026-04-15T22:25:00.000Z",
         });
     });

--- a/src/main/ai/service.prepare.test.ts
+++ b/src/main/ai/service.prepare.test.ts
@@ -1300,6 +1300,11 @@ describe("AiService prepareSession", () => {
         expect(update?.kind === "patch" ? update.patch.changes.title : null).toBe(
             "Late runtime title",
         );
+        expect(
+            update?.kind === "patch"
+                ? update.patch.changes.manualTitle
+                : null,
+        ).toBe("Manual title");
     });
 
     it("keeps manual titles when full native snapshots arrive later", async () => {

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -71,7 +71,6 @@ import {
     attachNativeReviewDeltaToTrackedFile,
     toNativeReviewDeltaReference,
 } from "@shared/ai-review-delta";
-import { normalizeAiSessionStatusTitle } from "@shared/ai-session-events";
 import {
     beginReviewWorkCycle,
     consolidateReviewDiffs,
@@ -1515,7 +1514,10 @@ export class AiService {
                         return launch.persistedSnapshot;
                     }
 
-                    return await nativeAi.prepareSession({ input, launch });
+                    return await nativeAi.prepareSession({
+                        input: nativePrepareLaunch.input,
+                        launch: nativePrepareLaunch.launch,
+                    });
                 },
             );
             this.#nativeSessionIds.add(snapshot.sessionId);
@@ -3547,7 +3549,6 @@ export class AiService {
         }
 
         if (event.kind === "status") {
-            const title = normalizeAiSessionStatusTitle(event.title);
             return {
                 ...base,
                 activeTurnStartedAt: event.activeTurnStartedAt,
@@ -3561,10 +3562,6 @@ export class AiService {
                         ? snapshot.pendingUserInput
                         : null,
                 status: event.status,
-                title: title
-                    ? setRuntimeTitleOnSnapshot(snapshot, title, event.updatedAt)
-                          .title
-                    : snapshot.title,
             };
         }
 
@@ -4091,7 +4088,6 @@ export class AiService {
                 ? {
                       ...incomingSnapshot,
                       manualTitle: previousSnapshot.manualTitle,
-                      title: previousSnapshot.title,
                   }
                 : incomingSnapshot;
         const previousReviewActionLog = previousSnapshot
@@ -4275,7 +4271,13 @@ export class AiService {
             launch.persistedSnapshot,
         );
         if (rootSnapshot.sessionId === launch.persistedSnapshot.sessionId) {
-            return { input, launch };
+            return {
+                input: {
+                    ...input,
+                    title: launch.persistedSnapshot.title,
+                },
+                launch,
+            };
         }
 
         const rootInput: SessionDescriptor = {
@@ -4433,6 +4435,9 @@ export class AiService {
             input: {
                 ...input,
                 additionalRoots,
+                // Tab titles are display caches and may contain a manual
+                // override; the runtime must receive its own base title.
+                title: persistedSnapshot.title,
                 worktreeId: input.worktreeId ?? null,
             },
             ownerWindowId,

--- a/src/main/ai/session-core.test.ts
+++ b/src/main/ai/session-core.test.ts
@@ -5,6 +5,7 @@ import type { AiSessionSnapshot } from "@shared/ipc";
 import {
     applyNormalizedSessionCatalogToSnapshot,
     applySessionCatalogToSnapshot,
+    getSessionDisplayTitle,
     isPathInsideRoot,
     isSamePath,
     normalizeAdditionalRoots,
@@ -72,13 +73,16 @@ describe("restored Codex activity normalization", () => {
 
         expect(normalizeAiSessionHierarchy(snapshot)).toMatchObject({
             closedAt: null,
+            manualTitle: "Original parent title",
             parentSessionId: null,
             sessionId: "session-codex",
-            title: "Original parent title",
+            title: "root",
         });
         expect(normalizeRestoredAiSessionSnapshot(snapshot)).toMatchObject({
             closedAt: null,
+            manualTitle: "Original parent title",
             parentSessionId: null,
+            title: "root",
         });
     });
 
@@ -737,9 +741,10 @@ describe("session-core model reconciliation", () => {
 
         expect(updated).toMatchObject({
             manualTitle: "Manual title",
-            title: "Manual title",
+            title: "Late Claude title",
             updatedAt: "2026-04-23T00:02:00.000Z",
         });
+        expect(getSessionDisplayTitle(updated)).toBe("Manual title");
     });
 
     it("applies runtime titles when the session was not manually renamed", () => {

--- a/src/main/ai/session-core.ts
+++ b/src/main/ai/session-core.ts
@@ -11,6 +11,7 @@ import {
     applyReasoningEffortToConfigOptions,
     isReasoningEffortConfigOption,
 } from "@shared/ai-config-options";
+import { getAiSessionDisplayTitle } from "@shared/ai-session-title";
 import {
     serializeComposerMessagePartsForDisplay,
 } from "@shared/composer-display-markers";
@@ -137,12 +138,9 @@ export function normalizeAiSessionHierarchy(
 
     return {
         ...snapshot,
-        // A session cannot be its own subagent. Clear the derived close state
-        // and restore a manual title overwritten by the same bad mapping.
+        // A session cannot be its own subagent.
         closedAt: null,
         parentSessionId: null,
-        title:
-            snapshot.manualTitle?.trim() || snapshot.title,
     };
 }
 
@@ -887,8 +885,7 @@ export function setTitleOnSnapshot(
 }
 
 export function getSessionDisplayTitle(snapshot: AiSessionSnapshot): string {
-    const manualTitle = snapshot.manualTitle?.trim();
-    return manualTitle || snapshot.title;
+    return getAiSessionDisplayTitle(snapshot);
 }
 
 export function setManualTitleOnSnapshot(
@@ -900,7 +897,6 @@ export function setManualTitleOnSnapshot(
     return {
         ...snapshot,
         manualTitle: manualTitle || null,
-        title: manualTitle || snapshot.title,
         updatedAt,
     };
 }
@@ -913,12 +909,6 @@ export function setRuntimeTitleOnSnapshot(
     const trimmedTitle = title.trim();
     if (!trimmedTitle) {
         return snapshot;
-    }
-    if (snapshot.manualTitle?.trim()) {
-        return {
-            ...snapshot,
-            updatedAt,
-        };
     }
     return {
         ...snapshot,

--- a/src/main/ai/session-core.ts
+++ b/src/main/ai/session-core.ts
@@ -316,6 +316,11 @@ function createAiSessionPatchChanges(
         }
     }
 
+    if ("title" in changes) {
+        // Consumers need both title owners to derive the display title safely.
+        changes.manualTitle = nextSnapshot.manualTitle ?? null;
+    }
+
     return changes;
 }
 

--- a/src/main/native-backend/ai.ts
+++ b/src/main/native-backend/ai.ts
@@ -1462,6 +1462,7 @@ function nativeSnapshotToIpc(snapshot: NativeAiSessionSnapshot): AiSessionSnapsh
             "Native AI snapshot configOptions",
         ) as AiSessionSnapshot["configOptions"],
         lastError: nullableString(snapshot.lastError),
+        manualTitle: nullableString(snapshot.manualTitle),
         messages: requireRecordArray(
             snapshot.messages,
             "Native AI snapshot messages",

--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -2463,7 +2463,7 @@ describe("ai-store queue", () => {
         ).toBe("high");
     });
 
-    it("applies inferred titles from status events", () => {
+    it("does not treat status summaries as session titles", () => {
         useAiStore.getState().applySessionSnapshot(
             createSnapshot({ title: "Codex 1" }),
         );
@@ -2479,7 +2479,38 @@ describe("ai-store queue", () => {
 
         expect(
             useAiStore.getState().sessions[TAB.sessionId]?.snapshot?.title,
-        ).toBe("Revisa login");
+        ).toBe("Codex 1");
+    });
+
+    it("keeps a manual display title when session info updates the runtime title", () => {
+        useAiStore.getState().registerSessionTab({
+            ...TAB,
+            title: "Manual title",
+        });
+        useAiStore.getState().applySessionSnapshot(
+            createSnapshot({
+                manualTitle: "Manual title",
+                title: "Codex 1",
+            }),
+        );
+
+        useAiStore.getState().applySessionEvent(
+            createSessionEvent({
+                kind: "session-info",
+                parentSessionId: null,
+                projectId: TAB.projectId,
+                title: "Late runtime title",
+                updatedAt: "2026-04-14T00:00:01.000Z",
+                worktreeId: null,
+            }),
+        );
+
+        const session = useAiStore.getState().sessions[TAB.sessionId];
+        expect(session?.snapshot).toMatchObject({
+            manualTitle: "Manual title",
+            title: "Late runtime title",
+        });
+        expect(session?.meta?.title).toBe("Manual title");
     });
 
     it("preserves the root chat title when cancellation only changes status", () => {

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -46,7 +46,7 @@ import { serializeComposerMessagePartsForDisplay } from "@shared/composer-displa
 import {
     attachNativeReviewDeltaToTrackedFile,
 } from "@shared/ai-review-delta";
-import { normalizeAiSessionStatusTitle } from "@shared/ai-session-events";
+import { getAiSessionDisplayTitle } from "@shared/ai-session-title";
 import { getAiTranscriptToolEntryId } from "@shared/ai-transcript";
 import {
     deriveTrackedFilesFromActionLog,
@@ -1361,13 +1361,14 @@ export const useAiStore = create<AiStore>((set, get) => ({
                 applySessionDomainEventToSnapshot(baseSnapshot, normalizedEvent),
                 nextTranscript,
             );
+            const displayTitle = getAiSessionDisplayTitle(nextSnapshot);
             const nextMeta = session.meta
-                ? session.meta.title === nextSnapshot.title
+                ? session.meta.title === displayTitle
                     ? session.meta
-                    : { ...session.meta, title: nextSnapshot.title }
+                    : { ...session.meta, title: displayTitle }
                 : createSessionMetaFromSnapshot(nextSnapshot);
             if (nextMeta !== session.meta) {
-                syncedTitle = nextSnapshot.title;
+                syncedTitle = displayTitle;
             }
 
             return {
@@ -1481,7 +1482,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
                     const nextSnapshot = resolved.snapshot;
                     const nextTranscript = resolved.transcript;
                     const nextMeta = createSessionMetaFromSnapshot(nextSnapshot);
-                    syncedTitle = nextSnapshot.title;
+                    syncedTitle = getAiSessionDisplayTitle(nextSnapshot);
 
                     return {
                         runtimeCatalogById:
@@ -1542,13 +1543,14 @@ export const useAiStore = create<AiStore>((set, get) => ({
             const nextSnapshot = resolved.snapshot;
             const nextTranscript = resolved.transcript;
             const resolvedCatalog = nextCatalog;
+            const displayTitle = getAiSessionDisplayTitle(nextSnapshot);
             const nextMeta = session.meta
-                ? session.meta.title === nextSnapshot.title
+                ? session.meta.title === displayTitle
                     ? session.meta
-                    : { ...session.meta, title: nextSnapshot.title }
+                    : { ...session.meta, title: displayTitle }
                 : session.meta;
             if (nextMeta !== session.meta) {
-                syncedTitle = nextSnapshot.title;
+                syncedTitle = displayTitle;
             }
 
             return {
@@ -1614,13 +1616,14 @@ export const useAiStore = create<AiStore>((set, get) => ({
             );
             const resolvedSnapshot = resolved.snapshot;
             const resolvedTranscript = resolved.transcript;
+            const displayTitle = getAiSessionDisplayTitle(resolvedSnapshot);
             const nextMeta = session.meta
-                ? session.meta.title === resolvedSnapshot.title
+                ? session.meta.title === displayTitle
                     ? session.meta
-                    : { ...session.meta, title: resolvedSnapshot.title }
+                    : { ...session.meta, title: displayTitle }
                 : session.meta;
             if (nextMeta !== session.meta) {
-                syncedTitle = resolvedSnapshot.title;
+                syncedTitle = displayTitle;
             }
             shouldRefreshSealedTranscript =
                 shouldRefreshSealedTranscript ||
@@ -2785,13 +2788,16 @@ export const useAiStore = create<AiStore>((set, get) => ({
                 return {
                     ...snapshot,
                     manualTitle,
-                    title: manualTitle || snapshot.title,
                     updatedAt: new Date().toISOString(),
                 };
             },
             () => getComandoApi().renameAiSession(input),
             set,
             get,
+            {
+                conflictKey: "manualTitle",
+                preserveDuringIncomingSnapshots: true,
+            },
         );
     },
 
@@ -3582,8 +3588,6 @@ function createSessionSnapshotFromEvent(
     const title =
         event.kind === "session-info" || event.kind === "subagent-created"
             ? event.title
-            : event.kind === "status"
-              ? (normalizeAiSessionStatusTitle(event.title) ?? "AI Session")
             : "AI Session";
     const modelId =
         event.kind === "subagent-created"
@@ -3704,7 +3708,6 @@ function applySessionDomainEventToSnapshot(
                 updatedAt: event.updatedAt,
             };
         case "status": {
-            const title = normalizeAiSessionStatusTitle(event.title);
             return {
                 ...snapshot,
                 activeTurnStartedAt: event.activeTurnStartedAt,
@@ -3712,7 +3715,6 @@ function applySessionDomainEventToSnapshot(
                 runtimeSessionId:
                     event.runtimeSessionId ?? snapshot.runtimeSessionId,
                 status: event.status,
-                title: title ?? snapshot.title,
                 updatedAt: event.updatedAt,
             };
         }
@@ -4115,7 +4117,7 @@ function createSessionMetaFromSnapshot(
     return {
         projectId: snapshot.projectId,
         runtimeId: snapshot.runtimeId,
-        title: snapshot.title,
+        title: getAiSessionDisplayTitle(snapshot),
         worktreeId: snapshot.worktreeId ?? null,
     };
 }

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
@@ -8,6 +8,7 @@ import type {
     AiHistorySessionSummary,
     AiSessionSnapshot,
     ComandoApi,
+    WorkspaceChatTab,
 } from "@shared/ipc";
 import {
     registerClaudeCodeSidebarSession,
@@ -17,6 +18,7 @@ import {
     resetAiStoreRuntimeBuffersForTests,
     useAiStore,
 } from "@renderer/app/store/ai-store";
+import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
 
 import {
     buildSidebarAgentsNewAgentMenuEntries,
@@ -41,6 +43,13 @@ import {
 
 const mountedRoots: Root[] = [];
 const mountedContainers: HTMLDivElement[] = [];
+
+beforeEach(() => {
+    useWorkspaceStore.setState((state) => ({
+        ...state,
+        tabsById: {},
+    }));
+});
 
 class MemoryStorage implements Storage {
     private readonly values = new Map<string, string>();
@@ -344,6 +353,34 @@ describe("SidebarAgentsPanel history cache", () => {
         expect(markup).toContain("Cached Session");
         expect(markup).toContain("1 thread");
         expect(markup).not.toContain("Loading...");
+    });
+
+    it("renders an open chat even before it appears in history", async () => {
+        const openTab: WorkspaceChatTab = {
+            createdAt: "2026-04-19T11:00:00.000Z",
+            draft: "",
+            id: "open-tab",
+            kind: "chat",
+            projectId: "project-1",
+            runtimeId: "claude",
+            sessionId: "open-session",
+            title: "Open Session",
+            worktreeId: "worktree-1",
+        };
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            tabsById: {
+                [openTab.id]: openTab,
+            },
+        }));
+
+        const container = await mountSidebarAgentsPanel([]);
+
+        expect(
+            container.querySelector(
+                '.sidebar-agents-row[title="Open Session"]',
+            ),
+        ).not.toBeNull();
     });
 
     it("queries the canonical primary worktree supplied by the host", async () => {

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -20,6 +20,7 @@ import {
     ACTIVE_AI_RUNTIME_IDS,
     type ActiveAiRuntimeId,
 } from "@shared/ai-runtimes";
+import { getAiSessionDisplayTitle } from "@shared/ai-session-title";
 
 import { useAiStore } from "@renderer/app/store/ai-store";
 import { areGitWorktreeIdsEquivalent } from "@renderer/app/git/context-key";
@@ -70,6 +71,7 @@ import { releaseCachedChatTimeline } from "@renderer/components/workspace/chat/c
 
 import {
     applySessionUpdateToSidebarHistory,
+    mergeOpenSessionFallbacks,
     SIDEBAR_AGENTS_HISTORY_LIMIT,
     type SidebarAgentsHistoryUnknownSessionSeed,
 } from "./sidebarAgentsHistory";
@@ -173,6 +175,7 @@ export function SidebarAgentsPanel({
         (state) => state.updateSessionTabTitles,
     );
     const tabsById = useWorkspaceStore((state) => state.tabsById);
+    const aiSessions = useAiStore((state) => state.sessions);
     const activePaneSessionId = useWorkspaceStore((state) => {
         const activePane = collectPaneNodes(state.rootNode).find(
             (pane) => pane.id === state.activePaneId,
@@ -279,10 +282,75 @@ export function SidebarAgentsPanel({
             }),
         [visibleFolderState.folderOrder, visibleFolderState.folders],
     );
-    const visibleHistorySessions =
+    const cachedHistorySessions =
         loadedHistoryScopeKey === historyScopeKey
             ? sessions
             : pendingHistoryCache?.sessions ?? EMPTY_AGENTS_SESSIONS;
+    const openSessionFallbacks = useMemo(() => {
+        const fallbacks = new Map<string, AiHistorySessionSummary>();
+        const sourceKinds = new Map<string, "chat" | "review">();
+
+        for (const tab of Object.values(tabsById)) {
+            if (tab.kind !== "chat" && tab.kind !== "review") {
+                continue;
+            }
+            const tabWorktreeId = tab.worktreeId ?? null;
+            const isInScope =
+                tab.projectId === projectId &&
+                (projectId
+                    ? areGitWorktreeIdsEquivalent(
+                          projectId,
+                          tabWorktreeId,
+                          worktreeId ?? null,
+                      )
+                    : tabWorktreeId === (worktreeId ?? null));
+            if (!isInScope) {
+                continue;
+            }
+
+            const existingKind = sourceKinds.get(tab.sessionId);
+            if (
+                existingKind === "chat" ||
+                (existingKind === "review" && tab.kind === "review")
+            ) {
+                continue;
+            }
+
+            const snapshot = aiSessions[tab.sessionId]?.snapshot ?? null;
+            const snapshotTitle = snapshot
+                ? getAiSessionDisplayTitle(snapshot).trim()
+                : "";
+            const title = snapshotTitle || tab.title.trim() || "AI Session";
+            fallbacks.set(tab.sessionId, {
+                createdAt: tab.createdAt,
+                messageCount: snapshot?.messages.length ?? 0,
+                parentSessionId: snapshot?.parentSessionId ?? null,
+                pinnedAt: null,
+                preview: null,
+                projectId: tab.projectId,
+                runtimeId: snapshot?.runtimeId ?? tab.runtimeId,
+                runtimeSessionId: snapshot?.runtimeSessionId ?? null,
+                sessionId: tab.sessionId,
+                title,
+                updatedAt: snapshot?.updatedAt ?? tab.createdAt,
+                worktreeId: tabWorktreeId,
+            });
+            sourceKinds.set(tab.sessionId, tab.kind);
+        }
+
+        return [...fallbacks.values()];
+    }, [aiSessions, projectId, tabsById, worktreeId]);
+    const visibleHistorySessions = useMemo(
+        () =>
+            mergeOpenSessionFallbacks(
+                cachedHistorySessions,
+                openSessionFallbacks.filter(
+                    (session) =>
+                        !deletedSessionIdsRef.current.has(session.sessionId),
+                ),
+            ),
+        [cachedHistorySessions, openSessionFallbacks],
+    );
     const scopedTerminalAgentSessions = useMemo(
         () =>
             terminalAgentSessions.filter(
@@ -1133,7 +1201,6 @@ export function SidebarAgentsPanel({
         return ids;
     }, [tabsById, terminalAgentSessionByTerminalId]);
 
-    const aiSessions = useAiStore((state) => state.sessions);
     const workingOrderRef = useRef<Map<string, number>>(new Map());
     const workingCounterRef = useRef(0);
     const [workingOrderRevision, setWorkingOrderRevision] = useState(0);
@@ -2508,7 +2575,9 @@ function buildUnknownSessionSeed(
         return null;
     }
 
-    const title = entry.snapshot?.title ?? entry.meta?.title ?? "";
+    const title = entry.snapshot
+        ? getAiSessionDisplayTitle(entry.snapshot)
+        : entry.meta?.title ?? "";
     if (title.trim().length === 0) {
         return null;
     }

--- a/src/renderer/src/components/sidebar/sidebarAgentsHistory.test.ts
+++ b/src/renderer/src/components/sidebar/sidebarAgentsHistory.test.ts
@@ -9,6 +9,7 @@ import type {
 
 import {
     applySessionUpdateToSidebarHistory,
+    mergeOpenSessionFallbacks,
     SIDEBAR_AGENTS_HISTORY_LIMIT,
 } from "./sidebarAgentsHistory";
 
@@ -269,6 +270,71 @@ describe("applySessionUpdateToSidebarHistory", () => {
         });
     });
 
+    it("preserves known history metadata when a partial snapshot omits messages", () => {
+        const sessions = [
+            createSummary({
+                messageCount: 12,
+                preview: "Persisted transcript preview.",
+                title: "Manual title",
+            }),
+        ] as const;
+
+        const result = applySessionUpdateToSidebarHistory({
+            limit: SIDEBAR_AGENTS_HISTORY_LIMIT,
+            scope: DEFAULT_SCOPE,
+            sessions,
+            update: {
+                kind: "snapshot",
+                snapshot: createSnapshot({
+                    manualTitle: "Manual title",
+                    messages: [],
+                    title: "Runtime title",
+                    updatedAt: "2026-04-19T12:30:00.000Z",
+                }),
+            },
+        });
+
+        expect(result.sessions).toHaveLength(1);
+        expect(result.sessions[0]).toMatchObject({
+            messageCount: 12,
+            preview: "Persisted transcript preview.",
+            title: "Manual title",
+            updatedAt: "2026-04-19T12:30:00.000Z",
+        });
+    });
+
+    it("preserves known history metadata when a partial patch has no messages", () => {
+        const sessions = [
+            createSummary({
+                messageCount: 12,
+                preview: "Persisted transcript preview.",
+            }),
+        ] as const;
+
+        const result = applySessionUpdateToSidebarHistory({
+            limit: SIDEBAR_AGENTS_HISTORY_LIMIT,
+            scope: DEFAULT_SCOPE,
+            sessions,
+            update: {
+                kind: "patch",
+                patch: {
+                    changes: {
+                        messages: [],
+                        updatedAt: "2026-04-19T12:30:00.000Z",
+                    },
+                    runtimeId: "codex",
+                    sessionId: "session-1",
+                },
+            },
+        });
+
+        expect(result.sessions[0]).toMatchObject({
+            messageCount: 12,
+            preview: "Persisted transcript preview.",
+            updatedAt: "2026-04-19T12:30:00.000Z",
+        });
+    });
+
     it("removes a known session when a patch moves it outside the active scope", () => {
         const sessions = [createSummary()] as const;
         const update: AiSessionUpdate = {
@@ -433,5 +499,37 @@ describe("applySessionUpdateToSidebarHistory", () => {
                 sessionId: "child",
             }),
         ]);
+    });
+});
+
+describe("mergeOpenSessionFallbacks", () => {
+    it("keeps every open session visible without duplicating history rows", () => {
+        const persisted = createSummary({ sessionId: "persisted" });
+        const openOnly = createSummary({
+            messageCount: 0,
+            preview: null,
+            sessionId: "open-only",
+            title: "Open Session",
+            updatedAt: "2026-04-19T11:00:00.000Z",
+        });
+
+        const result = mergeOpenSessionFallbacks(
+            [persisted],
+            [
+                openOnly,
+                createSummary({
+                    sessionId: "persisted",
+                    title: "Duplicate fallback",
+                }),
+            ],
+        );
+
+        expect(result.map((session) => session.sessionId)).toEqual([
+            "open-only",
+            "persisted",
+        ]);
+        expect(
+            result.find((session) => session.sessionId === "persisted")?.title,
+        ).toBe("Session One");
     });
 });

--- a/src/renderer/src/components/sidebar/sidebarAgentsHistory.test.ts
+++ b/src/renderer/src/components/sidebar/sidebarAgentsHistory.test.ts
@@ -335,6 +335,37 @@ describe("applySessionUpdateToSidebarHistory", () => {
         });
     });
 
+    it("keeps the manual title when a runtime title patch arrives", () => {
+        const sessions = [
+            createSummary({
+                title: "Manual title",
+            }),
+        ] as const;
+
+        const result = applySessionUpdateToSidebarHistory({
+            limit: SIDEBAR_AGENTS_HISTORY_LIMIT,
+            scope: DEFAULT_SCOPE,
+            sessions,
+            update: {
+                kind: "patch",
+                patch: {
+                    changes: {
+                        manualTitle: "Manual title",
+                        title: "Late runtime title",
+                        updatedAt: "2026-04-19T12:30:00.000Z",
+                    },
+                    runtimeId: "codex",
+                    sessionId: "session-1",
+                },
+            },
+        });
+
+        expect(result.sessions[0]).toMatchObject({
+            title: "Manual title",
+            updatedAt: "2026-04-19T12:30:00.000Z",
+        });
+    });
+
     it("removes a known session when a patch moves it outside the active scope", () => {
         const sessions = [createSummary()] as const;
         const update: AiSessionUpdate = {

--- a/src/renderer/src/components/sidebar/sidebarAgentsHistory.ts
+++ b/src/renderer/src/components/sidebar/sidebarAgentsHistory.ts
@@ -6,6 +6,7 @@ import type {
     AiSessionSnapshot,
     AiSessionUpdate,
 } from "@shared/ipc";
+import { getAiSessionDisplayTitle } from "@shared/ai-session-title";
 import { areGitWorktreeIdsEquivalent } from "@renderer/app/git/context-key";
 
 export interface SidebarAgentsHistoryScope {
@@ -29,6 +30,27 @@ export interface SidebarAgentsHistoryUnknownSessionSeed {
 }
 
 export const SIDEBAR_AGENTS_HISTORY_LIMIT = 250;
+
+export function mergeOpenSessionFallbacks(
+    historySessions: readonly AiHistorySessionSummary[],
+    openSessions: readonly AiHistorySessionSummary[],
+): readonly AiHistorySessionSummary[] {
+    const knownSessionIds = new Set(
+        historySessions.map((session) => session.sessionId),
+    );
+    const missingOpenSessions = openSessions.filter(
+        (session) => !knownSessionIds.has(session.sessionId),
+    );
+    if (missingOpenSessions.length === 0) {
+        return historySessions;
+    }
+
+    // Open sessions are never capped by the history limit. A live tab must
+    // remain reachable even before its first history record is persisted.
+    return [...historySessions, ...missingOpenSessions].sort(
+        compareHistorySummariesByUpdatedAtDesc,
+    );
+}
 
 export function applySessionUpdateToSidebarHistory({
     deletedSessionIds,
@@ -196,17 +218,24 @@ function createHistorySummaryFromSnapshot(
     snapshot: AiSessionSnapshot,
     existing: AiHistorySessionSummary | null,
 ): AiHistorySessionSummary {
+    const hasSnapshotMessages = snapshot.messages.length > 0;
     return {
         createdAt: existing?.createdAt ?? snapshot.updatedAt,
-        messageCount: snapshot.messages.length,
+        // Block-native snapshots intentionally omit paged transcript messages.
+        // An empty payload must not erase history metadata already loaded.
+        messageCount: hasSnapshotMessages
+            ? snapshot.messages.length
+            : existing?.messageCount ?? 0,
         parentSessionId: snapshot.parentSessionId ?? null,
         pinnedAt: existing?.pinnedAt ?? null,
-        preview: deriveSessionPreview(snapshot.messages),
+        preview: hasSnapshotMessages
+            ? deriveSessionPreview(snapshot.messages)
+            : existing?.preview ?? null,
         projectId: snapshot.projectId,
         runtimeId: snapshot.runtimeId,
         runtimeSessionId: snapshot.runtimeSessionId,
         sessionId: snapshot.sessionId,
-        title: snapshot.title,
+        title: getAiSessionDisplayTitle(snapshot),
         updatedAt: snapshot.updatedAt,
         worktreeId: snapshot.worktreeId ?? null,
     };
@@ -218,22 +247,22 @@ function applyPatchToHistorySummary(
 ): AiHistorySessionSummary {
     const changes = patch.changes;
     const nextMessages = resolvePatchedMessages(changes);
+    const hasPatchedMessages =
+        nextMessages !== null && nextMessages.length > 0;
 
     return {
         createdAt: existing.createdAt,
-        messageCount:
-            nextMessages?.length !== undefined
-                ? nextMessages.length
-                : existing.messageCount,
+        messageCount: hasPatchedMessages
+            ? nextMessages.length
+            : existing.messageCount,
         parentSessionId:
             changes.parentSessionId === undefined
                 ? existing.parentSessionId ?? null
                 : changes.parentSessionId,
         pinnedAt: existing.pinnedAt ?? null,
-        preview:
-            nextMessages !== null
-                ? deriveSessionPreview(nextMessages)
-                : existing.preview,
+        preview: hasPatchedMessages
+            ? deriveSessionPreview(nextMessages)
+            : existing.preview,
         projectId:
             changes.projectId === undefined
                 ? existing.projectId
@@ -245,7 +274,12 @@ function applyPatchToHistorySummary(
                 : changes.runtimeSessionId,
         sessionId: existing.sessionId,
         title:
-            typeof changes.title === "string" ? changes.title : existing.title,
+            typeof changes.manualTitle === "string" &&
+            changes.manualTitle.trim().length > 0
+                ? changes.manualTitle.trim()
+                : typeof changes.title === "string"
+                  ? changes.title
+                  : existing.title,
         updatedAt:
             typeof changes.updatedAt === "string"
                 ? changes.updatedAt

--- a/src/shared/ai-session-title.ts
+++ b/src/shared/ai-session-title.ts
@@ -1,0 +1,10 @@
+export interface AiSessionTitleState {
+    readonly manualTitle?: string | null;
+    readonly title: string;
+}
+
+export function getAiSessionDisplayTitle(
+    session: AiSessionTitleState,
+): string {
+    return session.manualTitle?.trim() || session.title;
+}

--- a/src/shared/native-backend/ai.ts
+++ b/src/shared/native-backend/ai.ts
@@ -472,6 +472,7 @@ export type NativeAiSessionSnapshot = {
     readonly projectId: NativeProjectId | null;
     readonly worktreeId: NativeWorktreeId | null;
     readonly title: string;
+    readonly manualTitle?: string | null;
     readonly status: NativeAiSessionStatus;
     readonly updatedAt: string;
     readonly activeTurnStartedAt: string | null;


### PR DESCRIPTION
## Summary

- separate runtime-generated session titles from manual title overrides across native history, IPC, main, and renderer state
- prevent status and prompt lifecycle updates from resetting user-facing tab names while preserving runtime title propagation
- keep partial snapshots from clearing known sidebar history metadata and include open workspace sessions as scoped fallbacks
- preserve subagent nicknames and existing transcript/history identity

## Validation

- cargo test -p comando-ai
- pnpm run typecheck
- targeted Vitest suites for AI session state, native protocol, history, and sidebar behavior
- ESLint on changed TypeScript files
- git diff --check