### PR TITLE
Persist pending review expansion per chat

### DIFF
--- a/src/renderer/src/app/store/ai-store.test.ts
+++ b/src/renderer/src/app/store/ai-store.test.ts
@@ -4554,6 +4554,19 @@ describe("ai-store queue", () => {
         ).toBe(true);
     });
 
+    it("keeps the pending review collapse preference per session", () => {
+        useAiStore.getState().registerSessionTab(TAB);
+
+        useAiStore
+            .getState()
+            .setSessionPendingReviewCollapsed(TAB.sessionId, false);
+
+        expect(
+            useAiStore.getState().sessions[TAB.sessionId]
+                ?.isPendingReviewCollapsed,
+        ).toBe(false);
+    });
+
     it("merges incremental session patches without replacing the whole snapshot", () => {
         useAiStore.getState().registerSessionTab(TAB);
         useAiStore.getState().applySessionSnapshot(

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -228,6 +228,7 @@ interface AiSessionClientState {
     readonly draftFileContexts: readonly AiFileContextAttachment[];
     readonly dismissedPlanUpdatedAt: string | null;
     readonly isPlanCollapsed: boolean;
+    readonly isPendingReviewCollapsed: boolean;
     readonly diffZoom: number | null;
     readonly editingQueuedPromptState: QueuedPromptEditState | null;
     readonly editingQueuedPrompt: QueuedPrompt | null;
@@ -298,6 +299,10 @@ interface AiStore {
     clearDraftAttachments: (sessionId: string) => void;
     dismissSessionPlan: (sessionId: string, planUpdatedAt: string) => void;
     setSessionPlanCollapsed: (sessionId: string, collapsed: boolean) => void;
+    setSessionPendingReviewCollapsed: (
+        sessionId: string,
+        collapsed: boolean,
+    ) => void;
     attachSelectionMention: (
         sessionId: string,
         selection: {
@@ -1720,6 +1725,26 @@ export const useAiStore = create<AiStore>((set, get) => ({
         });
     },
 
+    setSessionPendingReviewCollapsed: (sessionId, collapsed) => {
+        set((state) => {
+            const session = state.sessions[sessionId];
+            if (!session || session.isPendingReviewCollapsed === collapsed) {
+                return state;
+            }
+
+            return {
+                sessions: {
+                    ...state.sessions,
+                    [sessionId]: {
+                        ...session,
+                        // Keep this UI preference with the session when its view is cooled.
+                        isPendingReviewCollapsed: collapsed,
+                    },
+                },
+            };
+        });
+    },
+
     ensureSession: async (tab, options) => {
         const currentSession = get().sessions[tab.sessionId] ?? null;
         const shouldHydratePassively =
@@ -2912,6 +2937,7 @@ function createSessionState(
         draftFileContexts: [],
         dismissedPlanUpdatedAt: null,
         isPlanCollapsed: false,
+        isPendingReviewCollapsed: true,
         diffZoom: preferences?.diffZoom ?? null,
         editingQueuedPromptState: null,
         editingQueuedPrompt: null,

--- a/src/renderer/src/components/workspace/ChatTabView.tsx
+++ b/src/renderer/src/components/workspace/ChatTabView.tsx
@@ -246,6 +246,7 @@ type ChatSessionViewState = Pick<
     ReturnType<typeof useAiStore.getState>["sessions"][string],
     | "dismissedPlanUpdatedAt"
     | "isPlanCollapsed"
+    | "isPendingReviewCollapsed"
     | "draftAttachments"
     | "draftComposerParts"
     | "draftFileContexts"
@@ -281,6 +282,7 @@ function selectChatSessionViewState(
     return {
         dismissedPlanUpdatedAt: session.dismissedPlanUpdatedAt,
         isPlanCollapsed: session.isPlanCollapsed,
+        isPendingReviewCollapsed: session.isPendingReviewCollapsed,
         draftAttachments: session.draftAttachments,
         draftComposerParts: session.draftComposerParts,
         draftFileContexts: session.draftFileContexts,
@@ -361,8 +363,6 @@ export const ChatTabView = memo(function ChatTabView({
     onOpenReview,
     tab,
 }: ChatTabViewProps) {
-    // Keep the rail preference while its virtualized surface is temporarily unmounted.
-    const [pendingReviewCollapsed, setPendingReviewCollapsed] = useState(true);
     const aiChatSettings = useAiChatSettings();
     const cancelQueuedPromptEdit = useAiStore((s) => s.cancelQueuedPromptEdit);
     const clearQueuedPrompts = useAiStore((s) => s.clearQueuedPrompts);
@@ -394,6 +394,9 @@ export const ChatTabView = memo(function ChatTabView({
     const dismissSessionPlan = useAiStore((s) => s.dismissSessionPlan);
     const setSessionPlanCollapsed = useAiStore(
         (s) => s.setSessionPlanCollapsed,
+    );
+    const setSessionPendingReviewCollapsed = useAiStore(
+        (s) => s.setSessionPendingReviewCollapsed,
     );
 
     const keepAllTrackedFiles = useAiStore((s) => s.keepAllTrackedFiles);
@@ -882,6 +885,8 @@ export const ChatTabView = memo(function ChatTabView({
         sessionState?.draftFileContexts ?? EMPTY_DRAFT_FILE_CONTEXTS;
     const dismissedPlanUpdatedAt = sessionState?.dismissedPlanUpdatedAt ?? null;
     const isPlanCollapsed = sessionState?.isPlanCollapsed ?? false;
+    const pendingReviewCollapsed =
+        sessionState?.isPendingReviewCollapsed ?? true;
     const editingQueuedPrompt = sessionState?.editingQueuedPrompt ?? null;
     const queuedPrompts = sessionState?.queue ?? [];
     const pendingPermission = snapshot.pendingPermission;
@@ -3107,7 +3112,12 @@ export const ChatTabView = memo(function ChatTabView({
                                     onKeepItem={handleKeepPendingReviewItem}
                                     onOpenItem={handleOpenPendingReviewItem}
                                     onOpenReview={handleOpenReviewTab}
-                                    onCollapsedChange={setPendingReviewCollapsed}
+                                    onCollapsedChange={(collapsed) =>
+                                        setSessionPendingReviewCollapsed(
+                                            tab.sessionId,
+                                            collapsed,
+                                        )
+                                    }
                                     onRejectAll={handleRejectAllPendingReview}
                                     onRejectHunk={handleRejectPendingReviewHunk}
                                     onRejectItem={handleRejectPendingReviewItem}


### PR DESCRIPTION
## Summary
- retain the pending review panel's collapsed state in each chat session
- restore the state when a cooled chat view mounts again
- cover the session preference with an AI store test

## Validation
- pnpm exec vitest run src/renderer/src/app/store/ai-store.test.ts
- pnpm run typecheck
- pnpm exec eslint src/renderer/src/app/store/ai-store.ts src/renderer/src/app/store/ai-store.test.ts src/renderer/src/components/workspace/ChatTabView.tsx