### PR TITLE
Add image viewer context menu

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -17,6 +17,7 @@ import {
     type AiRuntimeId,
     type AiSessionConfigOptionMutationInput,
     type GetAiSessionTranscriptPageInput,
+    type ImageClipboardInput,
     type AiLoadTranscriptPayloadInput,
     type AiLoadTranscriptPayloadsInput,
     type AiLoadReviewDeltaInput,
@@ -157,6 +158,7 @@ import {
     type ReadClaudeCodeTranscriptInput,
     type SearchProjectEntriesInput,
     type SaveProjectFileInput,
+    type SaveImageAsInput,
     type AiQueuedPromptMutationInput,
     type UpdateAiQueuedPromptInput,
     type SettingsSnapshot,
@@ -183,11 +185,13 @@ import {
     dialog,
     ipcMain,
     Menu,
+    nativeImage,
     nativeTheme,
     shell,
     type MessageBoxOptions,
     type MenuItemConstructorOptions,
     type OpenDialogOptions,
+    type SaveDialogOptions,
 } from "electron";
 
 import {
@@ -512,6 +516,40 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
 
         clipboard.writeText(text);
     });
+    ipcMain.handle(
+        IPC_CHANNELS.writeClipboardImage,
+        (_event, input: ImageClipboardInput) => {
+            const image = resolveIpcImage(input);
+            clipboard.writeImage(image);
+        },
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.saveImageAs,
+        async (event, input: SaveImageAsInput) => {
+            assertIpcImageInput(input);
+            if (typeof input.suggestedName !== "string") {
+                throw new TypeError("Expected an image file name.");
+            }
+            const ownerWindow =
+                BrowserWindow.fromWebContents(event.sender) ??
+                BrowserWindow.getFocusedWindow();
+            const dialogOptions: SaveDialogOptions = {
+                defaultPath: path.basename(input.suggestedName.trim()) || "image",
+                title: "Save Image As",
+            };
+            const result = ownerWindow
+                ? await dialog.showSaveDialog(ownerWindow, dialogOptions)
+                : await dialog.showSaveDialog(dialogOptions);
+
+            if (!result.canceled && result.filePath) {
+                // Preserve the original bytes instead of re-encoding the image.
+                await fs.promises.writeFile(
+                    result.filePath,
+                    Buffer.from(input.dataBase64, "base64"),
+                );
+            }
+        },
+    );
     ipcMain.handle(IPC_CHANNELS.openExternalUrl, async (_event, url: string) => {
         if (typeof url !== "string") {
             throw new TypeError("Expected external URL to be a string.");
@@ -3674,4 +3712,30 @@ function deriveRepositoryFolderName(repositoryUrl: string): string {
     const withoutGitSuffix = lastSegment.replace(/\.git$/i, "");
     const sanitized = withoutGitSuffix.replace(/[^\w.-]+/g, "-");
     return sanitized.length > 0 ? sanitized : "repository";
+}
+
+function resolveIpcImage(input: ImageClipboardInput) {
+    assertIpcImageInput(input);
+
+    const image = nativeImage.createFromDataURL(
+        `data:${input.mimeType};base64,${input.dataBase64}`,
+    );
+    if (image.isEmpty()) {
+        throw new TypeError("Expected decodable image data.");
+    }
+
+    return image;
+}
+
+function assertIpcImageInput(
+    input: ImageClipboardInput,
+): asserts input is ImageClipboardInput {
+    if (
+        !input ||
+        typeof input.dataBase64 !== "string" ||
+        typeof input.mimeType !== "string" ||
+        !input.mimeType.startsWith("image/")
+    ) {
+        throw new TypeError("Expected valid image data.");
+    }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -64,6 +64,7 @@ import {
     type FileBufferNotificationInput,
     type EnqueueAiPromptInput,
     type GetAiSessionTranscriptPageInput,
+    type ImageClipboardInput,
     type ListAiSessionHistoryInput,
     type ListProjectTreeInput,
     type OpenProjectWindowInput,
@@ -180,6 +181,7 @@ import {
     type ResizeTerminalSessionInput,
     type SearchProjectEntriesInput,
     type SaveProjectFileInput,
+    type SaveImageAsInput,
     type UpdateAiQueuedPromptInput,
     type SettingsSnapshot,
     type SettingsUpdatedEvent,
@@ -1092,6 +1094,10 @@ const comandoApi: ComandoApi = {
         ),
     saveProjectFile: (input: SaveProjectFileInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.saveProjectFile, input),
+    writeClipboardImage: (input: ImageClipboardInput) =>
+        ipcRenderer.invoke(IPC_CHANNELS.writeClipboardImage, input),
+    saveImageAs: (input: SaveImageAsInput) =>
+        ipcRenderer.invoke(IPC_CHANNELS.saveImageAs, input),
     createProjectEntry: (input: CreateProjectEntryInput) =>
         ipcRenderer.invoke(IPC_CHANNELS.createProjectEntry, input),
     copyProjectEntries: async (input: CopyProjectEntriesInput) =>

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -7219,18 +7219,40 @@ function ImageFileView({
     readonly document: ProjectFileDocument;
 }) {
     const imageSrc = buildImageDataUrl(document);
+    const imageClipboardInput =
+        imageSrc && document.imageDataBase64 && document.mimeType
+            ? {
+                  dataBase64: document.imageDataBase64,
+                  mimeType: document.mimeType,
+              }
+            : null;
     const [scale, setScale] = useState(1);
     const [translate, setTranslate] = useState({ x: 0, y: 0 });
+    const [fitToView, setFitToView] = useState(true);
     const [isDragging, setIsDragging] = useState(false);
+    const [contextMenu, setContextMenu] =
+        useState<ContextMenuState<void> | null>(null);
     const isDraggingRef = useRef(false);
     const lastPointer = useRef({ x: 0, y: 0 });
     const containerRef = useRef<HTMLDivElement>(null);
 
-    const isZoomed = scale !== 1;
-
     const resetView = useCallback(() => {
         setScale(1);
         setTranslate({ x: 0, y: 0 });
+        setFitToView(true);
+    }, []);
+
+    const setActualSize = useCallback(() => {
+        setScale(1);
+        setTranslate({ x: 0, y: 0 });
+        setFitToView(false);
+    }, []);
+
+    const updateZoom = useCallback((factor: number) => {
+        setFitToView(false);
+        setScale((current) =>
+            Math.min(IMAGE_ZOOM_MAX, Math.max(IMAGE_ZOOM_MIN, current * factor)),
+        );
     }, []);
 
     // Reset view when document changes
@@ -7271,15 +7293,18 @@ function ImageFileView({
                 }));
                 return next;
             });
+            setFitToView(false);
         };
 
         container.addEventListener("wheel", onWheel, { passive: false });
         return () => container.removeEventListener("wheel", onWheel);
     }, []);
 
+    const isPannable = scale !== 1 || !fitToView;
+
     const handlePointerDown = useCallback(
         (event: React.PointerEvent<HTMLDivElement>) => {
-            if (!isZoomed) return;
+            if (!isPannable) return;
             isDraggingRef.current = true;
             setIsDragging(true);
             lastPointer.current = { x: event.clientX, y: event.clientY };
@@ -7287,7 +7312,7 @@ function ImageFileView({
                 event.pointerId,
             );
         },
-        [isZoomed],
+        [isPannable],
     );
 
     const handlePointerMove = useCallback(
@@ -7318,7 +7343,15 @@ function ImageFileView({
                 onPointerDown={handlePointerDown}
                 onPointerMove={handlePointerMove}
                 onPointerUp={handlePointerUp}
-                style={{ cursor: isZoomed ? "grab" : undefined }}
+                onContextMenu={(event) => {
+                    event.preventDefault();
+                    setContextMenu({
+                        x: event.clientX,
+                        y: event.clientY,
+                        payload: undefined,
+                    });
+                }}
+                style={{ cursor: isPannable ? "grab" : undefined }}
             >
                 {imageSrc ? (
                     <img
@@ -7328,8 +7361,8 @@ function ImageFileView({
                         onDoubleClick={resetView}
                         src={imageSrc}
                         style={{
-                            maxHeight: scale === 1 ? "100%" : undefined,
-                            maxWidth: scale === 1 ? "100%" : undefined,
+                            maxHeight: fitToView ? "100%" : undefined,
+                            maxWidth: fitToView ? "100%" : undefined,
                             transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
                             transformOrigin: "center center",
                             transition: isDragging
@@ -7347,7 +7380,7 @@ function ImageFileView({
                         </p>
                     </div>
                 )}
-                {isZoomed && (
+                {isPannable && (
                     <div
                         className="absolute bottom-3 left-1/2 -translate-x-1/2 rounded-md px-2 py-0.5 text-[10px] font-medium tabular-nums text-text-secondary"
                         style={{
@@ -7362,6 +7395,66 @@ function ImageFileView({
                     </div>
                 )}
             </div>
+            {contextMenu && imageClipboardInput ? (
+                <ContextMenu
+                    entries={[
+                        {
+                            label: "Copy Image",
+                            action: () =>
+                                void window.comando.writeClipboardImage({
+                                    ...imageClipboardInput,
+                                }),
+                        },
+                        {
+                            label: "Copy File Path",
+                            action: () =>
+                                void window.comando.writeClipboardText(
+                                    document.absolutePath,
+                                ),
+                        },
+                        {
+                            label: "Save As…",
+                            action: () =>
+                                void window.comando.saveImageAs({
+                                    ...imageClipboardInput,
+                                    suggestedName: document.name,
+                                }),
+                        },
+                        { type: "separator" },
+                        {
+                            label: "Zoom In",
+                            action: () => updateZoom(1.25),
+                            disabled: scale >= IMAGE_ZOOM_MAX,
+                        },
+                        {
+                            label: "Zoom Out",
+                            action: () => updateZoom(0.8),
+                            disabled: scale <= IMAGE_ZOOM_MIN,
+                        },
+                        {
+                            label: "Actual Size",
+                            action: setActualSize,
+                            disabled: scale === 1 && !fitToView,
+                        },
+                        {
+                            label: "Fit to View",
+                            action: resetView,
+                            disabled: fitToView && scale === 1,
+                        },
+                        {
+                            label: "Reset View",
+                            action: resetView,
+                            disabled:
+                                fitToView &&
+                                scale === 1 &&
+                                translate.x === 0 &&
+                                translate.y === 0,
+                        },
+                    ]}
+                    menu={contextMenu}
+                    onClose={() => setContextMenu(null)}
+                />
+            ) : null}
         </div>
     );
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -19,6 +19,8 @@ export const IPC_CHANNELS = {
     getWindowContext: "app:get-window-context",
     readClipboardText: "app:read-clipboard-text",
     writeClipboardText: "app:write-clipboard-text",
+    writeClipboardImage: "app:write-clipboard-image",
+    saveImageAs: "app:save-image-as",
     openExternalUrl: "app:open-external-url",
     openGeneratedImage: "app:open-generated-image",
     revealGeneratedImage: "app:reveal-generated-image",
@@ -3420,6 +3422,15 @@ export interface ConfirmWorkspaceCloseInput {
     readonly workspaceName: string;
 }
 
+export interface ImageClipboardInput {
+    readonly dataBase64: string;
+    readonly mimeType: string;
+}
+
+export interface SaveImageAsInput extends ImageClipboardInput {
+    readonly suggestedName: string;
+}
+
 export interface ComandoApi {
     getBootstrapSnapshot: () => Promise<AppBootstrapSnapshot>;
     getAppUpdateState: () => Promise<AppUpdateState>;
@@ -3432,6 +3443,8 @@ export interface ComandoApi {
     readClipboardText: () => Promise<string>;
     resolveDroppedFilePath: (file: File | null) => string | null;
     writeClipboardText: (text: string) => Promise<void>;
+    writeClipboardImage: (input: ImageClipboardInput) => Promise<void>;
+    saveImageAs: (input: SaveImageAsInput) => Promise<void>;
     openExternalUrl: (url: string) => Promise<void>;
     openGeneratedImage: (path: string) => Promise<void>;
     revealGeneratedImage: (path: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- add image context actions for copy, path copy, and Save As
- add zoom, actual-size, fit, and reset controls
- use native IPC for image clipboard and save dialogs

## Validation
- pnpm run typecheck
- pnpm exec eslint src/main/ipc/index.ts src/preload/index.ts src/shared/ipc.ts src/renderer/src/components/workspace/WorkspaceView.tsx
- pnpm test