### PR TITLE
Fix moving workspaces to windows with retained contexts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1182,7 +1182,10 @@ function attachMainWindowLifecycle(
             event.preventDefault();
             if (!closeFlushInFlight) {
                 closeFlushInFlight = true;
-                void requestWorkspaceFlushesForHost(window, context.windowId).finally(() => {
+                void prepareWorkspaceHostForClose(
+                    window,
+                    context.windowId,
+                ).finally(() => {
                     closeFlushComplete = true;
                     closeFlushInFlight = false;
                     if (!window.isDestroyed()) {
@@ -1203,7 +1206,7 @@ function attachMainWindowLifecycle(
         }
 
         detachAiSessionStream(context.windowId);
-        workspaceSurfaceManager.disposeHost(context.windowId);
+        workspaceSurfaceManager.disposeHost(context.windowId, window);
 
         if (!isQuitting) {
             persistenceService?.markWindowClosed(context.windowId);
@@ -1264,6 +1267,14 @@ async function requestWorkspaceFlushesForHost(
     ]);
 }
 
+async function prepareWorkspaceHostForClose(
+    window: BrowserWindow,
+    hostWindowId: string,
+): Promise<void> {
+    await workspaceSurfaceManager.prepareHostForClose(hostWindowId, window);
+    await requestWorkspaceFlushesForHost(window, hostWindowId);
+}
+
 async function requestWorkspaceSurfaceContextCapture(
     hostWindowId: string,
     contextKey: string,
@@ -1312,6 +1323,15 @@ async function flushAllWorkspaceWindowsForQuit(): Promise<void> {
         }
         return windowRegistry.getContextByBrowserWindow(window)?.windowKind === "main";
     });
+    await Promise.all(
+        windows.map((window) => {
+            const context = windowRegistry.getContextByBrowserWindow(window);
+            return workspaceSurfaceManager.prepareHostForClose(
+                context?.windowId ?? `${window.id}`,
+                window,
+            );
+        }),
+    );
     await Promise.all(
         windows.map((window) => {
             const context = windowRegistry.getContextByBrowserWindow(window);

--- a/src/main/native-backend/app-data.test.ts
+++ b/src/main/native-backend/app-data.test.ts
@@ -160,28 +160,55 @@ describe("createNativeAppDataClient", () => {
             null,
             "pane-target",
         );
+        const retainedTargetNavigation = {
+            ...targetNavigation,
+            contexts: [
+                ...targetNavigation.contexts,
+                {
+                    ...sourceNavigation.contexts[0],
+                    workspace: {
+                        ...sourceNavigation.contexts[0].workspace,
+                        activePaneId: "pane-stale",
+                        rootNode: {
+                            activeTabId: null,
+                            id: "pane-stale",
+                            tabIds: [],
+                            type: "pane" as const,
+                        },
+                    },
+                },
+            ],
+        };
         await client.workspace.saveSnapshot(
             targetWorkspaceId,
             {
-                ...targetNavigation,
-                // Closed contexts retain their layout but are not live duplicates.
-                contexts: [
-                    ...targetNavigation.contexts,
-                    {
-                        ...sourceNavigation.contexts[0],
-                        workspace: {
-                            ...sourceNavigation.contexts[0].workspace,
-                            activePaneId: "pane-stale",
-                            rootNode: {
-                                activeTabId: null,
-                                id: "pane-stale",
-                                tabIds: [],
-                                type: "pane",
-                            },
-                        },
-                    },
+                ...retainedTargetNavigation,
+                openContextKeys: [
+                    ...targetNavigation.openContextKeys,
+                    "project-1::__primary__",
                 ],
             },
+        );
+        const sourceWithDuplicate = await client.workspace.loadSnapshot(
+            sourceWorkspaceId,
+        );
+        const targetWithDuplicate = await client.workspace.loadSnapshot(
+            targetWorkspaceId,
+        );
+        await expect(
+            client.workspace.transferContext({
+                contextKey: "project-1::__primary__",
+                sourceRevision: sourceWithDuplicate.revision,
+                sourceWorkspaceId,
+                targetRevision: targetWithDuplicate.revision,
+                targetWorkspaceId,
+            }),
+        ).rejects.toThrow("destination already contains this workspace");
+
+        // Closed contexts retain their layout but are not live duplicates.
+        await client.workspace.saveSnapshot(
+            targetWorkspaceId,
+            retainedTargetNavigation,
         );
         const sourceBefore = await client.workspace.loadSnapshot(
             sourceWorkspaceId,

--- a/src/main/native-backend/app-data.test.ts
+++ b/src/main/native-backend/app-data.test.ts
@@ -146,13 +146,42 @@ describe("createNativeAppDataClient", () => {
         if (!sourceWorkspaceId || !targetWorkspaceId) {
             throw new Error("Expected transfer workspace ids.");
         }
+        const sourceNavigation = workspaceNavigation(
+            "project-1",
+            null,
+            "pane-source",
+        );
         await client.workspace.saveSnapshot(
             sourceWorkspaceId,
-            workspaceNavigation("project-1", null, "pane-source"),
+            sourceNavigation,
+        );
+        const targetNavigation = workspaceNavigation(
+            "project-2",
+            null,
+            "pane-target",
         );
         await client.workspace.saveSnapshot(
             targetWorkspaceId,
-            workspaceNavigation("project-2", null, "pane-target"),
+            {
+                ...targetNavigation,
+                // Closed contexts retain their layout but are not live duplicates.
+                contexts: [
+                    ...targetNavigation.contexts,
+                    {
+                        ...sourceNavigation.contexts[0],
+                        workspace: {
+                            ...sourceNavigation.contexts[0].workspace,
+                            activePaneId: "pane-stale",
+                            rootNode: {
+                                activeTabId: null,
+                                id: "pane-stale",
+                                tabIds: [],
+                                type: "pane",
+                            },
+                        },
+                    },
+                ],
+            },
         );
         const sourceBefore = await client.workspace.loadSnapshot(
             sourceWorkspaceId,
@@ -183,6 +212,13 @@ describe("createNativeAppDataClient", () => {
                 ],
             },
         });
+        const transferredContexts = transfer.target.snapshot.contexts.filter(
+            (context) => context.key === "project-1::__primary__",
+        );
+        expect(transferredContexts).toHaveLength(1);
+        expect(transferredContexts[0]?.workspace.activePaneId).toBe(
+            "pane-source",
+        );
         await expect(
             client.workspace.transferContext({
                 contextKey: "project-2::__primary__",

--- a/src/main/native-backend/app-data.ts
+++ b/src/main/native-backend/app-data.ts
@@ -55,7 +55,10 @@ import {
     createWindowWorkspaceRestoreRecord,
     normalizeWindowWorkspaceRestoreRecord,
 } from "@shared/workspace-restore";
-import { areWorkspaceScopesEquivalent } from "@shared/workspace-context";
+import {
+    areWorkspaceScopesEquivalent,
+    hasOpenWorkspaceScope,
+} from "@shared/workspace-context";
 
 import type {
     AiPersistenceGateway,
@@ -490,11 +493,7 @@ class NativePersistenceClient implements PersistenceGateway {
         ) {
             throw new Error("The workspace to move is no longer open.");
         }
-        if (
-            targetRestore.snapshot.contexts.some((candidate) =>
-                areWorkspaceScopesEquivalent(candidate, context),
-            )
-        ) {
+        if (hasOpenWorkspaceScope(targetRestore.snapshot, context)) {
             throw new Error("The destination already contains this workspace.");
         }
 
@@ -542,7 +541,15 @@ class NativePersistenceClient implements PersistenceGateway {
             {
                 ...targetRestore.snapshot,
                 activeContextKey: context.key,
-                contexts: [...targetRestore.snapshot.contexts, updatedContext],
+                // A closed retained context is a cache, not a live duplicate.
+                // Replace it with the incoming live context and its latest state.
+                contexts: [
+                    ...targetRestore.snapshot.contexts.filter(
+                        (candidate) =>
+                            !areWorkspaceScopesEquivalent(candidate, context),
+                    ),
+                    updatedContext,
+                ],
                 openContextKeys: targetOpenContextKeys,
             },
             targetRestore.revision + 1,

--- a/src/main/workspace/move-coordinator.test.ts
+++ b/src/main/workspace/move-coordinator.test.ts
@@ -176,6 +176,87 @@ describe("moveWorkspaceBetweenWindows", () => {
         );
     });
 
+    it("allows a target that only retains a closed equivalent context", async () => {
+        const primary = createContext("project-a::__primary__", null);
+        const other = {
+            ...createContext("project-b::__primary__", null),
+            projectId: "project-b",
+        };
+        const sourceSnapshot = createSnapshot(primary.key, [primary]);
+        const targetSnapshot = createSnapshot(
+            other.key,
+            [other, primary],
+            [other.key],
+        );
+        const committedSource = createSnapshot(null, []);
+        const committedTarget = createSnapshot(primary.key, [other, primary]);
+        const transferSurface = vi.fn(async (input: TransferSurfaceInput) => {
+            const committed = await input.commit();
+            return {
+                sourceSnapshot: committed.source.snapshot,
+                surfaceId: "surface-primary",
+                targetSnapshot: committed.target.snapshot,
+            };
+        });
+
+        await moveWorkspaceBetweenWindows(
+            "window-1",
+            {
+                contextKey: primary.key,
+                projectId: primary.projectId,
+                targetWindowId: "window-2",
+                worktreeId: null,
+            },
+            {
+                captureContext: vi.fn(() => Promise.resolve(sourceSnapshot)),
+                createEmptyTarget: vi.fn(),
+                flushHost: vi.fn(() => Promise.resolve()),
+                getWindowContext: (windowId) => createWindowContext(windowId),
+                isWindowAvailable: () => true,
+                manager: {
+                    getHostSnapshotForWindow: (windowId) =>
+                        windowId === "window-1" ? sourceSnapshot : targetSnapshot,
+                    listOpenWorkspaceLocations: () => [
+                        {
+                            contextKey: primary.key,
+                            hostWindowId: "window-1",
+                            isActive: true,
+                            lastActivatedAt: primary.lastActivatedAt,
+                            projectId: primary.projectId,
+                            worktreeId: null,
+                        },
+                    ],
+                    transferSurface,
+                },
+                onTransferred: vi.fn(),
+                workspaceService: createWorkspaceService({
+                    saveSnapshot: vi.fn(() => Promise.resolve()),
+                    sourceSnapshot,
+                    targetSnapshot,
+                    transferContext: vi.fn(() =>
+                        Promise.resolve({
+                            source: createWindowWorkspaceRestoreRecord(
+                                committedSource,
+                                4,
+                            ),
+                            target: createWindowWorkspaceRestoreRecord(
+                                committedTarget,
+                                7,
+                            ),
+                        }),
+                    ),
+                }),
+            },
+        );
+
+        expect(transferSurface).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contextKey: primary.key,
+                targetHostWindowId: "window-2",
+            }),
+        );
+    });
+
     it("leaves the source untouched when a selected target has closed", async () => {
         const primary = createContext("project-a::__primary__", null);
         const sourceSnapshot = createSnapshot(primary.key, [primary]);
@@ -287,11 +368,12 @@ function createContext(
 function createSnapshot(
     activeContextKey: string | null,
     contexts: readonly PersistedWorkspaceContext[],
+    openContextKeys = contexts.map((context) => context.key),
 ): WorkspaceNavigationSnapshot {
     return {
         activeContextKey,
         contexts,
-        openContextKeys: contexts.map((context) => context.key),
+        openContextKeys,
         version: 3,
     };
 }

--- a/src/main/workspace/move-coordinator.test.ts
+++ b/src/main/workspace/move-coordinator.test.ts
@@ -35,11 +35,13 @@ describe("moveWorkspaceBetweenWindows", () => {
         const onTransferred = vi.fn();
         const transferSurface = vi.fn(async (input: TransferSurfaceInput) => {
             const committed = await input.commit();
-            return {
+            const transfer = {
                 sourceSnapshot: committed.source.snapshot,
                 surfaceId: "surface-primary",
                 targetSnapshot: committed.target.snapshot,
             };
+            input.onCommitted?.(transfer);
+            return transfer;
         });
 
         await moveWorkspaceBetweenWindows(
@@ -112,11 +114,13 @@ describe("moveWorkspaceBetweenWindows", () => {
         const targetContext = createWindowContext("window-new");
         const transferSurface = vi.fn(async (input: TransferSurfaceInput) => {
             const committed = await input.commit();
-            return {
+            const transfer = {
                 sourceSnapshot: committed.source.snapshot,
                 surfaceId: "surface-primary",
                 targetSnapshot: committed.target.snapshot,
             };
+            input.onCommitted?.(transfer);
+            return transfer;
         });
 
         await moveWorkspaceBetweenWindows(
@@ -192,11 +196,13 @@ describe("moveWorkspaceBetweenWindows", () => {
         const committedTarget = createSnapshot(primary.key, [other, primary]);
         const transferSurface = vi.fn(async (input: TransferSurfaceInput) => {
             const committed = await input.commit();
-            return {
+            const transfer = {
                 sourceSnapshot: committed.source.snapshot,
                 surfaceId: "surface-primary",
                 targetSnapshot: committed.target.snapshot,
             };
+            input.onCommitted?.(transfer);
+            return transfer;
         });
 
         await moveWorkspaceBetweenWindows(

--- a/src/main/workspace/move-coordinator.ts
+++ b/src/main/workspace/move-coordinator.ts
@@ -127,7 +127,7 @@ export async function moveWorkspaceBetweenWindows(
         dependencies.workspaceService.loadSnapshot(sourceContext.workspaceId),
         dependencies.workspaceService.loadSnapshot(targetContext.workspaceId),
     ]);
-    const transfer = await dependencies.manager.transferSurface({
+    await dependencies.manager.transferSurface({
         commit: () =>
             Promise.resolve(
                 dependencies.workspaceService.transferContext({
@@ -139,12 +139,14 @@ export async function moveWorkspaceBetweenWindows(
                 }),
             ),
         contextKey: input.contextKey,
+        onCommitted: (transfer) => {
+            dependencies.onTransferred(
+                sourceWindowId,
+                targetContext.windowId,
+                transfer,
+            );
+        },
         sourceHostWindowId: sourceWindowId,
         targetHostWindowId: targetContext.windowId,
     });
-    dependencies.onTransferred(
-        sourceWindowId,
-        targetContext.windowId,
-        transfer,
-    );
 }

--- a/src/main/workspace/move-coordinator.ts
+++ b/src/main/workspace/move-coordinator.ts
@@ -3,7 +3,10 @@ import type {
     WindowContextSnapshot,
     WorkspaceNavigationSnapshot,
 } from "@shared/ipc";
-import { areWorkspaceScopesEquivalent } from "@shared/workspace-context";
+import {
+    areWorkspaceScopesEquivalent,
+    hasOpenWorkspaceScope,
+} from "@shared/workspace-context";
 
 import type { WorkspaceGateway } from "./service";
 import type {
@@ -92,11 +95,7 @@ export async function moveWorkspaceBetweenWindows(
     if (!targetSnapshot) {
         throw new Error("The destination window is still starting.");
     }
-    if (
-        targetSnapshot.contexts.some((context) =>
-            areWorkspaceScopesEquivalent(context, input),
-        )
-    ) {
+    if (hasOpenWorkspaceScope(targetSnapshot, input)) {
         throw new Error("The destination already contains this workspace.");
     }
 

--- a/src/main/workspace/move-destinations.test.ts
+++ b/src/main/workspace/move-destinations.test.ts
@@ -79,4 +79,48 @@ describe("buildWorkspaceMoveDestinations", () => {
             },
         ]);
     });
+
+    it("enables a destination that only retains a closed equivalent scope", () => {
+        const retainedContext = {
+            key: "project-a::__primary__",
+            lastActivatedAt: "2026-07-22T12:00:00.000Z",
+            projectId: "project-a",
+            workspace: {
+                activePaneId: "pane-retained",
+                rootNode: {
+                    activeTabId: null,
+                    id: "pane-retained",
+                    tabIds: [],
+                    type: "pane" as const,
+                },
+                tabs: [],
+            },
+            worktreeId: null,
+        };
+
+        expect(
+            buildWorkspaceMoveDestinations({
+                candidates: [
+                    {
+                        snapshot: {
+                            activeContextKey: null,
+                            contexts: [retainedContext],
+                            openContextKeys: [],
+                            version: 3,
+                        },
+                        windowId: "target",
+                        windowTitle: "Comando",
+                    },
+                ],
+                scope: { projectId: "project-a", worktreeId: null },
+                sourceWindowId: "source",
+            }),
+        ).toEqual([
+            {
+                enabled: true,
+                label: "Window 1",
+                targetWindowId: "target",
+            },
+        ]);
+    });
 });

--- a/src/main/workspace/move-destinations.ts
+++ b/src/main/workspace/move-destinations.ts
@@ -1,6 +1,6 @@
 import type { WorkspaceNavigationSnapshot } from "@shared/ipc";
 import {
-    areWorkspaceScopesEquivalent,
+    hasOpenWorkspaceScope,
     type WorkspaceScope,
 } from "@shared/workspace-context";
 
@@ -33,9 +33,7 @@ export function buildWorkspaceMoveDestinations(input: {
     }
 
     return candidates.map((candidate, index) => ({
-        enabled: !candidate.snapshot.contexts.some((context) =>
-            areWorkspaceScopesEquivalent(context, input.scope),
-        ),
+        enabled: !hasOpenWorkspaceScope(candidate.snapshot, input.scope),
         label:
             (labelCounts.get(baseLabels[index]) ?? 0) > 1
                 ? `${baseLabels[index]} — Window ${index + 1}`

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -551,13 +551,377 @@ describe("WorkspaceSurfaceManager action routing", () => {
                 : null,
         ).toMatchObject({ hostWindowId: "host-1", workspaceId: "workspace-1" });
     });
+
+    it("rejects transfers before a destination starts closing", async () => {
+        const manager = new WorkspaceSurfaceManager();
+        const sourceHost = createHostWindow();
+        const targetHost = createHostWindow();
+        manager.syncHost(sourceHost.window, createHostContext(), createSnapshot());
+        manager.syncHost(
+            targetHost.window,
+            {
+                ...createHostContext(),
+                projectId: "project-c",
+                windowId: "host-2",
+                workspaceId: "workspace-2",
+                workspaceSessionId: "workspace-session-2",
+            },
+            singleContextSnapshot("project-c::__primary__", "project-c"),
+        );
+        const commit = vi.fn();
+
+        await manager.prepareHostForClose("host-2");
+
+        await expect(
+            manager.transferSurface({
+                commit,
+                contextKey: "project-a::__primary__",
+                sourceHostWindowId: "host-1",
+                targetHostWindowId: "host-2",
+            }),
+        ).rejects.toThrow("window is closing");
+        expect(commit).not.toHaveBeenCalled();
+    });
+
+    it("waits for an in-flight transfer before allowing a host to close", async () => {
+        const manager = new WorkspaceSurfaceManager();
+        const sourceHost = createHostWindow();
+        const targetHost = createHostWindow();
+        const sourceSnapshot = createSnapshot();
+        const targetSnapshot = singleContextSnapshot(
+            "project-c::__primary__",
+            "project-c",
+        );
+        manager.syncHost(sourceHost.window, createHostContext(), sourceSnapshot);
+        manager.syncHost(
+            targetHost.window,
+            {
+                ...createHostContext(),
+                projectId: "project-c",
+                windowId: "host-2",
+                workspaceId: "workspace-2",
+                workspaceSessionId: "workspace-session-2",
+            },
+            targetSnapshot,
+        );
+        const movingContext = sourceSnapshot.contexts[0];
+        if (!movingContext) {
+            throw new Error("Expected a moving context.");
+        }
+        const committedSource = singleContextSnapshot(
+            "project-b::__primary__",
+            "project-b",
+        );
+        const committedTarget: WorkspaceNavigationSnapshot = {
+            activeContextKey: movingContext.key,
+            contexts: [...targetSnapshot.contexts, movingContext],
+            openContextKeys: [
+                ...targetSnapshot.openContextKeys,
+                movingContext.key,
+            ],
+            version: 3,
+        };
+        const deferredCommit = createDeferred(
+            {
+                source: createWindowWorkspaceRestoreRecord(
+                    committedSource,
+                    2,
+                ),
+                target: createWindowWorkspaceRestoreRecord(
+                    committedTarget,
+                    2,
+                ),
+            },
+        );
+        let hostsNotified = false;
+        const transfer = manager.transferSurface({
+            commit: () => deferredCommit.promise,
+            contextKey: movingContext.key,
+            onCommitted: () => {
+                hostsNotified = true;
+            },
+            sourceHostWindowId: "host-1",
+            targetHostWindowId: "host-2",
+        });
+        let closePrepared = false;
+        const closePreparation = manager
+            .prepareHostForClose("host-2")
+            .then(() => {
+                closePrepared = true;
+            });
+
+        await Promise.resolve();
+        expect(closePrepared).toBe(false);
+
+        deferredCommit.resolve();
+        await transfer;
+        await closePreparation;
+
+        expect(closePrepared).toBe(true);
+        expect(hostsNotified).toBe(true);
+        expect(
+            manager.getSurfaceWebContents("host-2", movingContext.key),
+        ).not.toBeNull();
+        await expect(
+            manager.transferSurface({
+                commit: vi.fn(),
+                contextKey: "project-b::__primary__",
+                sourceHostWindowId: "host-1",
+                targetHostWindowId: "host-2",
+            }),
+        ).rejects.toThrow("window is closing");
+    });
+
+    it("allows transfers after reopening a host with the same stable id", async () => {
+        const manager = new WorkspaceSurfaceManager();
+        const sourceHost = createHostWindow();
+        const closedTargetHost = createHostWindow();
+        const sourceSnapshot = createSnapshot();
+        const targetSnapshot = singleContextSnapshot(
+            "project-c::__primary__",
+            "project-c",
+        );
+        const targetContext = {
+            ...createHostContext(),
+            projectId: "project-c",
+            windowId: "host-2",
+            workspaceId: "workspace-2",
+            workspaceSessionId: "workspace-session-2",
+        };
+        manager.syncHost(sourceHost.window, createHostContext(), sourceSnapshot);
+        manager.syncHost(
+            closedTargetHost.window,
+            targetContext,
+            targetSnapshot,
+        );
+
+        await manager.prepareHostForClose("host-2");
+        manager.disposeHost("host-2");
+
+        const reopenedTargetHost = createHostWindow();
+        manager.syncHost(
+            reopenedTargetHost.window,
+            targetContext,
+            targetSnapshot,
+        );
+        const movingContext = sourceSnapshot.contexts[0];
+        if (!movingContext) {
+            throw new Error("Expected a moving context.");
+        }
+        const committedTarget: WorkspaceNavigationSnapshot = {
+            activeContextKey: movingContext.key,
+            contexts: [...targetSnapshot.contexts, movingContext],
+            openContextKeys: [
+                ...targetSnapshot.openContextKeys,
+                movingContext.key,
+            ],
+            version: 3,
+        };
+
+        await expect(
+            manager.transferSurface({
+                commit: () =>
+                    Promise.resolve({
+                        source: createWindowWorkspaceRestoreRecord(
+                            singleContextSnapshot(
+                                "project-b::__primary__",
+                                "project-b",
+                            ),
+                            2,
+                        ),
+                        target: createWindowWorkspaceRestoreRecord(
+                            committedTarget,
+                            2,
+                        ),
+                    }),
+                contextKey: movingContext.key,
+                sourceHostWindowId: "host-1",
+                targetHostWindowId: "host-2",
+            }),
+        ).resolves.toMatchObject({
+            targetSnapshot: committedTarget,
+        });
+        expect(
+            manager.getSurfaceWebContents("host-2", movingContext.key),
+        ).not.toBeNull();
+    });
+
+    it("does not let delayed disposal remove a replacement host generation", async () => {
+        const manager = new WorkspaceSurfaceManager();
+        const sourceHost = createHostWindow();
+        const oldTargetHost = createHostWindow();
+        const sourceSnapshot = createSnapshot();
+        const oldTargetSnapshot = singleContextSnapshot(
+            "project-c::__primary__",
+            "project-c",
+        );
+        const targetContext = {
+            ...createHostContext(),
+            projectId: "project-c",
+            windowId: "host-2",
+            workspaceId: "workspace-2",
+            workspaceSessionId: "workspace-session-2",
+        };
+        manager.syncHost(sourceHost.window, createHostContext(), sourceSnapshot);
+        manager.syncHost(
+            oldTargetHost.window,
+            targetContext,
+            oldTargetSnapshot,
+        );
+        const movingContext = sourceSnapshot.contexts[0];
+        if (!movingContext) {
+            throw new Error("Expected a moving context.");
+        }
+        const committedTarget: WorkspaceNavigationSnapshot = {
+            activeContextKey: movingContext.key,
+            contexts: [...oldTargetSnapshot.contexts, movingContext],
+            openContextKeys: [
+                ...oldTargetSnapshot.openContextKeys,
+                movingContext.key,
+            ],
+            version: 3,
+        };
+        const deferredCommit = createDeferred({
+            source: createWindowWorkspaceRestoreRecord(
+                singleContextSnapshot(
+                    "project-b::__primary__",
+                    "project-b",
+                ),
+                2,
+            ),
+            target: createWindowWorkspaceRestoreRecord(committedTarget, 2),
+        });
+        const transfer = manager.transferSurface({
+            commit: () => deferredCommit.promise,
+            contextKey: movingContext.key,
+            sourceHostWindowId: "host-1",
+            targetHostWindowId: "host-2",
+        });
+
+        manager.disposeHost("host-2");
+        const replacementHost = createHostWindow();
+        const replacementSnapshot = singleContextSnapshot(
+            "project-d::__primary__",
+            "project-d",
+        );
+        manager.syncHost(
+            replacementHost.window,
+            {
+                ...targetContext,
+                projectId: "project-d",
+                workspaceSessionId: "workspace-session-2-reopened",
+            },
+            replacementSnapshot,
+        );
+        await manager.prepareHostForClose(
+            "host-2",
+            oldTargetHost.window,
+        );
+        manager.disposeHost("host-2", oldTargetHost.window);
+
+        deferredCommit.resolve();
+        await transfer;
+        await Promise.resolve();
+
+        expect(manager.getHostSnapshotForWindow("host-2")).toEqual(
+            replacementSnapshot,
+        );
+        expect(
+            manager.getSurfaceWebContents(
+                "host-2",
+                "project-d::__primary__",
+            ),
+        ).not.toBeNull();
+    });
+
+    it("keeps committed ownership when presentation refresh fails", async () => {
+        const manager = new WorkspaceSurfaceManager();
+        const sourceHost = createHostWindow();
+        const targetHost = createHostWindow();
+        const sourceSnapshot = createSnapshot();
+        const targetSnapshot = singleContextSnapshot(
+            "project-c::__primary__",
+            "project-c",
+        );
+        manager.syncHost(sourceHost.window, createHostContext(), sourceSnapshot);
+        manager.syncHost(
+            targetHost.window,
+            {
+                ...createHostContext(),
+                projectId: "project-c",
+                windowId: "host-2",
+                workspaceId: "workspace-2",
+                workspaceSessionId: "workspace-session-2",
+            },
+            targetSnapshot,
+        );
+        const movingContext = sourceSnapshot.contexts[0];
+        if (!movingContext) {
+            throw new Error("Expected a moving context.");
+        }
+        const committedTarget: WorkspaceNavigationSnapshot = {
+            activeContextKey: movingContext.key,
+            contexts: [...targetSnapshot.contexts, movingContext],
+            openContextKeys: [
+                ...targetSnapshot.openContextKeys,
+                movingContext.key,
+            ],
+            version: 3,
+        };
+        targetHost.getContentBounds.mockImplementation(() => {
+            throw new Error("layout failed");
+        });
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+
+        const result = await manager.transferSurface({
+            commit: () =>
+                Promise.resolve({
+                    source: createWindowWorkspaceRestoreRecord(
+                        singleContextSnapshot(
+                            "project-b::__primary__",
+                            "project-b",
+                        ),
+                        2,
+                    ),
+                    target: createWindowWorkspaceRestoreRecord(
+                        committedTarget,
+                        2,
+                    ),
+                }),
+            contextKey: movingContext.key,
+            sourceHostWindowId: "host-1",
+            targetHostWindowId: "host-2",
+        });
+
+        expect(typeof result.surfaceId).toBe("string");
+        expect(
+            manager.getSurfaceWebContents("host-1", movingContext.key),
+        ).toBeNull();
+        expect(
+            manager.getSurfaceWebContents("host-2", movingContext.key),
+        ).not.toBeNull();
+        expect(consoleError).toHaveBeenCalledWith(
+            "[workspace] Failed to refresh surfaces after a committed transfer",
+            expect.any(Error),
+        );
+        consoleError.mockRestore();
+    });
 });
 
 function createHostWindow(): {
+    readonly getContentBounds: ReturnType<typeof vi.fn>;
     readonly send: ReturnType<typeof vi.fn>;
     readonly window: BrowserWindow;
 } {
     const send = vi.fn();
+    const getContentBounds = vi.fn(() => ({
+        height: 800,
+        width: 1200,
+        x: 0,
+        y: 0,
+    }));
     const webContents = {
         getZoomFactor: () => 1,
         isDestroyed: () => false,
@@ -568,12 +932,12 @@ function createHostWindow(): {
             addChildView: vi.fn(),
             removeChildView: vi.fn(),
         },
-        getContentBounds: () => ({ height: 800, width: 1200, x: 0, y: 0 }),
+        getContentBounds,
         isDestroyed: () => false,
         on: vi.fn(),
         webContents,
     } as unknown as BrowserWindow;
-    return { send, window };
+    return { getContentBounds, send, window };
 }
 
 function createHostContext(): WindowContextSnapshot {
@@ -630,6 +994,25 @@ function createPersistedContext(key: string, projectId: string) {
             tabs: [],
         },
         worktreeId: null,
+    };
+}
+
+function createDeferred<T>(value: T): {
+    readonly promise: Promise<T>;
+    readonly resolve: () => void;
+} {
+    let resolvePromise: ((value: T) => void) | null = null;
+    const promise = new Promise<T>((resolve) => {
+        resolvePromise = resolve;
+    });
+    return {
+        promise,
+        resolve: () => {
+            if (!resolvePromise) {
+                throw new Error("Deferred promise was not initialized.");
+            }
+            resolvePromise(value);
+        },
     };
 }
 

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -403,10 +403,21 @@ describe("WorkspaceSurfaceManager action routing", () => {
         const sourceHost = createHostWindow();
         const targetHost = createHostWindow();
         const sourceSnapshot = createSnapshot();
-        const targetSnapshot = singleContextSnapshot(
+        const targetOpenSnapshot = singleContextSnapshot(
             "project-c::__primary__",
             "project-c",
         );
+        const retainedClosedContext = sourceSnapshot.contexts[0];
+        if (!retainedClosedContext) {
+            throw new Error("Expected a retained source context.");
+        }
+        const targetSnapshot: WorkspaceNavigationSnapshot = {
+            ...targetOpenSnapshot,
+            contexts: [
+                ...targetOpenSnapshot.contexts,
+                retainedClosedContext,
+            ],
+        };
         manager.syncHost(
             sourceHost.window,
             createHostContext(),
@@ -437,7 +448,12 @@ describe("WorkspaceSurfaceManager action routing", () => {
         }
         const committedTarget: WorkspaceNavigationSnapshot = {
             activeContextKey: movedContext.key,
-            contexts: [...targetSnapshot.contexts, movedContext],
+            contexts: [
+                ...targetSnapshot.contexts.filter(
+                    (context) => context.key !== movedContext.key,
+                ),
+                movedContext,
+            ],
             openContextKeys: [
                 ...targetSnapshot.openContextKeys,
                 movedContext.key,
@@ -479,6 +495,11 @@ describe("WorkspaceSurfaceManager action routing", () => {
             "project-b::__primary__",
         );
         expect(result.targetSnapshot.activeContextKey).toBe(movedContext.key);
+        expect(
+            result.targetSnapshot.contexts.filter(
+                (context) => context.key === movedContext.key,
+            ),
+        ).toHaveLength(1);
         expect(onSurfaceDestroyed).not.toHaveBeenCalled();
     });
 

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -10,6 +10,7 @@ import { IPC_EVENTS } from "@shared/ipc";
 import {
     areWorkspaceScopesEquivalent,
     areWorkspaceWorktreeIdsEquivalent,
+    hasOpenWorkspaceScope,
     type WorkspaceLocation,
     type WorkspaceScope,
 } from "@shared/workspace-context";
@@ -674,9 +675,7 @@ export class WorkspaceSurfaceManager {
             throw new Error("The workspace context is no longer available.");
         }
         if (
-            targetHost.snapshot.contexts.some((context) =>
-                areWorkspaceScopesEquivalent(context, movingContext),
-            ) ||
+            hasOpenWorkspaceScope(targetHost.snapshot, movingContext) ||
             targetHost.surfaceIdsByContextKey.has(input.contextKey)
         ) {
             throw new Error("The destination already contains this workspace.");

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -65,9 +65,11 @@ interface WorkspaceSurfaceHostRecord {
     activeContextKey: string | null;
     contentInset: number;
     contentLeftInset: number;
+    disposalScheduled: boolean;
     readonly hostWindow: BrowserWindow;
     readonly hostWindowId: string;
     context: WindowContextSnapshot;
+    isClosing: boolean;
     pendingLayoutTimer: NodeJS.Timeout | null;
     snapshot: WorkspaceNavigationSnapshot;
     readonly surfaceIdsByContextKey: Map<string, string>;
@@ -109,6 +111,10 @@ export class WorkspaceSurfaceManager {
         string,
         Set<(ready: boolean) => void>
     >();
+    readonly #pendingTransfersByHost = new Map<
+        WorkspaceSurfaceHostRecord,
+        Set<Promise<void>>
+    >();
     readonly #surfaceIdsByWebContentsId = new Map<number, string>();
     readonly #surfacesById = new Map<string, WorkspaceSurfaceRecord>();
     readonly #actionsById = new Map<
@@ -127,14 +133,21 @@ export class WorkspaceSurfaceManager {
         snapshot: WorkspaceNavigationSnapshot,
     ): WorkspaceNavigationSnapshot {
         let host = this.#hostsByWindowId.get(hostContext.windowId);
+        if (host && host.hostWindow !== hostWindow) {
+            // Stable window ids can be reused by a newly opened BrowserWindow.
+            this.#scheduleHostDisposal(host);
+            host = undefined;
+        }
         if (!host) {
             host = {
                 activeContextKey: null,
                 contentInset: DESKTOP_TITLE_BAR_HEIGHT,
                 contentLeftInset: 0,
+                disposalScheduled: false,
                 hostWindow,
                 hostWindowId: hostContext.windowId,
                 context: hostContext,
+                isClosing: false,
                 pendingLayoutTimer: null,
                 snapshot,
                 surfaceIdsByContextKey: new Map(),
@@ -643,23 +656,51 @@ export class WorkspaceSurfaceManager {
             readonly target: WindowWorkspaceRestoreRecord;
         }>;
         readonly contextKey: string;
+        readonly onCommitted?: (
+            transfer: WorkspaceSurfaceTransferResult,
+        ) => void;
         readonly sourceHostWindowId: string;
         readonly targetHostWindowId: string;
     }): Promise<WorkspaceSurfaceTransferResult> {
         if (input.sourceHostWindowId === input.targetHostWindowId) {
             throw new Error("The workspace is already in the target window.");
         }
-        const sourceHost = this.#hostsByWindowId.get(
+        const reservation = this.#reserveTransfer(
             input.sourceHostWindowId,
-        );
-        const targetHost = this.#hostsByWindowId.get(
             input.targetHostWindowId,
         );
-        const surfaceId = sourceHost?.surfaceIdsByContextKey.get(
+        try {
+            return await this.#transferSurfaceNow(
+                input,
+                reservation.sourceHost,
+                reservation.targetHost,
+            );
+        } finally {
+            reservation.release();
+        }
+    }
+
+    async #transferSurfaceNow(
+        input: {
+            readonly commit: () => Promise<{
+                readonly source: WindowWorkspaceRestoreRecord;
+                readonly target: WindowWorkspaceRestoreRecord;
+            }>;
+            readonly contextKey: string;
+            readonly onCommitted?: (
+                transfer: WorkspaceSurfaceTransferResult,
+            ) => void;
+            readonly sourceHostWindowId: string;
+            readonly targetHostWindowId: string;
+        },
+        sourceHost: WorkspaceSurfaceHostRecord,
+        targetHost: WorkspaceSurfaceHostRecord,
+    ): Promise<WorkspaceSurfaceTransferResult> {
+        const surfaceId = sourceHost.surfaceIdsByContextKey.get(
             input.contextKey,
         );
         const surface = surfaceId ? this.#surfacesById.get(surfaceId) : null;
-        if (!sourceHost || !targetHost || !surface) {
+        if (!surface) {
             throw new Error("The workspace surface is no longer available.");
         }
         if (
@@ -684,6 +725,12 @@ export class WorkspaceSurfaceManager {
         const previousContext = surface.context;
         const previousActionHostIds = new Map<string, string>();
         let attachedToTarget = false;
+        let committed:
+            | {
+                  readonly source: WindowWorkspaceRestoreRecord;
+                  readonly target: WindowWorkspaceRestoreRecord;
+              }
+            | undefined;
         surface.view.setVisible(false);
         surface.isVisible = false;
         surface.bounds = null;
@@ -712,26 +759,7 @@ export class WorkspaceSurfaceManager {
                 action.hostWindowId = targetHost.hostWindowId;
             }
 
-            const committed = await input.commit();
-            sourceHost.snapshot = committed.source.snapshot;
-            sourceHost.activeContextKey =
-                committed.source.snapshot.activeContextKey;
-            targetHost.snapshot = committed.target.snapshot;
-            targetHost.activeContextKey =
-                committed.target.snapshot.activeContextKey;
-            surface.snapshot = toSurfaceSnapshot(
-                committed.target.snapshot,
-                input.contextKey,
-            );
-            this.#rejectInactiveActions(sourceHost);
-            this.#rejectInactiveActions(targetHost);
-            this.#applyVisibility(sourceHost);
-            this.#applyVisibility(targetHost, { focusActive: true });
-            return {
-                sourceSnapshot: sourceHost.snapshot,
-                surfaceId: surface.id,
-                targetSnapshot: targetHost.snapshot,
-            };
+            committed = await input.commit();
         } catch (error) {
             if (attachedToTarget && !targetHost.hostWindow.isDestroyed()) {
                 targetHost.hostWindow.contentView.removeChildView(surface.view);
@@ -759,6 +787,43 @@ export class WorkspaceSurfaceManager {
             });
             throw error;
         }
+
+        // Persistence is now canonical. Never visually roll back beyond this point.
+        sourceHost.snapshot = committed.source.snapshot;
+        sourceHost.activeContextKey = committed.source.snapshot.activeContextKey;
+        targetHost.snapshot = committed.target.snapshot;
+        targetHost.activeContextKey = committed.target.snapshot.activeContextKey;
+        surface.snapshot = toSurfaceSnapshot(
+            committed.target.snapshot,
+            input.contextKey,
+        );
+        const result = {
+            sourceSnapshot: sourceHost.snapshot,
+            surfaceId: surface.id,
+            targetSnapshot: targetHost.snapshot,
+        };
+        try {
+            // Notify host renderers before a waiting window close can flush them.
+            input.onCommitted?.(result);
+        } catch (error) {
+            console.error(
+                "[workspace] Failed to notify hosts after a committed transfer",
+                error,
+            );
+        }
+        try {
+            this.#rejectInactiveActions(sourceHost);
+            this.#rejectInactiveActions(targetHost);
+            this.#applyVisibility(sourceHost);
+            this.#applyVisibility(targetHost, { focusActive: true });
+        } catch (error) {
+            // A later host sync can repair presentation; ownership must remain committed.
+            console.error(
+                "[workspace] Failed to refresh surfaces after a committed transfer",
+                error,
+            );
+        }
+        return result;
     }
 
     activateProject(
@@ -785,11 +850,56 @@ export class WorkspaceSurfaceManager {
         return null;
     }
 
-    disposeHost(hostWindowId: string): void {
-        this.#resolveHostReadyWaiters(hostWindowId, false);
+    async prepareHostForClose(
+        hostWindowId: string,
+        hostWindow?: BrowserWindow,
+    ): Promise<void> {
+        const host = this.#hostsByWindowId.get(hostWindowId);
+        if (!host || (hostWindow && host.hostWindow !== hostWindow)) {
+            return;
+        }
+        // Mark this host generation before existing transfers drain.
+        host.isClosing = true;
+        const pendingTransfers = this.#pendingTransfersByHost.get(host);
+        if (pendingTransfers) {
+            await Promise.allSettled([...pendingTransfers]);
+        }
+    }
+
+    disposeHost(hostWindowId: string, hostWindow?: BrowserWindow): void {
         const host = this.#hostsByWindowId.get(hostWindowId);
         if (!host) {
+            this.#resolveHostReadyWaiters(hostWindowId, false);
             return;
+        }
+        if (hostWindow && host.hostWindow !== hostWindow) {
+            return;
+        }
+        this.#scheduleHostDisposal(host);
+    }
+
+    #scheduleHostDisposal(host: WorkspaceSurfaceHostRecord): void {
+        host.isClosing = true;
+        if (host.disposalScheduled) {
+            return;
+        }
+        host.disposalScheduled = true;
+        const pendingTransfers = this.#pendingTransfersByHost.get(host);
+        if (pendingTransfers?.size) {
+            // Forced window destruction still waits for the atomic move boundary.
+            void Promise.allSettled([...pendingTransfers]).then(() => {
+                this.#disposeHostNow(host);
+            });
+            return;
+        }
+        this.#disposeHostNow(host);
+    }
+
+    #disposeHostNow(host: WorkspaceSurfaceHostRecord): void {
+        const isCurrentHost =
+            this.#hostsByWindowId.get(host.hostWindowId) === host;
+        if (isCurrentHost) {
+            this.#resolveHostReadyWaiters(host.hostWindowId, false);
         }
         if (host.pendingLayoutTimer) {
             clearTimeout(host.pendingLayoutTimer);
@@ -797,7 +907,62 @@ export class WorkspaceSurfaceManager {
         for (const surfaceId of [...host.surfaceIdsByContextKey.values()]) {
             this.#destroySurface(host, surfaceId);
         }
-        this.#hostsByWindowId.delete(hostWindowId);
+        this.#pendingTransfersByHost.delete(host);
+        if (isCurrentHost) {
+            this.#hostsByWindowId.delete(host.hostWindowId);
+        }
+    }
+
+    #reserveTransfer(
+        sourceHostWindowId: string,
+        targetHostWindowId: string,
+    ): {
+        readonly release: () => void;
+        readonly sourceHost: WorkspaceSurfaceHostRecord;
+        readonly targetHost: WorkspaceSurfaceHostRecord;
+    } {
+        const sourceHost = this.#hostsByWindowId.get(sourceHostWindowId);
+        const targetHost = this.#hostsByWindowId.get(targetHostWindowId);
+        if (!sourceHost || !targetHost) {
+            throw new Error("The workspace surface is no longer available.");
+        }
+        if (sourceHost.isClosing || targetHost.isClosing) {
+            throw new Error("A workspace transfer window is closing.");
+        }
+
+        let resolveTransfer: (() => void) | undefined;
+        const transfer = new Promise<void>((resolve) => {
+            resolveTransfer = resolve;
+        });
+        const hosts = [sourceHost, targetHost];
+        for (const host of hosts) {
+            const pendingTransfers =
+                this.#pendingTransfersByHost.get(host) ??
+                new Set<Promise<void>>();
+            pendingTransfers.add(transfer);
+            this.#pendingTransfersByHost.set(host, pendingTransfers);
+        }
+
+        let released = false;
+        return {
+            release: () => {
+                if (released) {
+                    return;
+                }
+                released = true;
+                for (const host of hosts) {
+                    const pendingTransfers =
+                        this.#pendingTransfersByHost.get(host);
+                    pendingTransfers?.delete(transfer);
+                    if (pendingTransfers?.size === 0) {
+                        this.#pendingTransfersByHost.delete(host);
+                    }
+                }
+                resolveTransfer?.();
+            },
+            sourceHost,
+            targetHost,
+        };
     }
 
     #resolveHostReadyWaiters(hostWindowId: string, ready: boolean): void {

--- a/src/shared/workspace-context.test.ts
+++ b/src/shared/workspace-context.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
     areWorkspaceScopesEquivalent,
     getWorkspaceContextKey,
+    hasOpenWorkspaceScope,
     normalizeWorkspaceWorktreeId,
     type WorkspaceLocation,
 } from "./workspace-context";
@@ -48,5 +49,32 @@ describe("workspace context identity", () => {
             contextKey: "project-1::__primary__",
             hostWindowId: "window-1",
         });
+    });
+
+    it("does not treat retained closed contexts as open scopes", () => {
+        const retainedContext = {
+            key: "project-1::__primary__",
+            projectId: "project-1",
+            worktreeId: null,
+        };
+
+        expect(
+            hasOpenWorkspaceScope(
+                {
+                    contexts: [retainedContext],
+                    openContextKeys: [],
+                },
+                retainedContext,
+            ),
+        ).toBe(false);
+        expect(
+            hasOpenWorkspaceScope(
+                {
+                    contexts: [retainedContext],
+                    openContextKeys: [retainedContext.key],
+                },
+                retainedContext,
+            ),
+        ).toBe(true);
     });
 });

--- a/src/shared/workspace-context.ts
+++ b/src/shared/workspace-context.ts
@@ -12,6 +12,11 @@ export interface WorkspaceLocation extends WorkspaceScope {
     readonly hostWindowId: string;
 }
 
+export interface WorkspaceContextCollection {
+    readonly contexts: readonly (WorkspaceScope & { readonly key: string })[];
+    readonly openContextKeys: readonly string[];
+}
+
 export function normalizeWorkspaceWorktreeId(
     projectId: string,
     worktreeId: string | null | undefined,
@@ -58,5 +63,17 @@ export function areWorkspaceScopesEquivalent(
             left.worktreeId,
             right.worktreeId,
         )
+    );
+}
+
+export function hasOpenWorkspaceScope(
+    collection: WorkspaceContextCollection,
+    scope: WorkspaceScope,
+): boolean {
+    const openContextKeys = new Set(collection.openContextKeys);
+    return collection.contexts.some(
+        (context) =>
+            openContextKeys.has(context.key) &&
+            areWorkspaceScopesEquivalent(context, scope),
     );
 }


### PR DESCRIPTION
## Summary

- allow moves when the destination only retains a closed workspace context
- replace stale retained state during the atomic transfer
- coordinate transfers with window closing and reopening

## Testing

- `pnpm run check`