### PR TITLE
fix(ai): preserve ACP tool locations in activities

### DIFF
--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -4990,6 +4990,10 @@ mod tests {
             &json!({
                 "sessionId": "session-1",
                 "toolCallId": "edit-1",
+                "locations": [{
+                    "path": "/workspace/src/app.ts",
+                    "line": 14
+                }],
                 "diffs": [{
                     "hunks": [{
                         "lines": [
@@ -5017,6 +5021,13 @@ mod tests {
             })
         );
         assert!(compacted.payload.get("diffs").is_none());
+        assert_eq!(
+            compacted.payload["locations"],
+            json!([{
+                "path": "/workspace/src/app.ts",
+                "line": 14
+            }])
+        );
         assert_eq!(
             compacted.payload["toolActivityDetailId"],
             "tool-detail:session-1:edit-1"

--- a/apps/native-backend/src/review.rs
+++ b/apps/native-backend/src/review.rs
@@ -2992,6 +2992,7 @@ mod tests {
             diffs,
             exit_code: Some(0),
             kind: "edit".into(),
+            locations: Vec::new(),
             raw_input: None,
             raw_output: None,
             status: "completed".into(),

--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -27,9 +27,9 @@ use comando_types::ai::{
     NativeAiSessionCatalogUpdatedPayload, NativeAiSessionConfigOptionPayload,
     NativeAiSessionConfigSelectEntryPayload, NativeAiSessionStatus, NativeAiSessionSummary,
     NativeAiSubagentBreadcrumbPayload, NativeAiSubagentCreatedPayload, NativeAiTokenUsageCost,
-    NativeAiTokenUsagePayload, NativeAiToolActivityPayload, NativeAiUserInputQuestionOptionPayload,
-    NativeAiUserInputQuestionPayload, NativeAiUserInputRequestPayload,
-    NativeAiUserInputResponseInput, NativeCustomAcpLaunchSpec,
+    NativeAiTokenUsagePayload, NativeAiToolActivityLocation, NativeAiToolActivityPayload,
+    NativeAiUserInputQuestionOptionPayload, NativeAiUserInputQuestionPayload,
+    NativeAiUserInputRequestPayload, NativeAiUserInputResponseInput, NativeCustomAcpLaunchSpec,
 };
 use comando_types::ids::{
     MessageId, RuntimeId, RuntimeSessionId, SessionId, ToolCallId as NativeToolCallId,
@@ -2153,6 +2153,7 @@ struct PendingContentChunk {
 struct PendingToolActivity {
     diffs: Vec<serde_json::Value>,
     kind: String,
+    locations: Vec<NativeAiToolActivityLocation>,
     raw_input: Option<serde_json::Value>,
     raw_output: Option<serde_json::Value>,
     status: String,
@@ -2562,6 +2563,7 @@ impl NotificationContextInner {
                 title: tool_call.title,
                 tool_call_id: tool_call_id.clone(),
                 diffs,
+                locations: native_tool_activity_locations(&tool_call.locations),
                 terminal_output: terminal_update.terminal_output,
                 exit_code: terminal_update.exit_code,
             },
@@ -2612,6 +2614,7 @@ impl NotificationContextInner {
                 title: tool_call.title,
                 tool_call_id: tool_call_id.clone(),
                 diffs,
+                locations: native_tool_activity_locations(&tool_call.locations),
                 terminal_output: terminal_update.terminal_output,
                 exit_code: terminal_update.exit_code,
             },
@@ -2666,6 +2669,7 @@ impl NotificationContextInner {
         let pending = PendingToolActivity {
             diffs,
             kind: serde_label(&tool_call.kind),
+            locations: native_tool_activity_locations(&tool_call.locations),
             raw_input: tool_call.raw_input.clone(),
             raw_output: tool_call.raw_output.clone(),
             status: serde_label(&tool_call.status),
@@ -2712,6 +2716,7 @@ impl NotificationContextInner {
                     title: activity.title,
                     tool_call_id: activity.tool_call_id,
                     diffs: activity.diffs,
+                    locations: activity.locations,
                     terminal_output: activity.terminal_output,
                     exit_code: activity.exit_code,
                 },
@@ -4591,6 +4596,20 @@ fn default_true() -> bool {
     true
 }
 
+fn native_tool_activity_locations(
+    locations: &[agent_client_protocol::schema::v1::ToolCallLocation],
+) -> Vec<NativeAiToolActivityLocation> {
+    locations
+        .iter()
+        .map(|location| NativeAiToolActivityLocation {
+            // ACP paths originate in JSON, so this preserves absolute paths while
+            // keeping the native contract independent from the protocol SDK.
+            path: location.path.to_string_lossy().into_owned(),
+            line: location.line,
+        })
+        .collect()
+}
+
 fn tool_call_content_diffs(
     content: &[ToolCallContent],
     meta: &Meta,
@@ -5235,7 +5254,9 @@ impl<T> MaybeUndefinedExt<T> for agent_client_protocol::schema::MaybeUndefined<T
 mod tests {
     use super::*;
     use crate::runtime::RuntimeRegistry;
-    use agent_client_protocol::schema::v1::{ToolCallStatus, ToolCallUpdateFields, ToolKind};
+    use agent_client_protocol::schema::v1::{
+        ToolCallLocation, ToolCallStatus, ToolCallUpdateFields, ToolKind,
+    };
     use comando_types::ai::{
         NativeAiAuthHandshakeSpec, NativeAiDesiredSelections, NativeAiImageAttachment,
         NativeAiPrepareSessionInput, NativeAiRuntimeStatus, NativeAiUserInputAnswer,
@@ -5859,6 +5880,102 @@ mod tests {
         assert_eq!(event.event_name, AI_TOOL_ACTIVITY_EVENT);
         assert_eq!(event.payload["toolCallId"], "tool-1");
         assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn notification_context_projects_tool_call_locations() {
+        let (sender, receiver) = std_mpsc::sync_channel(8);
+        let context =
+            NotificationContext::new(native_test_session(), Some(sender), Vec::new(), true);
+        context.set_runtime_session_id(RuntimeSessionId("runtime-parent".to_string()));
+
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCall(
+                ToolCall::new("tool-1", "read")
+                    .kind(ToolKind::Read)
+                    .locations(vec![
+                        ToolCallLocation::new("/workspace/src/app.ts").line(12),
+                    ]),
+            ),
+        ));
+
+        let event = receiver.recv().unwrap();
+        assert_eq!(event.event_name, AI_TOOL_ACTIVITY_EVENT);
+        assert_eq!(
+            event.payload["locations"],
+            serde_json::json!([{
+                "path": "/workspace/src/app.ts",
+                "line": 12
+            }])
+        );
+    }
+
+    #[test]
+    fn notification_context_preserves_locations_across_partial_tool_updates() {
+        let (sender, receiver) = std_mpsc::sync_channel(8);
+        let context =
+            NotificationContext::new(native_test_session(), Some(sender), Vec::new(), true);
+        context.set_runtime_session_id(RuntimeSessionId("runtime-parent".to_string()));
+
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCall(ToolCall::new("tool-1", "read").locations(vec![
+                ToolCallLocation::new("/workspace/src/app.ts").line(12),
+            ])),
+        ));
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                "tool-1",
+                ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
+            )),
+        ));
+
+        let _initial = receiver.recv().unwrap();
+        let updated = receiver.recv().unwrap();
+        assert_eq!(
+            updated.payload["locations"],
+            serde_json::json!([{
+                "path": "/workspace/src/app.ts",
+                "line": 12
+            }])
+        );
+    }
+
+    #[test]
+    fn notification_context_projects_replaced_tool_locations() {
+        let (sender, receiver) = std_mpsc::sync_channel(8);
+        let context =
+            NotificationContext::new(native_test_session(), Some(sender), Vec::new(), true);
+        context.set_runtime_session_id(RuntimeSessionId("runtime-parent".to_string()));
+
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCall(
+                ToolCall::new("tool-1", "read")
+                    .locations(vec![ToolCallLocation::new("/workspace/src/old.ts")]),
+            ),
+        ));
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                "tool-1",
+                ToolCallUpdateFields::new().locations(vec![
+                    ToolCallLocation::new("/workspace/src/new.ts").line(27),
+                ]),
+            )),
+        ));
+
+        let _initial = receiver.recv().unwrap();
+        let updated = receiver.recv().unwrap();
+        assert_eq!(
+            updated.payload["locations"],
+            serde_json::json!([{
+                "path": "/workspace/src/new.ts",
+                "line": 27
+            }])
+        );
     }
 
     #[test]

--- a/crates/comando-ai/src/engine.rs
+++ b/crates/comando-ai/src/engine.rs
@@ -1125,7 +1125,9 @@ impl AiEngine {
                 "exitCode": payload.get("exitCode").filter(|value| value.is_number()).cloned().unwrap_or(Value::Null),
                 "id": tool_call_id,
                 "kind": payload.get("kind").and_then(Value::as_str).unwrap_or("tool"),
-                "locations": [],
+                // Locations are header-scale metadata and must remain available
+                // after the addressable detail payload is compacted.
+                "locations": payload.get("locations").cloned().unwrap_or_else(|| json!([])),
                 "rawInputJson": null,
                 "rawOutputJson": null,
                 "sessionId": session_id.0,
@@ -2853,6 +2855,10 @@ mod tests {
             json!({
                 "diffs": [],
                 "kind": "execute",
+                "locations": [{
+                    "path": "/tmp/project/src/app.ts",
+                    "line": 9
+                }],
                 "rawInput": { "command": "pnpm test" },
                 "runtimeId": "codex",
                 "runtimeSessionId": "runtime-history",
@@ -2897,6 +2903,13 @@ mod tests {
         assert_eq!(activity["rawOutputJson"], Value::Null);
         assert_eq!(activity["summary"], "Running tests");
         assert_eq!(activity["terminalOutput"], Value::Null);
+        assert_eq!(
+            activity["locations"],
+            json!([{
+                "path": "/tmp/project/src/app.ts",
+                "line": 9
+            }])
+        );
         let detail = engine
             .load_tool_activity_detail(&session_id, "tool-detail:s-history:tool-1")
             .expect("load detail")

--- a/crates/comando-types/src/ai.rs
+++ b/crates/comando-types/src/ai.rs
@@ -1114,6 +1114,14 @@ pub type NativeAiThinkingCompletedPayload = NativeAiMessageCompletedPayload;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct NativeAiToolActivityLocation {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct NativeAiToolActivityPayload {
     #[serde(flatten)]
     pub base: NativeAiEventBase,
@@ -1132,6 +1140,8 @@ pub struct NativeAiToolActivityPayload {
     pub raw_output: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub diffs: Vec<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub locations: Vec<NativeAiToolActivityLocation>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub terminal_output: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/comando-types/tests/fixtures.rs
+++ b/crates/comando-types/tests/fixtures.rs
@@ -156,6 +156,33 @@ fn ai_fixtures_deserialize() {
         Some("export function main() {}\n")
     );
     assert_eq!(payload.exit_code, Some(0));
+    assert_eq!(
+        payload.locations,
+        vec![comando_types::ai::NativeAiToolActivityLocation {
+            path: "/workspace/src/main.ts".to_string(),
+            line: Some(8),
+        }]
+    );
+
+    let legacy_payload: NativeAiToolActivityPayload = serde_json::from_value(serde_json::json!({
+        "sessionId": "session_legacy",
+        "runtimeId": "codex",
+        "runtimeSessionId": "runtime_legacy",
+        "updatedAt": "2026-06-20T00:00:00.200Z",
+        "toolCallId": "tool_legacy",
+        "title": "Read file",
+        "kind": "read",
+        "status": "completed",
+        "summary": null
+    }))
+    .expect("legacy payload should deserialize without locations");
+    assert!(legacy_payload.locations.is_empty());
+    assert!(
+        serde_json::to_value(legacy_payload)
+            .expect("legacy payload should serialize")
+            .get("locations")
+            .is_none()
+    );
 
     let review_delta: NativeRpcOutput = fixture("ai/event.review_delta_ready.json");
     let NativeRpcOutput::Event(review_delta) = review_delta else {

--- a/fixtures/native-backend/ai/event.tool_activity.json
+++ b/fixtures/native-backend/ai/event.tool_activity.json
@@ -11,6 +11,12 @@
     "kind": "read_file",
     "status": "completed",
     "summary": "Read src/main.ts",
+    "locations": [
+      {
+        "path": "/workspace/src/main.ts",
+        "line": 8
+      }
+    ],
     "terminalOutput": "export function main() {}\n",
     "exitCode": 0,
     "rawInput": {

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.test.ts
@@ -254,8 +254,8 @@ describe("ToolActivityItem", () => {
         );
 
         expect(markup).toContain('data-tool-activity-surface="rail-row"');
-        expect(markup).toContain("Read file");
-        expect(markup).toContain("src/app.ts");
+        expect(markup).toContain("Read src/app.ts");
+        expect(markup).not.toContain("Read file");
         expect(markup).not.toContain("raw-secret");
         expect(markup).not.toContain("rounded-lg");
     });
@@ -939,12 +939,12 @@ describe("ToolActivityItem", () => {
         expect(onOpenFile).not.toHaveBeenCalled();
     });
 
-    it("prefers structured read input over basename-only locations", () => {
+    it("prefers ACP read locations over raw input", () => {
         const onOpenFile = vi.fn(async () => {});
-        const fullPath = "src/domain/contracts.ts";
+        const locationPath = "src/domain/contracts.ts";
         mockProjectFileIndexState.paths = new Set([
             ...DEFAULT_PROJECT_FILE_INDEX_PATHS,
-            fullPath,
+            locationPath,
         ]);
         const container = renderInteractiveToolActivityItem({
             activity: createActivity({
@@ -953,10 +953,12 @@ describe("ToolActivityItem", () => {
                     {
                         endLine: null,
                         line: null,
-                        path: "contracts.ts",
+                        path: locationPath,
                     },
                 ],
-                rawInputJson: JSON.stringify({ file_path: fullPath }),
+                rawInputJson: JSON.stringify({
+                    file_path: "src/from-input/contracts.ts",
+                }),
                 summary: null,
                 title: "Read contracts.ts",
             }),
@@ -966,7 +968,7 @@ describe("ToolActivityItem", () => {
             worktreeId: null,
         });
         const linkButton = container.querySelector<HTMLButtonElement>(
-            `button[title="Open ${fullPath}"]`,
+            `button[title="Open ${locationPath}"]`,
         );
 
         expect(linkButton).not.toBeNull();
@@ -977,10 +979,95 @@ describe("ToolActivityItem", () => {
 
         expect(onOpenFile).toHaveBeenCalledWith(
             "project-1",
-            fullPath,
+            locationPath,
             null,
         );
     });
+
+    it.each(["card", "rail-row"] as const)(
+        "renders and opens a generic ACP read location on the %s surface",
+        (surface) => {
+            const onOpenFileReference = vi.fn();
+            const absolutePath = "/workspace/src/app.ts";
+            const reference = {
+                endLine: null,
+                isAbsolute: true,
+                path: absolutePath,
+                relativePath: "src/app.ts",
+                startLine: null,
+            };
+            const container = renderInteractiveToolActivityItem({
+                activity: createActivity({
+                    kind: "read",
+                    locations: [
+                        {
+                            endLine: null,
+                            line: null,
+                            path: absolutePath,
+                        },
+                    ],
+                    rawInputJson: null,
+                    summary: null,
+                    title: "read",
+                }),
+                canRenderFileReference: () => true,
+                onOpenFile: async () => {},
+                onOpenFileReference,
+                projectId: "project-1",
+                resolveFileReference: () => reference,
+                surface,
+                trackedFiles: [],
+                worktreeId: null,
+            });
+            const openButton = container.querySelector<HTMLButtonElement>(
+                `button[title="${surface === "card" ? "Open " : ""}${absolutePath}"]`,
+            );
+
+            expect(container.textContent).toContain("Read …/src/app.ts");
+            expect(openButton).not.toBeNull();
+            act(() => openButton?.click());
+            expect(onOpenFileReference).toHaveBeenCalledWith(reference);
+        },
+    );
+
+    it.each(["card", "rail-row"] as const)(
+        "does not duplicate descriptive read titles on the %s surface",
+        (surface) => {
+            const container = renderInteractiveToolActivityItem({
+                activity: createActivity({
+                    kind: "read",
+                    locations: [
+                        {
+                            endLine: null,
+                            line: null,
+                            path: "/workspace/src/app.ts",
+                        },
+                    ],
+                    rawInputJson: null,
+                    summary: null,
+                    title: "Read src/app.ts",
+                }),
+                canRenderFileReference: () => true,
+                onOpenFile: async () => {},
+                projectId: "project-1",
+                resolveFileReference: () => ({
+                    endLine: null,
+                    isAbsolute: true,
+                    path: "/workspace/src/app.ts",
+                    relativePath: "src/app.ts",
+                    startLine: null,
+                }),
+                surface,
+                trackedFiles: [],
+                worktreeId: null,
+            });
+
+            expect(container.textContent?.match(/Read src\/app\.ts/g)).toHaveLength(
+                1,
+            );
+            expect(container.textContent).not.toContain("/workspace/src/app.ts");
+        },
+    );
 
     it("passes raw relative location line ranges when no resolver is available", () => {
         const onOpenFile = vi.fn(async () => {});

--- a/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivityItem.tsx
@@ -23,15 +23,14 @@ import type {
 
 import { MarkdownContent } from "../MarkdownContent";
 import {
-    isLikelyProjectFileReference,
     parseProjectFileReference,
     type ResolvedProjectFileReference,
 } from "../projectFileReferences";
 import { ChangeReviewPanel } from "./ChangeReviewPanel";
 import {
+    getToolActivityHeaderPresentation,
     getToolActivityDescriptor,
     getStructuredToolCommand,
-    getStructuredToolTarget,
 } from "./toolActivityDescriptor";
 import {
     isEditedFileToolActivity,
@@ -282,49 +281,6 @@ function summarizeDiff(oldText: string | null, newText: string | null): string {
         : `Updates ${nl} line(s).`;
 }
 
-function parseToolTitleReference(
-    title: string,
-): {
-    readonly displayTarget: string;
-    readonly prefix: string;
-    readonly target: string;
-} | null {
-    const match =
-        /^(Read|Edit|Write|Create|Delete|Move|Search)\s+(.+)$/i.exec(
-            title.trim(),
-        );
-    const target = match?.[2]?.trim() ?? "";
-    if (
-        !target ||
-        isPlaceholderToolTarget(target) ||
-        !isLikelyProjectFileReference(target)
-    ) {
-        return null;
-    }
-
-    return {
-        displayTarget: target,
-        prefix: `${match?.[1] ?? ""} `,
-        target,
-    };
-}
-
-function isPlaceholderToolTarget(target: string): boolean {
-    return /^\.{2,}$/.test(target.trim());
-}
-
-function getToolActionPrefix(kind: string): string {
-    const lk = kind.toLowerCase();
-    if (lk === "read" || lk === "read_file") return "Read ";
-    if (lk === "search" || lk === "grep") return "Search ";
-    if (lk === "edit" || lk === "update") return "Edit ";
-    if (lk === "write") return "Write ";
-    if (lk === "create") return "Create ";
-    if (lk === "delete" || lk === "remove") return "Delete ";
-    if (lk === "move" || lk === "rename") return "Move ";
-    return "";
-}
-
 function buildCompactedToolPathCandidate({
     leadingSegments,
     separator,
@@ -347,15 +303,22 @@ function buildCompactedToolPathCandidate({
 
 function compactToolTitleTarget(target: string): string {
     const trimmedTarget = target.trim();
-    if (trimmedTarget.length <= TOOL_TITLE_TARGET_MAX_LENGTH) {
-        return trimmedTarget;
-    }
-
     const separator =
         trimmedTarget.includes("\\") && !trimmedTarget.includes("/")
             ? "\\"
             : "/";
     const rawSegments = trimmedTarget.split(/[\\/]+/).filter(Boolean);
+    const isAbsolute =
+        trimmedTarget.startsWith("/") ||
+        trimmedTarget.startsWith("\\") ||
+        /^[A-Za-z]:[\\/]/.test(trimmedTarget);
+    if (isAbsolute && rawSegments.length > 2) {
+        return `…${separator}${rawSegments.slice(-2).join(separator)}`;
+    }
+    if (trimmedTarget.length <= TOOL_TITLE_TARGET_MAX_LENGTH) {
+        return trimmedTarget;
+    }
+
     const segments =
         separator === "/" && trimmedTarget.startsWith("/")
             ? ["", ...rawSegments]
@@ -396,40 +359,6 @@ function compactToolTitleTarget(target: string): string {
         candidates.find(
             (candidate) => candidate.length <= TOOL_TITLE_TARGET_MAX_LENGTH,
         ) ?? candidates.at(-1) ?? trimmedTarget
-    );
-}
-
-function getToolTitleReference(
-    activity: AiToolActivity,
-): {
-    readonly displayTarget: string;
-    readonly prefix: string;
-    readonly target: string;
-} | null {
-    const titleReference = parseToolTitleReference(activity.title);
-    if (!shouldDeriveStructuredToolTarget(activity.kind)) {
-        return titleReference;
-    }
-
-    const structuredTarget = getStructuredToolTarget(activity);
-    if (structuredTarget && isLikelyProjectFileReference(structuredTarget)) {
-        return {
-            displayTarget: titleReference?.target ?? structuredTarget,
-            prefix: titleReference?.prefix ?? getToolActionPrefix(activity.kind),
-            target: structuredTarget,
-        };
-    }
-
-    return titleReference;
-}
-
-function shouldDeriveStructuredToolTarget(kind: string): boolean {
-    const lk = kind.toLowerCase();
-    return (
-        lk === "read" ||
-        lk === "read_file" ||
-        lk === "search" ||
-        lk === "grep"
     );
 }
 
@@ -1031,7 +960,7 @@ function FileToolMessage({
     const isInProgress = activity.status === "in_progress";
     const isCompleted = activity.status === "completed";
     const accent = getToolAccent(activity.kind);
-    const titleReference = getToolTitleReference(activity);
+    const titleReference = getToolActivityHeaderPresentation(activity);
     const compactTitleTarget = titleReference
         ? compactToolTitleTarget(titleReference.displayTarget)
         : null;
@@ -1887,8 +1816,12 @@ function CompactToolActivityRow({
     readonly worktreeId: string | null;
 }) {
     const descriptor = getToolActivityDescriptor(activity);
+    const headerPresentation =
+        getToolActivityHeaderPresentation(activity);
     const rawTarget =
-        descriptor.category === "file" ? descriptor.target : null;
+        descriptor.category === "file"
+            ? (headerPresentation?.target ?? descriptor.target)
+            : null;
     const canOpenReference =
         rawTarget !== null &&
         canOpenToolFileReference({
@@ -1898,13 +1831,11 @@ function CompactToolActivityRow({
             resolveFileReference,
             target: rawTarget,
         });
-    const displayTarget =
-        descriptor.target &&
-        !activity.title
-            .toLocaleLowerCase()
-            .includes(descriptor.target.toLocaleLowerCase())
-            ? descriptor.target
-            : null;
+    const displayTitle = headerPresentation
+        ? `${headerPresentation.prefix}${compactToolTitleTarget(
+              headerPresentation.displayTarget,
+          )}`
+        : activity.title;
     const hasRawInput = activity.rawInputJson !== null;
     const hasRawOutput = activity.rawOutputJson !== null;
     const hasTerminalOutput = activity.terminalOutput !== null;
@@ -1969,13 +1900,8 @@ function CompactToolActivityRow({
                         type="button"
                     >
                         <span className="min-w-0 truncate">
-                            {activity.title}
+                            {displayTitle}
                         </span>
-                        {displayTarget ? (
-                            <span className="min-w-0 truncate font-mono text-[10px] text-text-secondary">
-                                {displayTarget}
-                            </span>
-                        ) : null}
                     </button>
                 ) : (
                     <span
@@ -1983,13 +1909,8 @@ function CompactToolActivityRow({
                         title={activity.title}
                     >
                         <span className="min-w-0 truncate">
-                            {activity.title}
+                            {displayTitle}
                         </span>
-                        {displayTarget ? (
-                            <span className="min-w-0 truncate font-mono text-[10px] text-text-secondary">
-                                {displayTarget}
-                            </span>
-                        ) : null}
                     </span>
                 )}
                 {status ? (

--- a/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
+++ b/src/renderer/src/components/workspace/chat/ToolActivitySegment.tsx
@@ -6,7 +6,10 @@ import type {
     ChatTimelineActivitySegmentRow,
 } from "./chatTimelineModel";
 import { formatDiffStat } from "../review/reviewDiff";
-import { getToolActivityDescriptor } from "./toolActivityDescriptor";
+import {
+    getToolActivityDescriptor,
+    getToolActivityHeaderPresentation,
+} from "./toolActivityDescriptor";
 import {
     ToolActivityItem,
     type ToolActivityItemProps,
@@ -110,8 +113,14 @@ function getLatestActivityLabel(
     }
 
     const descriptor = getToolActivityDescriptor(latestActivity);
+    const headerPresentation =
+        getToolActivityHeaderPresentation(latestActivity);
     return (
-        descriptor.command ?? descriptor.target ?? segment.summary.latestTitle
+        descriptor.command ??
+        (headerPresentation
+            ? `${headerPresentation.prefix}${headerPresentation.displayTarget}`
+            : descriptor.target) ??
+        segment.summary.latestTitle
     );
 }
 

--- a/src/renderer/src/components/workspace/chat/toolActivityDescriptor.test.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityDescriptor.test.ts
@@ -5,6 +5,7 @@ import type { AiToolActivity, AiTrackedFile } from "@shared/ipc";
 import {
     getStructuredToolCommand,
     getStructuredToolTarget,
+    getToolActivityHeaderPresentation,
     getToolActivityDescriptor,
 } from "./toolActivityDescriptor";
 import { isEditedFileToolActivity } from "./toolActivityKinds";
@@ -46,7 +47,7 @@ describe("toolActivityDescriptor", () => {
         });
     });
 
-    it("prefers structured input over locations and never derives from titles", () => {
+    it("prefers ACP locations over raw input and never derives targets from titles", () => {
         const activity = createActivity({
             locations: [
                 {
@@ -59,7 +60,46 @@ describe("toolActivityDescriptor", () => {
             title: "Read src/from-title.ts",
         });
 
+        expect(getStructuredToolTarget(activity)).toBe(
+            "src/from-location.ts",
+        );
+    });
+
+    it("uses raw input as a fallback when ACP locations are missing", () => {
+        const activity = createActivity({
+            rawInputJson: JSON.stringify({ path: "src/from-input.ts" }),
+            title: "Read src/from-title.ts",
+        });
+
         expect(getStructuredToolTarget(activity)).toBe("src/from-input.ts");
+    });
+
+    it("separates the displayed title target from the structured navigation target", () => {
+        const genericTitle = createActivity({
+            locations: [
+                {
+                    endLine: null,
+                    line: 12,
+                    path: "/workspace/src/app.ts",
+                },
+            ],
+            title: "read",
+        });
+        const descriptiveTitle = createActivity({
+            locations: genericTitle.locations,
+            title: "Read src/app.ts",
+        });
+
+        expect(getToolActivityHeaderPresentation(genericTitle)).toEqual({
+            displayTarget: "/workspace/src/app.ts",
+            prefix: "Read ",
+            target: "/workspace/src/app.ts",
+        });
+        expect(getToolActivityHeaderPresentation(descriptiveTitle)).toEqual({
+            displayTarget: "src/app.ts",
+            prefix: "Read ",
+            target: "/workspace/src/app.ts",
+        });
     });
 
     it("preserves basename-only structured targets for later resolution", () => {

--- a/src/renderer/src/components/workspace/chat/toolActivityDescriptor.ts
+++ b/src/renderer/src/components/workspace/chat/toolActivityDescriptor.ts
@@ -1,5 +1,6 @@
 import type { AiToolActivity } from "@shared/ipc";
 
+import { isLikelyProjectFileReference } from "../projectFileReferences";
 import {
     FILE_TOOL_KINDS,
     isStatusToolActivity,
@@ -29,6 +30,12 @@ export interface ToolActivityDescriptor {
     readonly category: ToolActivityDescriptorCategory;
     readonly command: string | null;
     readonly target: string | null;
+}
+
+export interface ToolActivityHeaderPresentation {
+    readonly displayTarget: string;
+    readonly prefix: string;
+    readonly target: string;
 }
 
 function isRecordValue(value: unknown): value is Record<string, unknown> {
@@ -74,16 +81,16 @@ function readFirstString(
 export function getStructuredToolTarget(
     activity: AiToolActivity,
 ): string | null {
-    const rawInput = parseRawInput(activity.rawInputJson);
-    const rawTarget = readFirstString(rawInput, PATH_INPUT_KEYS);
-    if (rawTarget) {
-        return rawTarget;
+    const locationTarget =
+        activity.locations.find(
+            (location) => location.path.trim().length > 0,
+        )?.path.trim() ?? null;
+    if (locationTarget) {
+        return locationTarget;
     }
 
-    return (
-        activity.locations.find((location) => location.path.trim().length > 0)
-            ?.path.trim() ?? null
-    );
+    const rawInput = parseRawInput(activity.rawInputJson);
+    return readFirstString(rawInput, PATH_INPUT_KEYS);
 }
 
 export function getStructuredToolCommand(
@@ -116,6 +123,85 @@ function getDescriptorCategory(
         return "file";
     }
     return "unknown";
+}
+
+function parseToolTitleReference(
+    title: string,
+): ToolActivityHeaderPresentation | null {
+    const match =
+        /^(Read|Edit|Write|Create|Delete|Move|Search)\s+(.+)$/i.exec(
+            title.trim(),
+        );
+    const target = match?.[2]?.trim() ?? "";
+    if (
+        !target ||
+        /^\.{2,}$/.test(target) ||
+        !isLikelyProjectFileReference(target)
+    ) {
+        return null;
+    }
+
+    return {
+        displayTarget: target,
+        prefix: `${match?.[1] ?? ""} `,
+        target,
+    };
+}
+
+function getToolActionPrefix(kind: string): string {
+    const normalizedKind = kind.toLowerCase();
+    if (normalizedKind === "read" || normalizedKind === "read_file") {
+        return "Read ";
+    }
+    if (normalizedKind === "search" || normalizedKind === "grep") {
+        return "Search ";
+    }
+    if (normalizedKind === "edit" || normalizedKind === "update") {
+        return "Edit ";
+    }
+    if (normalizedKind === "write") return "Write ";
+    if (normalizedKind === "create") return "Create ";
+    if (normalizedKind === "delete" || normalizedKind === "remove") {
+        return "Delete ";
+    }
+    if (normalizedKind === "move" || normalizedKind === "rename") {
+        return "Move ";
+    }
+    return "";
+}
+
+function shouldUseStructuredHeaderTarget(kind: string): boolean {
+    const normalizedKind = kind.toLowerCase();
+    return (
+        normalizedKind === "read" ||
+        normalizedKind === "read_file" ||
+        normalizedKind === "search" ||
+        normalizedKind === "grep"
+    );
+}
+
+export function getToolActivityHeaderPresentation(
+    activity: AiToolActivity,
+): ToolActivityHeaderPresentation | null {
+    const titleReference = parseToolTitleReference(activity.title);
+    if (!shouldUseStructuredHeaderTarget(activity.kind)) {
+        return titleReference;
+    }
+
+    const structuredTarget = getStructuredToolTarget(activity);
+    if (structuredTarget && isLikelyProjectFileReference(structuredTarget)) {
+        return {
+            // Keep a useful provider title for display, but never use it as the
+            // navigation target when structured protocol metadata exists.
+            displayTarget: titleReference?.displayTarget ?? structuredTarget,
+            prefix:
+                titleReference?.prefix ??
+                getToolActionPrefix(activity.kind),
+            target: structuredTarget,
+        };
+    }
+
+    return titleReference;
 }
 
 export function getToolActivityDescriptor(

--- a/src/shared/native-backend/adapters.ts
+++ b/src/shared/native-backend/adapters.ts
@@ -627,7 +627,7 @@ function nativeAiToolActivityToIpc(
                 : null,
         id: payload.toolCallId,
         kind: payload.kind,
-        locations: [],
+        locations: nativeAiToolActivityLocationsToIpc(payload.locations),
         rawInputJson: stringifyNativeJson(payload.rawInput),
         rawOutputJson: stringifyNativeJson(payload.rawOutput),
         sessionId: payload.sessionId,
@@ -644,6 +644,44 @@ function nativeAiToolActivityToIpc(
         activity,
         kind: "tool-activity",
     };
+}
+
+function nativeAiToolActivityLocationsToIpc(
+    value: unknown,
+): AiToolActivity["locations"] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value.flatMap((entry) => {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+            return [];
+        }
+
+        const record = entry as Record<string, unknown>;
+        if (typeof record.path !== "string" || record.path.trim().length === 0) {
+            return [];
+        }
+
+        const line = record.line;
+        if (
+            line !== undefined &&
+            line !== null &&
+            (typeof line !== "number" ||
+                !Number.isFinite(line) ||
+                line < 0)
+        ) {
+            return [];
+        }
+
+        return [
+            {
+                endLine: null,
+                line: typeof line === "number" ? line : null,
+                path: record.path.trim(),
+            },
+        ];
+    });
 }
 
 function nativeAiToolActivityChangeStatsToIpc(

--- a/src/shared/native-backend/ai.ts
+++ b/src/shared/native-backend/ai.ts
@@ -694,6 +694,11 @@ export type NativeAiThinkingDeltaPayload = NativeAiMessageDeltaPayload;
 export type NativeAiThinkingStartedPayload = NativeAiMessageStartedPayload;
 export type NativeAiThinkingCompletedPayload = NativeAiMessageCompletedPayload;
 
+export type NativeAiToolActivityLocation = {
+    readonly path: string;
+    readonly line?: number | null;
+};
+
 export type NativeAiToolActivityPayload = NativeAiEventBase & {
     readonly changeStats?: {
         readonly additions: number;
@@ -710,6 +715,7 @@ export type NativeAiToolActivityPayload = NativeAiEventBase & {
     readonly rawInput?: unknown;
     readonly rawOutput?: unknown;
     readonly diffs?: readonly unknown[];
+    readonly locations?: readonly NativeAiToolActivityLocation[];
     readonly terminalOutput?: string | null;
     readonly exitCode?: number | null;
 };

--- a/src/shared/native-backend/fixtures.test.ts
+++ b/src/shared/native-backend/fixtures.test.ts
@@ -258,6 +258,13 @@ describe("native backend fixtures", () => {
             activity: {
                 id: "tool_1",
                 diffs: [],
+                locations: [
+                    {
+                        endLine: null,
+                        line: 8,
+                        path: "/workspace/src/main.ts",
+                    },
+                ],
                 rawInputJson: JSON.stringify({ file_path: "src/main.ts" }),
                 rawOutputJson: JSON.stringify("export function main() {}\n"),
                 terminalOutput: "export function main() {}\n",
@@ -325,6 +332,12 @@ describe("native backend fixtures", () => {
             payload: {
                 exitCode: 0,
                 kind: "edit",
+                locations: [
+                    {
+                        path: "/workspace/src/main.ts",
+                        line: 8,
+                    },
+                ],
                 runtimeId: "codex",
                 runtimeSessionId: "runtime-1",
                 sessionId: "session-1",
@@ -340,10 +353,57 @@ describe("native backend fixtures", () => {
         expect(compactActivityEvent).toMatchObject({
             activity: {
                 diffs: [],
+                locations: [
+                    {
+                        endLine: null,
+                        line: 8,
+                        path: "/workspace/src/main.ts",
+                    },
+                ],
                 rawInputJson: null,
                 rawOutputJson: null,
                 terminalOutput: null,
                 toolActivityDetailId: "tool-detail:session-1:tool-1",
+            },
+            kind: "tool-activity",
+        });
+        const malformedLocationsEvent = nativeAiEventToIpc({
+            eventName: "ai://tool-activity",
+            payload: {
+                kind: "read",
+                locations: [
+                    null,
+                    { path: "" },
+                    { path: "src/negative.ts", line: -1 },
+                    { path: "src/infinite.ts", line: Number.POSITIVE_INFINITY },
+                    { path: " src/valid.ts ", line: 4 },
+                    { path: "src/without-line.ts" },
+                ],
+                runtimeId: "custom-acp",
+                runtimeSessionId: "runtime-1",
+                sessionId: "session-1",
+                status: "completed",
+                summary: null,
+                title: "read",
+                toolCallId: "tool-locations",
+                updatedAt: "2026-07-20T00:00:00.000Z",
+            },
+            type: "event",
+        });
+        expect(malformedLocationsEvent).toMatchObject({
+            activity: {
+                locations: [
+                    {
+                        endLine: null,
+                        line: 4,
+                        path: "src/valid.ts",
+                    },
+                    {
+                        endLine: null,
+                        line: null,
+                        path: "src/without-line.ts",
+                    },
+                ],
             },
             kind: "tool-activity",
         });


### PR DESCRIPTION
## Summary

- project ACP tool-call locations into the provider-neutral native activity contract, including path and line metadata
- retain locations through compact event forwarding, partial updates, and persisted session snapshots while validating malformed external entries independently
- use structured locations as navigation targets in card and rail-row presentations without duplicating descriptive runtime titles

## Compatibility

- native payloads without locations continue to deserialize with an empty list
- raw input remains a fallback when ACP locations are unavailable
- existing historical sessions are not backfilled

## Testing

- cargo test --workspace
- pnpm run native:protocol:check
- pnpm run test
- pnpm run typecheck
- pnpm run lint
- cargo fmt --check
- git diff --check

The lint command completes with two existing renderer warnings in App.tsx and ChatTabView.tsx; there are no lint errors.
