### PR TITLE
Persist plan collapse state per session

### DIFF
--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -4544,6 +4544,16 @@ describe("ai-store queue", () => {
         ).toBe("2026-04-15T12:00:00.000Z");
     });
 
+    it("stores the plan collapse preference per session", () => {
+        useAiStore.getState().registerSessionTab(TAB);
+
+        useAiStore.getState().setSessionPlanCollapsed(TAB.sessionId, true);
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]?.isPlanCollapsed,
+        ).toBe(true);
+    });
+
     it("merges incremental session patches without replacing the whole snapshot", () => {
         useAiStore.getState().registerSessionTab(TAB);
         useAiStore.getState().applySessionSnapshot(

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -227,6 +227,7 @@ interface AiSessionClientState {
     readonly draftComposerParts: readonly AiComposerDraftPart[];
     readonly draftFileContexts: readonly AiFileContextAttachment[];
     readonly dismissedPlanUpdatedAt: string | null;
+    readonly isPlanCollapsed: boolean;
     readonly diffZoom: number | null;
     readonly editingQueuedPromptState: QueuedPromptEditState | null;
     readonly editingQueuedPrompt: QueuedPrompt | null;
@@ -296,6 +297,7 @@ interface AiStore {
     ) => readonly AiComposerDraftPart[] | null;
     clearDraftAttachments: (sessionId: string) => void;
     dismissSessionPlan: (sessionId: string, planUpdatedAt: string) => void;
+    setSessionPlanCollapsed: (sessionId: string, collapsed: boolean) => void;
     attachSelectionMention: (
         sessionId: string,
         selection: {
@@ -1699,6 +1701,25 @@ export const useAiStore = create<AiStore>((set, get) => ({
         });
     },
 
+    setSessionPlanCollapsed: (sessionId, collapsed) => {
+        set((state) => {
+            const session = state.sessions[sessionId];
+            if (!session || session.isPlanCollapsed === collapsed) {
+                return state;
+            }
+
+            return {
+                sessions: {
+                    ...state.sessions,
+                    [sessionId]: {
+                        ...session,
+                        isPlanCollapsed: collapsed,
+                    },
+                },
+            };
+        });
+    },
+
     ensureSession: async (tab, options) => {
         const currentSession = get().sessions[tab.sessionId] ?? null;
         const shouldHydratePassively =
@@ -2890,6 +2911,7 @@ function createSessionState(
         draftComposerParts: createEmptyComposerDraftParts(),
         draftFileContexts: [],
         dismissedPlanUpdatedAt: null,
+        isPlanCollapsed: false,
         diffZoom: preferences?.diffZoom ?? null,
         editingQueuedPromptState: null,
         editingQueuedPrompt: null,

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -245,6 +245,7 @@ function ChatPerformanceProfiler({
 type ChatSessionViewState = Pick<
     ReturnType<typeof useAiStore.getState>["sessions"][string],
     | "dismissedPlanUpdatedAt"
+    | "isPlanCollapsed"
     | "draftAttachments"
     | "draftComposerParts"
     | "draftFileContexts"
@@ -279,6 +280,7 @@ function selectChatSessionViewState(
 
     return {
         dismissedPlanUpdatedAt: session.dismissedPlanUpdatedAt,
+        isPlanCollapsed: session.isPlanCollapsed,
         draftAttachments: session.draftAttachments,
         draftComposerParts: session.draftComposerParts,
         draftFileContexts: session.draftFileContexts,
@@ -390,6 +392,9 @@ export const ChatTabView = memo(function ChatTabView({
     const addDraftFileContext = useAiStore((s) => s.addDraftFileContext);
     const clearDraftAttachments = useAiStore((s) => s.clearDraftAttachments);
     const dismissSessionPlan = useAiStore((s) => s.dismissSessionPlan);
+    const setSessionPlanCollapsed = useAiStore(
+        (s) => s.setSessionPlanCollapsed,
+    );
 
     const keepAllTrackedFiles = useAiStore((s) => s.keepAllTrackedFiles);
     const keepTrackedFile = useAiStore((s) => s.keepTrackedFile);
@@ -876,6 +881,7 @@ export const ChatTabView = memo(function ChatTabView({
     const draftFileContexts =
         sessionState?.draftFileContexts ?? EMPTY_DRAFT_FILE_CONTEXTS;
     const dismissedPlanUpdatedAt = sessionState?.dismissedPlanUpdatedAt ?? null;
+    const isPlanCollapsed = sessionState?.isPlanCollapsed ?? false;
     const editingQueuedPrompt = sessionState?.editingQueuedPrompt ?? null;
     const queuedPrompts = sessionState?.queue ?? [];
     const pendingPermission = snapshot.pendingPermission;
@@ -2953,10 +2959,17 @@ export const ChatTabView = memo(function ChatTabView({
                     >
                         <ChatContentColumn>
                             <PlanMessage
+                                expanded={!isPlanCollapsed}
                                 onDismiss={() => {
                                     dismissSessionPlan(
                                         snapshot.sessionId,
                                         visiblePlan.updatedAt,
+                                    );
+                                }}
+                                onExpandedChange={(expanded) => {
+                                    setSessionPlanCollapsed(
+                                        snapshot.sessionId,
+                                        !expanded,
                                     );
                                 }}
                                 plan={visiblePlan}

--- a/src/renderer/src/components/workspace/chat/PlanMessage.test.tsx
+++ b/src/renderer/src/components/workspace/chat/PlanMessage.test.tsx
@@ -72,4 +72,16 @@ describe("PlanMessage", () => {
         expect(markup).not.toContain("Inspect current behavior");
         expect(markup).toContain('aria-expanded="false"');
     });
+
+    it("shows the current plan entry in the collapsed header", () => {
+        const markup = renderToStaticMarkup(
+            createElement(PlanMessage, {
+                expanded: false,
+                plan: createPlan(),
+            }),
+        );
+
+        expect(markup).toContain("Plan - Adjust banner visibility");
+        expect(markup).not.toContain("In Progress");
+    });
 });

--- a/src/renderer/src/components/workspace/chat/PlanMessage.test.tsx
+++ b/src/renderer/src/components/workspace/chat/PlanMessage.test.tsx
@@ -60,4 +60,16 @@ describe("PlanMessage", () => {
 
         expect(markup).not.toContain("Dismiss plan banner");
     });
+
+    it("hides plan entries when controlled as collapsed", () => {
+        const markup = renderToStaticMarkup(
+            createElement(PlanMessage, {
+                expanded: false,
+                plan: createPlan(),
+            }),
+        );
+
+        expect(markup).not.toContain("Inspect current behavior");
+        expect(markup).toContain('aria-expanded="false"');
+    });
 });

--- a/src/renderer/src/components/workspace/chat/PlanMessage.tsx
+++ b/src/renderer/src/components/workspace/chat/PlanMessage.tsx
@@ -43,13 +43,18 @@ const PLAN_TONE_COLOR: Record<PlanTone, string> = {
 /* ─── Component ─── */
 
 export function PlanMessage({
+    expanded: controlledExpanded,
     onDismiss,
+    onExpandedChange,
     plan,
 }: {
+    readonly expanded?: boolean;
     readonly onDismiss?: () => void;
+    readonly onExpandedChange?: (expanded: boolean) => void;
     readonly plan: AiPlan;
 }) {
-    const [expanded, setExpanded] = useState(true);
+    const [uncontrolledExpanded, setUncontrolledExpanded] = useState(true);
+    const expanded = controlledExpanded ?? uncontrolledExpanded;
     const canExpand = plan.entries.length > 0;
 
     const completedCount = plan.entries.filter(
@@ -76,7 +81,11 @@ export function PlanMessage({
                     className="flex min-w-0 flex-1 items-center gap-2 text-left"
                     onClick={() => {
                         if (canExpand) {
-                            setExpanded((current) => !current);
+                            if (onExpandedChange) {
+                                onExpandedChange(!expanded);
+                            } else {
+                                setUncontrolledExpanded(!expanded);
+                            }
                         }
                     }}
                     style={{

--- a/src/renderer/src/components/workspace/chat/PlanMessage.tsx
+++ b/src/renderer/src/components/workspace/chat/PlanMessage.tsx
@@ -64,6 +64,12 @@ export function PlanMessage({
     const tone = getPlanTone(plan.entries);
     const toneColor = PLAN_TONE_COLOR[tone];
     const title = plan.title ?? "Plan";
+    const currentEntry =
+        plan.entries.find((entry) => entry.status === "in_progress") ??
+        plan.entries.find((entry) => entry.status === "pending");
+    const collapsedTitle = currentEntry
+        ? `${title} - ${currentEntry.content}`
+        : title;
 
     return (
         <div
@@ -145,20 +151,22 @@ export function PlanMessage({
                             fontWeight: 600,
                         }}
                     >
-                        {title}
+                        {expanded ? title : collapsedTitle}
                     </span>
-                    <span
-                        className="shrink-0 rounded-full"
-                        style={{
-                            background: `color-mix(in srgb, ${toneColor} 16%, transparent)`,
-                            color: toneColor,
-                            fontSize: "0.7em",
-                            fontWeight: 500,
-                            padding: "2px 8px",
-                        }}
-                    >
-                        {PLAN_TONE_LABEL[tone]}
-                    </span>
+                    {expanded ? (
+                        <span
+                            className="shrink-0 rounded-full"
+                            style={{
+                                background: `color-mix(in srgb, ${toneColor} 16%, transparent)`,
+                                color: toneColor,
+                                fontSize: "0.7em",
+                                fontWeight: 500,
+                                padding: "2px 8px",
+                            }}
+                        >
+                            {PLAN_TONE_LABEL[tone]}
+                        </span>
+                    ) : null}
                 </button>
                 {onDismiss ? (
                     <button


### PR DESCRIPTION
Persists the plan panel's expanded state per chat session and shows the active plan item when collapsed.