### PR TITLE
fix: prevent stale workspace file reloads

### DIFF
--- a/apps/native-backend/src/review.rs
+++ b/apps/native-backend/src/review.rs
@@ -1617,9 +1617,11 @@ impl NativeReviewService {
             fs::create_dir_all(parent)
                 .map_err(|error| review_io("create review parent directory", parent, error))?;
         }
-        fs::write(&resolved, text)
-            .map_err(|error| review_io("write review file", &resolved, error))?;
         write_tracker.track_content(resolved.clone(), text);
+        if let Err(error) = fs::write(&resolved, text) {
+            write_tracker.forget(&resolved);
+            return Err(review_io("write review file", &resolved, error));
+        }
         if let Some(buffer) = self.open_buffers.get_mut(&resolved) {
             buffer.content = text.to_string();
             buffer.content_hash = hash_content_bytes(text.as_bytes());
@@ -1641,14 +1643,20 @@ impl NativeReviewService {
             relative_path,
             ScopedPathIntent::ReadExisting,
         )?;
+        write_tracker.track_any(resolved.clone());
         match fs::remove_file(&resolved) {
             Ok(()) => {
-                write_tracker.track_any(resolved.clone());
                 self.open_buffers.remove(&resolved);
                 Ok(())
             }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(review_io("remove review file", &resolved, error)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                write_tracker.forget(&resolved);
+                Ok(())
+            }
+            Err(error) => {
+                write_tracker.forget(&resolved);
+                Err(review_io("remove review file", &resolved, error))
+            }
         }
     }
 
@@ -1699,19 +1707,23 @@ impl NativeReviewService {
                         review_io("restore review parent directory", parent, error)
                     })?;
                 }
-                fs::write(&backup.path, &content)
-                    .map_err(|error| review_io("restore review file", &backup.path, error))?;
                 write_tracker.track_bytes(backup.path.clone(), &content);
-            } else if let Err(error) = fs::remove_file(&backup.path)
-                && error.kind() != std::io::ErrorKind::NotFound
-            {
-                return Err(review_io(
-                    "remove restored review file",
-                    &backup.path,
-                    error,
-                ));
+                if let Err(error) = fs::write(&backup.path, &content) {
+                    write_tracker.forget(&backup.path);
+                    return Err(review_io("restore review file", &backup.path, error));
+                }
             } else {
                 write_tracker.track_any(backup.path.clone());
+                if let Err(error) = fs::remove_file(&backup.path)
+                    && error.kind() != std::io::ErrorKind::NotFound
+                {
+                    write_tracker.forget(&backup.path);
+                    return Err(review_io(
+                        "remove restored review file",
+                        &backup.path,
+                        error,
+                    ));
+                }
             }
 
             if let Some(buffer) = backup.open_buffer {

--- a/crates/comando-fs/src/copy.rs
+++ b/crates/comando-fs/src/copy.rs
@@ -1,6 +1,9 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, hash_map::DefaultHasher};
 use std::fs;
+use std::hash::{Hash, Hasher};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use comando_types::fs::{
     NativeFsCopyEntriesInput, NativeFsCopyExternalEntriesInput, NativeFsEntryKind,
@@ -15,6 +18,8 @@ use crate::path::{
     resolve_scoped_path, validate_entry_name,
 };
 use crate::registry::ProjectRoot;
+
+const COPY_TRACKER_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
 
 #[derive(Debug, Clone)]
 struct CopySourceEntry {
@@ -57,13 +62,12 @@ pub fn copy_entries(
         let destination_name =
             resolve_copy_destination_name(&source.name, source.kind, &mut reserved_names);
         let destination_path = destination_parent.join(destination_name);
-        track_copy_destination(
+        copy_source_to_destination(
             &source.absolute_path,
             &destination_path,
             source.kind,
             write_tracker,
         )?;
-        copy_source_to_destination(&source.absolute_path, &destination_path, source.kind)?;
         copied.push(mutation_result_for_path(root, &destination_path, None)?);
     }
 
@@ -97,13 +101,12 @@ pub fn copy_external_entries(
         let destination_name =
             resolve_copy_destination_name(&source.name, source.kind, &mut reserved_names);
         let destination_path = destination_parent.join(destination_name);
-        track_copy_destination(
+        copy_source_to_destination(
             &source.absolute_path,
             &destination_path,
             source.kind,
             write_tracker,
         )?;
-        copy_source_to_destination(&source.absolute_path, &destination_path, source.kind)?;
         copied.push(mutation_result_for_path(root, &destination_path, None)?);
     }
 
@@ -296,41 +299,61 @@ fn copy_source_to_destination(
     source: &Path,
     destination: &Path,
     kind: NativeFsEntryKind,
-) -> Result<(), FsError> {
-    match kind {
-        NativeFsEntryKind::File => {
-            fs::copy(source, destination)?;
-        }
-        NativeFsEntryKind::Directory => {
-            fs::create_dir(destination)?;
-            copy_dir_recursive(source, destination)?;
-        }
-        _ => return Err(FsError::InvalidPath),
-    }
-    Ok(())
-}
-
-fn track_copy_destination(
-    source: &Path,
-    destination: &Path,
-    kind: NativeFsEntryKind,
     write_tracker: &WriteTracker,
 ) -> Result<(), FsError> {
     match kind {
         NativeFsEntryKind::File => {
-            write_tracker.track_bytes(destination.to_path_buf(), &fs::read(source)?);
+            copy_file_tracked(source, destination, write_tracker)?;
         }
         NativeFsEntryKind::Directory => {
+            // Track each directory immediately before creation so long copies
+            // do not exhaust the self-write window before events are emitted.
             write_tracker.track_any(destination.to_path_buf());
-            track_copy_directory_descendants(source, destination, write_tracker)?;
+            fs::create_dir(destination)?;
+            copy_dir_recursive(source, destination, write_tracker)?;
         }
         _ => return Err(FsError::InvalidPath),
     }
-
     Ok(())
 }
 
-fn track_copy_directory_descendants(
+fn copy_file_tracked(
+    source: &Path,
+    destination: &Path,
+    write_tracker: &WriteTracker,
+) -> Result<(), FsError> {
+    let mut source_file = fs::File::open(source)?;
+    let metadata = source_file.metadata()?;
+    let content_len = usize::try_from(metadata.len()).map_err(|_| FsError::InvalidPath)?;
+    let mut hasher = DefaultHasher::new();
+    content_len.hash(&mut hasher);
+    let mut buffer = [0_u8; 64 * 1024];
+
+    // Any-content tracking covers watcher events emitted while the stream is
+    // still being copied; the exact hash replaces it once the file is complete.
+    write_tracker.track_any(destination.to_path_buf());
+    let mut last_tracker_refresh = Instant::now();
+    let mut destination_file = fs::File::create(destination)?;
+    loop {
+        let bytes_read = source_file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        destination_file.write_all(&buffer[..bytes_read])?;
+        hasher.write(&buffer[..bytes_read]);
+        if last_tracker_refresh.elapsed() >= COPY_TRACKER_REFRESH_INTERVAL {
+            // A single large file can outlive the tracker window too.
+            write_tracker.track_any(destination.to_path_buf());
+            last_tracker_refresh = Instant::now();
+        }
+    }
+    destination_file.flush()?;
+    fs::set_permissions(destination, metadata.permissions())?;
+    write_tracker.track_hash(destination.to_path_buf(), hasher.finish());
+    Ok(())
+}
+
+fn copy_dir_recursive(
     source: &Path,
     destination: &Path,
     write_tracker: &WriteTracker,
@@ -341,30 +364,12 @@ fn track_copy_directory_descendants(
         let destination_path = destination.join(entry.file_name());
         let metadata = fs::symlink_metadata(&source_path)?;
         reject_symlink_metadata(&metadata)?;
-
         if metadata.is_dir() {
             write_tracker.track_any(destination_path.clone());
-            track_copy_directory_descendants(&source_path, &destination_path, write_tracker)?;
-        } else if metadata.is_file() {
-            write_tracker.track_bytes(destination_path, &fs::read(source_path)?);
-        }
-    }
-
-    Ok(())
-}
-
-fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<(), FsError> {
-    for entry_result in fs::read_dir(source)? {
-        let entry = entry_result?;
-        let source_path = entry.path();
-        let destination_path = destination.join(entry.file_name());
-        let metadata = fs::symlink_metadata(&source_path)?;
-        reject_symlink_metadata(&metadata)?;
-        if metadata.is_dir() {
             fs::create_dir(&destination_path)?;
-            copy_dir_recursive(&source_path, &destination_path)?;
+            copy_dir_recursive(&source_path, &destination_path, write_tracker)?;
         } else if metadata.is_file() {
-            fs::copy(&source_path, &destination_path)?;
+            copy_file_tracked(&source_path, &destination_path, write_tracker)?;
         }
     }
     Ok(())
@@ -394,6 +399,7 @@ mod tests {
         let temp = TempDir::new().expect("temp");
         fs::write(temp.path().join("a.txt"), "a").expect("a");
         let root = project_root(temp.path());
+        let write_tracker = WriteTracker::new();
 
         let copied = copy_entries(
             &root,
@@ -404,7 +410,7 @@ mod tests {
                 destination_parent_relative_path: None,
                 origin: NativeFsMutationOrigin::User,
             },
-            &WriteTracker::new(),
+            &write_tracker,
         )
         .expect("copy");
 
@@ -413,6 +419,10 @@ mod tests {
             fs::read_to_string(temp.path().join("a copy.txt")).unwrap(),
             "a"
         );
+        assert!(write_tracker.has_recent_match(
+            &temp.path().join("a copy.txt"),
+            Some(crate::origin::hash_bytes(b"a")),
+        ));
     }
 
     #[test]
@@ -422,6 +432,7 @@ mod tests {
         fs::create_dir(external.path().join("pkg")).expect("pkg");
         fs::write(external.path().join("pkg/lib.rs"), "lib").expect("lib");
         let root = project_root(temp.path());
+        let write_tracker = WriteTracker::new();
 
         let copied = copy_external_entries(
             &root,
@@ -432,7 +443,7 @@ mod tests {
                 destination_parent_relative_path: None,
                 origin: NativeFsMutationOrigin::User,
             },
-            &WriteTracker::new(),
+            &write_tracker,
         )
         .expect("copy");
 
@@ -441,6 +452,10 @@ mod tests {
             fs::read_to_string(temp.path().join("pkg/lib.rs")).unwrap(),
             "lib"
         );
+        assert!(write_tracker.has_recent_match(
+            &temp.path().join("pkg/lib.rs"),
+            Some(crate::origin::hash_bytes(b"lib")),
+        ));
     }
 
     #[test]

--- a/crates/comando-fs/src/copy.rs
+++ b/crates/comando-fs/src/copy.rs
@@ -57,8 +57,13 @@ pub fn copy_entries(
         let destination_name =
             resolve_copy_destination_name(&source.name, source.kind, &mut reserved_names);
         let destination_path = destination_parent.join(destination_name);
+        track_copy_destination(
+            &source.absolute_path,
+            &destination_path,
+            source.kind,
+            write_tracker,
+        )?;
         copy_source_to_destination(&source.absolute_path, &destination_path, source.kind)?;
-        write_tracker.track_any(destination_path.clone());
         copied.push(mutation_result_for_path(root, &destination_path, None)?);
     }
 
@@ -92,8 +97,13 @@ pub fn copy_external_entries(
         let destination_name =
             resolve_copy_destination_name(&source.name, source.kind, &mut reserved_names);
         let destination_path = destination_parent.join(destination_name);
+        track_copy_destination(
+            &source.absolute_path,
+            &destination_path,
+            source.kind,
+            write_tracker,
+        )?;
         copy_source_to_destination(&source.absolute_path, &destination_path, source.kind)?;
-        write_tracker.track_any(destination_path.clone());
         copied.push(mutation_result_for_path(root, &destination_path, None)?);
     }
 
@@ -297,6 +307,49 @@ fn copy_source_to_destination(
         }
         _ => return Err(FsError::InvalidPath),
     }
+    Ok(())
+}
+
+fn track_copy_destination(
+    source: &Path,
+    destination: &Path,
+    kind: NativeFsEntryKind,
+    write_tracker: &WriteTracker,
+) -> Result<(), FsError> {
+    match kind {
+        NativeFsEntryKind::File => {
+            write_tracker.track_bytes(destination.to_path_buf(), &fs::read(source)?);
+        }
+        NativeFsEntryKind::Directory => {
+            write_tracker.track_any(destination.to_path_buf());
+            track_copy_directory_descendants(source, destination, write_tracker)?;
+        }
+        _ => return Err(FsError::InvalidPath),
+    }
+
+    Ok(())
+}
+
+fn track_copy_directory_descendants(
+    source: &Path,
+    destination: &Path,
+    write_tracker: &WriteTracker,
+) -> Result<(), FsError> {
+    for entry_result in fs::read_dir(source)? {
+        let entry = entry_result?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let metadata = fs::symlink_metadata(&source_path)?;
+        reject_symlink_metadata(&metadata)?;
+
+        if metadata.is_dir() {
+            write_tracker.track_any(destination_path.clone());
+            track_copy_directory_descendants(&source_path, &destination_path, write_tracker)?;
+        } else if metadata.is_file() {
+            write_tracker.track_bytes(destination_path, &fs::read(source_path)?);
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/comando-fs/src/mutations.rs
+++ b/crates/comando-fs/src/mutations.rs
@@ -89,9 +89,13 @@ pub fn rename_entry(
     }
 
     if current.absolute_path != next_absolute_path {
-        fs::rename(&current.absolute_path, &next_absolute_path)?;
-        write_tracker.track_any(current.absolute_path);
+        write_tracker.track_any(current.absolute_path.clone());
         write_tracker.track_any(next_absolute_path.clone());
+        if let Err(error) = fs::rename(&current.absolute_path, &next_absolute_path) {
+            write_tracker.forget(&current.absolute_path);
+            write_tracker.forget(&next_absolute_path);
+            return Err(error.into());
+        }
     }
 
     mutation_result_for_path(root, &next_absolute_path, Some(next_parent_relative_path))
@@ -114,12 +118,16 @@ pub fn delete_entry(
     )?;
     let result = mutation_result_for_path(root, &resolved.absolute_path, None)?;
     let metadata = fs::metadata(&resolved.absolute_path)?;
-    if metadata.is_dir() {
-        fs::remove_dir_all(&resolved.absolute_path)?;
+    write_tracker.track_any(resolved.absolute_path.clone());
+    let deletion_result = if metadata.is_dir() {
+        fs::remove_dir_all(&resolved.absolute_path)
     } else {
-        fs::remove_file(&resolved.absolute_path)?;
+        fs::remove_file(&resolved.absolute_path)
+    };
+    if let Err(error) = deletion_result {
+        write_tracker.forget(&resolved.absolute_path);
+        return Err(error.into());
     }
-    write_tracker.track_any(resolved.absolute_path);
 
     Ok(result)
 }
@@ -194,17 +202,25 @@ fn create_entry(
         return Err(FsError::AlreadyExists);
     }
 
-    match kind {
-        NativeFsEntryKind::Directory => fs::create_dir(&absolute_path)?,
+    let creation_result = match kind {
+        NativeFsEntryKind::Directory => {
+            write_tracker.track_any(absolute_path.clone());
+            fs::create_dir(&absolute_path)
+        }
         NativeFsEntryKind::File => {
+            write_tracker.track_content(absolute_path.clone(), "");
             fs::OpenOptions::new()
                 .write(true)
                 .create_new(true)
-                .open(&absolute_path)?;
+                .open(&absolute_path)
+                .map(|_| ())
         }
         _ => return Err(FsError::InvalidPath),
+    };
+    if let Err(error) = creation_result {
+        write_tracker.forget(&absolute_path);
+        return Err(error.into());
     }
-    write_tracker.track_any(absolute_path.clone());
 
     mutation_result_for_path(
         root,

--- a/crates/comando-fs/src/origin.rs
+++ b/crates/comando-fs/src/origin.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -50,6 +50,11 @@ impl WriteTracker {
 
     pub fn track_any(&self, path: PathBuf) {
         self.track_entry(path, TrackedWriteKind::Any);
+    }
+
+    pub fn forget(&self, path: &Path) {
+        let mut written = self.written.lock().expect("write tracker lock");
+        written.remove(path);
     }
 
     pub fn has_recent_match(&self, path: &PathBuf, current_hash: Option<u64>) -> bool {

--- a/crates/comando-fs/src/origin.rs
+++ b/crates/comando-fs/src/origin.rs
@@ -48,6 +48,10 @@ impl WriteTracker {
         );
     }
 
+    pub(crate) fn track_hash(&self, path: PathBuf, hash: u64) {
+        self.track_entry(path, TrackedWriteKind::Content { hash });
+    }
+
     pub fn track_any(&self, path: PathBuf) {
         self.track_entry(path, TrackedWriteKind::Any);
     }

--- a/crates/comando-fs/src/watcher.rs
+++ b/crates/comando-fs/src/watcher.rs
@@ -452,7 +452,7 @@ fn watch_key(root: &ProjectRoot) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::fs::{self, OpenOptions};
     use std::thread;
     use std::time::Duration;
 
@@ -507,6 +507,92 @@ mod tests {
 
         let drain = watchers.drain(true);
         assert!(drain.invalidations.is_empty());
+    }
+
+    #[test]
+    fn external_write_after_owned_write_still_invalidates_the_file() {
+        let temp = TempDir::new().expect("temp");
+        let path = temp.path().join("owned.txt");
+        fs::write(&path, "owned").expect("write");
+        let root = project_root(temp.path());
+        let mut watchers = WatcherRegistry::new();
+        let tracker = watchers.write_tracker();
+
+        tracker.track_content(path.clone(), "owned");
+        fs::write(&path, "owned").expect("write same");
+        fs::write(&path, "external").expect("write external");
+        let key = watch_key(&root);
+        let mut event = Event::new(EventKind::Modify(ModifyKind::Any));
+        event.paths.push(path);
+        handle_notify_event(
+            NotifyEventContext {
+                key: &key,
+                root: &root,
+                watch_root: temp.path(),
+                write_tracker: &tracker,
+                pending: &watchers.pending,
+                pending_git_invalidations: &watchers.pending_git_invalidations,
+                fs_events: &watchers.fs_events,
+            },
+            event,
+        );
+
+        let drain = watchers.drain(true);
+        assert!(drain.invalidations.iter().any(|invalidation| {
+            invalidation
+                .relative_paths
+                .as_ref()
+                .is_some_and(|paths| paths.iter().any(|path| path.0 == "owned.txt"))
+        }));
+        assert!(drain.fs_events.iter().any(|(_, event)| {
+            event
+                .relative_path
+                .as_ref()
+                .is_some_and(|path| path.0 == "owned.txt")
+                && event.origin == NativeFsMutationOrigin::External
+        }));
+    }
+
+    #[test]
+    fn waits_for_a_truncated_owned_write_to_settle_before_invalidating() {
+        let temp = TempDir::new().expect("temp");
+        let path = temp.path().join("owned.txt");
+        fs::write(&path, "owned").expect("write");
+        let root = project_root(temp.path());
+        let mut watchers = WatcherRegistry::new();
+        let tracker = watchers.write_tracker();
+
+        tracker.track_content(path.clone(), "owned");
+        let replacement_path = path.clone();
+        let replacement = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(30));
+            fs::write(replacement_path, "owned").expect("restore owned content");
+        });
+        OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .expect("truncate owned file");
+        let key = watch_key(&root);
+        let mut event = Event::new(EventKind::Modify(ModifyKind::Any));
+        event.paths.push(path);
+        handle_notify_event(
+            NotifyEventContext {
+                key: &key,
+                root: &root,
+                watch_root: temp.path(),
+                write_tracker: &tracker,
+                pending: &watchers.pending,
+                pending_git_invalidations: &watchers.pending_git_invalidations,
+                fs_events: &watchers.fs_events,
+            },
+            event,
+        );
+        replacement.join().expect("replacement thread");
+
+        let drain = watchers.drain(true);
+        assert!(drain.invalidations.is_empty());
+        assert!(drain.fs_events.is_empty());
     }
 
     #[test]

--- a/crates/comando-fs/src/write.rs
+++ b/crates/comando-fs/src/write.rs
@@ -56,8 +56,11 @@ pub fn write_file(
     }
 
     let content = preserve_line_ending_if_needed(&current_bytes, &input.content);
-    fs::write(&resolved.absolute_path, content.as_bytes())?;
     write_tracker.track_content(resolved.absolute_path.clone(), &content);
+    if let Err(error) = fs::write(&resolved.absolute_path, content.as_bytes()) {
+        write_tracker.forget(&resolved.absolute_path);
+        return Err(error.into());
+    }
 
     let read_input = comando_types::fs::NativeFsReadFileInput {
         project_id: input.project_id.clone(),

--- a/src/renderer/src/app/debug/fileSyncProbe.test.ts
+++ b/src/renderer/src/app/debug/fileSyncProbe.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+    getFileSyncTraceSnapshot,
+    recordFileSyncTrace,
+    resetFileSyncTraceForTests,
+    setFileSyncTraceEnabledForTests,
+} from "./fileSyncProbe";
+
+describe("fileSyncProbe", () => {
+    afterEach(() => {
+        resetFileSyncTraceForTests();
+    });
+
+    it("stays silent until explicitly enabled", () => {
+        recordFileSyncTrace({
+            content: "secret source text",
+            event: "draft_changed",
+            path: "src\\app.ts",
+        });
+
+        expect(getFileSyncTraceSnapshot()).toEqual([]);
+    });
+
+    it("records metadata without retaining source content", () => {
+        setFileSyncTraceEnabledForTests(true);
+
+        recordFileSyncTrace({
+            content: "const token = 'sensitive';",
+            contentRevision: 4,
+            event: "reload_accepted",
+            flags: {
+                hasExternalChange: false,
+                isDirty: false,
+                isLoading: false,
+                isSaving: false,
+            },
+            origin: "watcher",
+            path: "./src\\app.ts",
+            requestId: 7,
+            tabId: "file-1",
+        });
+
+        const [event] = getFileSyncTraceSnapshot();
+        expect(event?.contentHash).toMatch(/^[a-f0-9]{8}$/);
+        expect(event).toMatchObject({
+            contentLength: 26,
+            contentRevision: 4,
+            event: "reload_accepted",
+            origin: "watcher",
+            path: "src/app.ts",
+            requestId: 7,
+            tabId: "file-1",
+        });
+        expect(JSON.stringify(getFileSyncTraceSnapshot())).not.toContain(
+            "sensitive",
+        );
+    });
+
+    it("keeps only the most recent circular-buffer entries", () => {
+        setFileSyncTraceEnabledForTests(true);
+
+        for (let index = 0; index < 514; index += 1) {
+            recordFileSyncTrace({
+                event: "read_started",
+                requestId: index,
+            });
+        }
+
+        const events = getFileSyncTraceSnapshot();
+        expect(events).toHaveLength(512);
+        expect(events[0]?.requestId).toBe(2);
+        expect(events.at(-1)?.requestId).toBe(513);
+    });
+});

--- a/src/renderer/src/app/debug/fileSyncProbe.ts
+++ b/src/renderer/src/app/debug/fileSyncProbe.ts
@@ -1,0 +1,159 @@
+const FILE_SYNC_TRACE_STORAGE_KEY = "comando:file-sync-trace";
+const MAX_FILE_SYNC_TRACE_EVENTS = 512;
+
+export type FileSyncTraceEventName =
+    | "draft_changed"
+    | "invalidation_received"
+    | "model_changed"
+    | "read_completed"
+    | "read_failed"
+    | "read_started"
+    | "reload_accepted"
+    | "reload_discarded"
+    | "reload_skipped"
+    | "reload_started"
+    | "save_completed"
+    | "save_failed"
+    | "save_started"
+    | "scroll_jump"
+    | "selection_changed";
+
+export interface FileSyncTraceFlags {
+    readonly hasExternalChange: boolean;
+    readonly isDirty: boolean;
+    readonly isLoading: boolean;
+    readonly isSaving: boolean;
+}
+
+export interface FileSyncTraceEvent {
+    readonly contentHash: string | null;
+    readonly contentLength: number | null;
+    readonly contentRevision: number | null;
+    readonly event: FileSyncTraceEventName;
+    readonly flags: FileSyncTraceFlags | null;
+    readonly origin: string | null;
+    readonly path: string | null;
+    readonly requestId: number | null;
+    readonly tabId: string | null;
+    readonly timestamp: number;
+}
+
+export interface RecordFileSyncTraceInput {
+    readonly content?: string | null;
+    readonly contentRevision?: number | null;
+    readonly event: FileSyncTraceEventName;
+    readonly flags?: FileSyncTraceFlags | null;
+    readonly origin?: string | null;
+    readonly path?: string | null;
+    readonly requestId?: number | null;
+    readonly tabId?: string | null;
+}
+
+interface FileSyncTraceStore {
+    readonly events: FileSyncTraceEvent[];
+}
+
+type FileSyncTraceRoot = typeof globalThis & {
+    __COMANDO_FILE_SYNC_TRACE__?: FileSyncTraceStore;
+    __comandoFileSyncTraceDump?: () => readonly FileSyncTraceEvent[];
+    __comandoFileSyncTraceReset?: () => void;
+};
+
+let enabledForTests: boolean | null = null;
+let cachedEnabled: boolean | null = null;
+
+export function isFileSyncTraceEnabled(): boolean {
+    if (enabledForTests !== null) {
+        return enabledForTests;
+    }
+    if (cachedEnabled !== null) {
+        return cachedEnabled;
+    }
+    if (typeof window === "undefined") {
+        cachedEnabled = false;
+        return cachedEnabled;
+    }
+
+    try {
+        const value = window.localStorage
+            .getItem(FILE_SYNC_TRACE_STORAGE_KEY)
+            ?.trim()
+            .toLowerCase();
+        cachedEnabled = value === "1" || value === "true" || value === "on";
+    } catch {
+        cachedEnabled = false;
+    }
+    return cachedEnabled;
+}
+
+export function recordFileSyncTrace(input: RecordFileSyncTraceInput): void {
+    if (!isFileSyncTraceEnabled()) {
+        return;
+    }
+
+    const store = getFileSyncTraceStore();
+    store.events.push({
+        contentHash: shortContentHash(input.content),
+        contentLength:
+            typeof input.content === "string" ? input.content.length : null,
+        contentRevision: input.contentRevision ?? null,
+        event: input.event,
+        flags: input.flags ?? null,
+        origin: input.origin ?? null,
+        path: normalizeTracePath(input.path),
+        requestId: input.requestId ?? null,
+        tabId: input.tabId ?? null,
+        timestamp: Date.now(),
+    });
+    if (store.events.length > MAX_FILE_SYNC_TRACE_EVENTS) {
+        store.events.splice(0, store.events.length - MAX_FILE_SYNC_TRACE_EVENTS);
+    }
+}
+
+export function getFileSyncTraceSnapshot(): readonly FileSyncTraceEvent[] {
+    const root = globalThis as FileSyncTraceRoot;
+    return [...(root.__COMANDO_FILE_SYNC_TRACE__?.events ?? [])];
+}
+
+export function resetFileSyncTraceForTests(): void {
+    const root = globalThis as FileSyncTraceRoot;
+    root.__COMANDO_FILE_SYNC_TRACE__?.events.splice(0);
+    cachedEnabled = null;
+    enabledForTests = null;
+}
+
+export function setFileSyncTraceEnabledForTests(enabled: boolean | null): void {
+    enabledForTests = enabled;
+}
+
+function getFileSyncTraceStore(): FileSyncTraceStore {
+    const root = globalThis as FileSyncTraceRoot;
+    if (!root.__COMANDO_FILE_SYNC_TRACE__) {
+        root.__COMANDO_FILE_SYNC_TRACE__ = { events: [] };
+        root.__comandoFileSyncTraceDump = getFileSyncTraceSnapshot;
+        root.__comandoFileSyncTraceReset = resetFileSyncTraceForTests;
+    }
+    return root.__COMANDO_FILE_SYNC_TRACE__;
+}
+
+function normalizeTracePath(path: string | null | undefined): string | null {
+    if (!path) {
+        return null;
+    }
+
+    const normalized = path.replaceAll("\\", "/").replace(/^\.\//, "");
+    return normalized.replace(/\/{2,}/g, "/");
+}
+
+function shortContentHash(content: string | null | undefined): string | null {
+    if (typeof content !== "string") {
+        return null;
+    }
+
+    let hash = 2166136261;
+    for (let index = 0; index < content.length; index += 1) {
+        hash ^= content.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+    }
+    return (hash >>> 0).toString(16).padStart(8, "0");
+}

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -2894,9 +2894,20 @@ describe("workspace file opening", () => {
         });
     });
 
-    it("does not overwrite edits made while a watcher refresh is in flight", async () => {
+    it("keeps the draft and view state when a stale watcher refresh resolves", async () => {
         const relativePath = "src/app.ts";
         const staleExternalLoad = createDeferred<ProjectFileDocument>();
+        const preservedViewState = {
+            contributionsState: [],
+            cursorState: [
+                {
+                    inSelectionMode: false,
+                    position: { column: 7, lineNumber: 3 },
+                    selectionStart: { column: 7, lineNumber: 3 },
+                },
+            ],
+            viewState: { scrollLeft: 18, scrollTop: 640 },
+        } as unknown as MonacoEditor.ICodeEditorViewState;
         openProjectFileMock.mockImplementationOnce(
             () => staleExternalLoad.promise,
         );
@@ -2911,11 +2922,14 @@ describe("workspace file opening", () => {
                 type: "pane",
             },
             tabsById: {
-                "file-1": createLoadedWorkspaceFileTab(
-                    "file-1",
-                    relativePath,
-                    "export const value = 1;\n",
-                ),
+                "file-1": {
+                    ...createLoadedWorkspaceFileTab(
+                        "file-1",
+                        relativePath,
+                        "export const value = 1;\n",
+                    ),
+                    viewState: preservedViewState,
+                },
             },
         }));
 
@@ -2943,6 +2957,7 @@ describe("workspace file opening", () => {
             draftContent: "export const value = 3;\n",
             isDirty: true,
             savedContent: "export const value = 1;\n",
+            viewState: preservedViewState,
         });
     });
 

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -75,6 +75,43 @@ function createWorkspaceFileTab(id: string, relativePath: string) {
     };
 }
 
+function createProjectFileDocument(
+    relativePath: string,
+    content: string,
+    modifiedAtMs = 1,
+): ProjectFileDocument {
+    return {
+        absolutePath: `/tmp/${relativePath}`,
+        content,
+        imageDataBase64: null,
+        isBinary: false,
+        isTooLarge: false,
+        kind: "text",
+        languageId: "typescript",
+        languageLabel: "TypeScript",
+        mimeType: "text/typescript",
+        modifiedAtMs,
+        name: relativePath.split("/").at(-1) ?? relativePath,
+        projectId: "project-1",
+        relativePath,
+        sizeBytes: content.length,
+    };
+}
+
+function createLoadedWorkspaceFileTab(
+    id: string,
+    relativePath: string,
+    content: string,
+) {
+    return {
+        ...createWorkspaceFileTab(id, relativePath),
+        document: createProjectFileDocument(relativePath, content),
+        draftContent: content,
+        savedContent: content,
+        title: relativePath.split("/").at(-1) ?? relativePath,
+    };
+}
+
 function createWorkspaceChatTab(
     id: string,
     sessionId: string,
@@ -2744,6 +2781,205 @@ describe("workspace file opening", () => {
         expect(state.tabsById["file-clean-other"]).toMatchObject({
             draftContent: "export const other = 1;\n",
             isDirty: false,
+        });
+    });
+
+    it("applies a watcher refresh to a clean file", async () => {
+        const relativePath = "src/app.ts";
+        const externalDocument = createProjectFileDocument(
+            relativePath,
+            "export const value = 2;\n",
+            2,
+        );
+        openProjectFileMock.mockResolvedValueOnce(externalDocument);
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: "file-1",
+                id: "pane-root",
+                tabIds: ["file-1"],
+                type: "pane",
+            },
+            tabsById: {
+                "file-1": createLoadedWorkspaceFileTab(
+                    "file-1",
+                    relativePath,
+                    "export const value = 1;\n",
+                ),
+            },
+        }));
+
+        await useWorkspaceStore
+            .getState()
+            .refreshProjectTabs("project-1", null, [relativePath]);
+
+        expect(openProjectFileMock).toHaveBeenCalledWith({
+            projectId: "project-1",
+            relativePath,
+            worktreeId: null,
+        });
+        expect(useWorkspaceStore.getState().tabsById["file-1"]).toMatchObject({
+            document: { content: externalDocument.content, modifiedAtMs: 2 },
+            draftContent: externalDocument.content,
+            isDirty: false,
+            savedContent: externalDocument.content,
+        });
+    });
+
+    it("keeps duplicate tabs synchronized after a clean watcher refresh", async () => {
+        const relativePath = "src/app.ts";
+        const externalDocument = createProjectFileDocument(
+            relativePath,
+            "export const value = 2;\n",
+            2,
+        );
+        openProjectFileMock.mockResolvedValueOnce(externalDocument);
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: "file-left",
+                id: "pane-root",
+                tabIds: ["file-left", "file-right"],
+                type: "pane",
+            },
+            tabsById: {
+                "file-left": createLoadedWorkspaceFileTab(
+                    "file-left",
+                    relativePath,
+                    "export const value = 1;\n",
+                ),
+                "file-right": {
+                    ...createLoadedWorkspaceFileTab(
+                        "file-right",
+                        relativePath,
+                        "export const value = 1;\n",
+                    ),
+                    viewState: {
+                        contributionsState: [],
+                        cursorState: [],
+                        viewState: { scrollTop: 360 },
+                    } as MonacoEditor.ICodeEditorViewState,
+                },
+            },
+        }));
+
+        await useWorkspaceStore
+            .getState()
+            .refreshProjectTabs("project-1", null, [relativePath]);
+
+        expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        for (const tabId of ["file-left", "file-right"]) {
+            expect(useWorkspaceStore.getState().tabsById[tabId]).toMatchObject({
+                document: { content: externalDocument.content, modifiedAtMs: 2 },
+                draftContent: externalDocument.content,
+                isDirty: false,
+                savedContent: externalDocument.content,
+            });
+        }
+        expect(useWorkspaceStore.getState().tabsById["file-right"]?.kind).toBe(
+            "file",
+        );
+        const rightTab = useWorkspaceStore.getState().tabsById["file-right"];
+        expect(rightTab?.kind === "file" ? rightTab.viewState : null).toEqual({
+            contributionsState: [],
+            cursorState: [],
+            viewState: { scrollTop: 360 },
+        });
+    });
+
+    it("does not overwrite edits made while a watcher refresh is in flight", async () => {
+        const relativePath = "src/app.ts";
+        const staleExternalLoad = createDeferred<ProjectFileDocument>();
+        openProjectFileMock.mockImplementationOnce(
+            () => staleExternalLoad.promise,
+        );
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: "file-1",
+                id: "pane-root",
+                tabIds: ["file-1"],
+                type: "pane",
+            },
+            tabsById: {
+                "file-1": createLoadedWorkspaceFileTab(
+                    "file-1",
+                    relativePath,
+                    "export const value = 1;\n",
+                ),
+            },
+        }));
+
+        const refreshPromise = useWorkspaceStore
+            .getState()
+            .refreshProjectTabs("project-1", null, [relativePath]);
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        });
+
+        useWorkspaceStore
+            .getState()
+            .updateFileDraft("file-1", "export const value = 3;\n");
+        staleExternalLoad.resolve(
+            createProjectFileDocument(
+                relativePath,
+                "export const value = 2;\n",
+                2,
+            ),
+        );
+        await refreshPromise;
+
+        expect(useWorkspaceStore.getState().tabsById["file-1"]).toMatchObject({
+            draftContent: "export const value = 3;\n",
+            isDirty: true,
+            savedContent: "export const value = 1;\n",
+        });
+    });
+
+    it("allows a manual reload to replace a dirty draft", async () => {
+        const relativePath = "src/app.ts";
+        const externalDocument = createProjectFileDocument(
+            relativePath,
+            "export const value = 2;\n",
+            2,
+        );
+        openProjectFileMock.mockResolvedValueOnce(externalDocument);
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: "file-1",
+                id: "pane-root",
+                tabIds: ["file-1"],
+                type: "pane",
+            },
+            tabsById: {
+                "file-1": {
+                    ...createLoadedWorkspaceFileTab(
+                        "file-1",
+                        relativePath,
+                        "export const value = 1;\n",
+                    ),
+                    draftContent: "export const value = 3;\n",
+                    isDirty: true,
+                },
+            },
+        }));
+
+        await useWorkspaceStore.getState().reloadFileTab("file-1");
+
+        expect(useWorkspaceStore.getState().tabsById["file-1"]).toMatchObject({
+            document: { content: externalDocument.content, modifiedAtMs: 2 },
+            draftContent: externalDocument.content,
+            isDirty: false,
+            savedContent: externalDocument.content,
         });
     });
 

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -3032,6 +3032,74 @@ describe("workspace file opening", () => {
         });
     });
 
+    it("discards an older manual reload after a newer watcher read", async () => {
+        const relativePath = "src/app.ts";
+        const manualLoad = createDeferred<ProjectFileDocument>();
+        const watcherLoad = createDeferred<ProjectFileDocument>();
+        openProjectFileMock
+            .mockImplementationOnce(() => manualLoad.promise)
+            .mockImplementationOnce(() => watcherLoad.promise);
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: "file-1",
+                id: "pane-root",
+                tabIds: ["file-1"],
+                type: "pane",
+            },
+            tabsById: {
+                "file-1": createLoadedWorkspaceFileTab(
+                    "file-1",
+                    relativePath,
+                    "export const value = 1;\n",
+                ),
+            },
+        }));
+
+        const manualReload = useWorkspaceStore
+            .getState()
+            .reloadFileTab("file-1");
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        });
+
+        const watcherRefresh = useWorkspaceStore
+            .getState()
+            .refreshProjectTabs("project-1", null, [relativePath]);
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(2);
+        });
+
+        watcherLoad.resolve(
+            createProjectFileDocument(
+                relativePath,
+                "export const value = 3;\n",
+                3,
+            ),
+        );
+        await watcherRefresh;
+
+        manualLoad.resolve(
+            createProjectFileDocument(
+                relativePath,
+                "export const value = 2;\n",
+                2,
+            ),
+        );
+        await manualReload;
+
+        expect(useWorkspaceStore.getState().tabsById["file-1"]).toMatchObject({
+            contentRevision: 1,
+            document: { content: "export const value = 3;\n", modifiedAtMs: 3 },
+            draftContent: "export const value = 3;\n",
+            isDirty: false,
+            isLoading: false,
+            savedContent: "export const value = 3;\n",
+        });
+    });
+
     it("allows a manual reload to replace a dirty draft", async () => {
         const relativePath = "src/app.ts";
         const externalDocument = createProjectFileDocument(

--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -56,6 +56,7 @@ const originalEnsureSession = useAiStore.getState().ensureSession;
 function createWorkspaceFileTab(id: string, relativePath: string) {
     return {
         createdAt: "2026-04-14T00:00:00.000Z",
+        contentRevision: 0,
         document: null,
         draftContent: "",
         hasExternalChange: false,
@@ -2821,6 +2822,7 @@ describe("workspace file opening", () => {
             worktreeId: null,
         });
         expect(useWorkspaceStore.getState().tabsById["file-1"]).toMatchObject({
+            contentRevision: 1,
             document: { content: externalDocument.content, modifiedAtMs: 2 },
             draftContent: externalDocument.content,
             isDirty: false,
@@ -2862,7 +2864,7 @@ describe("workspace file opening", () => {
                         contributionsState: [],
                         cursorState: [],
                         viewState: { scrollTop: 360 },
-                    } as MonacoEditor.ICodeEditorViewState,
+                    } as unknown as MonacoEditor.ICodeEditorViewState,
                 },
             },
         }));
@@ -2874,6 +2876,7 @@ describe("workspace file opening", () => {
         expect(openProjectFileMock).toHaveBeenCalledTimes(1);
         for (const tabId of ["file-left", "file-right"]) {
             expect(useWorkspaceStore.getState().tabsById[tabId]).toMatchObject({
+                contentRevision: 1,
                 document: { content: externalDocument.content, modifiedAtMs: 2 },
                 draftContent: externalDocument.content,
                 isDirty: false,
@@ -2936,9 +2939,81 @@ describe("workspace file opening", () => {
         await refreshPromise;
 
         expect(useWorkspaceStore.getState().tabsById["file-1"]).toMatchObject({
+            contentRevision: 1,
             draftContent: "export const value = 3;\n",
             isDirty: true,
             savedContent: "export const value = 1;\n",
+        });
+    });
+
+    it("uses the newest watcher read after consecutive invalidations", async () => {
+        const relativePath = "src/app.ts";
+        const firstExternalLoad = createDeferred<ProjectFileDocument>();
+        const secondExternalLoad = createDeferred<ProjectFileDocument>();
+        openProjectFileMock
+            .mockImplementationOnce(() => firstExternalLoad.promise)
+            .mockImplementationOnce(() => secondExternalLoad.promise);
+
+        useWorkspaceStore.setState((state) => ({
+            ...state,
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: "file-1",
+                id: "pane-root",
+                tabIds: ["file-1"],
+                type: "pane",
+            },
+            tabsById: {
+                "file-1": createLoadedWorkspaceFileTab(
+                    "file-1",
+                    relativePath,
+                    "export const value = 1;\n",
+                ),
+            },
+        }));
+
+        const firstRefresh = useWorkspaceStore
+            .getState()
+            .refreshProjectTabs("project-1", null, [relativePath]);
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(1);
+        });
+
+        const secondRefresh = useWorkspaceStore
+            .getState()
+            .refreshProjectTabs("project-1", null, [relativePath]);
+        await vi.waitFor(() => {
+            expect(openProjectFileMock).toHaveBeenCalledTimes(2);
+        });
+
+        firstExternalLoad.resolve(
+            createProjectFileDocument(
+                relativePath,
+                "export const value = 2;\n",
+                2,
+            ),
+        );
+        await firstRefresh;
+        expect(useWorkspaceStore.getState().tabsById["file-1"]).toMatchObject({
+            draftContent: "export const value = 1;\n",
+            isLoading: true,
+        });
+
+        secondExternalLoad.resolve(
+            createProjectFileDocument(
+                relativePath,
+                "export const value = 3;\n",
+                3,
+            ),
+        );
+        await secondRefresh;
+
+        expect(useWorkspaceStore.getState().tabsById["file-1"]).toMatchObject({
+            contentRevision: 1,
+            document: { content: "export const value = 3;\n", modifiedAtMs: 3 },
+            draftContent: "export const value = 3;\n",
+            isDirty: false,
+            isLoading: false,
         });
     });
 
@@ -2976,6 +3051,7 @@ describe("workspace file opening", () => {
         await useWorkspaceStore.getState().reloadFileTab("file-1");
 
         expect(useWorkspaceStore.getState().tabsById["file-1"]).toMatchObject({
+            contentRevision: 1,
             document: { content: externalDocument.content, modifiedAtMs: 2 },
             draftContent: externalDocument.content,
             isDirty: false,

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -4044,18 +4044,24 @@ function shouldApplyFileLoad(
     tabId: string,
     snapshot: FileLoadSnapshot,
 ): boolean {
-    if (snapshot.origin !== "watcher") {
-        return true;
-    }
-
     const tab = state.tabsById[tabId];
     if (!tab || tab.kind !== "file") {
         return false;
     }
 
+    // Request ordering applies to every origin so an older open or manual read
+    // cannot overwrite a newer watcher result.
+    if (
+        latestFileLoadRequestIds.get(snapshot.requestKey) !== snapshot.requestId
+    ) {
+        return false;
+    }
+
+    if (snapshot.origin !== "watcher") {
+        return true;
+    }
+
     return (
-        latestFileLoadRequestIds.get(snapshot.requestKey) ===
-            snapshot.requestId &&
         getFileContentRevision(tab) === snapshot.contentRevision &&
         tab.document?.modifiedAtMs === snapshot.documentModifiedAtMs &&
         !tab.isDirty &&

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -94,6 +94,10 @@ import {
 } from "../workspace/pending-review";
 import { areGitWorktreeIdsEquivalent } from "../git/context-key";
 import { useTerminalRuntimeStore } from "@renderer/features/terminal/terminalRuntimeStore";
+import {
+    recordFileSyncTrace,
+    type FileSyncTraceEventName,
+} from "@renderer/app/debug/fileSyncProbe";
 import { useAiStore } from "./ai-store";
 import { useProjectsStore } from "./projects-store";
 import { getProjectContextKey } from "../projects/context-key";
@@ -2005,22 +2009,35 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         const refreshedFileKeys = new Set<string>();
         await Promise.all(
             fileTabs.map(async (tab) => {
-                if (
-                    !isFileTabAffectedByProjectInvalidation(
-                        tab.relativePath,
-                        invalidatedRelativePaths,
-                    ) ||
-                    tab.isDirty ||
-                    tab.isSaving
-                ) {
+                if (!isFileTabAffectedByProjectInvalidation(
+                    tab.relativePath,
+                    invalidatedRelativePaths,
+                )) {
+                    return;
+                }
+
+                recordFileTabTrace("invalidation_received", tab, {
+                    origin: "watcher",
+                });
+                if (tab.isDirty || tab.isSaving) {
+                    recordFileTabTrace("reload_skipped", tab, {
+                        origin: "watcher",
+                    });
                     return;
                 }
 
                 const fileKey = getWorkspaceFileLoadKey(tab);
                 if (refreshedFileKeys.has(fileKey)) {
+                    recordFileTabTrace("reload_skipped", tab, {
+                        origin: "watcher",
+                    });
                     return;
                 }
                 refreshedFileKeys.add(fileKey);
+
+                recordFileTabTrace("reload_started", tab, {
+                    origin: "watcher",
+                });
 
                 await loadFileTabDocument(
                     get,
@@ -2180,6 +2197,10 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         }));
 
         const savedDraftContent = tab.draftContent;
+        recordFileTabTrace("save_started", tab, {
+            content: savedDraftContent,
+            origin: options?.force ? "manual-force" : "manual",
+        });
 
         try {
             const document = await getComandoApi().saveProjectFile({
@@ -2197,6 +2218,12 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                 error: null,
             }));
             const currentTab = get().tabsById[tabId];
+            if (currentTab?.kind === "file") {
+                recordFileTabTrace("save_completed", currentTab, {
+                    content: document.content,
+                    origin: options?.force ? "manual-force" : "manual",
+                });
+            }
             const currentBufferContent =
                 currentTab?.kind === "file" &&
                 currentTab.document?.absolutePath === document.absolutePath &&
@@ -2224,6 +2251,13 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                     : setFileTabSaving(state, tabId, false, message)),
                 error: message,
             }));
+            const currentTab = get().tabsById[tabId];
+            if (currentTab?.kind === "file") {
+                recordFileTabTrace("save_failed", currentTab, {
+                    content: savedDraftContent,
+                    origin: options?.force ? "manual-force" : "manual",
+                });
+            }
         }
     },
 
@@ -2419,6 +2453,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         }));
         const tab = get().tabsById[tabId];
         if (tab?.kind === "file" && tab.document) {
+            recordFileTabTrace("draft_changed", tab, { content: draft });
             void getComandoApi().notifyFileBuffer({
                 absolutePath: tab.document.absolutePath,
                 content: draft,
@@ -2567,6 +2602,32 @@ interface FileLoadSnapshot {
     readonly origin: FileLoadOrigin;
     readonly requestId: number;
     readonly requestKey: string;
+}
+
+function recordFileTabTrace(
+    event: FileSyncTraceEventName,
+    tab: RuntimeWorkspaceFileTab,
+    options: {
+        readonly content?: string;
+        readonly origin?: string;
+        readonly requestId?: number;
+    } = {},
+): void {
+    recordFileSyncTrace({
+        content: options.content ?? tab.draftContent,
+        contentRevision: getFileContentRevision(tab),
+        event,
+        flags: {
+            hasExternalChange: tab.hasExternalChange,
+            isDirty: tab.isDirty,
+            isLoading: tab.isLoading,
+            isSaving: tab.isSaving,
+        },
+        origin: options.origin,
+        path: tab.relativePath,
+        requestId: options.requestId,
+        tabId: tab.id,
+    });
 }
 
 export function getWorkspaceTabRuntimeId(
@@ -3871,6 +3932,10 @@ async function loadFileTabDocument(
     }
 
     const snapshot = createFileLoadSnapshot(tab, options.origin ?? "open");
+    recordFileTabTrace("read_started", tab, {
+        origin: snapshot.origin,
+        requestId: snapshot.requestId,
+    });
 
     try {
         set((state) => ({
@@ -3882,13 +3947,28 @@ async function loadFileTabDocument(
             tab,
             snapshot.origin !== "watcher",
         );
+        recordFileTabTrace("read_completed", tab, {
+            content: document.content,
+            origin: snapshot.origin,
+            requestId: snapshot.requestId,
+        });
 
         if (!isWorkspaceScopeCurrent(get, scope)) {
+            recordFileTabTrace("reload_discarded", tab, {
+                content: document.content,
+                origin: snapshot.origin,
+                requestId: snapshot.requestId,
+            });
             clearStaleFileTabLoading(set, tabId, scope);
             return;
         }
 
         if (!shouldApplyFileLoad(get(), tabId, snapshot)) {
+            recordFileTabTrace("reload_discarded", tab, {
+                content: document.content,
+                origin: snapshot.origin,
+                requestId: snapshot.requestId,
+            });
             clearDiscardedFileLoad(set, tabId, snapshot);
             return;
         }
@@ -3897,15 +3977,35 @@ async function loadFileTabDocument(
             ...replaceFileDocument(state, tabId, document),
             error: null,
         }));
+        const currentTab = get().tabsById[tabId];
+        if (currentTab?.kind === "file") {
+            recordFileTabTrace("reload_accepted", currentTab, {
+                content: document.content,
+                origin: snapshot.origin,
+                requestId: snapshot.requestId,
+            });
+        }
     } catch (error) {
         if (!isWorkspaceScopeCurrent(get, scope)) {
+            recordFileTabTrace("reload_discarded", tab, {
+                origin: snapshot.origin,
+                requestId: snapshot.requestId,
+            });
             clearStaleFileTabLoading(set, tabId, scope);
             return;
         }
         if (!shouldApplyFileLoad(get(), tabId, snapshot)) {
+            recordFileTabTrace("reload_discarded", tab, {
+                origin: snapshot.origin,
+                requestId: snapshot.requestId,
+            });
             clearDiscardedFileLoad(set, tabId, snapshot);
             return;
         }
+        recordFileTabTrace("read_failed", tab, {
+            origin: snapshot.origin,
+            requestId: snapshot.requestId,
+        });
         set((state) => ({
             ...setFileTabLoadError(
                 state,

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -41,6 +41,7 @@ import {
     createDefaultWorkspaceState,
     findPaneById,
     getDefaultMarkdownFileViewMode,
+    getFileContentRevision,
     isMarkdownFilePath,
     moveActiveTabBetweenPanes,
     moveTabToPaneAtIndex,
@@ -1733,6 +1734,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
 
             const tab: RuntimeWorkspaceFileTab = {
                 createdAt: new Date().toISOString(),
+                contentRevision: 0,
                 document: null,
                 draftContent: "",
                 hasExternalChange: false,
@@ -1964,7 +1966,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             set,
             tabId,
             getCurrentWorkspaceScope(get),
-            { force: true },
+            { force: true, origin: "manual" },
         );
     },
 
@@ -2000,6 +2002,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             return;
         }
 
+        const refreshedFileKeys = new Set<string>();
         await Promise.all(
             fileTabs.map(async (tab) => {
                 if (
@@ -2013,12 +2016,18 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
                     return;
                 }
 
+                const fileKey = getWorkspaceFileLoadKey(tab);
+                if (refreshedFileKeys.has(fileKey)) {
+                    return;
+                }
+                refreshedFileKeys.add(fileKey);
+
                 await loadFileTabDocument(
                     get,
                     set,
                     tab.id,
                     getCurrentWorkspaceScope(get),
-                    { force: true },
+                    { force: true, origin: "watcher" },
                 );
             }),
         );
@@ -2548,6 +2557,17 @@ let workspacePersistGet: GetWorkspaceState | null = null;
 let workspacePersistInFlight: Promise<void> | null = null;
 let workspacePersistFailureCount = 0;
 const pendingFileDocumentLoads = new Map<string, Promise<ProjectFileDocument>>();
+const latestFileLoadRequestIds = new Map<string, number>();
+
+type FileLoadOrigin = "manual" | "open" | "watcher";
+
+interface FileLoadSnapshot {
+    readonly contentRevision: number;
+    readonly documentModifiedAtMs: number | null;
+    readonly origin: FileLoadOrigin;
+    readonly requestId: number;
+    readonly requestKey: string;
+}
 
 export function getWorkspaceTabRuntimeId(
     tab: RuntimeWorkspaceTab | null | undefined,
@@ -3487,6 +3507,7 @@ function createHydratedRuntimeTabs(
                 tab.id,
                 {
                     ...tab,
+                    contentRevision: 0,
                     document: null,
                     draftContent: "",
                     hasExternalChange: false,
@@ -3721,6 +3742,7 @@ export function resetWorkspacePersistenceForTests(): void {
     workspacePersistInFlight = null;
     workspacePersistFailureCount = 0;
     pendingFileDocumentLoads.clear();
+    latestFileLoadRequestIds.clear();
 }
 
 function scheduleWorkspacePersistence(get: GetWorkspaceState): void {
@@ -3833,6 +3855,7 @@ async function loadFileTabDocument(
     },
     options: {
         readonly force?: boolean;
+        readonly origin?: FileLoadOrigin;
     } = {},
 ): Promise<void> {
     if (!isWorkspaceScopeCurrent(get, scope)) {
@@ -3847,16 +3870,26 @@ async function loadFileTabDocument(
         return;
     }
 
+    const snapshot = createFileLoadSnapshot(tab, options.origin ?? "open");
+
     try {
         set((state) => ({
             ...setFileTabLoading(state, tabId, true),
             error: null,
         }));
 
-        const document = await getOrCreateFileDocumentLoad(tab);
+        const document = await getOrCreateFileDocumentLoad(
+            tab,
+            snapshot.origin !== "watcher",
+        );
 
         if (!isWorkspaceScopeCurrent(get, scope)) {
             clearStaleFileTabLoading(set, tabId, scope);
+            return;
+        }
+
+        if (!shouldApplyFileLoad(get(), tabId, snapshot)) {
+            clearDiscardedFileLoad(set, tabId, snapshot);
             return;
         }
 
@@ -3867,6 +3900,10 @@ async function loadFileTabDocument(
     } catch (error) {
         if (!isWorkspaceScopeCurrent(get, scope)) {
             clearStaleFileTabLoading(set, tabId, scope);
+            return;
+        }
+        if (!shouldApplyFileLoad(get(), tabId, snapshot)) {
+            clearDiscardedFileLoad(set, tabId, snapshot);
             return;
         }
         set((state) => ({
@@ -3885,12 +3922,69 @@ async function loadFileTabDocument(
     }
 }
 
+function createFileLoadSnapshot(
+    tab: RuntimeWorkspaceFileTab,
+    origin: FileLoadOrigin,
+): FileLoadSnapshot {
+    const requestKey = getWorkspaceFileLoadKey(tab);
+    const requestId = (latestFileLoadRequestIds.get(requestKey) ?? 0) + 1;
+    latestFileLoadRequestIds.set(requestKey, requestId);
+
+    return {
+        contentRevision: getFileContentRevision(tab),
+        documentModifiedAtMs: tab.document?.modifiedAtMs ?? null,
+        origin,
+        requestId,
+        requestKey,
+    };
+}
+
+function shouldApplyFileLoad(
+    state: WorkspaceStore,
+    tabId: string,
+    snapshot: FileLoadSnapshot,
+): boolean {
+    if (snapshot.origin !== "watcher") {
+        return true;
+    }
+
+    const tab = state.tabsById[tabId];
+    if (!tab || tab.kind !== "file") {
+        return false;
+    }
+
+    return (
+        latestFileLoadRequestIds.get(snapshot.requestKey) ===
+            snapshot.requestId &&
+        getFileContentRevision(tab) === snapshot.contentRevision &&
+        tab.document?.modifiedAtMs === snapshot.documentModifiedAtMs &&
+        !tab.isDirty &&
+        !tab.isSaving
+    );
+}
+
+function clearDiscardedFileLoad(
+    set: WorkspaceSetState,
+    tabId: string,
+    snapshot: FileLoadSnapshot,
+): void {
+    if (latestFileLoadRequestIds.get(snapshot.requestKey) !== snapshot.requestId) {
+        return;
+    }
+
+    set((state) => ({
+        ...setFileTabLoading(state, tabId, false),
+        error: null,
+    }));
+}
+
 function getOrCreateFileDocumentLoad(
     tab: RuntimeWorkspaceFileTab,
+    reusePendingLoad = true,
 ): Promise<ProjectFileDocument> {
     const key = getWorkspaceFileLoadKey(tab);
     const existingLoad = pendingFileDocumentLoads.get(key);
-    if (existingLoad) {
+    if (existingLoad && reusePendingLoad) {
         return existingLoad;
     }
 
@@ -4092,6 +4186,7 @@ function buildChatImageTab(
 
     return {
         createdAt: new Date().toISOString(),
+        contentRevision: 0,
         document,
         draftContent: document.content,
         hasExternalChange: false,

--- a/src/renderer/src/app/workspace/tree.test.ts
+++ b/src/renderer/src/app/workspace/tree.test.ts
@@ -52,6 +52,7 @@ function makeFileTab(
 ): RuntimeWorkspaceFileTab {
     return {
         createdAt: "2026-04-12T00:00:00.000Z",
+        contentRevision: 0,
         document: {
             absolutePath: `/tmp/${relativePath}`,
             content: "",
@@ -443,11 +444,13 @@ describe("workspace tree helpers", () => {
         const withDraft = updateFileDraft(baseState, "file-1", "next draft");
 
         expect(withDraft.tabsById["file-1"]).toMatchObject({
+            contentRevision: 1,
             draftContent: "next draft",
             isDirty: true,
             viewState: sourceViewState,
         });
         expect(withDraft.tabsById["file-2"]).toMatchObject({
+            contentRevision: 1,
             draftContent: "next draft",
             isDirty: true,
             reviewContext: {
@@ -477,6 +480,7 @@ describe("workspace tree helpers", () => {
         });
 
         expect(withSavedDocument.tabsById["file-1"]).toMatchObject({
+            contentRevision: 2,
             document: { content: "saved content", modifiedAtMs: 2 },
             draftContent: "saved content",
             isDirty: false,
@@ -485,6 +489,7 @@ describe("workspace tree helpers", () => {
             viewState: sourceViewState,
         });
         expect(withSavedDocument.tabsById["file-2"]).toMatchObject({
+            contentRevision: 2,
             document: { content: "saved content", modifiedAtMs: 2 },
             draftContent: "saved content",
             isDirty: false,

--- a/src/renderer/src/app/workspace/tree.test.ts
+++ b/src/renderer/src/app/workspace/tree.test.ts
@@ -477,6 +477,7 @@ describe("workspace tree helpers", () => {
         });
 
         expect(withSavedDocument.tabsById["file-1"]).toMatchObject({
+            document: { content: "saved content", modifiedAtMs: 2 },
             draftContent: "saved content",
             isDirty: false,
             isSaving: false,
@@ -484,6 +485,7 @@ describe("workspace tree helpers", () => {
             viewState: sourceViewState,
         });
         expect(withSavedDocument.tabsById["file-2"]).toMatchObject({
+            document: { content: "saved content", modifiedAtMs: 2 },
             draftContent: "saved content",
             isDirty: false,
             isSaving: false,

--- a/src/renderer/src/app/workspace/tree.ts
+++ b/src/renderer/src/app/workspace/tree.ts
@@ -40,6 +40,7 @@ export interface RuntimeWorkspaceFileOpenLocation {
 export type MarkdownFileViewMode = "edit" | "preview";
 
 export interface RuntimeWorkspaceFileTab extends WorkspaceFileTab {
+    readonly contentRevision?: number;
     readonly document: ProjectFileDocument | null;
     readonly draftContent: string;
     readonly hasExternalChange: boolean;
@@ -972,8 +973,19 @@ export function updateFileDraft(
     tabId: string,
     draftContent: string,
 ): WorkspaceTreeState {
+    const sourceTab = state.tabsById[tabId];
+    if (!sourceTab || sourceTab.kind !== "file") {
+        return state;
+    }
+
+    const contentRevision =
+        sourceTab.draftContent === draftContent
+            ? getFileContentRevision(sourceTab)
+            : getFileContentRevision(sourceTab) + 1;
+
     return updateMatchingFileTabs(state, tabId, (tab) => ({
         ...tab,
+        contentRevision,
         draftContent,
         isDirty: draftContent !== tab.savedContent,
         saveError: null,
@@ -1113,8 +1125,20 @@ export function replaceFileDocument(
     tabId: string,
     document: ProjectFileDocument,
 ): WorkspaceTreeState {
+    const sourceTab = state.tabsById[tabId];
+    if (!sourceTab || sourceTab.kind !== "file") {
+        return state;
+    }
+
+    const contentRevision =
+        sourceTab.draftContent === document.content &&
+        sourceTab.document?.modifiedAtMs === document.modifiedAtMs
+            ? getFileContentRevision(sourceTab)
+            : getFileContentRevision(sourceTab) + 1;
+
     return updateMatchingFileTabs(state, tabId, (tab) => ({
         ...tab,
+        contentRevision,
         document,
         draftContent: document.content,
         hasExternalChange: false,
@@ -1142,6 +1166,9 @@ export function completeFileSave(
 
         return {
             ...tab,
+            // Saving acknowledges an existing buffer revision; it must not
+            // make an older asynchronous response current again.
+            contentRevision: getFileContentRevision(tab),
             document,
             draftContent,
             hasExternalChange: false,
@@ -1154,6 +1181,11 @@ export function completeFileSave(
             title: document.name,
         };
     });
+}
+
+export function getFileContentRevision(tab: RuntimeWorkspaceFileTab): number {
+    // Persisted workspaces from before buffer versioning are revision zero.
+    return tab.contentRevision ?? 0;
 }
 
 export function setFileTabSaving(
@@ -1490,8 +1522,14 @@ function normalizeRuntimeTabsForWorkspace(
                 return [tabId, tab];
             }
 
+            const normalizedTab = {
+                ...tab,
+                contentRevision: getFileContentRevision(tab),
+            };
+
             if (!isMarkdownFilePath(tab.relativePath)) {
-                const { markdownViewMode: _markdownViewMode, ...nextTab } = tab;
+                const { markdownViewMode: _markdownViewMode, ...nextTab } =
+                    normalizedTab;
                 void _markdownViewMode;
                 return [tabId, nextTab];
             }
@@ -1499,7 +1537,7 @@ function normalizeRuntimeTabsForWorkspace(
             return [
                 tabId,
                 {
-                    ...tab,
+                    ...normalizedTab,
                     markdownViewMode:
                         tab.markdownViewMode === "preview" ? "preview" : "edit",
                 },

--- a/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx
@@ -1302,6 +1302,70 @@ describe("WorkspaceFileEditorHost", () => {
         );
     });
 
+    it("preserves and clamps the Monaco viewport after a valid disk refresh", async () => {
+        const initialContent = [
+            "first line",
+            "second line",
+            "third line",
+            "fourth line",
+        ].join("\n");
+        const refreshedContent = ["short", "tail"].join("\n");
+        const tab = createFileTab("file-1", "src/app.ts", initialContent);
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: tab,
+                    fileTabs: [tab],
+                }),
+            );
+        });
+        await flushEffects();
+
+        const editor = monacoHarness.codeEditors[0];
+        if (!editor) {
+            throw new Error("Expected Monaco editor to mount.");
+        }
+        editor.setPosition({ column: 12, lineNumber: 4 });
+        editor.setScrollLeft(15);
+        editor.setScrollTop(420);
+        vi.mocked(editor.setPosition).mockClear();
+        vi.mocked(editor.setScrollLeft).mockClear();
+        vi.mocked(editor.setScrollTop).mockClear();
+
+        const refreshedTab = {
+            ...tab,
+            document: {
+                ...tab.document!,
+                content: refreshedContent,
+                modifiedAtMs: 2,
+                sizeBytes: refreshedContent.length,
+            },
+            draftContent: refreshedContent,
+            savedContent: refreshedContent,
+        } satisfies RuntimeWorkspaceFileTab;
+
+        act(() => {
+            root.render(
+                renderHost({
+                    activeFileTab: refreshedTab,
+                    fileTabs: [refreshedTab],
+                }),
+            );
+        });
+        await flushEffects();
+        await flushAnimationFrame();
+
+        expect(editor.getModel()?.getValue()).toBe(refreshedContent);
+        expect(editor.getPosition()).toEqual({ column: 5, lineNumber: 2 });
+        expect(editor.getScrollLeft()).toBe(15);
+        expect(editor.getScrollTop()).toBe(420);
+        expect(editor.setPosition).toHaveBeenCalledWith({
+            column: 5,
+            lineNumber: 2,
+        });
+    });
+
     it("renders the Markdown view switch for .md and .markdown file tabs", async () => {
         const markdownTab = createFileTab("file-1", "README.md", "# Readme\n");
         const longMarkdownTab = createFileTab(

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -94,6 +94,10 @@ import {
     useLifecycleProbe,
     useRenderProbe,
 } from "@renderer/app/debug/renderProbe";
+import {
+    recordFileSyncTrace,
+    type FileSyncTraceEventName,
+} from "@renderer/app/debug/fileSyncProbe";
 import { recordWorkspacePerformanceEvent } from "@renderer/app/debug/workspacePerformanceProbe";
 import {
     applyAiTranscriptMemoryPressure,
@@ -4455,6 +4459,8 @@ function FileTabView({
         readonly tabId: string;
     } | null>(null);
     const fileTabIdRef = useRef(tab.id);
+    const fileSyncTabRef = useRef(tab);
+    const lastEditorScrollTopRef = useRef<number | null>(null);
     const inlineReviewActiveRef = useRef(false);
     const inlineReviewSignatureRef = useRef<string | null>(null);
     const latestDraftContentRef = useRef(tab.draftContent);
@@ -4478,6 +4484,26 @@ function FileTabView({
         isInlineReviewFindWidgetVisible,
         setIsInlineReviewFindWidgetVisible,
     ] = useState(false);
+    const recordEditorFileSyncTrace = useCallback(
+        (event: FileSyncTraceEventName, origin: string) => {
+            const traceTab = fileSyncTabRef.current;
+            recordFileSyncTrace({
+                content: latestDraftContentRef.current,
+                contentRevision: traceTab.contentRevision,
+                event,
+                flags: {
+                    hasExternalChange: traceTab.hasExternalChange,
+                    isDirty: traceTab.isDirty,
+                    isLoading: traceTab.isLoading,
+                    isSaving: traceTab.isSaving,
+                },
+                origin,
+                path: traceTab.relativePath,
+                tabId: traceTab.id,
+            });
+        },
+        [],
+    );
     const [hoveredInlineReviewHunkState, setHoveredInlineReviewHunkState] =
         useState<{
             readonly hunkId: string;
@@ -5486,7 +5512,8 @@ function FileTabView({
 
     useLayoutEffect(() => {
         latestDraftContentRef.current = tab.draftContent;
-    }, [tab.draftContent]);
+        fileSyncTabRef.current = tab;
+    }, [tab]);
 
     useLayoutEffect(() => {
         if (
@@ -5529,6 +5556,10 @@ function FileTabView({
         }
         previousLease?.release();
 
+        if (didChangeContent) {
+            recordEditorFileSyncTrace("model_changed", "monaco");
+        }
+
         if (!isVisible || inlineReviewTrackedFile) {
             return;
         }
@@ -5558,6 +5589,7 @@ function FileTabView({
         inlineReviewTrackedFile,
         isVisible,
         monacoLanguageId,
+        recordEditorFileSyncTrace,
         restorePortableEditorState,
         restoreEditorViewStateForTab,
         runWithoutEditorChangeNotification,
@@ -6882,12 +6914,32 @@ function FileTabView({
                                 () => {
                                     captureEditorStateForInlineReview(editor);
                                     scheduleEditorViewStatePersist(editor);
+                                    const nextScrollTop = editor.getScrollTop();
+                                    const previousScrollTop =
+                                        lastEditorScrollTopRef.current;
+                                    lastEditorScrollTopRef.current =
+                                        nextScrollTop;
+                                    if (
+                                        previousScrollTop !== null &&
+                                        Math.abs(
+                                            nextScrollTop - previousScrollTop,
+                                        ) >= 240
+                                    ) {
+                                        recordEditorFileSyncTrace(
+                                            "scroll_jump",
+                                            "monaco",
+                                        );
+                                    }
                                 },
                             );
                             const cursorListener =
                                 editor.onDidChangeCursorSelection(() => {
                                     captureEditorStateForInlineReview(editor);
                                     scheduleEditorViewStatePersist(editor);
+                                    recordEditorFileSyncTrace(
+                                        "selection_changed",
+                                        "monaco",
+                                    );
                                 });
                             const hiddenAreasListener =
                                 editor.onDidChangeHiddenAreas(() => {

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -171,7 +171,7 @@ import {
     acquireWorkspaceFileModel,
     buildWorkspaceEditorModelPath,
     buildWorkspaceFileEditorModelPath,
-    getOrCreateWorkspaceFileModel,
+    syncWorkspaceFileModel,
     type WorkspaceFileModelLease,
 } from "@renderer/components/workspace/editorModelPath";
 import { appendSelectionMentionToRegisteredComposer } from "@renderer/components/workspace/chat/composerSelectionBridge";
@@ -4798,6 +4798,7 @@ function FileTabView({
             readonly monaco: MonacoNamespace;
             readonly value: string;
         }): {
+            readonly didChangeContent: boolean;
             readonly model: MonacoEditor.ITextModel;
             readonly previousLease: WorkspaceFileModelLease | null;
         } => {
@@ -4810,9 +4811,13 @@ function FileTabView({
                 currentLease?.modelPath === modelPath &&
                 !currentLease.model.isDisposed()
             ) {
-                const model = getOrCreateWorkspaceFileModel(input);
-                if (model === currentLease.model) {
-                    return { model, previousLease: null };
+                const syncResult = syncWorkspaceFileModel(input);
+                if (syncResult.model === currentLease.model) {
+                    return {
+                        didChangeContent: syncResult.didChangeContent,
+                        model: syncResult.model,
+                        previousLease: null,
+                    };
                 }
             }
 
@@ -4820,6 +4825,7 @@ function FileTabView({
             workspaceFileModelLeaseRef.current = nextLease;
 
             return {
+                didChangeContent: nextLease.didChangeContent,
                 model: nextLease.model,
                 previousLease: currentLease,
             };
@@ -5497,14 +5503,24 @@ function FileTabView({
             return;
         }
 
-        const { model, previousLease } = runWithoutEditorChangeNotification(() =>
-            acquireFileEditorModel({
-                absolutePath: document.absolutePath,
-                language: monacoLanguageId,
-                monaco,
-                value: latestDraftContentRef.current,
-            }),
-        );
+        const currentLease = workspaceFileModelLeaseRef.current;
+        const capturedEditorState =
+            isVisible &&
+            !inlineReviewTrackedFile &&
+            currentLease?.modelPath ===
+                buildWorkspaceFileEditorModelPath(document.absolutePath) &&
+            editor.getModel() === currentLease.model
+                ? capturePortableEditorRestoreState(editor)
+                : null;
+        const { didChangeContent, model, previousLease } =
+            runWithoutEditorChangeNotification(() =>
+                acquireFileEditorModel({
+                    absolutePath: document.absolutePath,
+                    language: monacoLanguageId,
+                    monaco,
+                    value: latestDraftContentRef.current,
+                }),
+            );
 
         if (editor.getModel() !== model) {
             runWithoutEditorChangeNotification(() => {
@@ -5518,6 +5534,13 @@ function FileTabView({
         }
 
         if (consumePendingOpenLocation(editor)) {
+            return;
+        }
+
+        if (didChangeContent && capturedEditorState) {
+            // A disk refresh resets Monaco's viewport, so restore only the
+            // current editor's portable state after a same-model replacement.
+            restorePortableEditorState(editor, capturedEditorState);
             return;
         }
 
@@ -5535,6 +5558,7 @@ function FileTabView({
         inlineReviewTrackedFile,
         isVisible,
         monacoLanguageId,
+        restorePortableEditorState,
         restoreEditorViewStateForTab,
         runWithoutEditorChangeNotification,
         tab.id,

--- a/src/renderer/src/components/workspace/editorModelPath.test.ts
+++ b/src/renderer/src/components/workspace/editorModelPath.test.ts
@@ -5,6 +5,7 @@ import {
     buildWorkspaceEditorModelPath,
     buildWorkspaceFileEditorModelPath,
     getOrCreateWorkspaceFileModel,
+    syncWorkspaceFileModel,
 } from "./editorModelPath";
 
 describe("buildWorkspaceEditorModelPath", () => {
@@ -167,6 +168,35 @@ describe("getOrCreateWorkspaceFileModel", () => {
         });
 
         expect(createdModels[0]?.setValueCalls).toEqual(["const a = 2;"]);
+    });
+});
+
+describe("syncWorkspaceFileModel", () => {
+    it("reports whether synchronizing replaced the model content", () => {
+        const { monaco } = createFakeMonaco();
+        const initial = syncWorkspaceFileModel({
+            absolutePath: "/workspace/comando/src/app.ts",
+            language: "typescript",
+            monaco,
+            value: "const a = 1;",
+        });
+        const matching = syncWorkspaceFileModel({
+            absolutePath: "/workspace/comando/src/app.ts",
+            language: "typescript",
+            monaco,
+            value: "const a = 1;",
+        });
+        const changed = syncWorkspaceFileModel({
+            absolutePath: "/workspace/comando/src/app.ts",
+            language: "typescript",
+            monaco,
+            value: "const a = 2;",
+        });
+
+        expect(initial.didChangeContent).toBe(false);
+        expect(matching.didChangeContent).toBe(false);
+        expect(changed.didChangeContent).toBe(true);
+        expect(changed.model).toBe(initial.model);
     });
 });
 

--- a/src/renderer/src/components/workspace/editorModelPath.ts
+++ b/src/renderer/src/components/workspace/editorModelPath.ts
@@ -7,9 +7,15 @@ export type WorkspaceEditorModelVariant =
 type MonacoNamespace = typeof import("monaco-editor");
 
 export interface WorkspaceFileModelLease {
+    readonly didChangeContent: boolean;
     readonly model: MonacoEditor.ITextModel;
     readonly modelPath: string;
     readonly release: () => void;
+}
+
+export interface WorkspaceFileModelSyncResult {
+    readonly didChangeContent: boolean;
+    readonly model: MonacoEditor.ITextModel;
 }
 
 const retainedWorkspaceFileModels = new Map<
@@ -89,20 +95,33 @@ export function getOrCreateWorkspaceFileModel(input: {
     readonly monaco: MonacoNamespace;
     readonly value: string;
 }): MonacoEditor.ITextModel {
+    return syncWorkspaceFileModel(input).model;
+}
+
+export function syncWorkspaceFileModel(input: {
+    readonly absolutePath: string;
+    readonly language: string;
+    readonly monaco: MonacoNamespace;
+    readonly value: string;
+}): WorkspaceFileModelSyncResult {
     const uri = input.monaco.Uri.parse(
         buildWorkspaceFileEditorModelPath(input.absolutePath),
     );
     const existingModel = input.monaco.editor.getModel(uri);
 
     if (existingModel) {
+        const didChangeContent = existingModel.getValue() !== input.value;
         if (existingModel.getValue() !== input.value) {
             existingModel.setValue(input.value);
         }
         input.monaco.editor.setModelLanguage(existingModel, input.language);
-        return existingModel;
+        return { didChangeContent, model: existingModel };
     }
 
-    return input.monaco.editor.createModel(input.value, input.language, uri);
+    return {
+        didChangeContent: false,
+        model: input.monaco.editor.createModel(input.value, input.language, uri),
+    };
 }
 
 export function acquireWorkspaceFileModel(input: {
@@ -112,7 +131,7 @@ export function acquireWorkspaceFileModel(input: {
     readonly value: string;
 }): WorkspaceFileModelLease {
     const modelPath = buildWorkspaceFileEditorModelPath(input.absolutePath);
-    const model = getOrCreateWorkspaceFileModel(input);
+    const { didChangeContent, model } = syncWorkspaceFileModel(input);
     const retainedModel = retainedWorkspaceFileModels.get(modelPath);
 
     if (retainedModel?.model === model) {
@@ -127,6 +146,7 @@ export function acquireWorkspaceFileModel(input: {
     let released = false;
 
     return {
+        didChangeContent,
         model,
         modelPath,
         release: () => {


### PR DESCRIPTION
## Summary

Fixes race conditions in workspace file synchronization that could apply stale reloads, overwrite newer buffers, or cause Monaco viewport jumps.

It also hardens watcher suppression for application-owned writes, including large files copied in chunks.

## Key changes

- Versions workspace buffers and discards reload results that have become stale.
- Preserves Monaco editor position and selection after disk-driven updates.
- Detects actual content changes while synchronizing shared Monaco models.
- Strengthens `WriteTracker` handling for writes, deletes, renames, and restores.
- Keeps watcher suppression active during long-running copies and tracks every created file and directory.
- Adds file-sync diagnostic traces to investigate events and scroll jumps.
- Expands regression coverage for stale reloads, workspace tree behavior, and editor models.

## Validation

- `cargo test -p comando-fs` — 34 tests passed.
- `pnpm exec vitest run src/renderer/src/app/store/workspace-store.test.ts src/renderer/src/app/workspace/tree.test.ts src/renderer/src/app/debug/fileSyncProbe.test.ts src/renderer/src/components/workspace/WorkspaceView.file-editor-host.test.tsx src/renderer/src/components/workspace/editorModelPath.test.ts` — 159 tests passed.

## Risk

This touches the synchronization path across the filesystem, watcher, store, and Monaco. The added coverage exercises the identified races, but manual verification with external edits and large file copies is recommended before release.