### PR TITLE
fix(ai): make transcript history recovery durable

### DIFF
--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -229,6 +229,7 @@ impl NativeBackend {
             | "ai_checkpoint_open_transcript_tail"
             | "ai_load_open_transcript_tail"
             | "ai_seal_transcript_turn"
+            | "ai_reconcile_terminal_open_transcript_tail"
             | "ai_load_transcript_block_metadata"
             | "ai_load_transcript_block"
             | "ai_load_transcript_payload"
@@ -367,6 +368,7 @@ impl NativeBackend {
             | "ai_checkpoint_open_transcript_tail"
             | "ai_load_open_transcript_tail"
             | "ai_seal_transcript_turn"
+            | "ai_reconcile_terminal_open_transcript_tail"
             | "ai_load_transcript_block_metadata"
             | "ai_load_transcript_block"
             | "ai_load_transcript_payload"
@@ -2459,6 +2461,27 @@ impl NativeBackend {
                         request.id,
                         serde_json::to_value(metadata)
                             .expect("AI sealed transcript metadata serializes"),
+                    ),
+                    Err(error) => error_only(request.id, error),
+                }
+            }
+            "ai_reconcile_terminal_open_transcript_tail" => {
+                let input = match parse_args::<
+                    native_ai::NativeAiReconcileTerminalOpenTranscriptTailInput,
+                >(&request)
+                {
+                    Ok(input) => input,
+                    Err(error) => return error_only(request.id, error),
+                };
+                match self.ai_history_store().and_then(|store| {
+                    store
+                        .reconcile_terminal_open_transcript_tail(&input.session_id, &input.turn_id)
+                        .map_err(|error| error.to_native_error())
+                }) {
+                    Ok(metadata) => response_only(
+                        request.id,
+                        serde_json::to_value(metadata)
+                            .expect("AI reconciled transcript metadata serializes"),
                     ),
                     Err(error) => error_only(request.id, error),
                 }

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -1040,9 +1040,14 @@ impl AiHistoryStore {
             }
 
             let metadata_path = entry.path().join(SESSION_META_FILE);
-            let Ok(metadata) = read_json_file::<AiHistorySessionMetadata>(&metadata_path) else {
+            let Ok(initial_metadata) = read_json_file::<AiHistorySessionMetadata>(&metadata_path)
+            else {
                 continue;
             };
+            // A synced JSONL write can have a pending marker while metadata
+            // still says zero messages. Recover before applying visibility filters.
+            self.recover_if_needed(&initial_metadata.session_id)?;
+            let metadata: AiHistorySessionMetadata = read_json_file(&metadata_path)?;
             if metadata.project_id != input.project_id {
                 continue;
             }
@@ -4586,7 +4591,7 @@ mod tests {
 
     #[test]
     fn transcript_write_recovery_restores_metadata_for_a_first_synced_write() {
-        let (_temp, store) = store();
+        let (temp, store) = store();
         let session_id = SessionId("recover_first_transcript_write_metadata".to_string());
         store.create_session(metadata(&session_id.0)).unwrap();
 
@@ -4631,25 +4636,11 @@ mod tests {
             .and_then(|_| file.sync_all())
             .unwrap();
 
-        let page = store
-            .load_transcript_page(NativeAiLoadSessionTranscriptPageInput {
-                session_id: session_id.clone(),
-                offset: 0,
-                limit: 10,
-            })
-            .unwrap()
-            .unwrap();
-        assert_eq!(page.messages, vec![first_message]);
-        assert!(!store.transcript_write_marker_path(&session_id).exists());
-
-        let recovered_metadata = store.load_metadata(&session_id).unwrap();
-        assert_eq!(
-            recovered_metadata.message_count,
-            target_metadata.message_count
-        );
-        assert_eq!(recovered_metadata.preview, target_metadata.preview);
-        assert_eq!(recovered_metadata.updated_at, target_metadata.updated_at);
-        let history = store
+        // Listing history is the first operation after restart, so it must
+        // recover the pending marker before filtering zero-message sessions.
+        drop(store);
+        let reopened = AiHistoryStore::new(temp.path()).unwrap();
+        let history = reopened
             .list_session_history(NativeAiListSessionHistoryInput {
                 project_id: Some(ProjectId("project_1".to_string())),
                 worktree_id: Some(WorktreeId("worktree_1".to_string())),
@@ -4658,6 +4649,25 @@ mod tests {
             .unwrap();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].session_id, session_id);
+        assert!(!reopened.transcript_write_marker_path(&session_id).exists());
+
+        let page = reopened
+            .load_transcript_page(NativeAiLoadSessionTranscriptPageInput {
+                session_id: session_id.clone(),
+                offset: 0,
+                limit: 10,
+            })
+            .unwrap()
+            .unwrap();
+        assert_eq!(page.messages, vec![first_message]);
+
+        let recovered_metadata = reopened.load_metadata(&session_id).unwrap();
+        assert_eq!(
+            recovered_metadata.message_count,
+            target_metadata.message_count
+        );
+        assert_eq!(recovered_metadata.preview, target_metadata.preview);
+        assert_eq!(recovered_metadata.updated_at, target_metadata.updated_at);
     }
 
     #[test]

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -579,6 +579,10 @@ impl AiHistoryStore {
         metadata.preview = derive_session_preview(records.iter().map(|record| &record.payload));
         metadata.updated_at = now_iso8601();
         self.save_index(session_id, &next_index)?;
+        if reuse_len < index.len() || reuse_len < records.len() {
+            self.transcript_store(session_id)
+                .invalidate_legacy_transcript_backfill_from(session_id, reuse_len)?;
+        }
         self.save_metadata(&metadata)?;
         self.compact_transcript_if_needed(session_id)?;
         Ok(())
@@ -765,6 +769,11 @@ impl AiHistoryStore {
         let legacy_fallback_available = self.transcript_path(session_id).exists();
         let legacy_transcript_pending = legacy_fallback_available
             && self.with_legacy_transcript_backfill_index(session_id, |index| {
+                // Every session starts with an empty compatibility file; it
+                // is not migration input until it contains a record.
+                if index.len() == 0 {
+                    return Ok(false);
+                }
                 if transcript_store
                     .legacy_transcript_backfill_is_current(session_id, index.len())?
                 {
@@ -2474,7 +2483,14 @@ fn legacy_transcript_entry(
         .and_then(Value::as_str)
         .map(str::to_string)
         .unwrap_or_else(now_iso8601);
-    let payload_ref = format!("legacy-message:{message_id}");
+    let payload_value = json!({ "kind": "message", "message": message });
+    // Payload refs include their content version because sealed payloads are
+    // immutable while the compatibility transcript may revise a message.
+    let payload_ref = format!(
+        "legacy-message:{}:{}",
+        sha256_hex(message_id.as_bytes()),
+        hash_message_payload(&payload_value)?
+    );
     let preview = message_preview_text(&message).map(truncate_session_preview);
 
     Ok((
@@ -2504,7 +2520,7 @@ fn legacy_transcript_entry(
         },
         AiTranscriptPayloadWrite {
             payload_ref,
-            value: json!({ "kind": "message", "message": message }),
+            value: payload_value,
         },
     ))
 }
@@ -4126,7 +4142,11 @@ mod tests {
             .unwrap();
         assert_eq!(block.entries.len(), 2);
         let payload = store
-            .load_native_transcript_payload(&session_id, "legacy-message:legacy-1", 1024)
+            .load_native_transcript_payload(
+                &session_id,
+                block.entries[0].payload_ref.as_deref().unwrap(),
+                1024,
+            )
             .unwrap();
         assert_eq!(payload.value["kind"], "message");
         assert_eq!(payload.value["message"]["id"], "legacy-1");
@@ -4209,6 +4229,44 @@ mod tests {
                 .messages
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn transcript_storage_state_reconciles_a_revised_legacy_message() {
+        let (_temp, store) = store();
+        let session_id = SessionId("reconcile_revised_legacy_message".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store
+            .save_transcript_window(&session_id, vec![message("legacy-1", "draft")])
+            .unwrap();
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+
+        store
+            .save_transcript_window(&session_id, vec![message("legacy-1", "complete")])
+            .unwrap();
+        let fallback = store.load_session_snapshot(&session_id).unwrap().unwrap();
+        assert_eq!(fallback.messages[0]["content"], "complete");
+
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+        let metadata = store.load_transcript_block_metadata(&session_id).unwrap();
+        let block = store
+            .load_transcript_block(&session_id, &metadata[0].block_id)
+            .unwrap()
+            .unwrap();
+        let payload = store
+            .load_native_transcript_payload(
+                &session_id,
+                block.entries[0].payload_ref.as_deref().unwrap(),
+                1024,
+            )
+            .unwrap();
+        assert_eq!(payload.value["message"]["content"], "complete");
     }
 
     #[test]

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -4270,6 +4270,119 @@ mod tests {
     }
 
     #[test]
+    fn transcript_storage_state_removes_entries_truncated_from_legacy_history() {
+        let (_temp, store) = store();
+        let session_id = SessionId("truncate_legacy_transcript".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store
+            .save_transcript_window(
+                &session_id,
+                vec![message("legacy-1", "first"), message("legacy-2", "removed")],
+            )
+            .unwrap();
+        store.transcript_storage_state(&session_id).unwrap();
+        let metadata = store.load_transcript_block_metadata(&session_id).unwrap();
+        let obsolete_payload_ref = store
+            .load_transcript_block(&session_id, &metadata[0].block_id)
+            .unwrap()
+            .unwrap()
+            .entries
+            .into_iter()
+            .find(|entry| entry.id == "message:legacy-2")
+            .unwrap()
+            .payload_ref
+            .unwrap();
+
+        store
+            .save_transcript_window(&session_id, vec![message("legacy-1", "first")])
+            .unwrap();
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+
+        let metadata = store.load_transcript_block_metadata(&session_id).unwrap();
+        let entries = metadata
+            .iter()
+            .flat_map(|block| {
+                store
+                    .load_transcript_block(&session_id, &block.block_id)
+                    .unwrap()
+                    .unwrap()
+                    .entries
+            })
+            .map(|entry| entry.id)
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec!["message:legacy-1"]);
+        assert!(
+            store
+                .load_native_transcript_payload(&session_id, &obsolete_payload_ref, 1024)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn transcript_storage_state_replaces_legacy_entries_with_new_ids() {
+        let (_temp, store) = store();
+        let session_id = SessionId("replace_legacy_transcript_id".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store
+            .save_transcript_window(
+                &session_id,
+                vec![
+                    message("legacy-1", "first"),
+                    message("legacy-2", "replaced"),
+                ],
+            )
+            .unwrap();
+        store.transcript_storage_state(&session_id).unwrap();
+        let metadata = store.load_transcript_block_metadata(&session_id).unwrap();
+        let obsolete_payload_ref = store
+            .load_transcript_block(&session_id, &metadata[0].block_id)
+            .unwrap()
+            .unwrap()
+            .entries
+            .into_iter()
+            .find(|entry| entry.id == "message:legacy-2")
+            .unwrap()
+            .payload_ref
+            .unwrap();
+
+        store
+            .save_transcript_window(
+                &session_id,
+                vec![
+                    message("legacy-1", "first"),
+                    message("legacy-3", "replacement"),
+                ],
+            )
+            .unwrap();
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+
+        let metadata = store.load_transcript_block_metadata(&session_id).unwrap();
+        let entries = metadata
+            .iter()
+            .flat_map(|block| {
+                store
+                    .load_transcript_block(&session_id, &block.block_id)
+                    .unwrap()
+                    .unwrap()
+                    .entries
+            })
+            .map(|entry| entry.id)
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec!["message:legacy-1", "message:legacy-3"]);
+        assert!(
+            store
+                .load_native_transcript_payload(&session_id, &obsolete_payload_ref, 1024)
+                .is_err()
+        );
+    }
+
+    #[test]
     fn transcript_storage_state_resumes_a_partial_legacy_backfill() {
         let (_temp, store) = store();
         let session_id = SessionId("resume_legacy_transcript_backfill".to_string());

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -775,8 +775,14 @@ impl AiHistoryStore {
             && legacy_fallback_available
             && self.with_legacy_transcript_backfill_index(session_id, |index| {
                 // Every session starts with an empty compatibility file; it
-                // is not migration input until it contains a record.
+                // is not migration input until it contains a record. A
+                // previously invalidated backfill still needs completion.
                 if index.len() == 0 {
+                    if transcript_store.has_data_source()
+                        && !transcript_store.legacy_transcript_backfill_complete(session_id)?
+                    {
+                        transcript_store.advance_legacy_transcript_backfill(session_id, 0, true)?;
+                    }
                     return Ok(false);
                 }
                 if transcript_store
@@ -4414,6 +4420,37 @@ mod tests {
                 .load_native_transcript_payload(&session_id, &obsolete_payload_ref, 1024)
                 .is_err()
         );
+    }
+
+    #[test]
+    fn transcript_storage_state_completes_a_legacy_backfill_truncated_to_empty() {
+        let (_temp, store) = store();
+        let session_id = SessionId("empty_legacy_transcript_after_truncation".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store
+            .save_transcript_window(&session_id, vec![message("legacy-1", "first")])
+            .unwrap();
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+
+        store
+            .save_transcript_window(&session_id, Vec::new())
+            .unwrap();
+
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+        assert!(
+            store
+                .load_transcript_block_metadata(&session_id)
+                .unwrap()
+                .is_empty()
+        );
+        let snapshot = store.load_session_snapshot(&session_id).unwrap().unwrap();
+        assert!(snapshot.messages.is_empty());
     }
 
     #[test]

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -581,8 +581,16 @@ impl AiHistoryStore {
         if reuse_len < index.len() || reuse_len < records.len() {
             // Keep the previous index visible until SQLite has acknowledged
             // the invalidation, so a retry recomputes the same changed tail.
+            let stale_legacy_entry_ids = index.message_ids[reuse_len..]
+                .iter()
+                .map(|message_id| format!("message:{message_id}"))
+                .collect::<Vec<_>>();
             self.transcript_store(session_id)
-                .invalidate_legacy_transcript_backfill_from(session_id, reuse_len)?;
+                .invalidate_legacy_transcript_backfill_from(
+                    session_id,
+                    reuse_len,
+                    &stale_legacy_entry_ids,
+                )?;
         }
         self.save_index(session_id, &next_index)?;
         self.save_metadata(&metadata)?;
@@ -4611,6 +4619,63 @@ mod tests {
                 .sum::<usize>(),
             300
         );
+    }
+
+    #[test]
+    fn transcript_reconciliation_removes_replaced_legacy_entry_after_native_gap() {
+        let (_temp, store) = store();
+        let session_id = SessionId("mixed_transcript_reconciliation".to_string());
+        let mut messages = (0..300)
+            .map(|index| message(&format!("legacy-{index}"), "legacy content"))
+            .collect::<Vec<_>>();
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store
+            .save_transcript_window(&session_id, messages.clone())
+            .unwrap();
+
+        let transcript_store = store.transcript_store(&session_id);
+        transcript_store
+            .begin_legacy_transcript_backfill(&session_id)
+            .unwrap();
+        let (native_entry, native_payload) =
+            legacy_transcript_entry(&session_id, messages[0].clone()).unwrap();
+        transcript_store
+            .seal_turn(
+                &session_id,
+                "native-turn",
+                vec![native_entry],
+                vec![native_payload],
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::Migrating
+        );
+
+        messages[100] = message("legacy-replacement", "replacement content");
+        store.save_transcript_window(&session_id, messages).unwrap();
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+
+        let entry_ids = store
+            .load_transcript_block_metadata(&session_id)
+            .unwrap()
+            .into_iter()
+            .flat_map(|block| {
+                store
+                    .load_transcript_block(&session_id, &block.block_id)
+                    .unwrap()
+                    .unwrap()
+                    .entries
+            })
+            .map(|entry| entry.id)
+            .collect::<Vec<_>>();
+        assert_eq!(entry_ids.len(), 300);
+        assert!(!entry_ids.contains(&"message:legacy-100".to_string()));
+        assert!(entry_ids.contains(&"message:legacy-replacement".to_string()));
     }
 
     #[test]

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -764,14 +764,17 @@ impl AiHistoryStore {
         let migration_manifest_exists = self.history_root().join("migrations").exists();
         let legacy_fallback_available = self.transcript_path(session_id).exists();
         let legacy_transcript_pending = legacy_fallback_available
-            && !transcript_store.legacy_transcript_backfill_complete(session_id)?
             && self.with_legacy_transcript_backfill_index(session_id, |index| {
-                if index.len() > 0 {
-                    self.backfill_legacy_transcript_page(session_id, index)?;
-                    Ok(true)
-                } else {
-                    Ok(false)
+                if transcript_store
+                    .legacy_transcript_backfill_is_current(session_id, index.len())?
+                {
+                    return Ok(false);
                 }
+                self.backfill_legacy_transcript_page(session_id, index)?;
+                // A single invocation can finish a small transcript. Keep the
+                // caller in migrating mode only while more pages remain.
+                Ok(!transcript_store
+                    .legacy_transcript_backfill_is_current(session_id, index.len())?)
             })?;
         let mode = if transcript_store.has_data_source()
             && transcript_store.legacy_transcript_backfill_complete(session_id)?
@@ -801,7 +804,12 @@ impl AiHistoryStore {
         index: &AiTranscriptIndex,
     ) -> AiResult<()> {
         let transcript_store = self.transcript_store(session_id);
-        if transcript_store.legacy_transcript_backfill_complete(session_id)? {
+        let offset = transcript_store
+            .legacy_transcript_backfill_next_offset(session_id)?
+            .min(index.len());
+        if transcript_store.legacy_transcript_backfill_complete(session_id)?
+            && offset >= index.len()
+        {
             return Ok(());
         }
 
@@ -4155,6 +4163,52 @@ mod tests {
         let snapshot = store.load_session_snapshot(&session_id).unwrap().unwrap();
         assert_eq!(snapshot.messages.len(), 3);
         assert_eq!(snapshot.messages[2]["id"], "legacy-3");
+    }
+
+    #[test]
+    fn transcript_storage_state_resumes_a_completed_backfill_when_legacy_history_grows() {
+        let (_temp, store) = store();
+        let session_id = SessionId("resume_completed_legacy_backfill".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store
+            .save_transcript_window(&session_id, vec![message("legacy-1", "first")])
+            .unwrap();
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+
+        store
+            .save_transcript_window(
+                &session_id,
+                vec![
+                    message("legacy-1", "first"),
+                    message("legacy-2", "second"),
+                    message("legacy-3", "third"),
+                ],
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+        let metadata = store.load_transcript_block_metadata(&session_id).unwrap();
+        assert_eq!(
+            metadata
+                .iter()
+                .map(|block| block.entry_count)
+                .sum::<usize>(),
+            3
+        );
+        assert!(
+            store
+                .load_session_snapshot(&session_id)
+                .unwrap()
+                .unwrap()
+                .messages
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -828,6 +828,26 @@ impl AiHistoryStore {
         transcript_store.advance_legacy_transcript_backfill(session_id, end, end == index.len())
     }
 
+    fn has_current_block_native_transcript(
+        &self,
+        session_id: &SessionId,
+        transcript_store: &TranscriptStore,
+    ) -> AiResult<bool> {
+        if !transcript_store.has_data_source()
+            || !transcript_store.legacy_transcript_backfill_complete(session_id)?
+        {
+            return Ok(false);
+        }
+        if !self.transcript_path(session_id).exists() {
+            return Ok(true);
+        }
+
+        // A completed flag alone is stale when the compatibility transcript
+        // continues growing after its initial backfill.
+        let index = self.load_or_repair_index(session_id)?;
+        transcript_store.legacy_transcript_backfill_is_current(session_id, index.len())
+    }
+
     pub fn load_session_snapshot(
         &self,
         session_id: &SessionId,
@@ -838,8 +858,8 @@ impl AiHistoryStore {
         let metadata = self.load_metadata(session_id)?;
         let state = self.load_session_state(session_id)?;
         let transcript_store = self.transcript_store(session_id);
-        let is_block_native = transcript_store.has_data_source()
-            && transcript_store.legacy_transcript_backfill_complete(session_id)?;
+        let is_block_native =
+            self.has_current_block_native_transcript(session_id, &transcript_store)?;
         // Block-native sessions expose their sealed history through the paged
         // transcript APIs. Loading it here would reintroduce an O(history)
         // startup path before the renderer can hydrate its bounded window.
@@ -4106,6 +4126,35 @@ mod tests {
         let snapshot = store.load_session_snapshot(&session_id).unwrap().unwrap();
         assert!(snapshot.messages.is_empty());
         assert!(snapshot.tool_activity.is_empty());
+    }
+
+    #[test]
+    fn snapshot_keeps_a_legacy_transcript_visible_when_a_completed_backfill_is_stale() {
+        let (_temp, store) = store();
+        let session_id = SessionId("stale_legacy_backfill_snapshot".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store
+            .save_transcript_window(&session_id, vec![message("legacy-1", "first")])
+            .unwrap();
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+
+        store
+            .save_transcript_window(
+                &session_id,
+                vec![
+                    message("legacy-1", "first"),
+                    message("legacy-2", "second"),
+                    message("legacy-3", "third"),
+                ],
+            )
+            .unwrap();
+
+        let snapshot = store.load_session_snapshot(&session_id).unwrap().unwrap();
+        assert_eq!(snapshot.messages.len(), 3);
+        assert_eq!(snapshot.messages[2]["id"], "legacy-3");
     }
 
     #[test]

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -5065,6 +5065,79 @@ mod tests {
     }
 
     #[test]
+    fn interrupted_native_tail_is_absent_from_sealed_history_after_restart() {
+        let (temp, store) = store();
+        let session_id = SessionId("interrupted_native_tail".to_string());
+        let legacy_message = message("assistant-1", "Recovered streamed output.");
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store
+            .save_transcript_window(&session_id, vec![legacy_message.clone()])
+            .unwrap();
+
+        let mut entry = transcript_entry(
+            &session_id,
+            "message:assistant-1",
+            "Recovered streamed output.",
+        );
+        entry.payload_ref = Some("tail:assistant-1".to_string());
+        store
+            .checkpoint_open_transcript_tail(NativeAiCheckpointOpenTranscriptTailInput {
+                session_id: session_id.clone(),
+                turn_id: "interrupted-turn".to_string(),
+                terminal_status: None,
+                entries: vec![entry],
+                payloads: vec![AiTranscriptPayloadWrite {
+                    payload_ref: "tail:assistant-1".to_string(),
+                    value: json!({ "kind": "message", "message": legacy_message }),
+                }],
+                removed_entry_ids: Vec::new(),
+                entry_order: vec![NativeAiOpenTranscriptEntryRef {
+                    entry_id: "message:assistant-1".to_string(),
+                    entry_revision: 1,
+                    ordinal: 0,
+                }],
+            })
+            .unwrap();
+        drop(store);
+
+        let reopened = AiHistoryStore::new(temp.path()).unwrap();
+        let snapshot = reopened
+            .load_session_snapshot(&session_id)
+            .unwrap()
+            .unwrap();
+        let page = reopened
+            .load_transcript_page(NativeAiLoadSessionTranscriptPageInput {
+                session_id: session_id.clone(),
+                offset: 0,
+                limit: 10,
+            })
+            .unwrap()
+            .unwrap();
+
+        // The native snapshot delegates history to sealed blocks, but an
+        // interrupted tail has not produced one yet.
+        assert!(snapshot.messages.is_empty());
+        assert_eq!(page.messages.len(), 1);
+        assert!(
+            reopened
+                .load_transcript_block_metadata(&session_id)
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            reopened
+                .load_open_transcript_tail(&session_id)
+                .unwrap()
+                .unwrap()
+                .entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["message:assistant-1"]
+        );
+    }
+
+    #[test]
     fn sealing_turn_persists_payload_and_stable_block_revision() {
         let (_temp, store) = store();
         let session_id = SessionId("sealed_turn".to_string());

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -671,6 +671,15 @@ impl AiHistoryStore {
             .seal_turn(session_id, turn_id, entries, payloads)
     }
 
+    pub fn reconcile_terminal_open_transcript_tail(
+        &self,
+        session_id: &SessionId,
+        turn_id: &str,
+    ) -> AiResult<Vec<NativeAiTranscriptBlockMetadata>> {
+        self.transcript_store(session_id)
+            .reconcile_terminal_open_tail(session_id, turn_id)
+    }
+
     pub fn checkpoint_open_transcript_tail(
         &self,
         input: NativeAiCheckpointOpenTranscriptTailInput,

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -37,6 +37,7 @@ const SESSION_STATE_FILE: &str = "session-state.json";
 const SESSION_TRANSCRIPT_FILE: &str = "transcript.jsonl";
 const SESSION_INDEX_FILE: &str = "index.json";
 const SESSION_COMPACT_STATE_FILE: &str = "compact-state.json";
+const SESSION_TRANSCRIPT_WRITE_STATE_FILE: &str = "transcript-write-state.json";
 const SESSION_TOOL_DETAILS_FILE: &str = "tool-details.json";
 const SESSION_TOOL_DETAILS_DIR: &str = "tool-details";
 const DEFAULT_PAGE_LIMIT: usize = 50;
@@ -353,6 +354,15 @@ struct HistoryCompactionState {
     started_at: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct TranscriptWriteState {
+    version: u32,
+    next_index: AiTranscriptIndex,
+    first_changed_offset: usize,
+    stale_legacy_entry_ids: Vec<String>,
+}
+
 impl AiHistoryStore {
     pub fn new(app_data_dir: impl Into<PathBuf>) -> AiResult<Self> {
         let app_data_dir = app_data_dir.into();
@@ -550,27 +560,51 @@ impl AiHistoryStore {
             indexed_transcript_bytes: index.message_lengths[..reuse_len].iter().sum(),
         };
 
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&transcript_path)
-            .map_err(|error| history_io("open AI transcript", &transcript_path, error))?;
+        let transcript_changed = reuse_len < index.len() || reuse_len < records.len();
+        let stale_legacy_entry_ids = index.message_ids[reuse_len..]
+            .iter()
+            .map(|message_id| format!("message:{message_id}"))
+            .collect::<Vec<_>>();
+
+        let mut append_offset = transcript_len;
+        let mut lines_to_append = Vec::with_capacity(records.len().saturating_sub(reuse_len));
         for record in records.iter().skip(reuse_len) {
-            let offset = file
-                .seek(SeekFrom::End(0))
-                .map_err(|error| history_io("seek AI transcript", &transcript_path, error))?;
             let line = serialize_record_line(record)?;
-            file.write_all(line.as_bytes())
-                .and_then(|_| file.write_all(b"\n"))
-                .map_err(|error| history_io("append AI transcript", &transcript_path, error))?;
             let length = line.len() as u64 + 1;
-            next_index.message_offsets.push(offset);
+            next_index.message_offsets.push(append_offset);
             next_index.message_lengths.push(length);
             next_index.message_hashes.push(record.hash.clone());
             next_index.message_ids.push(record.message_id.clone());
             next_index.message_kinds.push(record.kind.clone());
             next_index.message_roles.push(record.role.clone());
             next_index.indexed_transcript_bytes += length;
+            append_offset += length;
+            lines_to_append.push(line);
+        }
+
+        if transcript_changed {
+            // Persist the target index before touching JSONL so recovery can
+            // never mistake an unindexed write for a current SQLite backfill.
+            self.write_transcript_write_marker(
+                session_id,
+                &TranscriptWriteState {
+                    version: HISTORY_FORMAT_VERSION,
+                    next_index: next_index.clone(),
+                    first_changed_offset: reuse_len,
+                    stale_legacy_entry_ids: stale_legacy_entry_ids.clone(),
+                },
+            )?;
+        }
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&transcript_path)
+            .map_err(|error| history_io("open AI transcript", &transcript_path, error))?;
+        for line in &lines_to_append {
+            file.write_all(line.as_bytes())
+                .and_then(|_| file.write_all(b"\n"))
+                .map_err(|error| history_io("append AI transcript", &transcript_path, error))?;
         }
         file.sync_all()
             .map_err(|error| history_io("sync AI transcript", &transcript_path, error))?;
@@ -578,13 +612,7 @@ impl AiHistoryStore {
         metadata.message_count = records.len();
         metadata.preview = derive_session_preview(records.iter().map(|record| &record.payload));
         metadata.updated_at = now_iso8601();
-        if reuse_len < index.len() || reuse_len < records.len() {
-            // Keep the previous index visible until SQLite has acknowledged
-            // the invalidation, so a retry recomputes the same changed tail.
-            let stale_legacy_entry_ids = index.message_ids[reuse_len..]
-                .iter()
-                .map(|message_id| format!("message:{message_id}"))
-                .collect::<Vec<_>>();
+        if transcript_changed {
             self.transcript_store(session_id)
                 .invalidate_legacy_transcript_backfill_from(
                     session_id,
@@ -594,6 +622,7 @@ impl AiHistoryStore {
         }
         self.save_index(session_id, &next_index)?;
         self.save_metadata(&metadata)?;
+        self.clear_transcript_write_marker(session_id)?;
         self.compact_transcript_if_needed(session_id)?;
         Ok(())
     }
@@ -1403,16 +1432,15 @@ impl AiHistoryStore {
 
     fn recover_if_needed(&self, session_id: &SessionId) -> AiResult<()> {
         let marker = self.compaction_marker_path(session_id);
-        if !marker.exists() {
-            return Ok(());
+        if marker.exists() {
+            let transcript_path = self.transcript_path(session_id);
+            let transcript_backup = self.sidecar_path(session_id, "transcript.bak");
+            if !transcript_path.exists() && transcript_backup.exists() {
+                copy_or_replace(&transcript_backup, &transcript_path)?;
+            }
+            self.clear_compaction_sidecars(session_id)?;
         }
-
-        let transcript_path = self.transcript_path(session_id);
-        let transcript_backup = self.sidecar_path(session_id, "transcript.bak");
-        if !transcript_path.exists() && transcript_backup.exists() {
-            copy_or_replace(&transcript_backup, &transcript_path)?;
-        }
-        self.clear_compaction_sidecars(session_id)
+        self.recover_pending_transcript_write(session_id)
     }
 
     fn write_compaction_marker(&self, session_id: &SessionId) -> AiResult<()> {
@@ -1421,6 +1449,54 @@ impl AiHistoryStore {
             started_at: now_iso8601(),
         };
         atomic_write_json(&self.compaction_marker_path(session_id), &state)
+    }
+
+    fn write_transcript_write_marker(
+        &self,
+        session_id: &SessionId,
+        state: &TranscriptWriteState,
+    ) -> AiResult<()> {
+        atomic_write_json(&self.transcript_write_marker_path(session_id), state)
+    }
+
+    fn clear_transcript_write_marker(&self, session_id: &SessionId) -> AiResult<()> {
+        let marker = self.transcript_write_marker_path(session_id);
+        if marker.exists() {
+            fs::remove_file(&marker)
+                .map_err(|error| history_io("remove transcript write marker", &marker, error))?;
+        }
+        Ok(())
+    }
+
+    fn recover_pending_transcript_write(&self, session_id: &SessionId) -> AiResult<()> {
+        let marker = self.transcript_write_marker_path(session_id);
+        if !marker.exists() {
+            return Ok(());
+        }
+        let state: TranscriptWriteState = read_json_file(&marker)?;
+        if state.version != HISTORY_FORMAT_VERSION {
+            return Err(history_error(
+                "AI transcript write marker has an unsupported version.",
+            ));
+        }
+
+        let transcript_len = file_len(&self.transcript_path(session_id)).unwrap_or(0);
+        let write_completed = state.next_index.validate(transcript_len).is_ok()
+            && self
+                .read_payloads_by_index(session_id, &state.next_index, 0, state.next_index.len())
+                .is_ok();
+        if write_completed {
+            // The source write reached disk, so SQLite must be invalidated
+            // before this index can make the revised transcript authoritative.
+            self.transcript_store(session_id)
+                .invalidate_legacy_transcript_backfill_from(
+                    session_id,
+                    state.first_changed_offset,
+                    &state.stale_legacy_entry_ids,
+                )?;
+            self.save_index(session_id, &state.next_index)?;
+        }
+        self.clear_transcript_write_marker(session_id)
     }
 
     fn clear_compaction_sidecars(&self, session_id: &SessionId) -> AiResult<()> {
@@ -1552,6 +1628,11 @@ impl AiHistoryStore {
     fn compaction_marker_path(&self, session_id: &SessionId) -> PathBuf {
         self.session_dir(session_id)
             .join(SESSION_COMPACT_STATE_FILE)
+    }
+
+    fn transcript_write_marker_path(&self, session_id: &SessionId) -> PathBuf {
+        self.session_dir(session_id)
+            .join(SESSION_TRANSCRIPT_WRITE_STATE_FILE)
     }
 
     fn sidecar_path(&self, session_id: &SessionId, name: &str) -> PathBuf {
@@ -4383,6 +4464,75 @@ mod tests {
     }
 
     #[test]
+    fn transcript_write_recovery_reconciles_jsonl_written_before_sqlite_invalidation() {
+        let (_temp, store) = store();
+        let session_id = SessionId("recover_transcript_write_before_sqlite".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store
+            .save_transcript_window(&session_id, vec![message("legacy-1", "draft")])
+            .unwrap();
+        store.transcript_storage_state(&session_id).unwrap();
+
+        let replacement = message("legacy-1", "complete");
+        let record = AiTranscriptRecord::from_payload(replacement.clone()).unwrap();
+        let line = serialize_record_line(&record).unwrap();
+        let length = line.len() as u64 + 1;
+        let offset = file_len(&store.transcript_path(&session_id)).unwrap();
+        let next_index = AiTranscriptIndex {
+            version: HISTORY_FORMAT_VERSION,
+            message_offsets: vec![offset],
+            message_lengths: vec![length],
+            message_hashes: vec![record.hash],
+            message_ids: vec![record.message_id],
+            message_kinds: vec![record.kind],
+            message_roles: vec![record.role],
+            updated_at: now_iso8601(),
+            indexed_transcript_bytes: length,
+        };
+        store
+            .write_transcript_write_marker(
+                &session_id,
+                &TranscriptWriteState {
+                    version: HISTORY_FORMAT_VERSION,
+                    next_index,
+                    first_changed_offset: 0,
+                    stale_legacy_entry_ids: vec!["message:legacy-1".to_string()],
+                },
+            )
+            .unwrap();
+        let mut file = OpenOptions::new()
+            .append(true)
+            .open(store.transcript_path(&session_id))
+            .unwrap();
+        file.write_all(line.as_bytes())
+            .and_then(|_| file.write_all(b"\n"))
+            .and_then(|_| file.sync_all())
+            .unwrap();
+
+        let snapshot = store.load_session_snapshot(&session_id).unwrap().unwrap();
+        assert_eq!(snapshot.messages[0], replacement);
+        assert!(!store.transcript_write_marker_path(&session_id).exists());
+
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+        let block_id = &store.load_transcript_block_metadata(&session_id).unwrap()[0].block_id;
+        let block = store
+            .load_transcript_block(&session_id, block_id)
+            .unwrap()
+            .unwrap();
+        let payload = store
+            .load_native_transcript_payload(
+                &session_id,
+                block.entries[0].payload_ref.as_deref().unwrap(),
+                1024,
+            )
+            .unwrap();
+        assert_eq!(payload.value["message"]["content"], "complete");
+    }
+
+    #[test]
     fn transcript_save_retries_invalidation_after_a_sqlite_failure() {
         let (_temp, store) = store();
         let session_id = SessionId("retry_legacy_invalidation".to_string());
@@ -4402,7 +4552,7 @@ mod tests {
         fs::set_permissions(&database_path, original_permissions).unwrap();
         assert!(failed_save.is_err());
 
-        let stale_page = store
+        let recovered_page = store
             .load_transcript_page(NativeAiLoadSessionTranscriptPageInput {
                 session_id: session_id.clone(),
                 offset: 0,
@@ -4410,7 +4560,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        assert_eq!(stale_page.messages[0]["content"], "draft");
+        assert_eq!(recovered_page.messages[0]["content"], "complete");
 
         store
             .save_transcript_window(&session_id, vec![message("legacy-1", "complete")])

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -361,6 +361,16 @@ struct TranscriptWriteState {
     next_index: AiTranscriptIndex,
     first_changed_offset: usize,
     stale_legacy_entry_ids: Vec<String>,
+    #[serde(default)]
+    session_metadata: Option<TranscriptWriteSessionMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct TranscriptWriteSessionMetadata {
+    message_count: usize,
+    preview: Option<String>,
+    updated_at: String,
 }
 
 impl AiHistoryStore {
@@ -535,6 +545,11 @@ impl AiHistoryStore {
             .into_iter()
             .map(AiTranscriptRecord::from_payload)
             .collect::<AiResult<Vec<_>>>()?;
+        let next_session_metadata = TranscriptWriteSessionMetadata {
+            message_count: records.len(),
+            preview: derive_session_preview(records.iter().map(|record| &record.payload)),
+            updated_at: now_iso8601(),
+        };
         let first_changed = records
             .iter()
             .enumerate()
@@ -592,6 +607,7 @@ impl AiHistoryStore {
                     next_index: next_index.clone(),
                     first_changed_offset: reuse_len,
                     stale_legacy_entry_ids: stale_legacy_entry_ids.clone(),
+                    session_metadata: Some(next_session_metadata.clone()),
                 },
             )?;
         }
@@ -609,9 +625,9 @@ impl AiHistoryStore {
         file.sync_all()
             .map_err(|error| history_io("sync AI transcript", &transcript_path, error))?;
 
-        metadata.message_count = records.len();
-        metadata.preview = derive_session_preview(records.iter().map(|record| &record.payload));
-        metadata.updated_at = now_iso8601();
+        metadata.message_count = next_session_metadata.message_count;
+        metadata.preview = next_session_metadata.preview;
+        metadata.updated_at = next_session_metadata.updated_at;
         if transcript_changed {
             self.transcript_store(session_id)
                 .invalidate_legacy_transcript_backfill_from(
@@ -1490,11 +1506,20 @@ impl AiHistoryStore {
         }
 
         let transcript_len = file_len(&self.transcript_path(session_id)).unwrap_or(0);
-        let write_completed = state.next_index.validate(transcript_len).is_ok()
-            && self
-                .read_payloads_by_index(session_id, &state.next_index, 0, state.next_index.len())
-                .is_ok();
-        if write_completed {
+        let recovered_messages = state
+            .next_index
+            .validate(transcript_len)
+            .is_ok()
+            .then(|| {
+                self.read_payloads_by_index(
+                    session_id,
+                    &state.next_index,
+                    0,
+                    state.next_index.len(),
+                )
+            })
+            .transpose()?;
+        if let Some(messages) = recovered_messages {
             // The source write reached disk, so SQLite must be invalidated
             // before this index can make the revised transcript authoritative.
             self.transcript_store(session_id)
@@ -1504,6 +1529,23 @@ impl AiHistoryStore {
                     &state.stale_legacy_entry_ids,
                 )?;
             self.save_index(session_id, &state.next_index)?;
+            let recovered_metadata = state.session_metadata.unwrap_or_else(|| {
+                // Markers created before session metadata was included still
+                // recover accurately from the JSONL payloads they validate.
+                TranscriptWriteSessionMetadata {
+                    message_count: messages.len(),
+                    preview: derive_session_preview(messages.iter()),
+                    updated_at: now_iso8601(),
+                }
+            });
+            // The recovery marker is still present, so avoid load_metadata()
+            // recursively entering this recovery path before it is cleared.
+            let mut metadata: AiHistorySessionMetadata =
+                read_json_file(&self.metadata_path(session_id))?;
+            metadata.message_count = recovered_metadata.message_count;
+            metadata.preview = recovered_metadata.preview;
+            metadata.updated_at = recovered_metadata.updated_at;
+            self.save_metadata(&metadata)?;
         }
         self.clear_transcript_write_marker(session_id)
     }
@@ -4506,6 +4548,7 @@ mod tests {
                     next_index,
                     first_changed_offset: 0,
                     stale_legacy_entry_ids: vec!["message:legacy-1".to_string()],
+                    session_metadata: None,
                 },
             )
             .unwrap();
@@ -4539,6 +4582,82 @@ mod tests {
             )
             .unwrap();
         assert_eq!(payload.value["message"]["content"], "complete");
+    }
+
+    #[test]
+    fn transcript_write_recovery_restores_metadata_for_a_first_synced_write() {
+        let (_temp, store) = store();
+        let session_id = SessionId("recover_first_transcript_write_metadata".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+
+        let first_message = message("assistant-1", "Recovered first answer.");
+        let record = AiTranscriptRecord::from_payload(first_message.clone()).unwrap();
+        let line = serialize_record_line(&record).unwrap();
+        let length = line.len() as u64 + 1;
+        let target_metadata = TranscriptWriteSessionMetadata {
+            message_count: 1,
+            preview: Some("Recovered first answer.".to_string()),
+            updated_at: "2026-07-20T00:00:00.000Z".to_string(),
+        };
+        let next_index = AiTranscriptIndex {
+            version: HISTORY_FORMAT_VERSION,
+            message_offsets: vec![0],
+            message_lengths: vec![length],
+            message_hashes: vec![record.hash],
+            message_ids: vec![record.message_id],
+            message_kinds: vec![record.kind],
+            message_roles: vec![record.role],
+            updated_at: target_metadata.updated_at.clone(),
+            indexed_transcript_bytes: length,
+        };
+        store
+            .write_transcript_write_marker(
+                &session_id,
+                &TranscriptWriteState {
+                    version: HISTORY_FORMAT_VERSION,
+                    next_index,
+                    first_changed_offset: 0,
+                    stale_legacy_entry_ids: Vec::new(),
+                    session_metadata: Some(target_metadata.clone()),
+                },
+            )
+            .unwrap();
+        let mut file = OpenOptions::new()
+            .append(true)
+            .open(store.transcript_path(&session_id))
+            .unwrap();
+        file.write_all(line.as_bytes())
+            .and_then(|_| file.write_all(b"\n"))
+            .and_then(|_| file.sync_all())
+            .unwrap();
+
+        let page = store
+            .load_transcript_page(NativeAiLoadSessionTranscriptPageInput {
+                session_id: session_id.clone(),
+                offset: 0,
+                limit: 10,
+            })
+            .unwrap()
+            .unwrap();
+        assert_eq!(page.messages, vec![first_message]);
+        assert!(!store.transcript_write_marker_path(&session_id).exists());
+
+        let recovered_metadata = store.load_metadata(&session_id).unwrap();
+        assert_eq!(
+            recovered_metadata.message_count,
+            target_metadata.message_count
+        );
+        assert_eq!(recovered_metadata.preview, target_metadata.preview);
+        assert_eq!(recovered_metadata.updated_at, target_metadata.updated_at);
+        let history = store
+            .list_session_history(NativeAiListSessionHistoryInput {
+                project_id: Some(ProjectId("project_1".to_string())),
+                worktree_id: Some(WorktreeId("worktree_1".to_string())),
+                limit: None,
+            })
+            .unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].session_id, session_id);
     }
 
     #[test]

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -1044,20 +1044,20 @@ impl AiHistoryStore {
             else {
                 continue;
             };
-            // A synced JSONL write can have a pending marker while metadata
-            // still says zero messages. Recover before applying visibility filters.
-            self.recover_if_needed(&initial_metadata.session_id)?;
-            let metadata: AiHistorySessionMetadata = read_json_file(&metadata_path)?;
-            if metadata.project_id != input.project_id {
+            if initial_metadata.project_id != input.project_id {
                 continue;
             }
             if !history_worktree_scope_matches(
-                metadata.project_id.as_ref(),
-                metadata.worktree_id.as_ref(),
+                initial_metadata.project_id.as_ref(),
+                initial_metadata.worktree_id.as_ref(),
                 input.worktree_id.as_ref(),
             ) {
                 continue;
             }
+            // A synced JSONL write can have a pending marker while metadata
+            // still says zero messages. Scope before recovering unrelated sessions.
+            self.recover_if_needed(&initial_metadata.session_id)?;
+            let metadata: AiHistorySessionMetadata = read_json_file(&metadata_path)?;
             if metadata.message_count == 0 && metadata.parent_session_id.is_none() {
                 continue;
             }
@@ -3516,6 +3516,46 @@ mod tests {
 
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].session_id, child.session_id);
+    }
+
+    #[test]
+    fn list_ignores_a_corrupt_recovery_marker_outside_its_scope() {
+        let (_temp, store) = store();
+        let mut scoped = metadata("scoped");
+        scoped.message_count = 1;
+        store.create_session(scoped.clone()).unwrap();
+
+        let mut other = metadata("other");
+        other.project_id = Some(ProjectId("project_2".to_string()));
+        store.create_session(other.clone()).unwrap();
+        store
+            .write_transcript_write_marker(
+                &other.session_id,
+                &TranscriptWriteState {
+                    version: HISTORY_FORMAT_VERSION + 1,
+                    next_index: AiTranscriptIndex::empty(),
+                    first_changed_offset: 0,
+                    stale_legacy_entry_ids: Vec::new(),
+                    session_metadata: None,
+                },
+            )
+            .unwrap();
+
+        let history = store
+            .list_session_history(NativeAiListSessionHistoryInput {
+                project_id: Some(ProjectId("project_1".to_string())),
+                worktree_id: Some(WorktreeId("worktree_1".to_string())),
+                limit: None,
+            })
+            .unwrap();
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].session_id, scoped.session_id);
+        assert!(
+            store
+                .transcript_write_marker_path(&other.session_id)
+                .exists()
+        );
     }
 
     #[test]

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -5147,6 +5147,137 @@ mod tests {
     }
 
     #[test]
+    fn restart_reconciles_terminal_tail_so_history_and_block_native_chat_are_complete() {
+        let (temp, store) = store();
+        let session_id = SessionId("restart_terminal_tail_reconciliation".to_string());
+        let mut session_metadata = metadata(&session_id.0);
+        session_metadata.status = NativeAiSessionStatus::Streaming;
+        store.create_session(session_metadata).unwrap();
+
+        // History continues to read the compatibility transcript while an open
+        // terminal tail can leave the block-native projection incomplete.
+        store
+            .save_transcript_window(
+                &session_id,
+                vec![
+                    message("assistant-a", "First durable answer."),
+                    message("assistant-b", "Completed answer awaiting recovery."),
+                ],
+            )
+            .unwrap();
+
+        let first = transcript_entry(&session_id, "message:assistant-a", "First durable answer.");
+        let second = transcript_entry(
+            &session_id,
+            "message:assistant-b",
+            "Completed answer awaiting recovery.",
+        );
+        store
+            .seal_transcript_turn(&session_id, "turn-a", vec![first.clone()], vec![])
+            .unwrap();
+        store
+            .checkpoint_open_transcript_tail(NativeAiCheckpointOpenTranscriptTailInput {
+                session_id: session_id.clone(),
+                turn_id: "turn-b".to_string(),
+                terminal_status: Some(NativeAiTranscriptTerminalStatus::Completed),
+                entries: vec![first.clone(), second.clone()],
+                payloads: vec![],
+                removed_entry_ids: vec![],
+                entry_order: vec![
+                    NativeAiOpenTranscriptEntryRef {
+                        entry_id: first.id.clone(),
+                        entry_revision: 1,
+                        ordinal: 0,
+                    },
+                    NativeAiOpenTranscriptEntryRef {
+                        entry_id: second.id.clone(),
+                        entry_revision: 1,
+                        ordinal: 1,
+                    },
+                ],
+            })
+            .unwrap();
+        drop(store);
+
+        let reopened = AiHistoryStore::new(temp.path()).unwrap();
+        let startup_snapshot = reopened
+            .load_session_snapshot(&session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(startup_snapshot.status, NativeAiSessionStatus::Streaming);
+        assert!(startup_snapshot.messages.is_empty());
+        let history = reopened
+            .load_transcript_page(NativeAiLoadSessionTranscriptPageInput {
+                session_id: session_id.clone(),
+                offset: 0,
+                limit: 10,
+            })
+            .unwrap()
+            .unwrap();
+        assert_eq!(history.messages.len(), 2);
+        assert_eq!(
+            reopened
+                .load_transcript_block_metadata(&session_id)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            reopened
+                .load_open_transcript_tail(&session_id)
+                .unwrap()
+                .unwrap()
+                .terminal_status,
+            Some(NativeAiTranscriptTerminalStatus::Completed)
+        );
+
+        let metadata = reopened
+            .reconcile_terminal_open_transcript_tail(&session_id, "turn-b")
+            .unwrap();
+        assert!(
+            reopened
+                .load_open_transcript_tail(&session_id)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(metadata.len(), 2);
+
+        let block_entry_ids = metadata
+            .iter()
+            .flat_map(|block| {
+                reopened
+                    .load_transcript_block(&session_id, &block.block_id)
+                    .unwrap()
+                    .unwrap()
+                    .entries
+            })
+            .map(|entry| entry.id)
+            .collect::<Vec<_>>();
+        assert_eq!(block_entry_ids, vec![first.id, second.id]);
+        assert_eq!(
+            reopened
+                .load_transcript_page(NativeAiLoadSessionTranscriptPageInput {
+                    session_id: session_id.clone(),
+                    offset: 0,
+                    limit: 10,
+                })
+                .unwrap()
+                .unwrap()
+                .messages
+                .len(),
+            2
+        );
+
+        assert_eq!(
+            reopened
+                .reconcile_terminal_open_transcript_tail(&session_id, "turn-b")
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
     fn sealing_turn_persists_payload_and_stable_block_revision() {
         let (_temp, store) = store();
         let session_id = SessionId("sealed_turn".to_string());

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -850,13 +850,25 @@ impl AiHistoryStore {
             .into_iter()
             .map(|message| legacy_transcript_entry(session_id, message))
             .collect::<AiResult<Vec<_>>>()?;
-        let (entries, payloads): (Vec<_>, Vec<_>) = entries_and_payloads.into_iter().unzip();
-        transcript_store.seal_turn(
-            session_id,
-            &format!("legacy-transcript:{offset}"),
-            entries,
-            payloads,
-        )?;
+        let candidate_entry_ids = entries_and_payloads
+            .iter()
+            .map(|(entry, _)| entry.id.clone())
+            .collect::<Vec<_>>();
+        let native_entry_ids =
+            transcript_store.native_transcript_entry_ids(session_id, &candidate_entry_ids)?;
+        let (entries, payloads): (Vec<_>, Vec<_>) = entries_and_payloads
+            .into_iter()
+            .filter(|(entry, _)| !native_entry_ids.contains(&entry.id))
+            .unzip();
+        if !entries.is_empty() {
+            // Native entries already cover their matching JSONL records.
+            transcript_store.seal_turn(
+                session_id,
+                &format!("legacy-transcript:{offset}"),
+                entries,
+                payloads,
+            )?;
+        }
         transcript_store.advance_legacy_transcript_backfill(session_id, end, end == index.len())
     }
 
@@ -4599,6 +4611,68 @@ mod tests {
                 .sum::<usize>(),
             300
         );
+    }
+
+    #[test]
+    fn schema_upgrade_keeps_an_incomplete_legacy_backfill_with_native_entries() {
+        let (_temp, store) = store();
+        let session_id = SessionId("schema_upgrade_partial_legacy_backfill".to_string());
+        let mut messages = (0..300)
+            .map(|index| message(&format!("legacy-{index}"), "legacy content"))
+            .collect::<Vec<_>>();
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store
+            .save_transcript_window(&session_id, messages.clone())
+            .unwrap();
+
+        let transcript_store = store.transcript_store(&session_id);
+        transcript_store
+            .begin_legacy_transcript_backfill(&session_id)
+            .unwrap();
+        let first_page = messages[..256]
+            .iter()
+            .cloned()
+            .map(|message| legacy_transcript_entry(&session_id, message))
+            .collect::<AiResult<Vec<_>>>()
+            .unwrap();
+        let (entries, payloads): (Vec<_>, Vec<_>) = first_page.into_iter().unzip();
+        transcript_store
+            .seal_turn(&session_id, "legacy-transcript:0", entries, payloads)
+            .unwrap();
+        transcript_store
+            .advance_legacy_transcript_backfill(&session_id, 256, false)
+            .unwrap();
+
+        let native_message = message("native-1", "native content");
+        let (entry, payload) =
+            legacy_transcript_entry(&session_id, native_message.clone()).unwrap();
+        transcript_store
+            .seal_turn(&session_id, "native-turn", vec![entry], vec![payload])
+            .unwrap();
+        messages.push(native_message);
+        store.save_transcript_window(&session_id, messages).unwrap();
+
+        let database_path = store.session_dir(&session_id).join("transcript-v2.sqlite3");
+        let connection = Connection::open(database_path).unwrap();
+        connection
+            .execute_batch(
+                "ALTER TABLE transcript_sessions DROP COLUMN transcript_origin;
+                 PRAGMA user_version = 5;",
+            )
+            .unwrap();
+        drop(connection);
+
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+        let entry_count = store
+            .load_transcript_block_metadata(&session_id)
+            .unwrap()
+            .into_iter()
+            .map(|block| block.entry_count)
+            .sum::<usize>();
+        assert_eq!(entry_count, 301);
     }
 
     #[test]

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -767,7 +767,10 @@ impl AiHistoryStore {
         let transcript_store = self.transcript_store(session_id);
         let migration_manifest_exists = self.history_root().join("migrations").exists();
         let legacy_fallback_available = self.transcript_path(session_id).exists();
-        let legacy_transcript_pending = legacy_fallback_available
+        let uses_legacy_transcript_backfill =
+            transcript_store.uses_legacy_transcript_backfill(session_id)?;
+        let legacy_transcript_pending = uses_legacy_transcript_backfill
+            && legacy_fallback_available
             && self.with_legacy_transcript_backfill_index(session_id, |index| {
                 // Every session starts with an empty compatibility file; it
                 // is not migration input until it contains a record.
@@ -786,7 +789,8 @@ impl AiHistoryStore {
                     .legacy_transcript_backfill_is_current(session_id, index.len())?)
             })?;
         let mode = if transcript_store.has_data_source()
-            && transcript_store.legacy_transcript_backfill_complete(session_id)?
+            && (!uses_legacy_transcript_backfill
+                || transcript_store.legacy_transcript_backfill_complete(session_id)?)
         {
             NativeAiTranscriptStorageMode::BlockNative
         } else if legacy_transcript_pending || migration_manifest_exists {
@@ -813,6 +817,9 @@ impl AiHistoryStore {
         index: &AiTranscriptIndex,
     ) -> AiResult<()> {
         let transcript_store = self.transcript_store(session_id);
+        if !transcript_store.uses_legacy_transcript_backfill(session_id)? {
+            return Ok(());
+        }
         let offset = transcript_store
             .legacy_transcript_backfill_next_offset(session_id)?
             .min(index.len());
@@ -850,9 +857,13 @@ impl AiHistoryStore {
         session_id: &SessionId,
         transcript_store: &TranscriptStore,
     ) -> AiResult<bool> {
-        if !transcript_store.has_data_source()
-            || !transcript_store.legacy_transcript_backfill_complete(session_id)?
-        {
+        if !transcript_store.has_data_source() {
+            return Ok(false);
+        }
+        if !transcript_store.uses_legacy_transcript_backfill(session_id)? {
+            return Ok(true);
+        }
+        if !transcript_store.legacy_transcript_backfill_complete(session_id)? {
             return Ok(false);
         }
         if !self.transcript_path(session_id).exists() {
@@ -4154,6 +4165,36 @@ mod tests {
         let snapshot = store.load_session_snapshot(&session_id).unwrap().unwrap();
         assert!(snapshot.messages.is_empty());
         assert!(snapshot.tool_activity.is_empty());
+    }
+
+    #[test]
+    fn transcript_storage_state_skips_legacy_backfill_for_native_transcripts() {
+        let (_temp, store) = store();
+        let session_id = SessionId("native_transcript_with_legacy_jsonl".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+        let message = message("message-1", "native content");
+        store
+            .save_transcript_window(&session_id, vec![message.clone()])
+            .unwrap();
+        let (entry, payload) = legacy_transcript_entry(&session_id, message).unwrap();
+        store
+            .seal_transcript_turn(&session_id, "native-turn", vec![entry], vec![payload])
+            .unwrap();
+
+        let state = store.transcript_storage_state(&session_id).unwrap();
+
+        assert_eq!(state.mode, NativeAiTranscriptStorageMode::BlockNative);
+        let transcript_store = store.transcript_store(&session_id);
+        assert!(
+            !transcript_store
+                .uses_legacy_transcript_backfill(&session_id)
+                .unwrap()
+        );
+        assert!(
+            transcript_store
+                .legacy_transcript_backfill_complete(&session_id)
+                .unwrap()
+        );
     }
 
     #[test]

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -578,11 +578,13 @@ impl AiHistoryStore {
         metadata.message_count = records.len();
         metadata.preview = derive_session_preview(records.iter().map(|record| &record.payload));
         metadata.updated_at = now_iso8601();
-        self.save_index(session_id, &next_index)?;
         if reuse_len < index.len() || reuse_len < records.len() {
+            // Keep the previous index visible until SQLite has acknowledged
+            // the invalidation, so a retry recomputes the same changed tail.
             self.transcript_store(session_id)
                 .invalidate_legacy_transcript_backfill_from(session_id, reuse_len)?;
         }
+        self.save_index(session_id, &next_index)?;
         self.save_metadata(&metadata)?;
         self.compact_transcript_if_needed(session_id)?;
         Ok(())
@@ -4291,6 +4293,58 @@ mod tests {
         let fallback = store.load_session_snapshot(&session_id).unwrap().unwrap();
         assert_eq!(fallback.messages[0]["content"], "complete");
 
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+        let metadata = store.load_transcript_block_metadata(&session_id).unwrap();
+        let block = store
+            .load_transcript_block(&session_id, &metadata[0].block_id)
+            .unwrap()
+            .unwrap();
+        let payload = store
+            .load_native_transcript_payload(
+                &session_id,
+                block.entries[0].payload_ref.as_deref().unwrap(),
+                1024,
+            )
+            .unwrap();
+        assert_eq!(payload.value["message"]["content"], "complete");
+    }
+
+    #[test]
+    fn transcript_save_retries_invalidation_after_a_sqlite_failure() {
+        let (_temp, store) = store();
+        let session_id = SessionId("retry_legacy_invalidation".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store
+            .save_transcript_window(&session_id, vec![message("legacy-1", "draft")])
+            .unwrap();
+        store.transcript_storage_state(&session_id).unwrap();
+
+        let database_path = store.session_dir(&session_id).join("transcript-v2.sqlite3");
+        let original_permissions = fs::metadata(&database_path).unwrap().permissions();
+        let mut read_only_permissions = original_permissions.clone();
+        read_only_permissions.set_readonly(true);
+        fs::set_permissions(&database_path, read_only_permissions).unwrap();
+        let failed_save =
+            store.save_transcript_window(&session_id, vec![message("legacy-1", "complete")]);
+        fs::set_permissions(&database_path, original_permissions).unwrap();
+        assert!(failed_save.is_err());
+
+        let stale_page = store
+            .load_transcript_page(NativeAiLoadSessionTranscriptPageInput {
+                session_id: session_id.clone(),
+                offset: 0,
+                limit: 1,
+            })
+            .unwrap()
+            .unwrap();
+        assert_eq!(stale_page.messages[0]["content"], "draft");
+
+        store
+            .save_transcript_window(&session_id, vec![message("legacy-1", "complete")])
+            .unwrap();
         assert_eq!(
             store.transcript_storage_state(&session_id).unwrap().mode,
             NativeAiTranscriptStorageMode::BlockNative

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -4206,6 +4206,50 @@ mod tests {
     }
 
     #[test]
+    fn transcript_storage_state_keeps_native_entries_authoritative_after_legacy_migration() {
+        let (_temp, store) = store();
+        let session_id = SessionId("native_entry_after_legacy_migration".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+        let legacy_message = message("legacy-1", "legacy content");
+        store
+            .save_transcript_window(&session_id, vec![legacy_message.clone()])
+            .unwrap();
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+
+        let native_message = message("native-1", "native content");
+        let (entry, payload) =
+            legacy_transcript_entry(&session_id, native_message.clone()).unwrap();
+        store
+            .seal_transcript_turn(&session_id, "native-turn", vec![entry], vec![payload])
+            .unwrap();
+        store
+            .save_transcript_window(&session_id, vec![legacy_message, native_message])
+            .unwrap();
+
+        assert_eq!(
+            store.transcript_storage_state(&session_id).unwrap().mode,
+            NativeAiTranscriptStorageMode::BlockNative
+        );
+        let entries = store
+            .load_transcript_block_metadata(&session_id)
+            .unwrap()
+            .into_iter()
+            .flat_map(|block| {
+                store
+                    .load_transcript_block(&session_id, &block.block_id)
+                    .unwrap()
+                    .unwrap()
+                    .entries
+            })
+            .map(|entry| entry.id)
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec!["message:legacy-1", "message:native-1"]);
+    }
+
+    #[test]
     fn snapshot_keeps_a_legacy_transcript_visible_when_a_completed_backfill_is_stale() {
         let (_temp, store) = store();
         let session_id = SessionId("stale_legacy_backfill_snapshot".to_string());

--- a/crates/comando-ai/src/transcript_store.rs
+++ b/crates/comando-ai/src/transcript_store.rs
@@ -22,7 +22,7 @@ use crate::events::now_iso8601;
 const TRANSCRIPT_DATABASE_FILE: &str = "transcript-v2.sqlite3";
 const LEGACY_TRANSCRIPT_ENTRIES_FILE: &str = "transcript-entries.json";
 const TRANSCRIPT_PAYLOADS_DIR: &str = "transcript-payloads";
-pub(crate) const TRANSCRIPT_SCHEMA_VERSION: u32 = 5;
+pub(crate) const TRANSCRIPT_SCHEMA_VERSION: u32 = 6;
 const TRANSCRIPT_BLOCK_SIZE: usize = 256;
 const INLINE_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
 const TRANSCRIPT_PAYLOAD_REF_MAX_BYTES: usize = 512;
@@ -84,7 +84,52 @@ impl TranscriptStore {
         Ok(state.unwrap_or(1) == 1)
     }
 
+    pub(crate) fn uses_legacy_transcript_backfill(&self, session_id: &SessionId) -> AiResult<bool> {
+        if !self.database_path.exists() {
+            return Ok(true);
+        }
+        let connection = self.open(session_id, false)?;
+        let origin = connection
+            .query_row(
+                "SELECT transcript_origin
+                 FROM transcript_sessions
+                 WHERE session_id = ?1",
+                params![session_id.0],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|error| transcript_sql("load transcript origin", error))?;
+        if origin.as_deref() != Some("native") {
+            return Ok(true);
+        }
+
+        let has_native_entries = connection
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM transcript_entries AS entries
+                    LEFT JOIN transcript_blocks AS blocks
+                        ON blocks.session_id = entries.session_id
+                        AND blocks.block_id = entries.block_id
+                    WHERE entries.session_id = ?1
+                        AND (blocks.turn_id IS NULL
+                            OR blocks.turn_id NOT GLOB 'legacy-transcript:*')
+                )",
+                params![session_id.0],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(|error| transcript_sql("detect native transcript entries", error))?
+            == 1;
+        // Opening the store creates an empty native-default row. It must not
+        // suppress a JSONL backfill until actual native content exists.
+        Ok(!has_native_entries)
+    }
+
     pub(crate) fn begin_legacy_transcript_backfill(&self, session_id: &SessionId) -> AiResult<()> {
+        if !self.uses_legacy_transcript_backfill(session_id)? {
+            return Err(AiError::InvalidInput(
+                "A native transcript cannot start a legacy backfill".to_string(),
+            ));
+        }
         let connection = self.open(session_id, true)?;
         connection
             .execute(
@@ -92,10 +137,12 @@ impl TranscriptStore {
                     session_id,
                     next_sequence,
                     legacy_entries_imported,
-                    legacy_transcript_backfill_complete
-                 ) VALUES (?1, 1, 1, 0)
+                    legacy_transcript_backfill_complete,
+                    transcript_origin
+                 ) VALUES (?1, 1, 1, 0, 'legacy_backfill')
                  ON CONFLICT (session_id) DO UPDATE SET
-                    legacy_transcript_backfill_complete = 0",
+                    legacy_transcript_backfill_complete = 0,
+                    transcript_origin = 'legacy_backfill'",
                 params![session_id.0],
             )
             .map_err(|error| transcript_sql("start legacy transcript backfill", error))?;
@@ -137,6 +184,9 @@ impl TranscriptStore {
         first_changed_offset: usize,
     ) -> AiResult<()> {
         if !self.database_path.exists() {
+            return Ok(());
+        }
+        if !self.uses_legacy_transcript_backfill(session_id)? {
             return Ok(());
         }
 
@@ -921,7 +971,9 @@ fn migrate_schema(connection: &mut Connection) -> AiResult<()> {
                 legacy_transcript_backfill_complete INTEGER NOT NULL DEFAULT 1
                     CHECK (legacy_transcript_backfill_complete IN (0, 1)),
                 legacy_transcript_backfill_next_offset INTEGER NOT NULL DEFAULT 0
-                    CHECK (legacy_transcript_backfill_next_offset >= 0)
+                    CHECK (legacy_transcript_backfill_next_offset >= 0),
+                transcript_origin TEXT NOT NULL DEFAULT 'native'
+                    CHECK (transcript_origin IN ('native', 'legacy_backfill'))
              ) STRICT;
 
              CREATE TABLE IF NOT EXISTS transcript_entries (
@@ -963,6 +1015,14 @@ fn migrate_schema(connection: &mut Connection) -> AiResult<()> {
                  CHECK (legacy_transcript_backfill_next_offset >= 0);",
             )
             .map_err(|error| transcript_sql("add legacy transcript backfill checkpoint", error))?;
+    } else if locked_version == 5 {
+        transaction
+            .execute_batch(
+                "ALTER TABLE transcript_sessions
+                 ADD COLUMN transcript_origin TEXT NOT NULL DEFAULT 'native'
+                 CHECK (transcript_origin IN ('native', 'legacy_backfill'));",
+            )
+            .map_err(|error| transcript_sql("add transcript origin", error))?;
     } else {
         return Err(AiError::Internal(format!(
             "Transcript database schema version {locked_version} cannot be migrated"
@@ -987,6 +1047,16 @@ fn migrate_schema(connection: &mut Connection) -> AiResult<()> {
                  CHECK (legacy_transcript_backfill_next_offset >= 0);",
             )
             .map_err(|error| transcript_sql("add legacy transcript backfill checkpoint", error))?;
+    }
+
+    if matches!(locked_version, 1..=4) {
+        transaction
+            .execute_batch(
+                "ALTER TABLE transcript_sessions
+                 ADD COLUMN transcript_origin TEXT NOT NULL DEFAULT 'native'
+                 CHECK (transcript_origin IN ('native', 'legacy_backfill'));",
+            )
+            .map_err(|error| transcript_sql("add transcript origin", error))?;
     }
 
     transaction
@@ -1144,6 +1214,30 @@ fn migrate_schema(connection: &mut Connection) -> AiResult<()> {
                 params![now_iso8601()],
             )
             .map_err(|error| transcript_sql("seal migrated transcript blocks", error))?;
+    }
+    if matches!(locked_version, 1..=5) {
+        // Existing backfills are identifiable by their own turns. A native
+        // block always wins so a failed legacy attempt cannot poison it.
+        transaction
+            .execute_batch(
+                "UPDATE transcript_sessions AS sessions
+                 SET transcript_origin = 'legacy_backfill'
+                 WHERE (
+                    sessions.legacy_transcript_backfill_complete = 0
+                    OR EXISTS (
+                        SELECT 1 FROM transcript_blocks AS blocks
+                        WHERE blocks.session_id = sessions.session_id
+                            AND blocks.turn_id GLOB 'legacy-transcript:*'
+                    )
+                 )
+                 AND NOT EXISTS (
+                    SELECT 1 FROM transcript_blocks AS blocks
+                    WHERE blocks.session_id = sessions.session_id
+                        AND (blocks.turn_id IS NULL
+                            OR blocks.turn_id NOT GLOB 'legacy-transcript:*')
+                 );",
+            )
+            .map_err(|error| transcript_sql("classify transcript origins", error))?;
     }
     transaction
         .pragma_update(None, "user_version", i64::from(TRANSCRIPT_SCHEMA_VERSION))

--- a/crates/comando-ai/src/transcript_store.rs
+++ b/crates/comando-ai/src/transcript_store.rs
@@ -410,6 +410,7 @@ impl TranscriptStore {
                 .map_err(|error| {
                     transcript_sql("start open transcript checkpoint transaction", error)
                 })?;
+            validate_open_tail_turn_transition(&transaction, &session_id, &turn_id)?;
             let obsolete_payload_files =
                 persist_payloads(&transaction, &session_id, &prepared_payloads)?;
             append_entries_in_transaction(&transaction, &session_id, entries)?;
@@ -1644,6 +1645,35 @@ fn persist_open_tail(
     Ok(())
 }
 
+fn validate_open_tail_turn_transition(
+    transaction: &Transaction<'_>,
+    session_id: &SessionId,
+    turn_id: &str,
+) -> AiResult<()> {
+    let state = transaction
+        .query_row(
+            "SELECT turn_id, terminal_status
+             FROM transcript_open_tails
+             WHERE session_id = ?1",
+            params![session_id.0],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+        )
+        .optional()
+        .map_err(|error| transcript_sql("load open transcript turn transition", error))?;
+    let Some((existing_turn_id, terminal_status)) = state else {
+        return Ok(());
+    };
+    if existing_turn_id == turn_id {
+        return Ok(());
+    }
+    let message = if terminal_status.is_some() {
+        "Terminal open transcript tail must be reconciled before changing turns"
+    } else {
+        "Open transcript tail belongs to another unresolved turn"
+    };
+    Err(AiError::InvalidInput(message.to_string()))
+}
+
 fn reserve_open_tail_ordinals(
     transaction: &Transaction<'_>,
     session_id: &SessionId,
@@ -2528,6 +2558,32 @@ mod tests {
         }
     }
 
+    fn open_tail_checkpoint(
+        session_id: &SessionId,
+        turn_id: &str,
+        terminal_status: Option<NativeAiTranscriptTerminalStatus>,
+        entries: Vec<NativeAiTranscriptEntryEnvelope>,
+    ) -> NativeAiCheckpointOpenTranscriptTailInput {
+        let entry_order = entries
+            .iter()
+            .enumerate()
+            .map(|(ordinal, entry)| NativeAiOpenTranscriptEntryRef {
+                entry_id: entry.id.clone(),
+                entry_revision: 1,
+                ordinal,
+            })
+            .collect();
+        NativeAiCheckpointOpenTranscriptTailInput {
+            session_id: session_id.clone(),
+            turn_id: turn_id.to_string(),
+            terminal_status,
+            entries,
+            payloads: Vec::new(),
+            removed_entry_ids: Vec::new(),
+            entry_order,
+        }
+    }
+
     #[test]
     fn newer_schema_is_rejected_without_touching_provisional_entries() {
         let temp = tempfile::tempdir().unwrap();
@@ -2714,6 +2770,102 @@ mod tests {
                 .map(|entry| &entry.id)
                 .collect::<Vec<_>>(),
             vec![&first.id]
+        );
+    }
+
+    #[test]
+    fn checkpoint_rejects_replacing_an_unresolved_open_tail() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_id = SessionId("unresolved-turn-transition".to_string());
+        let store = TranscriptStore::new(temp.path());
+        let first = entry(&session_id, "entry-a");
+        let second = entry(&session_id, "entry-b");
+
+        store
+            .checkpoint_open_tail(open_tail_checkpoint(
+                &session_id,
+                "turn-a",
+                None,
+                vec![first.clone()],
+            ))
+            .unwrap();
+
+        let error = store
+            .checkpoint_open_tail(open_tail_checkpoint(
+                &session_id,
+                "turn-b",
+                None,
+                vec![second],
+            ))
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Open transcript tail belongs to another unresolved turn")
+        );
+        let tail = store.load_open_tail(&session_id).unwrap().unwrap();
+        assert_eq!(tail.turn_id, "turn-a");
+        assert_eq!(
+            tail.entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![first.id.as_str()]
+        );
+    }
+
+    #[test]
+    fn checkpoint_requires_terminal_tail_reconciliation_before_turn_change() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_id = SessionId("terminal-turn-transition".to_string());
+        let store = TranscriptStore::new(temp.path());
+        let first = entry(&session_id, "entry-a");
+        let second = entry(&session_id, "entry-b");
+
+        store
+            .checkpoint_open_tail(open_tail_checkpoint(
+                &session_id,
+                "turn-a",
+                Some(NativeAiTranscriptTerminalStatus::Completed),
+                vec![first],
+            ))
+            .unwrap();
+
+        let error = store
+            .checkpoint_open_tail(open_tail_checkpoint(
+                &session_id,
+                "turn-b",
+                None,
+                vec![second.clone()],
+            ))
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Terminal open transcript tail must be reconciled")
+        );
+
+        store
+            .reconcile_terminal_open_tail(&session_id, "turn-a")
+            .unwrap();
+        store
+            .checkpoint_open_tail(open_tail_checkpoint(
+                &session_id,
+                "turn-b",
+                None,
+                vec![second.clone()],
+            ))
+            .unwrap();
+
+        let tail = store.load_open_tail(&session_id).unwrap().unwrap();
+        assert_eq!(tail.turn_id, "turn-b");
+        assert_eq!(
+            tail.entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![second.id.as_str()]
         );
     }
 

--- a/crates/comando-ai/src/transcript_store.rs
+++ b/crates/comando-ai/src/transcript_store.rs
@@ -89,20 +89,6 @@ impl TranscriptStore {
             return Ok(true);
         }
         let connection = self.open(session_id, false)?;
-        let origin = connection
-            .query_row(
-                "SELECT transcript_origin
-                 FROM transcript_sessions
-                 WHERE session_id = ?1",
-                params![session_id.0],
-                |row| row.get::<_, String>(0),
-            )
-            .optional()
-            .map_err(|error| transcript_sql("load transcript origin", error))?;
-        if origin.as_deref() != Some("native") {
-            return Ok(true);
-        }
-
         let has_native_entries = connection
             .query_row(
                 "SELECT EXISTS(
@@ -119,8 +105,8 @@ impl TranscriptStore {
             )
             .map_err(|error| transcript_sql("detect native transcript entries", error))?
             == 1;
-        // Opening the store creates an empty native-default row. It must not
-        // suppress a JSONL backfill until actual native content exists.
+        // Native entries are authoritative even when the session began as a
+        // legacy backfill. An empty native-default row is not sufficient.
         Ok(!has_native_entries)
     }
 

--- a/crates/comando-ai/src/transcript_store.rs
+++ b/crates/comando-ai/src/transcript_store.rs
@@ -221,6 +221,7 @@ impl TranscriptStore {
         &self,
         session_id: &SessionId,
         first_changed_offset: usize,
+        stale_entry_ids: &[String],
     ) -> AiResult<()> {
         if !self.database_path.exists() {
             return Ok(());
@@ -238,11 +239,8 @@ impl TranscriptStore {
                 .map_err(|error| {
                     transcript_sql("start legacy transcript invalidation transaction", error)
                 })?;
-            let obsolete_payload_files = purge_legacy_transcript_entries_from(
-                &transaction,
-                session_id,
-                first_changed_offset,
-            )?;
+            let obsolete_payload_files =
+                purge_legacy_transcript_entries_from(&transaction, session_id, stale_entry_ids)?;
             transaction
                 .execute(
                     "UPDATE transcript_sessions
@@ -1728,57 +1726,67 @@ fn refresh_block_metadata(
 fn purge_legacy_transcript_entries_from(
     transaction: &Transaction<'_>,
     session_id: &SessionId,
-    first_changed_offset: usize,
+    stale_entry_ids: &[String],
 ) -> AiResult<Vec<String>> {
-    let affected_blocks = {
+    let mut affected_blocks = BTreeSet::new();
+    // IDs preserve the JSONL-to-SQLite mapping even when native entries were
+    // skipped during backfill and therefore consumed no SQLite sequence.
+    for entry_ids in stale_entry_ids.chunks(500) {
+        let placeholders = std::iter::repeat_n("?", entry_ids.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let parameters = std::iter::once(session_id.0.as_str())
+            .chain(entry_ids.iter().map(String::as_str))
+            .collect::<Vec<_>>();
+        let lookup_sql = format!(
+            "SELECT DISTINCT entries.block_id
+             FROM transcript_entries AS entries
+             JOIN transcript_blocks AS blocks
+                ON blocks.session_id = entries.session_id
+                AND blocks.block_id = entries.block_id
+             WHERE entries.session_id = ?
+                AND entries.entry_id IN ({placeholders})
+                AND blocks.turn_id GLOB 'legacy-transcript:*'"
+        );
         let mut statement = transaction
-            .prepare(
-                "SELECT entries.block_id
-                 FROM transcript_entries AS entries
-                 JOIN transcript_blocks AS blocks
-                    ON blocks.session_id = entries.session_id
-                    AND blocks.block_id = entries.block_id
-                 WHERE entries.session_id = ?1
-                    AND blocks.turn_id GLOB 'legacy-transcript:*'
-                 ORDER BY entries.sequence ASC
-                 LIMIT -1 OFFSET ?2",
-            )
+            .prepare(&lookup_sql)
             .map_err(|error| transcript_sql("prepare legacy transcript purge blocks", error))?;
-        statement
-            .query_map(params![session_id.0, first_changed_offset as i64], |row| {
+        let block_ids = statement
+            .query_map(params_from_iter(parameters.iter()), |row| {
                 row.get::<_, String>(0)
             })
             .map_err(|error| transcript_sql("query legacy transcript purge blocks", error))?
-            .collect::<Result<BTreeSet<_>, _>>()
-            .map_err(|error| transcript_sql("read legacy transcript purge block", error))?
-    };
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| transcript_sql("read legacy transcript purge block", error))?;
+        affected_blocks.extend(block_ids);
+
+        // Only backfill turns participate here so native transcript entries
+        // keep their own lifecycle during compatibility reconciliation.
+        let delete_sql = format!(
+            "DELETE FROM transcript_entries
+             WHERE session_id = ?
+                AND entry_id IN (
+                    SELECT entries.entry_id
+                    FROM transcript_entries AS entries
+                    JOIN transcript_blocks AS blocks
+                        ON blocks.session_id = entries.session_id
+                        AND blocks.block_id = entries.block_id
+                    WHERE entries.session_id = ?
+                        AND entries.entry_id IN ({placeholders})
+                        AND blocks.turn_id GLOB 'legacy-transcript:*'
+                )"
+        );
+        let delete_parameters = std::iter::once(session_id.0.as_str())
+            .chain(std::iter::once(session_id.0.as_str()))
+            .chain(entry_ids.iter().map(String::as_str));
+        transaction
+            .execute(&delete_sql, params_from_iter(delete_parameters))
+            .map_err(|error| transcript_sql("remove stale legacy transcript entries", error))?;
+    }
 
     if affected_blocks.is_empty() {
         return Ok(Vec::new());
     }
-
-    // Only backfill turns participate here so native transcript entries keep
-    // their own lifecycle when the compatibility transcript is reconciled.
-    transaction
-        .execute(
-            "DELETE FROM transcript_entries
-             WHERE session_id = ?1
-                AND entry_id IN (
-                    SELECT entry_id FROM (
-                        SELECT entries.entry_id
-                        FROM transcript_entries AS entries
-                        JOIN transcript_blocks AS blocks
-                            ON blocks.session_id = entries.session_id
-                            AND blocks.block_id = entries.block_id
-                        WHERE entries.session_id = ?1
-                            AND blocks.turn_id GLOB 'legacy-transcript:*'
-                        ORDER BY entries.sequence ASC
-                        LIMIT -1 OFFSET ?2
-                    )
-                )",
-            params![session_id.0, first_changed_offset as i64],
-        )
-        .map_err(|error| transcript_sql("remove stale legacy transcript entries", error))?;
 
     for block_id in affected_blocks {
         let has_entries = transaction

--- a/crates/comando-ai/src/transcript_store.rs
+++ b/crates/comando-ai/src/transcript_store.rs
@@ -120,6 +120,17 @@ impl TranscriptStore {
             .map(|offset| offset.unwrap_or(0).max(0) as usize)
     }
 
+    pub(crate) fn legacy_transcript_backfill_is_current(
+        &self,
+        session_id: &SessionId,
+        legacy_record_count: usize,
+    ) -> AiResult<bool> {
+        if !self.legacy_transcript_backfill_complete(session_id)? {
+            return Ok(false);
+        }
+        Ok(self.legacy_transcript_backfill_next_offset(session_id)? >= legacy_record_count)
+    }
+
     pub(crate) fn advance_legacy_transcript_backfill(
         &self,
         session_id: &SessionId,

--- a/crates/comando-ai/src/transcript_store.rs
+++ b/crates/comando-ai/src/transcript_store.rs
@@ -131,6 +131,35 @@ impl TranscriptStore {
         Ok(self.legacy_transcript_backfill_next_offset(session_id)? >= legacy_record_count)
     }
 
+    pub(crate) fn invalidate_legacy_transcript_backfill_from(
+        &self,
+        session_id: &SessionId,
+        first_changed_offset: usize,
+    ) -> AiResult<()> {
+        if !self.database_path.exists() {
+            return Ok(());
+        }
+
+        let connection = self.open(session_id, false)?;
+        // The JSONL writer can revise streaming messages in place, so retain
+        // the earliest affected cursor instead of trusting a completed flag.
+        connection
+            .execute(
+                "UPDATE transcript_sessions
+                 SET
+                    legacy_transcript_backfill_complete = 0,
+                    legacy_transcript_backfill_next_offset = MIN(
+                        legacy_transcript_backfill_next_offset,
+                        ?2
+                    )
+                 WHERE session_id = ?1",
+                params![session_id.0, first_changed_offset as i64],
+            )
+            .map_err(|error| transcript_sql("invalidate legacy transcript backfill", error))?;
+
+        Ok(())
+    }
+
     pub(crate) fn advance_legacy_transcript_backfill(
         &self,
         session_id: &SessionId,

--- a/crates/comando-ai/src/transcript_store.rs
+++ b/crates/comando-ai/src/transcript_store.rs
@@ -454,7 +454,7 @@ impl TranscriptStore {
             ));
         }
         let mut connection = self.open(session_id, true)?;
-        let result = (|| {
+        (|| {
             let transaction = connection
                 .transaction_with_behavior(TransactionBehavior::Immediate)
                 .map_err(|error| {
@@ -533,8 +533,7 @@ impl TranscriptStore {
                 transcript_sql("commit terminal open transcript reconciliation", error)
             })?;
             Ok(metadata)
-        })();
-        result
+        })()
     }
 
     pub(crate) fn load_open_tail(

--- a/crates/comando-ai/src/transcript_store.rs
+++ b/crates/comando-ai/src/transcript_store.rs
@@ -140,12 +140,23 @@ impl TranscriptStore {
             return Ok(());
         }
 
-        let connection = self.open(session_id, false)?;
+        let mut connection = self.open(session_id, false)?;
         // The JSONL writer can revise streaming messages in place, so retain
         // the earliest affected cursor instead of trusting a completed flag.
-        connection
-            .execute(
-                "UPDATE transcript_sessions
+        let obsolete_payload_files = (|| {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(|error| {
+                    transcript_sql("start legacy transcript invalidation transaction", error)
+                })?;
+            let obsolete_payload_files = purge_legacy_transcript_entries_from(
+                &transaction,
+                session_id,
+                first_changed_offset,
+            )?;
+            transaction
+                .execute(
+                    "UPDATE transcript_sessions
                  SET
                     legacy_transcript_backfill_complete = 0,
                     legacy_transcript_backfill_next_offset = MIN(
@@ -153,9 +164,15 @@ impl TranscriptStore {
                         ?2
                     )
                  WHERE session_id = ?1",
-                params![session_id.0, first_changed_offset as i64],
-            )
-            .map_err(|error| transcript_sql("invalidate legacy transcript backfill", error))?;
+                    params![session_id.0, first_changed_offset as i64],
+                )
+                .map_err(|error| transcript_sql("invalidate legacy transcript backfill", error))?;
+            transaction
+                .commit()
+                .map_err(|error| transcript_sql("commit legacy transcript invalidation", error))?;
+            Ok(obsolete_payload_files)
+        })()?;
+        self.remove_unreferenced_payload_files(&connection, session_id, &obsolete_payload_files);
 
         Ok(())
     }
@@ -1573,6 +1590,122 @@ fn refresh_block_metadata(
         ));
     }
     Ok(())
+}
+
+fn purge_legacy_transcript_entries_from(
+    transaction: &Transaction<'_>,
+    session_id: &SessionId,
+    first_changed_offset: usize,
+) -> AiResult<Vec<String>> {
+    let affected_blocks = {
+        let mut statement = transaction
+            .prepare(
+                "SELECT entries.block_id
+                 FROM transcript_entries AS entries
+                 JOIN transcript_blocks AS blocks
+                    ON blocks.session_id = entries.session_id
+                    AND blocks.block_id = entries.block_id
+                 WHERE entries.session_id = ?1
+                    AND blocks.turn_id GLOB 'legacy-transcript:*'
+                 ORDER BY entries.sequence ASC
+                 LIMIT -1 OFFSET ?2",
+            )
+            .map_err(|error| transcript_sql("prepare legacy transcript purge blocks", error))?;
+        statement
+            .query_map(params![session_id.0, first_changed_offset as i64], |row| {
+                row.get::<_, String>(0)
+            })
+            .map_err(|error| transcript_sql("query legacy transcript purge blocks", error))?
+            .collect::<Result<BTreeSet<_>, _>>()
+            .map_err(|error| transcript_sql("read legacy transcript purge block", error))?
+    };
+
+    if affected_blocks.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Only backfill turns participate here so native transcript entries keep
+    // their own lifecycle when the compatibility transcript is reconciled.
+    transaction
+        .execute(
+            "DELETE FROM transcript_entries
+             WHERE session_id = ?1
+                AND entry_id IN (
+                    SELECT entry_id FROM (
+                        SELECT entries.entry_id
+                        FROM transcript_entries AS entries
+                        JOIN transcript_blocks AS blocks
+                            ON blocks.session_id = entries.session_id
+                            AND blocks.block_id = entries.block_id
+                        WHERE entries.session_id = ?1
+                            AND blocks.turn_id GLOB 'legacy-transcript:*'
+                        ORDER BY entries.sequence ASC
+                        LIMIT -1 OFFSET ?2
+                    )
+                )",
+            params![session_id.0, first_changed_offset as i64],
+        )
+        .map_err(|error| transcript_sql("remove stale legacy transcript entries", error))?;
+
+    for block_id in affected_blocks {
+        let has_entries = transaction
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM transcript_entries
+                    WHERE session_id = ?1 AND block_id = ?2
+                )",
+                params![session_id.0, block_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(|error| transcript_sql("check legacy transcript block after purge", error))?
+            == 1;
+        if has_entries {
+            refresh_block_metadata(transaction, session_id, &block_id)?;
+        } else {
+            transaction
+                .execute(
+                    "DELETE FROM transcript_blocks
+                     WHERE session_id = ?1 AND block_id = ?2",
+                    params![session_id.0, block_id],
+                )
+                .map_err(|error| transcript_sql("remove empty legacy transcript block", error))?;
+        }
+    }
+
+    let obsolete_payload_files = {
+        let mut statement = transaction
+            .prepare(
+                "SELECT file_name
+                 FROM transcript_payloads AS payloads
+                 WHERE payloads.session_id = ?1
+                    AND payloads.file_name IS NOT NULL
+                    AND NOT EXISTS (
+                        SELECT 1 FROM transcript_entries AS entries
+                        WHERE entries.session_id = payloads.session_id
+                            AND entries.payload_ref = payloads.payload_ref
+                    )",
+            )
+            .map_err(|error| transcript_sql("prepare stale transcript payload cleanup", error))?;
+        statement
+            .query_map(params![session_id.0], |row| row.get::<_, String>(0))
+            .map_err(|error| transcript_sql("query stale transcript payload files", error))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| transcript_sql("read stale transcript payload file", error))?
+    };
+    transaction
+        .execute(
+            "DELETE FROM transcript_payloads
+             WHERE session_id = ?1
+                AND NOT EXISTS (
+                    SELECT 1 FROM transcript_entries AS entries
+                    WHERE entries.session_id = transcript_payloads.session_id
+                        AND entries.payload_ref = transcript_payloads.payload_ref
+                )",
+            params![session_id.0],
+        )
+        .map_err(|error| transcript_sql("remove stale transcript payloads", error))?;
+
+    Ok(obsolete_payload_files)
 }
 
 #[derive(Debug)]

--- a/crates/comando-ai/src/transcript_store.rs
+++ b/crates/comando-ai/src/transcript_store.rs
@@ -442,6 +442,100 @@ impl TranscriptStore {
         }
     }
 
+    pub(crate) fn reconcile_terminal_open_tail(
+        &self,
+        session_id: &SessionId,
+        turn_id: &str,
+    ) -> AiResult<Vec<NativeAiTranscriptBlockMetadata>> {
+        if turn_id.trim().is_empty() {
+            return Err(AiError::InvalidInput(
+                "Open transcript turn ID must not be empty".to_string(),
+            ));
+        }
+        let mut connection = self.open(session_id, true)?;
+        let result = (|| {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(|error| {
+                    transcript_sql("start terminal open transcript reconciliation", error)
+                })?;
+            let state = transaction
+                .query_row(
+                    "SELECT turn_id, terminal_status
+                     FROM transcript_open_tails
+                     WHERE session_id = ?1",
+                    params![session_id.0],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+                )
+                .optional()
+                .map_err(|error| transcript_sql("load terminal open transcript tail", error))?;
+            let Some((stored_turn_id, terminal_status)) = state else {
+                return load_all_block_metadata(&transaction, session_id);
+            };
+            if stored_turn_id != turn_id {
+                return Err(AiError::InvalidInput(
+                    "Open transcript tail belongs to a different turn".to_string(),
+                ));
+            }
+            if terminal_status.is_none() {
+                return Err(AiError::InvalidInput(
+                    "Open transcript tail is not terminal".to_string(),
+                ));
+            }
+
+            let mut statement = transaction
+                .prepare(
+                    "SELECT entry_id
+                     FROM transcript_open_tail_entries
+                     WHERE session_id = ?1
+                     ORDER BY ordinal ASC",
+                )
+                .map_err(|error| transcript_sql("prepare terminal open tail entries", error))?;
+            let entry_ids = statement
+                .query_map(params![session_id.0], |row| row.get::<_, String>(0))
+                .map_err(|error| transcript_sql("query terminal open tail entries", error))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| transcript_sql("read terminal open tail entry", error))?;
+            drop(statement);
+
+            let block_ids = block_ids_for_entries(&transaction, session_id, &entry_ids)?;
+            validate_block_payload_references(&transaction, session_id, &block_ids)?;
+            let mut open_block_ids = Vec::new();
+            for block_id in &block_ids {
+                let is_sealed = transaction
+                    .query_row(
+                        "SELECT is_sealed
+                         FROM transcript_blocks
+                         WHERE session_id = ?1 AND block_id = ?2",
+                        params![session_id.0, block_id],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .map_err(|error| {
+                        transcript_sql("load transcript block reconciliation state", error)
+                    })?;
+                if is_sealed == 0 {
+                    open_block_ids.push(block_id.clone());
+                }
+            }
+
+            // Blocks already sealed by another turn are durable and must not be reassigned.
+            seal_blocks(&transaction, session_id, turn_id, &open_block_ids)?;
+            let metadata = load_block_metadata_by_ids(&transaction, session_id, &block_ids)?;
+            transaction
+                .execute(
+                    "DELETE FROM transcript_open_tails
+                     WHERE session_id = ?1 AND turn_id = ?2",
+                    params![session_id.0, turn_id],
+                )
+                .map_err(|error| transcript_sql("clear reconciled open transcript tail", error))?;
+            transaction.commit().map_err(|error| {
+                transcript_sql("commit terminal open transcript reconciliation", error)
+            })?;
+            Ok(metadata)
+        })();
+        result
+    }
+
     pub(crate) fn load_open_tail(
         &self,
         session_id: &SessionId,
@@ -2624,7 +2718,7 @@ mod tests {
     }
 
     #[test]
-    fn terminal_open_tail_with_a_foreign_sealed_block_reproduces_seal_failure() {
+    fn terminal_open_tail_reconciles_a_foreign_sealed_block() {
         let temp = tempfile::tempdir().unwrap();
         let session_id = SessionId("foreign-sealed-tail".to_string());
         let store = TranscriptStore::new(temp.path());
@@ -2660,34 +2754,20 @@ mod tests {
             })
             .unwrap();
 
-        let error = store
-            .seal_turn(
-                &session_id,
-                "turn-b",
-                vec![first.clone(), second.clone()],
-                Vec::new(),
-            )
-            .unwrap_err();
+        let metadata = store
+            .reconcile_terminal_open_tail(&session_id, "turn-b")
+            .unwrap();
 
-        assert!(
-            error
-                .to_string()
-                .contains("Transcript block is already sealed by another turn")
-        );
-        let tail = store.load_open_tail(&session_id).unwrap().unwrap();
-        assert_eq!(tail.turn_id, "turn-b");
+        assert!(store.load_open_tail(&session_id).unwrap().is_none());
+        assert_eq!(metadata.len(), 2);
+        assert_eq!(store.load_block_metadata(&session_id).unwrap().len(), 2);
         assert_eq!(
-            tail.terminal_status,
-            Some(NativeAiTranscriptTerminalStatus::Completed)
+            store
+                .reconcile_terminal_open_tail(&session_id, "turn-b")
+                .unwrap()
+                .len(),
+            2
         );
-        assert_eq!(
-            tail.entries
-                .iter()
-                .map(|entry| entry.id.as_str())
-                .collect::<Vec<_>>(),
-            vec![first.id.as_str(), second.id.as_str()]
-        );
-        assert_eq!(store.load_block_metadata(&session_id).unwrap().len(), 1);
 
         let connection = store.open(&session_id, false).unwrap();
         let (sealed, open): (i64, i64) = connection
@@ -2701,7 +2781,23 @@ mod tests {
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .unwrap();
-        assert_eq!((sealed, open), (1, 1));
+        assert_eq!((sealed, open), (2, 0));
+        let owners = connection
+            .prepare(
+                "SELECT turn_id
+                 FROM transcript_blocks
+                 WHERE session_id = ?1
+                 ORDER BY ordinal ASC",
+            )
+            .unwrap()
+            .query_map(params![session_id.0], |row| row.get::<_, Option<String>>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            owners,
+            vec![Some("turn-a".to_string()), Some("turn-b".to_string())]
+        );
     }
 
     #[test]

--- a/crates/comando-ai/src/transcript_store.rs
+++ b/crates/comando-ai/src/transcript_store.rs
@@ -2624,6 +2624,87 @@ mod tests {
     }
 
     #[test]
+    fn terminal_open_tail_with_a_foreign_sealed_block_reproduces_seal_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_id = SessionId("foreign-sealed-tail".to_string());
+        let store = TranscriptStore::new(temp.path());
+        let first = entry(&session_id, "entry-in-sealed-block");
+        let second = entry(&session_id, "entry-in-open-block");
+
+        store.append(&session_id, vec![first.clone()]).unwrap();
+        store
+            .seal_turn(&session_id, "turn-a", vec![first.clone()], Vec::new())
+            .unwrap();
+
+        // The recovered terminal tail deliberately retains a reference owned by turn-a.
+        store
+            .checkpoint_open_tail(NativeAiCheckpointOpenTranscriptTailInput {
+                session_id: session_id.clone(),
+                turn_id: "turn-b".to_string(),
+                terminal_status: Some(NativeAiTranscriptTerminalStatus::Completed),
+                entries: vec![first.clone(), second.clone()],
+                payloads: Vec::new(),
+                removed_entry_ids: Vec::new(),
+                entry_order: vec![
+                    NativeAiOpenTranscriptEntryRef {
+                        entry_id: first.id.clone(),
+                        entry_revision: 1,
+                        ordinal: 0,
+                    },
+                    NativeAiOpenTranscriptEntryRef {
+                        entry_id: second.id.clone(),
+                        entry_revision: 1,
+                        ordinal: 1,
+                    },
+                ],
+            })
+            .unwrap();
+
+        let error = store
+            .seal_turn(
+                &session_id,
+                "turn-b",
+                vec![first.clone(), second.clone()],
+                Vec::new(),
+            )
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Transcript block is already sealed by another turn")
+        );
+        let tail = store.load_open_tail(&session_id).unwrap().unwrap();
+        assert_eq!(tail.turn_id, "turn-b");
+        assert_eq!(
+            tail.terminal_status,
+            Some(NativeAiTranscriptTerminalStatus::Completed)
+        );
+        assert_eq!(
+            tail.entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![first.id.as_str(), second.id.as_str()]
+        );
+        assert_eq!(store.load_block_metadata(&session_id).unwrap().len(), 1);
+
+        let connection = store.open(&session_id, false).unwrap();
+        let (sealed, open): (i64, i64) = connection
+            .query_row(
+                "SELECT
+                    SUM(CASE WHEN is_sealed = 1 THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN is_sealed = 0 THEN 1 ELSE 0 END)
+                 FROM transcript_blocks
+                 WHERE session_id = ?1",
+                params![session_id.0],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((sealed, open), (1, 1));
+    }
+
+    #[test]
     fn checkpoint_reorders_only_the_changed_open_tail_rows() {
         let temp = tempfile::tempdir().unwrap();
         let session_id = SessionId("reordered-open-tail".to_string());

--- a/crates/comando-ai/src/transcript_store.rs
+++ b/crates/comando-ai/src/transcript_store.rs
@@ -11,7 +11,9 @@ use comando_types::ai::{
     NativeAiTranscriptPayloadWrite, NativeAiTranscriptTerminalStatus,
 };
 use comando_types::ids::SessionId;
-use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
+use rusqlite::{
+    Connection, OptionalExtension, Transaction, TransactionBehavior, params, params_from_iter,
+};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -89,6 +91,22 @@ impl TranscriptStore {
             return Ok(true);
         }
         let connection = self.open(session_id, false)?;
+        let backfill_incomplete = connection
+            .query_row(
+                "SELECT
+                    transcript_origin = 'legacy_backfill'
+                    AND legacy_transcript_backfill_complete = 0
+                 FROM transcript_sessions
+                 WHERE session_id = ?1",
+                params![session_id.0],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .map_err(|error| transcript_sql("load transcript backfill origin", error))?
+            == Some(1);
+        if backfill_incomplete {
+            return Ok(true);
+        }
         let has_native_entries = connection
             .query_row(
                 "SELECT EXISTS(
@@ -108,6 +126,41 @@ impl TranscriptStore {
         // Native entries are authoritative even when the session began as a
         // legacy backfill. An empty native-default row is not sufficient.
         Ok(!has_native_entries)
+    }
+
+    pub(crate) fn native_transcript_entry_ids(
+        &self,
+        session_id: &SessionId,
+        entry_ids: &[String],
+    ) -> AiResult<BTreeSet<String>> {
+        if !self.database_path.exists() || entry_ids.is_empty() {
+            return Ok(BTreeSet::new());
+        }
+        let connection = self.open(session_id, false)?;
+        let placeholders = std::iter::repeat_n("?", entry_ids.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT entries.entry_id
+             FROM transcript_entries AS entries
+             JOIN transcript_blocks AS blocks
+                ON blocks.session_id = entries.session_id
+                AND blocks.block_id = entries.block_id
+             WHERE entries.session_id = ?
+                AND entries.entry_id IN ({placeholders})
+                AND (blocks.turn_id IS NULL
+                    OR blocks.turn_id NOT GLOB 'legacy-transcript:*')"
+        );
+        let mut statement = connection
+            .prepare(&sql)
+            .map_err(|error| transcript_sql("prepare native transcript entry lookup", error))?;
+        let parameters =
+            std::iter::once(session_id.0.as_str()).chain(entry_ids.iter().map(String::as_str));
+        statement
+            .query_map(params_from_iter(parameters), |row| row.get::<_, String>(0))
+            .map_err(|error| transcript_sql("query native transcript entries", error))?
+            .collect::<Result<BTreeSet<_>, _>>()
+            .map_err(|error| transcript_sql("read native transcript entry", error))
     }
 
     pub(crate) fn begin_legacy_transcript_backfill(&self, session_id: &SessionId) -> AiResult<()> {
@@ -1208,20 +1261,20 @@ fn migrate_schema(connection: &mut Connection) -> AiResult<()> {
             .execute_batch(
                 "UPDATE transcript_sessions AS sessions
                  SET transcript_origin = 'legacy_backfill'
-                 WHERE (
-                    sessions.legacy_transcript_backfill_complete = 0
-                    OR EXISTS (
+                 WHERE sessions.legacy_transcript_backfill_complete = 0
+                    OR (
+                        EXISTS (
                         SELECT 1 FROM transcript_blocks AS blocks
                         WHERE blocks.session_id = sessions.session_id
                             AND blocks.turn_id GLOB 'legacy-transcript:*'
-                    )
-                 )
-                 AND NOT EXISTS (
-                    SELECT 1 FROM transcript_blocks AS blocks
-                    WHERE blocks.session_id = sessions.session_id
-                        AND (blocks.turn_id IS NULL
-                            OR blocks.turn_id NOT GLOB 'legacy-transcript:*')
-                 );",
+                        )
+                        AND NOT EXISTS (
+                            SELECT 1 FROM transcript_blocks AS blocks
+                            WHERE blocks.session_id = sessions.session_id
+                                AND (blocks.turn_id IS NULL
+                                    OR blocks.turn_id NOT GLOB 'legacy-transcript:*')
+                        )
+                    );",
             )
             .map_err(|error| transcript_sql("classify transcript origins", error))?;
     }

--- a/crates/comando-types/src/ai.rs
+++ b/crates/comando-types/src/ai.rs
@@ -732,6 +732,13 @@ pub struct NativeAiSealTranscriptTurnInput {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct NativeAiReconcileTerminalOpenTranscriptTailInput {
+    pub session_id: SessionId,
+    pub turn_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct NativeAiLoadTranscriptBlockInput {
     pub session_id: SessionId,
     pub block_id: String,

--- a/src/main/ai/contracts.ts
+++ b/src/main/ai/contracts.ts
@@ -36,6 +36,7 @@ import type {
     AiTranscriptPayload,
     AiTranscriptPayloadsOutput,
     AiTranscriptStorageState,
+    AiReconcileTerminalOpenTranscriptTailInput,
     AiSealTranscriptTurnInput,
     AiUserInputResponseInput,
     FileBufferNotificationInput,
@@ -208,6 +209,9 @@ export interface NativeAiGateway {
     respondUserInput(input: AiUserInputResponseInput): Promise<void>;
     sealTranscriptTurn?(
         input: AiSealTranscriptTurnInput,
+    ): Promise<readonly AiTranscriptBlockMetadata[]>;
+    reconcileTerminalOpenTranscriptTail?(
+        input: AiReconcileTerminalOpenTranscriptTailInput,
     ): Promise<readonly AiTranscriptBlockMetadata[]>;
     sendPrompt(input: NativeAiSendPromptRpcInput): Promise<AiPromptResult>;
     setSessionPinned(input: AiSessionPinnedMutationInput): Promise<void>;

--- a/src/main/ai/service.history.test.ts
+++ b/src/main/ai/service.history.test.ts
@@ -440,6 +440,54 @@ describe("AiService history", () => {
         }
     });
 
+    it("does not mark a terminal tail as recovered when reconciliation fails", async () => {
+        const snapshot = createSnapshot({
+            activeTurnStartedAt: null,
+            status: "idle",
+        });
+        const loadOpenTranscriptTail = vi.fn(() => Promise.resolve(
+            terminalTail(snapshot.sessionId),
+        ));
+        const reconcileTerminalOpenTranscriptTail = vi.fn(() => Promise.reject(
+            new Error("reconciliation unavailable"),
+        ));
+        const service = createService({
+            nativeAi: createNativeAiGateway({
+                checkpointOpenTranscriptTail: vi.fn(() => Promise.resolve()),
+                getTranscriptCapability: vi.fn(() => ({
+                    blockNativeVersion: 1,
+                    legacyFallbackAvailable: true,
+                })),
+                getTranscriptStorageState: vi.fn(() => Promise.resolve({
+                    capabilityVersion: 1,
+                    legacyFallbackAvailable: true,
+                    migrationManifestExists: false,
+                    mode: "block-native" as const,
+                    sessionId: snapshot.sessionId,
+                    storageVersion: 5,
+                })),
+                loadOpenTranscriptTail,
+                loadSessionSnapshot: vi.fn(() => Promise.resolve(snapshot)),
+                reconcileTerminalOpenTranscriptTail,
+                sealTranscriptTurn: vi.fn(() => Promise.resolve([])),
+            }),
+        });
+
+        try {
+            await expect(service.getSessionSnapshot(snapshot.sessionId)).rejects.toThrow(
+                "reconciliation unavailable",
+            );
+            await expect(service.getSessionSnapshot(snapshot.sessionId)).rejects.toThrow(
+                "reconciliation unavailable",
+            );
+
+            expect(loadOpenTranscriptTail).toHaveBeenCalledTimes(2);
+            expect(reconcileTerminalOpenTranscriptTail).toHaveBeenCalled();
+        } finally {
+            service.close();
+        }
+    });
+
     it("retries a transient transcript migration status failure", async () => {
         vi.useFakeTimers();
         const snapshot = createSnapshot();
@@ -1213,6 +1261,19 @@ function createSnapshot(
     };
 }
 
+function terminalTail(sessionId: string): AiOpenTranscriptTail {
+    return {
+        entries: [],
+        entryRevisions: [],
+        payloads: [],
+        revision: 1,
+        sessionId,
+        terminalStatus: "completed",
+        turnId: "terminal-turn",
+        updatedAt: "2026-04-16T12:00:01.000Z",
+    };
+}
+
 function createTrackedFile(
     overrides: Partial<AiTrackedFile> = {},
 ): AiTrackedFile {
@@ -1344,6 +1405,7 @@ function createNativeAiGateway(
         loadSessionSnapshot: vi.fn(() => Promise.resolve(null)),
         loadSessionTranscriptPage: vi.fn(() => Promise.resolve(null)),
         prepareSession: vi.fn(),
+        reconcileTerminalOpenTranscriptTail: vi.fn(() => Promise.resolve([])),
         renameSession: vi.fn(),
         respondPermission: vi.fn(),
         respondUserInput: vi.fn(),

--- a/src/main/ai/service.history.test.ts
+++ b/src/main/ai/service.history.test.ts
@@ -197,7 +197,7 @@ describe("AiService history", () => {
                 expect(checkpointOpenTranscriptTail).toHaveBeenCalledOnce(),
             );
             await vi.waitFor(() =>
-                expect(loadTranscriptBlockMetadata).toHaveBeenCalled(),
+                expect(loadTranscriptBlockMetadata).toHaveBeenCalledOnce(),
             );
         } finally {
             service.close();

--- a/src/main/ai/service.history.test.ts
+++ b/src/main/ai/service.history.test.ts
@@ -327,6 +327,93 @@ describe("AiService history", () => {
         }
     });
 
+    it("exposes an interrupted tail outside sealed block metadata", async () => {
+        const snapshot = createSnapshot();
+        const openTail: AiOpenTranscriptTail = {
+            entries: [{
+                createdAt: "2026-04-16T12:00:01.000Z",
+                id: "message:assistant-1",
+                kind: "message",
+                payloadRef: "tail:assistant-1",
+                sequence: 1,
+                sessionId: snapshot.sessionId,
+                summary: {
+                    label: "Assistant",
+                    preview: "Recovered streamed output.",
+                    status: "streaming",
+                },
+                updatedAt: "2026-04-16T12:00:01.000Z",
+            }],
+            entryRevisions: [{
+                entryId: "message:assistant-1",
+                entryRevision: 1,
+                ordinal: 0,
+            }],
+            payloads: [{
+                payloadRef: "tail:assistant-1",
+                value: {
+                    kind: "message",
+                    message: {
+                        attachments: [],
+                        content: "Recovered streamed output.",
+                        createdAt: "2026-04-16T12:00:01.000Z",
+                        id: "assistant-1",
+                        kind: "assistant",
+                        status: "streaming",
+                    },
+                },
+            }],
+            revision: 1,
+            sessionId: snapshot.sessionId,
+            terminalStatus: null,
+            turnId: "interrupted-turn",
+            updatedAt: "2026-04-16T12:00:01.000Z",
+        };
+        const loadTranscriptBlockMetadata = vi.fn(() => Promise.resolve({
+            blocks: [],
+            capabilityVersion: 1,
+            sessionId: snapshot.sessionId,
+            transcriptRevision: 1,
+        }));
+        const service = createService({
+            nativeAi: createNativeAiGateway({
+                checkpointOpenTranscriptTail: vi.fn(() => Promise.resolve()),
+                getTranscriptCapability: vi.fn(() => ({
+                    blockNativeVersion: 1,
+                    legacyFallbackAvailable: true,
+                })),
+                getTranscriptStorageState: vi.fn(() => Promise.resolve({
+                    capabilityVersion: 1,
+                    legacyFallbackAvailable: true,
+                    migrationManifestExists: false,
+                    mode: "block-native" as const,
+                    sessionId: snapshot.sessionId,
+                    storageVersion: 5,
+                })),
+                loadOpenTranscriptTail: vi.fn(() => Promise.resolve(openTail)),
+                loadSessionSnapshot: vi.fn(() => Promise.resolve(snapshot)),
+                loadTranscriptBlockMetadata,
+                sealTranscriptTurn: vi.fn(() => Promise.resolve([])),
+            }),
+        });
+
+        try {
+            const restored = await service.getSessionSnapshot(snapshot.sessionId);
+            const metadata = await service.getTranscriptBlockMetadata(snapshot.sessionId);
+
+            // A renderer that reads only sealed blocks has no representation
+            // for this otherwise recoverable historical message.
+            expect(restored?.messages).toMatchObject([{
+                content: "Recovered streamed output.",
+                id: "assistant-1",
+            }]);
+            expect(metadata?.blocks).toEqual([]);
+            expect(loadTranscriptBlockMetadata).toHaveBeenCalledOnce();
+        } finally {
+            service.close();
+        }
+    });
+
     it("retries a transient transcript migration status failure", async () => {
         vi.useFakeTimers();
         const snapshot = createSnapshot();

--- a/src/main/ai/service.history.test.ts
+++ b/src/main/ai/service.history.test.ts
@@ -246,7 +246,7 @@ describe("AiService history", () => {
         expect(loadTranscriptBlockMetadata).not.toHaveBeenCalled();
     });
 
-    it("restores an open tail before returning a historical block-native snapshot", async () => {
+    it("keeps an open tail visible while a live runtime owns the session", async () => {
         const snapshot = createSnapshot({
             activeTurnStartedAt: "2026-04-16T12:00:00.000Z",
             status: "streaming",
@@ -292,6 +292,7 @@ describe("AiService history", () => {
             updatedAt: "2026-04-16T12:00:01.000Z",
         };
         const loadOpenTranscriptTail = vi.fn(() => Promise.resolve(openTail));
+        const sealTranscriptTurn = vi.fn(() => Promise.resolve([]));
         const service = createService({
             nativeAi: createNativeAiGateway({
                 checkpointOpenTranscriptTail: vi.fn(() => Promise.resolve()),
@@ -309,26 +310,50 @@ describe("AiService history", () => {
                 })),
                 loadOpenTranscriptTail,
                 loadSessionSnapshot: vi.fn(() => Promise.resolve(snapshot)),
-                sealTranscriptTurn: vi.fn(() => Promise.resolve([])),
+                sealTranscriptTurn,
             }),
         });
 
         try {
-            await expect(service.getSessionSnapshot(snapshot.sessionId)).resolves
-                .toMatchObject({
-                    messages: [{
-                        content: "Recovered streamed output.",
-                        id: "assistant-1",
-                    }],
-                });
+            service.handleNativeSessionSnapshot("window-1", {
+                kind: "snapshot",
+                snapshot,
+            });
+            await vi.waitFor(() => expect(loadOpenTranscriptTail).toHaveBeenCalledOnce());
+            const restored = await service.getSessionSnapshot(snapshot.sessionId);
+            const recoveredMessage = service
+                .getLiveTranscriptTail(snapshot.sessionId)
+                ?.entries.find((entry) => entry.envelope.id === "message:assistant-1");
+            expect(recoveredMessage?.payload).toMatchObject({
+                message: { id: "assistant-1" },
+            });
+            expect(restored).toMatchObject({
+                messages: [{
+                    content: "Recovered streamed output.",
+                    id: "assistant-1",
+                }],
+            });
+            expect(sealTranscriptTurn).not.toHaveBeenCalled();
             expect(loadOpenTranscriptTail).toHaveBeenCalledOnce();
         } finally {
             service.close();
         }
     });
 
-    it("exposes an interrupted tail outside sealed block metadata", async () => {
+    it("seals an interrupted historical tail before loading block metadata", async () => {
         const snapshot = createSnapshot();
+        const sealedBlock = {
+            blockId: `${snapshot.sessionId}:0`,
+            endSequence: 1,
+            entryCount: 1,
+            estimatedHeight: 72,
+            estimatedRowCount: 1,
+            firstCreatedAt: "2026-04-16T12:00:01.000Z",
+            lastCreatedAt: "2026-04-16T12:00:01.000Z",
+            revision: 1,
+            sessionId: snapshot.sessionId,
+            startSequence: 1,
+        };
         const openTail: AiOpenTranscriptTail = {
             entries: [{
                 createdAt: "2026-04-16T12:00:01.000Z",
@@ -370,7 +395,7 @@ describe("AiService history", () => {
             updatedAt: "2026-04-16T12:00:01.000Z",
         };
         const loadTranscriptBlockMetadata = vi.fn(() => Promise.resolve({
-            blocks: [],
+            blocks: [sealedBlock],
             capabilityVersion: 1,
             sessionId: snapshot.sessionId,
             transcriptRevision: 1,
@@ -390,25 +415,26 @@ describe("AiService history", () => {
                     sessionId: snapshot.sessionId,
                     storageVersion: 5,
                 })),
-                loadOpenTranscriptTail: vi.fn(() => Promise.resolve(openTail)),
+                loadOpenTranscriptTail: vi
+                    .fn()
+                    .mockResolvedValueOnce(openTail)
+                    .mockResolvedValue(null),
                 loadSessionSnapshot: vi.fn(() => Promise.resolve(snapshot)),
                 loadTranscriptBlockMetadata,
-                sealTranscriptTurn: vi.fn(() => Promise.resolve([])),
+                sealTranscriptTurn: vi.fn(() => Promise.resolve([sealedBlock])),
             }),
         });
 
         try {
-            const restored = await service.getSessionSnapshot(snapshot.sessionId);
             const metadata = await service.getTranscriptBlockMetadata(snapshot.sessionId);
+            const restored = await service.getSessionSnapshot(snapshot.sessionId);
 
-            // A renderer that reads only sealed blocks has no representation
-            // for this otherwise recoverable historical message.
-            expect(restored?.messages).toMatchObject([{
-                content: "Recovered streamed output.",
-                id: "assistant-1",
-            }]);
-            expect(metadata?.blocks).toEqual([]);
-            expect(loadTranscriptBlockMetadata).toHaveBeenCalledOnce();
+            expect(restored?.messages).toEqual([]);
+            expect(metadata?.blocks).toEqual([sealedBlock]);
+            expect(
+                service.getLiveTranscriptTail(snapshot.sessionId)?.stableBlocks,
+            ).toEqual([sealedBlock]);
+            expect(loadTranscriptBlockMetadata).toHaveBeenCalled();
         } finally {
             service.close();
         }

--- a/src/main/ai/service.history.test.ts
+++ b/src/main/ai/service.history.test.ts
@@ -6,6 +6,7 @@ import type {
     AiSessionSnapshot,
     AiSessionTranscriptPage,
     AiSessionUpdate,
+    AiTranscriptBlockMetadataOutput,
     AiTrackedFile,
 } from "@shared/ipc";
 
@@ -122,6 +123,174 @@ describe("AiService history", () => {
                     expect.objectContaining({ id: "message:assistant-1" }),
                 ]),
             );
+        } finally {
+            service.close();
+        }
+    });
+
+    it("reconciles a recovered terminal tail before checkpointing a newer snapshot", async () => {
+        let resolveReconciliation!: (value: readonly ReturnType<typeof transcriptBlock>[]) => void;
+        const reconciliation = new Promise<readonly ReturnType<typeof transcriptBlock>[]>((resolve) => {
+            resolveReconciliation = resolve;
+        });
+        const checkpointOpenTranscriptTail = vi.fn<
+            NonNullable<NativeAiGateway["checkpointOpenTranscriptTail"]>
+        >(() => Promise.resolve());
+        const loadTranscriptBlockMetadata = vi.fn(() => Promise.resolve({
+            blocks: [],
+            capabilityVersion: 1,
+            sessionId: "session-1",
+            transcriptRevision: 2,
+        }));
+        const snapshot = createSnapshot({
+            activeTurnStartedAt: "2026-04-16T12:02:00.000Z",
+            messages: [{
+                attachments: [],
+                content: "New runtime output.",
+                createdAt: "2026-04-16T12:02:01.000Z",
+                id: "assistant-new",
+                kind: "assistant",
+                status: "streaming",
+            }],
+            status: "streaming",
+        });
+        const reconcileTerminalOpenTranscriptTail = vi.fn(() => reconciliation);
+        const service = createService({
+            nativeAi: createNativeAiGateway({
+                checkpointOpenTranscriptTail,
+                getTranscriptCapability: vi.fn(() => ({
+                    blockNativeVersion: 1,
+                    legacyFallbackAvailable: true,
+                })),
+                getTranscriptStorageState: vi.fn(() => Promise.resolve({
+                    capabilityVersion: 1,
+                    legacyFallbackAvailable: true,
+                    migrationManifestExists: false,
+                    mode: "block-native" as const,
+                    sessionId: snapshot.sessionId,
+                    storageVersion: 5,
+                })),
+                loadOpenTranscriptTail: vi.fn(() => Promise.resolve(
+                    terminalTail(snapshot.sessionId),
+                )),
+                loadTranscriptBlockMetadata,
+                reconcileTerminalOpenTranscriptTail,
+                sealTranscriptTurn: vi.fn(() => Promise.resolve([])),
+            }),
+        });
+
+        try {
+            service.handleNativeSessionSnapshot("window-1", {
+                kind: "snapshot",
+                snapshot,
+            });
+
+            await vi.waitFor(() =>
+                expect(reconcileTerminalOpenTranscriptTail).toHaveBeenCalledOnce(),
+            );
+            expect(checkpointOpenTranscriptTail).not.toHaveBeenCalled();
+            expect(loadTranscriptBlockMetadata).not.toHaveBeenCalled();
+
+            resolveReconciliation([]);
+
+            await vi.waitFor(() =>
+                expect(checkpointOpenTranscriptTail).toHaveBeenCalledOnce(),
+            );
+            await vi.waitFor(() =>
+                expect(loadTranscriptBlockMetadata).toHaveBeenCalled(),
+            );
+        } finally {
+            service.close();
+        }
+    });
+
+    it("discards metadata that was loaded before a concurrent seal", async () => {
+        let resolveFirstMetadata!: (value: AiTranscriptBlockMetadataOutput) => void;
+        const firstMetadata = new Promise<AiTranscriptBlockMetadataOutput>((resolve) => {
+            resolveFirstMetadata = resolve;
+        });
+        const snapshot = createSnapshot({
+            activeTurnStartedAt: "2026-04-16T12:03:00.000Z",
+            messages: [{
+                attachments: [],
+                content: "Output that will be sealed.",
+                createdAt: "2026-04-16T12:03:01.000Z",
+                id: "assistant-sealed",
+                kind: "assistant",
+                status: "streaming",
+            }],
+            status: "streaming",
+        });
+        const staleBlock = transcriptBlock(snapshot.sessionId, "stale", 1);
+        const sealedBlock = transcriptBlock(snapshot.sessionId, "sealed", 2);
+        const loadTranscriptBlockMetadata = vi
+            .fn()
+            .mockReturnValueOnce(firstMetadata)
+            .mockResolvedValueOnce({
+                blocks: [sealedBlock],
+                capabilityVersion: 1,
+                sessionId: snapshot.sessionId,
+                transcriptRevision: 2,
+            });
+        const service = createService({
+            nativeAi: createNativeAiGateway({
+                checkpointOpenTranscriptTail: vi.fn(() => Promise.resolve()),
+                getTranscriptCapability: vi.fn(() => ({
+                    blockNativeVersion: 1,
+                    legacyFallbackAvailable: true,
+                })),
+                getTranscriptStorageState: vi.fn(() => Promise.resolve({
+                    capabilityVersion: 1,
+                    legacyFallbackAvailable: true,
+                    migrationManifestExists: false,
+                    mode: "block-native" as const,
+                    sessionId: snapshot.sessionId,
+                    storageVersion: 5,
+                })),
+                loadOpenTranscriptTail: vi.fn(() => Promise.resolve(null)),
+                loadTranscriptBlockMetadata,
+                sealTranscriptTurn: vi.fn(() => Promise.resolve([sealedBlock])),
+            }),
+        });
+
+        try {
+            service.handleNativeSessionSnapshot("window-1", {
+                kind: "snapshot",
+                snapshot,
+            });
+            await vi.waitFor(() =>
+                expect(loadTranscriptBlockMetadata).toHaveBeenCalledOnce(),
+            );
+
+            service.handleNativeSessionEvent("window-1", {
+                error: null,
+                kind: "turn-status",
+                origin: "live",
+                parentSessionId: null,
+                runtimeId: "codex",
+                runtimeSessionId: snapshot.runtimeSessionId,
+                sessionId: snapshot.sessionId,
+                status: "completed",
+                turnId: snapshot.activeTurnStartedAt!,
+                updatedAt: "2026-04-16T12:03:02.000Z",
+            });
+            await vi.waitFor(() =>
+                expect(loadTranscriptBlockMetadata).toHaveBeenCalledTimes(1),
+            );
+
+            resolveFirstMetadata({
+                blocks: [staleBlock],
+                capabilityVersion: 1,
+                sessionId: snapshot.sessionId,
+                transcriptRevision: 1,
+            });
+
+            await vi.waitFor(() =>
+                expect(loadTranscriptBlockMetadata).toHaveBeenCalledTimes(2),
+            );
+            expect(
+                service.getLiveTranscriptTail(snapshot.sessionId)?.stableBlocks,
+            ).toEqual([sealedBlock]);
         } finally {
             service.close();
         }
@@ -1271,6 +1440,25 @@ function terminalTail(sessionId: string): AiOpenTranscriptTail {
         terminalStatus: "completed",
         turnId: "terminal-turn",
         updatedAt: "2026-04-16T12:00:01.000Z",
+    };
+}
+
+function transcriptBlock(
+    sessionId: string,
+    suffix: string,
+    revision: number,
+) {
+    return {
+        blockId: `${sessionId}:${suffix}`,
+        endSequence: revision,
+        entryCount: 1,
+        estimatedHeight: 72,
+        estimatedRowCount: 1,
+        firstCreatedAt: "2026-04-16T12:00:01.000Z",
+        lastCreatedAt: "2026-04-16T12:00:01.000Z",
+        revision,
+        sessionId,
+        startSequence: revision,
     };
 }
 

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -493,6 +493,7 @@ export class AiService {
     readonly #loadedTranscriptBlockMetadataSessionIds = new Set<string>();
     readonly #legacyTranscriptSessionIds = new Set<string>();
     readonly #loadingTranscriptBlockMetadataSessionIds = new Set<string>();
+    readonly #loadingTranscriptBlockMetadataRequestSessionIds = new Set<string>();
     readonly #pendingTranscriptBlockMetadataReloadSessionIds = new Set<string>();
     readonly #transcriptBlockMetadataGenerations = new Map<string, number>();
     readonly #recoveredTranscriptTailSessionIds = new Set<string>();
@@ -621,6 +622,7 @@ export class AiService {
         this.#liveTranscriptTails.clear();
         this.#loadedTranscriptBlockMetadataSessionIds.clear();
         this.#loadingTranscriptBlockMetadataSessionIds.clear();
+        this.#loadingTranscriptBlockMetadataRequestSessionIds.clear();
         this.#pendingTranscriptBlockMetadataReloadSessionIds.clear();
         this.#transcriptBlockMetadataGenerations.clear();
         this.#recoveredTranscriptTailSessionIds.clear();
@@ -2690,7 +2692,15 @@ export class AiService {
             return;
         }
         if (this.#loadingTranscriptBlockMetadataSessionIds.has(sessionId)) {
-            this.#pendingTranscriptBlockMetadataReloadSessionIds.add(sessionId);
+            if (
+                this.#loadingTranscriptBlockMetadataRequestSessionIds.has(
+                    sessionId,
+                )
+            ) {
+                this.#pendingTranscriptBlockMetadataReloadSessionIds.add(
+                    sessionId,
+                );
+            }
             return;
         }
         const loadTranscriptBlockMetadata = (targetSessionId: string) =>
@@ -2706,7 +2716,15 @@ export class AiService {
                 const generation =
                     this.#transcriptBlockMetadataGenerations.get(sessionId) ??
                     0;
-                const output = await loadTranscriptBlockMetadata(sessionId);
+                this.#loadingTranscriptBlockMetadataRequestSessionIds.add(
+                    sessionId,
+                );
+                const output = await loadTranscriptBlockMetadata(sessionId)
+                    .finally(() => {
+                        this.#loadingTranscriptBlockMetadataRequestSessionIds.delete(
+                            sessionId,
+                        );
+                    });
                 return { generation, output };
             })
             .then((result) => {
@@ -2756,7 +2774,9 @@ export class AiService {
             sessionId,
             (this.#transcriptBlockMetadataGenerations.get(sessionId) ?? 0) + 1,
         );
-        if (this.#loadingTranscriptBlockMetadataSessionIds.has(sessionId)) {
+        if (
+            this.#loadingTranscriptBlockMetadataRequestSessionIds.has(sessionId)
+        ) {
             this.#pendingTranscriptBlockMetadataReloadSessionIds.add(sessionId);
         }
     }
@@ -2971,6 +2991,9 @@ export class AiService {
                 currentSessionId,
             );
             this.#loadingTranscriptBlockMetadataSessionIds.delete(
+                currentSessionId,
+            );
+            this.#loadingTranscriptBlockMetadataRequestSessionIds.delete(
                 currentSessionId,
             );
             this.#pendingTranscriptBlockMetadataReloadSessionIds.delete(

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -1317,10 +1317,13 @@ export class AiService {
             preserveLegacyFallback: true,
         });
         if (this.#usesBlockNativeTranscript(sessionId)) {
-            // Open tails are intentionally absent from sealed block metadata.
-            // Restore one before projecting the historical snapshot so an
-            // interrupted streaming turn remains visible after restart.
-            await this.#recoverTranscriptTail(sessionId);
+            // Historical sessions cannot receive the terminal event that
+            // would normally seal an interrupted tail after a restart.
+            await this.#recoverTranscriptTail(sessionId, {
+                sealInterruptedTail: !isResyncEligibleAiSessionStatus(
+                    persistedSnapshot.status,
+                ),
+            });
         }
         return this.#toRendererSessionSnapshot(
             this.#hydrateSnapshotRuntimeCatalog(persistedSnapshot),
@@ -1389,6 +1392,20 @@ export class AiService {
         }
         if (!(await this.#refreshTranscriptStorageMode(sessionId))) {
             return null;
+        }
+        if (!this.#liveSnapshots.has(sessionId)) {
+            const persistedSnapshot =
+                await this.#loadPersistedSessionSnapshot(sessionId);
+            if (
+                persistedSnapshot &&
+                !isResyncEligibleAiSessionStatus(persistedSnapshot.status)
+            ) {
+                // Metadata can race ahead of session hydration after restart.
+                // Resolve the historical tail before exposing sealed blocks.
+                await this.#recoverTranscriptTail(sessionId, {
+                    sealInterruptedTail: true,
+                });
+            }
         }
         return await nativeAi.loadTranscriptBlockMetadata(sessionId);
     }
@@ -2722,20 +2739,26 @@ export class AiService {
         });
     }
 
-    async #recoverTranscriptTail(sessionId: string): Promise<void> {
+    async #recoverTranscriptTail(
+        sessionId: string,
+        options: { readonly sealInterruptedTail?: boolean } = {},
+    ): Promise<void> {
         if (
             !this.#transcriptPersistence ||
-            this.#recoveredTranscriptTailSessionIds.has(sessionId)
+            (!options.sealInterruptedTail &&
+                this.#recoveredTranscriptTailSessionIds.has(sessionId))
         ) {
             return;
         }
         const existing = this.#transcriptRecoveryPromises.get(sessionId);
         if (existing) {
             await existing;
-            return;
+            if (!options.sealInterruptedTail) {
+                return;
+            }
         }
         const recovery = this.#transcriptPersistence
-            .recover(sessionId)
+            .recover(sessionId, options)
             .then(() => {
                 this.#recoveredTranscriptTailSessionIds.add(sessionId);
             })

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -2707,6 +2707,7 @@ export class AiService {
         if (
             !nativeAi?.checkpointOpenTranscriptTail ||
             !nativeAi.loadOpenTranscriptTail ||
+            !nativeAi.reconcileTerminalOpenTranscriptTail ||
             !nativeAi.sealTranscriptTurn ||
             !nativeAi.getTranscriptCapability?.().blockNativeVersion
         ) {
@@ -2714,10 +2715,11 @@ export class AiService {
         }
         const checkpoint = nativeAi.checkpointOpenTranscriptTail.bind(nativeAi);
         const load = nativeAi.loadOpenTranscriptTail.bind(nativeAi);
+        const reconcile = nativeAi.reconcileTerminalOpenTranscriptTail.bind(nativeAi);
         const seal = nativeAi.sealTranscriptTurn.bind(nativeAi);
         return new AiTranscriptPersistenceCoordinator(
             this.#liveTranscriptTails,
-            { checkpoint, load, seal },
+            { checkpoint, load, reconcile, seal },
             undefined,
             {
                 onSealed: (sessionId) => {

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -493,6 +493,8 @@ export class AiService {
     readonly #loadedTranscriptBlockMetadataSessionIds = new Set<string>();
     readonly #legacyTranscriptSessionIds = new Set<string>();
     readonly #loadingTranscriptBlockMetadataSessionIds = new Set<string>();
+    readonly #pendingTranscriptBlockMetadataReloadSessionIds = new Set<string>();
+    readonly #transcriptBlockMetadataGenerations = new Map<string, number>();
     readonly #recoveredTranscriptTailSessionIds = new Set<string>();
     readonly #transcriptRecoveryPromises = new Map<string, Promise<void>>();
     readonly #transcriptMigrationTimers = new Map<
@@ -619,6 +621,8 @@ export class AiService {
         this.#liveTranscriptTails.clear();
         this.#loadedTranscriptBlockMetadataSessionIds.clear();
         this.#loadingTranscriptBlockMetadataSessionIds.clear();
+        this.#pendingTranscriptBlockMetadataReloadSessionIds.clear();
+        this.#transcriptBlockMetadataGenerations.clear();
         this.#recoveredTranscriptTailSessionIds.clear();
         this.#transcriptRecoveryPromises.clear();
         for (const timer of this.#transcriptMigrationTimers.values()) {
@@ -764,8 +768,9 @@ export class AiService {
         this.#liveTranscriptTails.synchronizeSnapshot(nextSnapshot);
         // Snapshots can be the only delivery path during a reconnect, so their
         // active tail must enter the same durable queue as event-driven updates.
-        this.#transcriptPersistence?.scheduleCheckpoint(nextSnapshot.sessionId);
-        this.#scheduleTranscriptRecovery(nextSnapshot.sessionId);
+        // Recovery runs first so a restarted runtime cannot overwrite an older
+        // persisted tail before it is restored or reconciled.
+        this.#scheduleTranscriptCheckpointAfterRecovery(nextSnapshot.sessionId);
         this.#scheduleTranscriptBlockMetadataLoad(nextSnapshot.sessionId);
         const cachedSnapshot = this.#cacheLiveSessionSnapshot(
             preserveCanonicalTranscriptArrays(
@@ -805,7 +810,7 @@ export class AiService {
         }
 
         this.#liveTranscriptTails.applyEvent(event);
-        this.#transcriptPersistence?.scheduleCheckpoint(event.sessionId);
+        this.#scheduleTranscriptCheckpointAfterRecovery(event.sessionId);
         if (event.kind === "turn-status") {
             this.#transcriptPersistence?.requestSeal(
                 event.sessionId,
@@ -1393,7 +1398,8 @@ export class AiService {
         if (!(await this.#refreshTranscriptStorageMode(sessionId))) {
             return null;
         }
-        if (!this.#liveSnapshots.has(sessionId)) {
+        const hasLiveSnapshot = this.#liveSnapshots.has(sessionId);
+        if (!hasLiveSnapshot) {
             const persistedSnapshot =
                 await this.#loadPersistedSessionSnapshot(sessionId);
             if (
@@ -1405,7 +1411,18 @@ export class AiService {
                 await this.#recoverTranscriptTail(sessionId, {
                     sealInterruptedTail: true,
                 });
+            } else {
+                await this.#recoverTranscriptTail(sessionId);
             }
+        } else {
+            // A live snapshot can arrive before the persisted tail is loaded.
+            // Do not expose block metadata until that predecessor is resolved.
+            await this.#recoverTranscriptTail(sessionId);
+        }
+        // Recovery can seal blocks and advance the storage revision. Re-read
+        // the mode before returning metadata from the post-recovery state.
+        if (!(await this.#refreshTranscriptStorageMode(sessionId))) {
+            return null;
         }
         return await nativeAi.loadTranscriptBlockMetadata(sessionId);
     }
@@ -2665,28 +2682,52 @@ export class AiService {
         if (
             !nativeAi?.loadTranscriptBlockMetadata ||
             !nativeAi.getTranscriptCapability?.().blockNativeVersion ||
-            this.#loadedTranscriptBlockMetadataSessionIds.has(sessionId) ||
-            this.#loadingTranscriptBlockMetadataSessionIds.has(sessionId)
+            (this.#loadedTranscriptBlockMetadataSessionIds.has(sessionId) &&
+                !this.#pendingTranscriptBlockMetadataReloadSessionIds.has(
+                    sessionId,
+                ))
         ) {
+            return;
+        }
+        if (this.#loadingTranscriptBlockMetadataSessionIds.has(sessionId)) {
+            this.#pendingTranscriptBlockMetadataReloadSessionIds.add(sessionId);
             return;
         }
         const loadTranscriptBlockMetadata = (targetSessionId: string) =>
             nativeAi.loadTranscriptBlockMetadata!(targetSessionId);
 
         this.#loadingTranscriptBlockMetadataSessionIds.add(sessionId);
-        void this.#refreshTranscriptStorageMode(sessionId)
-            .then((isBlockNative) =>
-                isBlockNative
-                    ? loadTranscriptBlockMetadata(sessionId)
-                    : null,
-            )
-            .then((output) => {
-                if (!output || this.#deletedSessionIds.has(sessionId)) {
+        void this.#recoverTranscriptTail(sessionId)
+            .then(() => this.#refreshTranscriptStorageMode(sessionId))
+            .then(async (isBlockNative) => {
+                if (!isBlockNative) {
+                    return null;
+                }
+                const generation =
+                    this.#transcriptBlockMetadataGenerations.get(sessionId) ??
+                    0;
+                const output = await loadTranscriptBlockMetadata(sessionId);
+                return { generation, output };
+            })
+            .then((result) => {
+                if (!result || this.#deletedSessionIds.has(sessionId)) {
+                    return;
+                }
+                if (
+                    result.generation !==
+                    (this.#transcriptBlockMetadataGenerations.get(sessionId) ??
+                        0)
+                ) {
+                    // A seal completed while this request was in flight. Drop
+                    // the stale response and reload after the active request.
+                    this.#pendingTranscriptBlockMetadataReloadSessionIds.add(
+                        sessionId,
+                    );
                     return;
                 }
                 this.#liveTranscriptTails.setStableBlocks(
                     sessionId,
-                    output.blocks,
+                    result.output.blocks,
                 );
                 this.#loadedTranscriptBlockMetadataSessionIds.add(sessionId);
             })
@@ -2698,7 +2739,26 @@ export class AiService {
             })
             .finally(() => {
                 this.#loadingTranscriptBlockMetadataSessionIds.delete(sessionId);
+                if (
+                    this.#pendingTranscriptBlockMetadataReloadSessionIds.delete(
+                        sessionId,
+                    )
+                ) {
+                    this.#loadedTranscriptBlockMetadataSessionIds.delete(sessionId);
+                    this.#scheduleTranscriptBlockMetadataLoad(sessionId);
+                }
             });
+    }
+
+    #invalidateTranscriptBlockMetadata(sessionId: string): void {
+        this.#loadedTranscriptBlockMetadataSessionIds.delete(sessionId);
+        this.#transcriptBlockMetadataGenerations.set(
+            sessionId,
+            (this.#transcriptBlockMetadataGenerations.get(sessionId) ?? 0) + 1,
+        );
+        if (this.#loadingTranscriptBlockMetadataSessionIds.has(sessionId)) {
+            this.#pendingTranscriptBlockMetadataReloadSessionIds.add(sessionId);
+        }
     }
 
     #createTranscriptPersistence(
@@ -2727,7 +2787,7 @@ export class AiService {
                         return;
                     }
                     this.#transcriptStorageModes.set(sessionId, "block-native");
-                    this.#loadedTranscriptBlockMetadataSessionIds.delete(sessionId);
+                    this.#invalidateTranscriptBlockMetadata(sessionId);
                     this.#scheduleTranscriptBlockMetadataLoad(sessionId);
                     this.#emitSealedTranscriptSnapshot(sessionId);
                 },
@@ -2735,10 +2795,17 @@ export class AiService {
         );
     }
 
-    #scheduleTranscriptRecovery(sessionId: string): void {
-        void this.#recoverTranscriptTail(sessionId).catch((error: unknown) => {
-            debugBenignError("ai.service.recoverTranscriptTail", error);
-        });
+    #scheduleTranscriptCheckpointAfterRecovery(sessionId: string): void {
+        void this.#recoverTranscriptTail(sessionId)
+            .then(() => {
+                this.#transcriptPersistence?.scheduleCheckpoint(sessionId);
+            })
+            .catch((error: unknown) => {
+                debugBenignError(
+                    "ai.service.recoverTranscriptTailBeforeCheckpoint",
+                    error,
+                );
+            });
     }
 
     async #recoverTranscriptTail(
@@ -2906,6 +2973,10 @@ export class AiService {
             this.#loadingTranscriptBlockMetadataSessionIds.delete(
                 currentSessionId,
             );
+            this.#pendingTranscriptBlockMetadataReloadSessionIds.delete(
+                currentSessionId,
+            );
+            this.#transcriptBlockMetadataGenerations.delete(currentSessionId);
             this.#liveSessionContexts.delete(currentSessionId);
             this.#liveSessionTouches.delete(currentSessionId);
             this.#freezingSessionIds.delete(currentSessionId);
@@ -3351,7 +3422,7 @@ export class AiService {
         this.#liveTranscriptTails.synchronizeSnapshot(nextSnapshot);
         // A prepared session may already contain streamed output before events
         // resume, so do not wait for a later event to make it crash-safe.
-        this.#transcriptPersistence?.scheduleCheckpoint(nextSnapshot.sessionId);
+        this.#scheduleTranscriptCheckpointAfterRecovery(nextSnapshot.sessionId);
         const cachedSnapshot = this.#cacheLiveSessionSnapshot(
             preserveCanonicalTranscriptArrays(
                 previousSnapshot,
@@ -3360,7 +3431,6 @@ export class AiService {
             ownerWindowId,
         );
         this.#scheduleTranscriptBlockMetadataLoad(cachedSnapshot.sessionId);
-        this.#scheduleTranscriptRecovery(cachedSnapshot.sessionId);
         if (!this.#isNativeAiSession(cachedSnapshot.sessionId)) {
             this.#persistence.saveSessionSnapshot(cachedSnapshot);
         }
@@ -5905,9 +5975,7 @@ export class AiService {
             void this.#refreshTranscriptStorageMode(sessionId)
                 .then((isBlockNative) => {
                     if (isBlockNative) {
-                        this.#loadedTranscriptBlockMetadataSessionIds.delete(
-                            sessionId,
-                        );
+                        this.#invalidateTranscriptBlockMetadata(sessionId);
                         this.#scheduleTranscriptBlockMetadataLoad(sessionId);
                         // The renderer may have observed an empty block-native
                         // snapshot while this migration was still pending.

--- a/src/main/ai/transcript-persistence.test.ts
+++ b/src/main/ai/transcript-persistence.test.ts
@@ -300,24 +300,24 @@ describe("AiTranscriptPersistenceCoordinator", () => {
         ]);
     });
 
-    it("seals a completed recovered tail despite a delayed streaming snapshot", async () => {
+    it("reconciles a completed recovered tail despite a delayed streaming snapshot", async () => {
         const store = new AiLiveTranscriptTailStore();
         const recovered = {
             ...recoveredTail(),
             terminalStatus: "completed" as const,
         };
-        const seal = vi.fn(() => Promise.resolve([sealedMetadata()]));
+        const reconcile = vi.fn(() => Promise.resolve([sealedMetadata()]));
         const coordinator = new AiTranscriptPersistenceCoordinator(
             store,
             adapterStub({
                 load: vi.fn(() => Promise.resolve(recovered)),
-                seal,
+                reconcile,
             }),
         );
 
         await coordinator.recover(SESSION_ID);
 
-        expect(seal).toHaveBeenCalledWith(expect.objectContaining({
+        expect(reconcile).toHaveBeenCalledWith(expect.objectContaining({
             turnId: recovered.turnId,
         }));
         expect(store.getSnapshot(SESSION_ID)).toMatchObject({
@@ -327,7 +327,7 @@ describe("AiTranscriptPersistenceCoordinator", () => {
         });
     });
 
-    it("seals a displaced nonterminal tail before preserving a newer turn", async () => {
+    it("defers a displaced nonterminal tail without sealing or replacing it", async () => {
         const store = liveStore();
         store.applyEvent(messageStarted("new turn output"));
         const recovered = {
@@ -343,24 +343,24 @@ describe("AiTranscriptPersistenceCoordinator", () => {
             }),
         );
 
-        await coordinator.recover(SESSION_ID);
+        await expect(coordinator.recover(SESSION_ID)).rejects.toThrow(
+            "Open transcript tail belongs to another unresolved turn.",
+        );
 
-        expect(seal).toHaveBeenCalledWith(expect.objectContaining({
-            turnId: "previous-turn",
-        }));
+        expect(seal).not.toHaveBeenCalled();
         expect(store.getSnapshot(SESSION_ID)).toMatchObject({
             turnId: TURN_ID,
         });
     });
 
-    it("seals a recovered completed tail when a streaming snapshot creates a newer turn", async () => {
+    it("reconciles a completed tail when a streaming snapshot creates a newer turn", async () => {
         const store = new AiLiveTranscriptTailStore();
         const load = deferred<AiOpenTranscriptTail | null>();
         const checkpoint = vi.fn((input: CheckpointInput) => {
             void input;
             return Promise.resolve();
         });
-        const seal = vi.fn((input: SealInput) => {
+        const reconcile = vi.fn((input: { sessionId: string; turnId: string }) => {
             void input;
             return Promise.resolve([sealedMetadata()]);
         });
@@ -374,7 +374,7 @@ describe("AiTranscriptPersistenceCoordinator", () => {
             adapterStub({
                 checkpoint,
                 load: vi.fn(() => load.promise),
-                seal,
+                reconcile,
             }),
         );
 
@@ -388,8 +388,8 @@ describe("AiTranscriptPersistenceCoordinator", () => {
         await recovery;
         await expect(coordinator.flushSession(SESSION_ID, 500)).resolves.toBe(true);
 
-        expect(seal).toHaveBeenCalledOnce();
-        expect(seal).toHaveBeenCalledWith(
+        expect(reconcile).toHaveBeenCalledOnce();
+        expect(reconcile).toHaveBeenCalledWith(
             expect.objectContaining({ turnId: recovered.turnId }),
         );
         expect(checkpoint).toHaveBeenCalledWith(
@@ -525,6 +525,7 @@ function adapterStub(
     return {
         checkpoint: vi.fn(() => Promise.resolve()),
         load: vi.fn(() => Promise.resolve(null)),
+        reconcile: vi.fn(() => Promise.resolve([])),
         seal: vi.fn(() => Promise.resolve([])),
         ...overrides,
     };

--- a/src/main/ai/transcript-persistence.test.ts
+++ b/src/main/ai/transcript-persistence.test.ts
@@ -415,6 +415,52 @@ describe("AiTranscriptPersistenceCoordinator", () => {
         });
     });
 
+    it("preserves a terminal seal requested while loading a nonterminal tail", async () => {
+        const store = new AiLiveTranscriptTailStore();
+        const load = deferred<AiOpenTranscriptTail | null>();
+        const checkpoints: CheckpointInput[] = [];
+        const seal = vi.fn((input: SealInput) => {
+            void input;
+            return Promise.resolve([sealedMetadata()]);
+        });
+        const coordinator = new AiTranscriptPersistenceCoordinator(
+            store,
+            adapterStub({
+                checkpoint: vi.fn((input: CheckpointInput) => {
+                    checkpoints.push(input);
+                    return Promise.resolve();
+                }),
+                load: vi.fn(() => load.promise),
+                seal,
+            }),
+        );
+
+        const recovery = coordinator.recover(SESSION_ID);
+        store.applyEvent({
+            ...eventBase,
+            error: null,
+            kind: "turn-status",
+            status: "completed",
+            turnId: TURN_ID,
+        });
+        coordinator.requestSeal(SESSION_ID, "completed");
+
+        load.resolve(recoveredTail());
+        await recovery;
+        await expect(coordinator.flushSession(SESSION_ID, 500)).resolves.toBe(true);
+
+        expect(checkpoints).toHaveLength(1);
+        expect(checkpoints[0]).toMatchObject({
+            terminalStatus: "completed",
+            turnId: TURN_ID,
+        });
+        expect(seal).toHaveBeenCalledOnce();
+        expect(seal).toHaveBeenCalledWith(expect.objectContaining({
+            sessionId: SESSION_ID,
+            turnId: TURN_ID,
+        }));
+    });
+
     it("checkpoints terminal state before sealing and clears the live tail", async () => {
         const store = liveStore();
         const metadata = sealedMetadata();

--- a/src/main/ai/transcript-persistence.test.ts
+++ b/src/main/ai/transcript-persistence.test.ts
@@ -4,6 +4,7 @@ import type {
     AiMessage,
     AiOpenTranscriptTail,
     AiSessionDomainEventBase,
+    AiSessionSnapshot,
     AiTranscriptBlockMetadata,
 } from "@shared/ipc";
 
@@ -352,7 +353,7 @@ describe("AiTranscriptPersistenceCoordinator", () => {
         });
     });
 
-    it("seals a recovered terminal tail without sealing a newer live turn", async () => {
+    it("seals a recovered completed tail when a streaming snapshot creates a newer turn", async () => {
         const store = new AiLiveTranscriptTailStore();
         const load = deferred<AiOpenTranscriptTail | null>();
         const checkpoint = vi.fn((input: CheckpointInput) => {
@@ -378,14 +379,7 @@ describe("AiTranscriptPersistenceCoordinator", () => {
         );
 
         const recovery = coordinator.recover(SESSION_ID);
-        store.applyEvent({
-            ...eventBase,
-            activeTurnStartedAt: TURN_ID,
-            kind: "status",
-            lastError: null,
-            status: "streaming",
-        });
-        store.applyEvent(messageStarted("new turn output"));
+        store.synchronizeSnapshot(streamingSnapshot(TURN_ID));
         coordinator.scheduleCheckpoint(SESSION_ID);
         await Promise.resolve();
         expect(checkpoint).not.toHaveBeenCalled();
@@ -577,6 +571,33 @@ function message(id: string, content: string, createdAt: string): AiMessage {
         id,
         kind: "assistant",
         status: "streaming",
+    };
+}
+
+function streamingSnapshot(activeTurnStartedAt: string): AiSessionSnapshot {
+    return {
+        activeTurnStartedAt,
+        availableCommands: [],
+        configOptions: [],
+        lastError: null,
+        messages: [message("assistant-1", "new turn output", activeTurnStartedAt)],
+        modeId: null,
+        modes: [],
+        modelId: null,
+        models: [],
+        pendingPermission: null,
+        pendingUserInput: null,
+        plan: null,
+        projectId: null,
+        runtimeId: "codex",
+        runtimeSessionId: "runtime-1",
+        sessionId: SESSION_ID,
+        status: "streaming",
+        title: "Streaming recovery",
+        tokenUsage: null,
+        toolActivity: [],
+        trackedFiles: [],
+        updatedAt: activeTurnStartedAt,
     };
 }
 

--- a/src/main/ai/transcript-persistence.test.ts
+++ b/src/main/ai/transcript-persistence.test.ts
@@ -327,7 +327,7 @@ describe("AiTranscriptPersistenceCoordinator", () => {
         });
     });
 
-    it("defers a displaced nonterminal tail without sealing or replacing it", async () => {
+    it("seals a displaced nonterminal tail before checkpointing the newer turn", async () => {
         const store = liveStore();
         store.applyEvent(messageStarted("new turn output"));
         const recovered = {
@@ -335,20 +335,32 @@ describe("AiTranscriptPersistenceCoordinator", () => {
             turnId: "previous-turn",
         };
         const seal = vi.fn(() => Promise.resolve([sealedMetadata()]));
+        const checkpoint = vi.fn((input: CheckpointInput) => {
+            void input;
+            return Promise.resolve();
+        });
         const coordinator = new AiTranscriptPersistenceCoordinator(
             store,
             adapterStub({
+                checkpoint,
                 load: vi.fn(() => Promise.resolve(recovered)),
                 seal,
             }),
         );
 
-        await expect(coordinator.recover(SESSION_ID)).rejects.toThrow(
-            "Open transcript tail belongs to another unresolved turn.",
-        );
+        await coordinator.recover(SESSION_ID);
+        await expect(coordinator.flushSession(SESSION_ID, 500)).resolves.toBe(true);
 
-        expect(seal).not.toHaveBeenCalled();
+        expect(seal).toHaveBeenCalledWith(expect.objectContaining({
+            sessionId: SESSION_ID,
+            turnId: recovered.turnId,
+        }));
+        expect(checkpoint).toHaveBeenCalledWith(expect.objectContaining({
+            sessionId: SESSION_ID,
+            turnId: TURN_ID,
+        }));
         expect(store.getSnapshot(SESSION_ID)).toMatchObject({
+            stableBlocks: [sealedMetadata()],
             turnId: TURN_ID,
         });
     });

--- a/src/main/ai/transcript-persistence.test.ts
+++ b/src/main/ai/transcript-persistence.test.ts
@@ -277,6 +277,81 @@ describe("AiTranscriptPersistenceCoordinator", () => {
         });
     });
 
+    it("seals an interrupted tail recovered without a live runtime", async () => {
+        const store = new AiLiveTranscriptTailStore();
+        const seal = vi.fn(() => Promise.resolve([sealedMetadata()]));
+        const coordinator = new AiTranscriptPersistenceCoordinator(
+            store,
+            adapterStub({
+                load: vi.fn(() => Promise.resolve(recoveredTail())),
+                seal,
+            }),
+        );
+
+        await coordinator.recover(SESSION_ID, { sealInterruptedTail: true });
+
+        expect(seal).toHaveBeenCalledWith(expect.objectContaining({
+            sessionId: SESSION_ID,
+            turnId: TURN_ID,
+        }));
+        expect(store.getSnapshot(SESSION_ID)?.stableBlocks).toEqual([
+            sealedMetadata(),
+        ]);
+    });
+
+    it("seals a completed recovered tail despite a delayed streaming snapshot", async () => {
+        const store = new AiLiveTranscriptTailStore();
+        const recovered = {
+            ...recoveredTail(),
+            terminalStatus: "completed" as const,
+        };
+        const seal = vi.fn(() => Promise.resolve([sealedMetadata()]));
+        const coordinator = new AiTranscriptPersistenceCoordinator(
+            store,
+            adapterStub({
+                load: vi.fn(() => Promise.resolve(recovered)),
+                seal,
+            }),
+        );
+
+        await coordinator.recover(SESSION_ID);
+
+        expect(seal).toHaveBeenCalledWith(expect.objectContaining({
+            turnId: recovered.turnId,
+        }));
+        expect(store.getSnapshot(SESSION_ID)).toMatchObject({
+            entries: [],
+            stableBlocks: [sealedMetadata()],
+            turnId: null,
+        });
+    });
+
+    it("seals a displaced nonterminal tail before preserving a newer turn", async () => {
+        const store = liveStore();
+        store.applyEvent(messageStarted("new turn output"));
+        const recovered = {
+            ...recoveredTail(),
+            turnId: "previous-turn",
+        };
+        const seal = vi.fn(() => Promise.resolve([sealedMetadata()]));
+        const coordinator = new AiTranscriptPersistenceCoordinator(
+            store,
+            adapterStub({
+                load: vi.fn(() => Promise.resolve(recovered)),
+                seal,
+            }),
+        );
+
+        await coordinator.recover(SESSION_ID);
+
+        expect(seal).toHaveBeenCalledWith(expect.objectContaining({
+            turnId: "previous-turn",
+        }));
+        expect(store.getSnapshot(SESSION_ID)).toMatchObject({
+            turnId: TURN_ID,
+        });
+    });
+
     it("seals a recovered terminal tail without sealing a newer live turn", async () => {
         const store = new AiLiveTranscriptTailStore();
         const load = deferred<AiOpenTranscriptTail | null>();

--- a/src/main/ai/transcript-persistence.ts
+++ b/src/main/ai/transcript-persistence.ts
@@ -24,6 +24,11 @@ export interface AiTranscriptPersistenceOptions {
     readonly retryMaxDelayMs?: number;
 }
 
+export interface AiTranscriptRecoveryOptions {
+    /** Seal an unfinished tail when no live runtime owns the session. */
+    readonly sealInterruptedTail?: boolean;
+}
+
 export interface AiTranscriptPersistenceAdapter {
     checkpoint(input: AiOpenTranscriptTailCheckpoint): Promise<void>;
     load(sessionId: string): Promise<AiOpenTranscriptTail | null>;
@@ -101,7 +106,10 @@ export class AiTranscriptPersistenceCoordinator {
         this.#pump(sessionId);
     }
 
-    async recover(sessionId: string): Promise<AiOpenTranscriptTail | null> {
+    async recover(
+        sessionId: string,
+        options: AiTranscriptRecoveryOptions = {},
+    ): Promise<AiOpenTranscriptTail | null> {
         const queue = this.#queueFor(sessionId);
         queue.isRecovering = true;
         try {
@@ -110,12 +118,10 @@ export class AiTranscriptPersistenceCoordinator {
                 return null;
             }
             if (!this.store.restoreOpenTail(recovered)) {
-                // A newer turn reached memory before recovery completed. Seal
-                // the old terminal tail independently instead of applying its
-                // terminal status to the newer turn.
-                if (recovered.terminalStatus) {
-                    queue.recoveredTerminalTail = recovered;
-                }
+                // The native store has one open tail per session. A newer
+                // in-memory turn therefore makes the recovered one stale and
+                // it must be sealed before either turn can be projected.
+                await this.#sealRecoveredTail(sessionId, queue, recovered);
                 return recovered;
             }
             queue.checkpointedRevision = recovered.revision;
@@ -123,6 +129,14 @@ export class AiTranscriptPersistenceCoordinator {
             queue.sealTurnId = recovered.terminalStatus
                 ? recovered.turnId
                 : null;
+            if (
+                recovered.terminalStatus !== null ||
+                options.sealInterruptedTail
+            ) {
+                // Terminal tails are authoritative even when a delayed
+                // session snapshot still reports streaming after restart.
+                await this.#sealRecoveredTail(sessionId, queue, recovered);
+            }
             return recovered;
         } finally {
             queue.isRecovering = false;
@@ -232,6 +246,10 @@ export class AiTranscriptPersistenceCoordinator {
                 });
                 queue.recoveredTerminalTail = null;
                 this.store.setStableBlocks(sessionId, metadata);
+                if (queue.sealTurnId === tail.turnId) {
+                    queue.sealStatus = null;
+                    queue.sealTurnId = null;
+                }
                 this.options.onSealed?.(sessionId, metadata);
                 queue.attempt = 0;
                 return;
@@ -431,6 +449,40 @@ export class AiTranscriptPersistenceCoordinator {
             this.#queues.set(sessionId, queue);
         }
         return queue;
+    }
+
+    async #sealRecoveredTail(
+        sessionId: string,
+        queue: SessionPersistenceQueue,
+        tail: AiOpenTranscriptTail,
+    ): Promise<void> {
+        this.#setStatus(sessionId, queue, "sealing", null);
+        try {
+            const metadata = await this.adapter.seal({
+                entries: tail.entries,
+                payloads: tail.payloads,
+                sessionId,
+                turnId: tail.turnId,
+            });
+            if (!this.store.acknowledgeSealedTurn(
+                sessionId,
+                tail.turnId,
+                metadata,
+                tail.revision,
+            )) {
+                this.store.setStableBlocks(sessionId, metadata);
+            }
+            this.options.onSealed?.(sessionId, metadata);
+            queue.attempt = 0;
+            if (queue.sealTurnId === tail.turnId) {
+                queue.sealStatus = null;
+                queue.sealTurnId = null;
+            }
+        } catch {
+            // Preserve the tail for the regular retry loop when sealing is
+            // temporarily unavailable during startup.
+            queue.recoveredTerminalTail = tail;
+        }
     }
 
     #setStatus(

--- a/src/main/ai/transcript-persistence.ts
+++ b/src/main/ai/transcript-persistence.ts
@@ -58,6 +58,7 @@ interface SessionPersistenceQueue {
     checkpointedRevision: number;
     inFlight: Promise<void> | null;
     isRecovering: boolean;
+    recoveredInterruptedTail: AiOpenTranscriptTail | null;
     recoveredTerminalTail: AiOpenTranscriptTail | null;
     retryTimer: ReturnType<typeof setTimeout> | null;
     sealStatus: AiTranscriptTerminalStatus | null;
@@ -123,10 +124,9 @@ export class AiTranscriptPersistenceCoordinator {
             }
             if (!this.store.restoreOpenTail(recovered)) {
                 // The native store has one open tail per session. A newer
-                // in-memory turn therefore makes the recovered one stale and
-                // a terminal predecessor must be reconciled before either
-                // turn can be projected. An unresolved predecessor is kept
-                // durable until the runtime can resolve the conflict.
+                // in-memory turn therefore makes the recovered one stale.
+                // Preserve the predecessor by sealing it as interrupted before
+                // the successor is allowed to replace the native open tail.
                 if (recovered.terminalStatus !== null) {
                     await this.#reconcileRecoveredTerminalTail(
                         sessionId,
@@ -134,8 +134,10 @@ export class AiTranscriptPersistenceCoordinator {
                         recovered,
                     );
                 } else {
-                    throw new Error(
-                        "Open transcript tail belongs to another unresolved turn.",
+                    await this.#sealDisplacedInterruptedTail(
+                        sessionId,
+                        queue,
+                        recovered,
                     );
                 }
                 return recovered;
@@ -271,6 +273,15 @@ export class AiTranscriptPersistenceCoordinator {
                     queue,
                     tail,
                     metadata,
+                );
+                return;
+            }
+            if (queue.recoveredInterruptedTail) {
+                const tail = queue.recoveredInterruptedTail;
+                await this.#sealDisplacedInterruptedTail(
+                    sessionId,
+                    queue,
+                    tail,
                 );
                 return;
             }
@@ -430,6 +441,7 @@ export class AiTranscriptPersistenceCoordinator {
     ): boolean {
         return (
             queue.isRecovering ||
+            queue.recoveredInterruptedTail !== null ||
             queue.recoveredTerminalTail !== null ||
             this.store.getPendingTerminalTurn(sessionId) !== null ||
             this.store.takePendingEntries(sessionId).length > 0 ||
@@ -460,6 +472,7 @@ export class AiTranscriptPersistenceCoordinator {
                 checkpointedRevision: 0,
                 inFlight: null,
                 isRecovering: false,
+                recoveredInterruptedTail: null,
                 recoveredTerminalTail: null,
                 retryTimer: null,
                 sealStatus: null,
@@ -525,6 +538,30 @@ export class AiTranscriptPersistenceCoordinator {
         if (queue.sealTurnId === tail.turnId) {
             queue.sealStatus = null;
             queue.sealTurnId = null;
+        }
+    }
+
+    async #sealDisplacedInterruptedTail(
+        sessionId: string,
+        queue: SessionPersistenceQueue,
+        tail: AiOpenTranscriptTail,
+    ): Promise<void> {
+        this.#setStatus(sessionId, queue, "sealing", null);
+        try {
+            await this.#sealInterruptedRecoveredTail(sessionId, queue, tail);
+            queue.recoveredInterruptedTail = null;
+        } catch (error) {
+            // Keep the predecessor ahead of the successor in the retry queue.
+            // SQLite still owns this tail, so checkpointing the newer turn
+            // cannot succeed until the interrupted predecessor is sealed.
+            queue.recoveredInterruptedTail = tail;
+            this.#setStatus(
+                sessionId,
+                queue,
+                "retrying",
+                error instanceof Error ? error.message : String(error),
+            );
+            throw error;
         }
     }
 

--- a/src/main/ai/transcript-persistence.ts
+++ b/src/main/ai/transcript-persistence.ts
@@ -143,10 +143,14 @@ export class AiTranscriptPersistenceCoordinator {
                 return recovered;
             }
             queue.checkpointedRevision = recovered.revision;
-            queue.sealStatus = recovered.terminalStatus;
-            queue.sealTurnId = recovered.terminalStatus
-                ? recovered.turnId
-                : null;
+            // A terminal event can arrive while load() is pending; its
+            // same-turn seal request must outlive a nonterminal snapshot.
+            if (queue.sealStatus === null || queue.sealTurnId !== recovered.turnId) {
+                queue.sealStatus = recovered.terminalStatus;
+                queue.sealTurnId = recovered.terminalStatus
+                    ? recovered.turnId
+                    : null;
+            }
             if (recovered.terminalStatus !== null) {
                 // Terminal tails are authoritative even when a delayed
                 // session snapshot still reports streaming after restart.

--- a/src/main/ai/transcript-persistence.ts
+++ b/src/main/ai/transcript-persistence.ts
@@ -1,6 +1,7 @@
 import type {
     AiOpenTranscriptTail,
     AiOpenTranscriptTailCheckpoint,
+    AiReconcileTerminalOpenTranscriptTailInput,
     AiSealTranscriptTurnInput,
     AiTranscriptBlockMetadata,
     AiTranscriptTerminalStatus,
@@ -32,6 +33,9 @@ export interface AiTranscriptRecoveryOptions {
 export interface AiTranscriptPersistenceAdapter {
     checkpoint(input: AiOpenTranscriptTailCheckpoint): Promise<void>;
     load(sessionId: string): Promise<AiOpenTranscriptTail | null>;
+    reconcile(
+        input: AiReconcileTerminalOpenTranscriptTailInput,
+    ): Promise<readonly AiTranscriptBlockMetadata[]>;
     seal(
         input: AiSealTranscriptTurnInput,
     ): Promise<readonly AiTranscriptBlockMetadata[]>;
@@ -120,8 +124,20 @@ export class AiTranscriptPersistenceCoordinator {
             if (!this.store.restoreOpenTail(recovered)) {
                 // The native store has one open tail per session. A newer
                 // in-memory turn therefore makes the recovered one stale and
-                // it must be sealed before either turn can be projected.
-                await this.#sealRecoveredTail(sessionId, queue, recovered);
+                // a terminal predecessor must be reconciled before either
+                // turn can be projected. An unresolved predecessor is kept
+                // durable until the runtime can resolve the conflict.
+                if (recovered.terminalStatus !== null) {
+                    await this.#reconcileRecoveredTerminalTail(
+                        sessionId,
+                        queue,
+                        recovered,
+                    );
+                } else {
+                    throw new Error(
+                        "Open transcript tail belongs to another unresolved turn.",
+                    );
+                }
                 return recovered;
             }
             queue.checkpointedRevision = recovered.revision;
@@ -129,13 +145,20 @@ export class AiTranscriptPersistenceCoordinator {
             queue.sealTurnId = recovered.terminalStatus
                 ? recovered.turnId
                 : null;
-            if (
-                recovered.terminalStatus !== null ||
-                options.sealInterruptedTail
-            ) {
+            if (recovered.terminalStatus !== null) {
                 // Terminal tails are authoritative even when a delayed
                 // session snapshot still reports streaming after restart.
-                await this.#sealRecoveredTail(sessionId, queue, recovered);
+                await this.#reconcileRecoveredTerminalTail(
+                    sessionId,
+                    queue,
+                    recovered,
+                );
+            } else if (options.sealInterruptedTail) {
+                await this.#sealInterruptedRecoveredTail(
+                    sessionId,
+                    queue,
+                    recovered,
+                );
             }
             return recovered;
         } finally {
@@ -238,20 +261,17 @@ export class AiTranscriptPersistenceCoordinator {
             if (queue.recoveredTerminalTail) {
                 const tail = queue.recoveredTerminalTail;
                 this.#setStatus(sessionId, queue, "sealing", null);
-                const metadata = await this.adapter.seal({
-                    entries: tail.entries,
-                    payloads: tail.payloads,
+                const metadata = await this.adapter.reconcile({
                     sessionId,
                     turnId: tail.turnId,
                 });
                 queue.recoveredTerminalTail = null;
-                this.store.setStableBlocks(sessionId, metadata);
-                if (queue.sealTurnId === tail.turnId) {
-                    queue.sealStatus = null;
-                    queue.sealTurnId = null;
-                }
-                this.options.onSealed?.(sessionId, metadata);
-                queue.attempt = 0;
+                this.#acknowledgeReconciledTerminalTail(
+                    sessionId,
+                    queue,
+                    tail,
+                    metadata,
+                );
                 return;
             }
             const pendingTerminal = this.store.getPendingTerminalTurn(sessionId);
@@ -451,37 +471,82 @@ export class AiTranscriptPersistenceCoordinator {
         return queue;
     }
 
-    async #sealRecoveredTail(
+    async #reconcileRecoveredTerminalTail(
         sessionId: string,
         queue: SessionPersistenceQueue,
         tail: AiOpenTranscriptTail,
     ): Promise<void> {
         this.#setStatus(sessionId, queue, "sealing", null);
         try {
-            const metadata = await this.adapter.seal({
-                entries: tail.entries,
-                payloads: tail.payloads,
+            const metadata = await this.adapter.reconcile({
                 sessionId,
                 turnId: tail.turnId,
             });
-            if (!this.store.acknowledgeSealedTurn(
+            this.#acknowledgeReconciledTerminalTail(
                 sessionId,
-                tail.turnId,
+                queue,
+                tail,
                 metadata,
-                tail.revision,
-            )) {
-                this.store.setStableBlocks(sessionId, metadata);
-            }
-            this.options.onSealed?.(sessionId, metadata);
-            queue.attempt = 0;
-            if (queue.sealTurnId === tail.turnId) {
-                queue.sealStatus = null;
-                queue.sealTurnId = null;
-            }
-        } catch {
-            // Preserve the tail for the regular retry loop when sealing is
-            // temporarily unavailable during startup.
+            );
+        } catch (error) {
             queue.recoveredTerminalTail = tail;
+            this.#setStatus(
+                sessionId,
+                queue,
+                "retrying",
+                error instanceof Error ? error.message : String(error),
+            );
+            throw error;
+        }
+    }
+
+    async #sealInterruptedRecoveredTail(
+        sessionId: string,
+        queue: SessionPersistenceQueue,
+        tail: AiOpenTranscriptTail,
+    ): Promise<void> {
+        this.#setStatus(sessionId, queue, "sealing", null);
+        const metadata = await this.adapter.seal({
+            entries: tail.entries,
+            payloads: tail.payloads,
+            sessionId,
+            turnId: tail.turnId,
+        });
+        if (!this.store.acknowledgeSealedTurn(
+            sessionId,
+            tail.turnId,
+            metadata,
+            tail.revision,
+        )) {
+            this.store.setStableBlocks(sessionId, metadata);
+        }
+        this.options.onSealed?.(sessionId, metadata);
+        queue.attempt = 0;
+        if (queue.sealTurnId === tail.turnId) {
+            queue.sealStatus = null;
+            queue.sealTurnId = null;
+        }
+    }
+
+    #acknowledgeReconciledTerminalTail(
+        sessionId: string,
+        queue: SessionPersistenceQueue,
+        tail: AiOpenTranscriptTail,
+        metadata: readonly AiTranscriptBlockMetadata[],
+    ): void {
+        if (!this.store.acknowledgeSealedTurn(
+            sessionId,
+            tail.turnId,
+            metadata,
+            tail.revision,
+        )) {
+            this.store.setStableBlocks(sessionId, metadata);
+        }
+        this.options.onSealed?.(sessionId, metadata);
+        queue.attempt = 0;
+        if (queue.sealTurnId === tail.turnId) {
+            queue.sealStatus = null;
+            queue.sealTurnId = null;
         }
     }
 

--- a/src/main/native-backend/ai.test.ts
+++ b/src/main/native-backend/ai.test.ts
@@ -796,6 +796,22 @@ describe("NativeAiGateway", () => {
                         },
                     ] as T);
                 }
+                if (command === "ai_reconcile_terminal_open_transcript_tail") {
+                    return Promise.resolve([
+                        {
+                            blockId: "session-1:0",
+                            endSequence: 1,
+                            entryCount: 1,
+                            estimatedHeight: 72,
+                            estimatedRowCount: 1,
+                            firstCreatedAt: TURN_STARTED_AT,
+                            lastCreatedAt: TURN_STARTED_AT,
+                            revision: 2,
+                            sessionId: "session-1",
+                            startSequence: 1,
+                        },
+                    ] as T);
+                }
                 return Promise.resolve({ ok: true } as T);
             },
         );
@@ -822,6 +838,12 @@ describe("NativeAiGateway", () => {
                 turnId: tail.turnId,
             }),
         ).resolves.toMatchObject([{ blockId: "session-1:0" }]);
+        await expect(
+            gateway.reconcileTerminalOpenTranscriptTail({
+                sessionId: tail.sessionId,
+                turnId: tail.turnId,
+            }),
+        ).resolves.toMatchObject([{ blockId: "session-1:0" }]);
 
         expect(client.request).toHaveBeenCalledWith(
             "ai_checkpoint_open_transcript_tail",
@@ -830,6 +852,10 @@ describe("NativeAiGateway", () => {
         expect(client.request).toHaveBeenCalledWith(
             "ai_load_open_transcript_tail",
             { sessionId: "session-1" },
+        );
+        expect(client.request).toHaveBeenCalledWith(
+            "ai_reconcile_terminal_open_transcript_tail",
+            { sessionId: "session-1", turnId: tail.turnId },
         );
     });
 

--- a/src/main/native-backend/ai.ts
+++ b/src/main/native-backend/ai.ts
@@ -33,6 +33,7 @@ import type {
     AiTranscriptPayload,
     AiTranscriptPayloadsOutput,
     AiTranscriptStorageState,
+    AiReconcileTerminalOpenTranscriptTailInput,
     AiSealTranscriptTurnInput,
     AiTrackedFile,
     AiTrackedFileHunkMutationInput,
@@ -483,6 +484,22 @@ export class NativeAiGateway implements NativeAiGatewayContract {
         );
         if (!Array.isArray(output)) {
             throw new Error("Native sealed transcript metadata must be an array.");
+        }
+        return output as NativeAiTranscriptBlockMetadata[];
+    }
+
+    async reconcileTerminalOpenTranscriptTail(
+        input: AiReconcileTerminalOpenTranscriptTailInput,
+    ): Promise<readonly AiTranscriptBlockMetadata[]> {
+        const output = await this.#client.request<unknown>(
+            "ai_reconcile_terminal_open_transcript_tail",
+            {
+                sessionId: input.sessionId,
+                turnId: input.turnId,
+            },
+        );
+        if (!Array.isArray(output)) {
+            throw new Error("Native reconciled transcript metadata must be an array.");
         }
         return output as NativeAiTranscriptBlockMetadata[];
     }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -2957,6 +2957,11 @@ export interface AiSealTranscriptTurnInput {
     readonly payloads: readonly AiTranscriptPayloadWrite[];
 }
 
+export interface AiReconcileTerminalOpenTranscriptTailInput {
+    readonly sessionId: string;
+    readonly turnId: string;
+}
+
 export const AI_TRANSCRIPT_BLOCK_CAPABILITY_VERSION = 1;
 export const AI_TRANSCRIPT_PAYLOAD_LIMIT_MAX = 64 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary

Fixes persistent chat-history loss after restart when JSONL history is complete but the block-native transcript has an unresolved open tail.

## What changed

- Added atomic Rust reconciliation for terminal open tails, preserving foreign sealed blocks and sealing only open blocks.
- Prevented unresolved predecessor tails from being silently replaced by a newer turn.
- Serialized startup recovery, runtime checkpoints, and metadata refreshes in the main process.
- Preserved terminal seal requests received while transcript-tail loading is pending.
- Restored `message_count`, preview, and timestamps from JSONL recovery markers.
- Made history listing recover pending scoped sessions before visibility filtering, without recovering unrelated projects.
- Added IPC plumbing and deterministic regression coverage for restart, recovery, metadata, and scope races.

## Validation

- `pnpm exec vitest run src/main/ai/transcript-persistence.test.ts src/main/ai/service.history.test.ts src/main/native-backend/ai.test.ts` — 68 passed
- `pnpm run typecheck`
- `cargo test -p comando-ai` — 190 passed, 1 ignored stress test
- `cargo clippy -p comando-ai -- -D warnings`
- `cargo fmt --check`
- `git diff --check main...HEAD`

## Notes

- Existing affected sessions are repaired idempotently when they are recovered or opened. A bulk repair operation for sessions never reopened is intentionally out of scope.
- Package-level Electron smoke testing is not included in this PR.