### PR TITLE
Review uncommitted and branch changes in one tab

### DIFF
--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -19,8 +19,8 @@ use comando_git::{
     GitBranchListScope, GitError, GitFileDiffRequest, GitRunOptions, GitRunner, checkout_branch,
     commit, create_branch, create_worktree, delete_local_branch, delete_remote_branch,
     discard_paths, fetch, get_commit_detail, get_diff_stats, get_file_diff, get_original_file,
-    get_repository_snapshot, get_status, init_repository, list_branches, list_history,
-    list_remotes, list_worktree_diff, list_worktrees, pull, push, remove_worktree,
+    get_repository_snapshot, get_status, init_repository, list_branch_diff, list_branches,
+    list_history, list_remotes, list_worktree_diff, list_worktrees, pull, push, remove_worktree,
     resolve_repository, stage_paths, unstage_paths,
 };
 use comando_index::{
@@ -333,6 +333,7 @@ impl NativeBackend {
             "git_list_remotes" => self.git_list_remotes(request),
             "git_get_diff_stats" => self.git_get_diff_stats(request),
             "git_list_worktree_diff" => self.git_list_worktree_diff(request),
+            "git_list_branch_diff" => self.git_list_branch_diff(request),
             "git_init_repository" => self.git_init_repository(request),
             "git_clone_repository" => self.git_clone_repository(request),
             "git_stage_paths" => self.git_stage_paths(request),
@@ -3476,6 +3477,24 @@ impl NativeBackend {
                 input.scopes.as_deref(),
             ),
             "git worktree diff serializes",
+        )
+    }
+
+    fn git_list_branch_diff(&mut self, request: RpcRequest) -> CommandResult {
+        let scope = match parse_args::<native_git::NativeGitRepositoryScope>(&request) {
+            Ok(scope) => scope,
+            Err(error) => return error_only(request.id, error),
+        };
+
+        git_response(
+            request.id,
+            list_branch_diff(
+                &self.git_runner,
+                scope.root_path,
+                scope.project_id,
+                scope.worktree_id,
+            ),
+            "git branch diff serializes",
         )
     }
 

--- a/crates/comando-git/src/branch_diff.rs
+++ b/crates/comando-git/src/branch_diff.rs
@@ -1,0 +1,568 @@
+use std::path::Path;
+
+use comando_types::git::{NativeGitBranchDiffFile, NativeGitBranchDiffResult, NativeGitFileDiff};
+use comando_types::ids::{ProjectId, WorktreeId};
+
+use crate::diff::parse_unified_diff;
+use crate::error::GitResult;
+use crate::runner::{GitRunOptions, GitRunner};
+
+const NO_BASE_REASON: &str = "No base branch available for comparison.";
+const DETACHED_HEAD_REASON: &str = "Branch changes are unavailable in detached HEAD.";
+const NO_MERGE_BASE_REASON: &str = "No common ancestor is available for comparison.";
+
+pub fn list_branch_diff(
+    runner: &GitRunner,
+    root_path: impl AsRef<Path>,
+    project_id: ProjectId,
+    worktree_id: Option<WorktreeId>,
+) -> GitResult<NativeGitBranchDiffResult> {
+    let root_path = root_path.as_ref();
+    let Some(head_ref) = current_branch(runner, root_path)? else {
+        return Ok(unavailable_result(
+            project_id,
+            worktree_id,
+            "HEAD",
+            DETACHED_HEAD_REASON,
+        ));
+    };
+    let Some(base_ref) = resolve_base_ref(runner, root_path, &head_ref)? else {
+        return Ok(unavailable_result(
+            project_id,
+            worktree_id,
+            &head_ref,
+            NO_BASE_REASON,
+        ));
+    };
+
+    if merge_base(runner, root_path, &base_ref)?.is_none() {
+        return Ok(NativeGitBranchDiffResult {
+            project_id,
+            worktree_id,
+            base_ref: Some(base_ref),
+            head_ref,
+            files: Vec::new(),
+            unavailable_reason: Some(NO_MERGE_BASE_REASON.to_string()),
+            updated_at: now_rfc3339(),
+        });
+    }
+
+    let files = list_changed_files(runner, root_path, &base_ref)?
+        .into_iter()
+        .map(|change| build_branch_diff_file(runner, root_path, &base_ref, change))
+        .collect();
+
+    Ok(NativeGitBranchDiffResult {
+        project_id,
+        worktree_id,
+        base_ref: Some(base_ref),
+        head_ref,
+        files,
+        unavailable_reason: None,
+        updated_at: now_rfc3339(),
+    })
+}
+
+fn current_branch(runner: &GitRunner, root_path: &Path) -> GitResult<Option<String>> {
+    let output = runner.run(
+        root_path,
+        &["symbolic-ref", "--quiet", "--short", "HEAD"],
+        GitRunOptions::read_only().allow_exit_code(1),
+    )?;
+    Ok((output.status_code == Some(0))
+        .then(|| output.stdout.trim().to_string())
+        .filter(|branch| !branch.is_empty()))
+}
+
+fn resolve_base_ref(
+    runner: &GitRunner,
+    root_path: &Path,
+    head_ref: &str,
+) -> GitResult<Option<String>> {
+    if let Some(configured) = config_value(
+        runner,
+        root_path,
+        &format!("branch.{head_ref}.gh-merge-base"),
+    )? {
+        // An explicit GitHub merge base is authoritative; never mask a stale
+        // configuration by silently comparing against another branch.
+        let is_valid = is_valid_base(runner, root_path, head_ref, &configured)?;
+        return Ok(is_valid.then_some(configured));
+    }
+
+    let remote = primary_remote(runner, root_path, head_ref)?;
+    if let Some(remote) = remote.as_deref()
+        && let Some(remote_default) = remote_default_branch(runner, root_path, remote)?
+    {
+        for candidate in [
+            remote_default.clone(),
+            remote_default
+                .strip_prefix(&format!("{remote}/"))
+                .unwrap_or(&remote_default)
+                .to_string(),
+        ] {
+            if is_valid_base(runner, root_path, head_ref, &candidate)? {
+                return Ok(Some(candidate));
+            }
+        }
+    }
+
+    for candidate in ["main", "master"] {
+        if is_valid_base(runner, root_path, head_ref, candidate)? {
+            return Ok(Some(candidate.to_string()));
+        }
+    }
+
+    if let Some(remote) = remote {
+        for branch in ["main", "master"] {
+            let candidate = format!("{remote}/{branch}");
+            if is_valid_base(runner, root_path, head_ref, &candidate)? {
+                return Ok(Some(candidate));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn config_value(runner: &GitRunner, root_path: &Path, key: &str) -> GitResult<Option<String>> {
+    let output = runner.run(
+        root_path,
+        &["config", "--get", key],
+        GitRunOptions::read_only().allow_exit_code(1),
+    )?;
+    Ok((output.status_code == Some(0))
+        .then(|| output.stdout.trim().to_string())
+        .filter(|value| !value.is_empty()))
+}
+
+fn primary_remote(
+    runner: &GitRunner,
+    root_path: &Path,
+    head_ref: &str,
+) -> GitResult<Option<String>> {
+    if let Some(remote) = config_value(runner, root_path, &format!("branch.{head_ref}.remote"))?
+        && remote != "."
+    {
+        return Ok(Some(remote));
+    }
+
+    let output = runner.run(root_path, &["remote"], GitRunOptions::read_only())?;
+    let remotes = output
+        .stdout
+        .lines()
+        .map(str::trim)
+        .filter(|remote| !remote.is_empty())
+        .collect::<Vec<_>>();
+    Ok(remotes
+        .iter()
+        .find(|remote| **remote == "origin")
+        .or_else(|| remotes.first())
+        .map(|remote| (*remote).to_string()))
+}
+
+fn remote_default_branch(
+    runner: &GitRunner,
+    root_path: &Path,
+    remote: &str,
+) -> GitResult<Option<String>> {
+    let remote_head = format!("refs/remotes/{remote}/HEAD");
+    let output = runner.run(
+        root_path,
+        &["symbolic-ref", "--quiet", "--short", &remote_head],
+        GitRunOptions::read_only().allow_exit_code(1),
+    )?;
+    Ok((output.status_code == Some(0))
+        .then(|| output.stdout.trim().to_string())
+        .filter(|value| !value.is_empty()))
+}
+
+fn is_valid_base(
+    runner: &GitRunner,
+    root_path: &Path,
+    head_ref: &str,
+    candidate: &str,
+) -> GitResult<bool> {
+    if candidate == head_ref || candidate == format!("refs/heads/{head_ref}") {
+        return Ok(false);
+    }
+
+    let revision = format!("{candidate}^{{commit}}");
+    let output = runner.run(
+        root_path,
+        &["rev-parse", "--verify", "--quiet", &revision],
+        GitRunOptions::read_only().allow_exit_code(1),
+    )?;
+    Ok(output.status_code == Some(0))
+}
+
+fn merge_base(runner: &GitRunner, root_path: &Path, base_ref: &str) -> GitResult<Option<String>> {
+    let output = runner.run(
+        root_path,
+        &["merge-base", base_ref, "HEAD"],
+        GitRunOptions::read_only().allow_exit_code(1),
+    )?;
+    Ok((output.status_code == Some(0))
+        .then(|| output.stdout.trim().to_string())
+        .filter(|value| !value.is_empty()))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BranchChange {
+    kind: String,
+    path: String,
+    previous_path: Option<String>,
+}
+
+fn list_changed_files(
+    runner: &GitRunner,
+    root_path: &Path,
+    base_ref: &str,
+) -> GitResult<Vec<BranchChange>> {
+    let range = format!("{base_ref}...HEAD");
+    let output = runner.run(
+        root_path,
+        &[
+            "diff",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            "--find-copies",
+            &range,
+        ],
+        GitRunOptions::read_only(),
+    )?;
+    Ok(parse_name_status(&output.stdout))
+}
+
+fn parse_name_status(output: &str) -> Vec<BranchChange> {
+    let fields = output
+        .split('\0')
+        .filter(|field| !field.is_empty())
+        .collect::<Vec<_>>();
+    let mut changes = Vec::new();
+    let mut index = 0;
+
+    while index < fields.len() {
+        let status = fields[index];
+        index += 1;
+        let status_kind = status.chars().next().unwrap_or('M');
+        if matches!(status_kind, 'R' | 'C') {
+            let (Some(previous_path), Some(path)) = (fields.get(index), fields.get(index + 1))
+            else {
+                break;
+            };
+            changes.push(BranchChange {
+                kind: if status_kind == 'R' {
+                    "renamed"
+                } else {
+                    "copied"
+                }
+                .to_string(),
+                path: (*path).to_string(),
+                previous_path: Some((*previous_path).to_string()),
+            });
+            index += 2;
+            continue;
+        }
+
+        let Some(path) = fields.get(index) else {
+            break;
+        };
+        changes.push(BranchChange {
+            kind: match status_kind {
+                'A' => "added",
+                'D' => "deleted",
+                'T' => "typechange",
+                _ => "modified",
+            }
+            .to_string(),
+            path: (*path).to_string(),
+            previous_path: None,
+        });
+        index += 1;
+    }
+
+    changes
+}
+
+fn build_branch_diff_file(
+    runner: &GitRunner,
+    root_path: &Path,
+    base_ref: &str,
+    change: BranchChange,
+) -> NativeGitBranchDiffFile {
+    match load_file_diff(runner, root_path, base_ref, &change) {
+        Ok(diff) => NativeGitBranchDiffFile {
+            additions: (!diff.is_binary).then_some(diff.summary.insertions),
+            deletions: (!diff.is_binary).then_some(diff.summary.deletions),
+            is_binary: diff.is_binary,
+            diff: Some(diff),
+            error: None,
+            kind: change.kind,
+            path: change.path,
+            previous_path: change.previous_path,
+        },
+        Err(error) => NativeGitBranchDiffFile {
+            additions: None,
+            deletions: None,
+            diff: None,
+            error: Some(error.to_string()),
+            is_binary: false,
+            kind: change.kind,
+            path: change.path,
+            previous_path: change.previous_path,
+        },
+    }
+}
+
+fn load_file_diff(
+    runner: &GitRunner,
+    root_path: &Path,
+    base_ref: &str,
+    change: &BranchChange,
+) -> GitResult<NativeGitFileDiff> {
+    let range = format!("{base_ref}...HEAD");
+    let mut args = vec![
+        "diff".to_string(),
+        "--find-renames".to_string(),
+        "--find-copies".to_string(),
+        "--no-color".to_string(),
+        "--unified=3".to_string(),
+        range,
+        "--".to_string(),
+    ];
+    if let Some(previous_path) = &change.previous_path {
+        args.push(previous_path.clone());
+    }
+    args.push(change.path.clone());
+
+    let output = runner.run(root_path, &args, GitRunOptions::read_only())?;
+    let parsed = parse_unified_diff(&output.stdout, &change.path);
+    Ok(NativeGitFileDiff {
+        path: change.path.clone(),
+        previous_path: change.previous_path.clone(),
+        kind: match change.kind.as_str() {
+            "added" => "create",
+            "deleted" => "delete",
+            "renamed" => "move",
+            _ => "update",
+        }
+        .to_string(),
+        staged: false,
+        is_binary: parsed.is_binary,
+        is_text: !parsed.is_binary,
+        is_too_large: false,
+        old_text: None,
+        new_text: None,
+        raw: output.stdout,
+        summary: parsed.summary,
+        hunks: parsed.hunks,
+    })
+}
+
+fn unavailable_result(
+    project_id: ProjectId,
+    worktree_id: Option<WorktreeId>,
+    head_ref: &str,
+    reason: &str,
+) -> NativeGitBranchDiffResult {
+    NativeGitBranchDiffResult {
+        project_id,
+        worktree_id,
+        base_ref: None,
+        head_ref: head_ref.to_string(),
+        files: Vec::new(),
+        unavailable_reason: Some(reason.to_string()),
+        updated_at: now_rfc3339(),
+    }
+}
+
+fn now_rfc3339() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use comando_types::ids::ProjectId;
+
+    use crate::runner::GitRunner;
+    use crate::test_support::run_git_fixture;
+
+    use super::list_branch_diff;
+
+    #[test]
+    fn includes_only_branch_commits_when_main_advances() {
+        let temp = initialized_repo();
+        run_git_fixture(temp.path(), &["switch", "-c", "feature"]);
+        fs::write(temp.path().join("feature.txt"), "feature\n").expect("feature");
+        commit_all(&temp, "feature");
+        run_git_fixture(temp.path(), &["switch", "main"]);
+        fs::write(temp.path().join("main.txt"), "main\n").expect("main");
+        commit_all(&temp, "main advances");
+        run_git_fixture(temp.path(), &["switch", "feature"]);
+        fs::write(temp.path().join("local.txt"), "local\n").expect("local");
+
+        let result = branch_diff(&temp);
+
+        assert_eq!(result.base_ref.as_deref(), Some("main"));
+        assert_eq!(result.files.len(), 1);
+        assert_eq!(result.files[0].path, "feature.txt");
+    }
+
+    #[test]
+    fn returns_empty_diff_for_branch_without_commits() {
+        let temp = initialized_repo();
+        run_git_fixture(temp.path(), &["switch", "-c", "feature"]);
+
+        let result = branch_diff(&temp);
+
+        assert_eq!(result.base_ref.as_deref(), Some("main"));
+        assert!(result.files.is_empty());
+        assert!(result.unavailable_reason.is_none());
+    }
+
+    #[test]
+    fn reports_when_the_current_base_branch_has_no_comparison() {
+        let temp = initialized_repo();
+
+        let result = branch_diff(&temp);
+
+        assert!(result.base_ref.is_none());
+        assert_eq!(
+            result.unavailable_reason.as_deref(),
+            Some("No base branch available for comparison.")
+        );
+    }
+
+    #[test]
+    fn prefers_explicit_merge_base_configuration() {
+        let temp = initialized_repo();
+        run_git_fixture(temp.path(), &["branch", "release"]);
+        run_git_fixture(temp.path(), &["switch", "-c", "feature"]);
+        run_git_fixture(
+            temp.path(),
+            &["config", "branch.feature.gh-merge-base", "release"],
+        );
+
+        let result = branch_diff(&temp);
+
+        assert_eq!(result.base_ref.as_deref(), Some("release"));
+    }
+
+    #[test]
+    fn does_not_mask_an_invalid_explicit_merge_base() {
+        let temp = initialized_repo();
+        run_git_fixture(temp.path(), &["switch", "-c", "feature"]);
+        run_git_fixture(
+            temp.path(),
+            &["config", "branch.feature.gh-merge-base", "missing"],
+        );
+
+        let result = branch_diff(&temp);
+
+        assert!(result.base_ref.is_none());
+        assert_eq!(
+            result.unavailable_reason.as_deref(),
+            Some("No base branch available for comparison.")
+        );
+    }
+
+    #[test]
+    fn resolves_default_branch_for_a_non_origin_remote() {
+        let temp = initialized_repo();
+        run_git_fixture(
+            temp.path(),
+            &["update-ref", "refs/remotes/upstream/trunk", "HEAD"],
+        );
+        run_git_fixture(
+            temp.path(),
+            &[
+                "symbolic-ref",
+                "refs/remotes/upstream/HEAD",
+                "refs/remotes/upstream/trunk",
+            ],
+        );
+        run_git_fixture(
+            temp.path(),
+            &[
+                "remote",
+                "add",
+                "upstream",
+                "https://example.invalid/repo.git",
+            ],
+        );
+        run_git_fixture(temp.path(), &["switch", "-c", "feature"]);
+
+        let result = branch_diff(&temp);
+
+        assert_eq!(result.base_ref.as_deref(), Some("upstream/trunk"));
+    }
+
+    #[test]
+    fn returns_explicit_result_for_detached_head() {
+        let temp = initialized_repo();
+        run_git_fixture(temp.path(), &["checkout", "--detach", "HEAD"]);
+
+        let result = branch_diff(&temp);
+
+        assert!(result.files.is_empty());
+        assert_eq!(
+            result.unavailable_reason.as_deref(),
+            Some("Branch changes are unavailable in detached HEAD.")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_master_and_handles_renames_and_binary_files() {
+        let temp = initialized_repo_with_branch("master");
+        run_git_fixture(temp.path(), &["switch", "-c", "feature"]);
+        run_git_fixture(temp.path(), &["mv", "tracked.txt", "renamed.txt"]);
+        fs::write(temp.path().join("binary.bin"), [0, 159, 146, 150]).expect("binary");
+        commit_all(&temp, "rename and binary");
+
+        let result = branch_diff(&temp);
+
+        assert_eq!(result.base_ref.as_deref(), Some("master"));
+        assert!(result.files.iter().any(|file| file.kind == "renamed"));
+        assert!(result.files.iter().any(|file| file.is_binary));
+    }
+
+    fn branch_diff(temp: &TempDir) -> comando_types::git::NativeGitBranchDiffResult {
+        list_branch_diff(
+            &GitRunner::new(),
+            temp.path(),
+            ProjectId("project_1".to_string()),
+            None,
+        )
+        .expect("branch diff")
+    }
+
+    fn initialized_repo() -> TempDir {
+        initialized_repo_with_branch("main")
+    }
+
+    fn initialized_repo_with_branch(branch: &str) -> TempDir {
+        let temp = TempDir::new().expect("temp");
+        run_git_fixture(temp.path(), &["init", "-b", branch]);
+        run_git_fixture(temp.path(), &["config", "user.name", "Test User"]);
+        run_git_fixture(
+            temp.path(),
+            &["config", "user.email", "test@example.invalid"],
+        );
+        fs::write(temp.path().join("tracked.txt"), "base\n").expect("base");
+        commit_all(&temp, "initial");
+        temp
+    }
+
+    fn commit_all(temp: &TempDir, message: &str) {
+        run_git_fixture(temp.path(), &["add", "-A"]);
+        run_git_fixture(temp.path(), &["commit", "-m", message]);
+    }
+}

--- a/crates/comando-git/src/diff.rs
+++ b/crates/comando-git/src/diff.rs
@@ -90,7 +90,7 @@ pub fn parse_unified_diff(raw: &str, path: &str) -> ParsedUnifiedDiff {
     let mut is_binary = false;
 
     for line in raw.split('\n') {
-        if line.starts_with("Binary files ") {
+        if line.starts_with("Binary files ") || line == "GIT binary patch" {
             is_binary = true;
             continue;
         }

--- a/crates/comando-git/src/lib.rs
+++ b/crates/comando-git/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod branch_diff;
 pub mod branches;
 pub mod diff;
 pub mod env;
@@ -16,6 +17,7 @@ pub mod worktrees;
 #[cfg(test)]
 pub mod test_support;
 
+pub use branch_diff::list_branch_diff;
 pub use branches::{GitBranchListScope, list_branches};
 pub use diff::{GitFileDiffRequest, get_diff_stats, get_file_diff, parse_unified_diff};
 pub use env::GitEnvironment;

--- a/crates/comando-types/src/commands.rs
+++ b/crates/comando-types/src/commands.rs
@@ -99,6 +99,7 @@ pub const GIT_COMMANDS: &[&str] = &[
     "git_list_remotes",
     "git_get_diff_stats",
     "git_list_worktree_diff",
+    "git_list_branch_diff",
     "git_init_repository",
     "git_clone_repository",
     "git_stage_paths",

--- a/crates/comando-types/src/git.rs
+++ b/crates/comando-types/src/git.rs
@@ -323,6 +323,31 @@ pub struct NativeGitWorktreeDiffResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct NativeGitBranchDiffFile {
+    pub additions: Option<i64>,
+    pub deletions: Option<i64>,
+    pub diff: Option<NativeGitFileDiff>,
+    pub error: Option<String>,
+    pub is_binary: bool,
+    pub kind: String,
+    pub path: String,
+    pub previous_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeGitBranchDiffResult {
+    pub project_id: ProjectId,
+    pub worktree_id: Option<WorktreeId>,
+    pub base_ref: Option<String>,
+    pub head_ref: String,
+    pub files: Vec<NativeGitBranchDiffFile>,
+    pub unavailable_reason: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct NativeGitRepositorySnapshot {
     pub repository_id: RepositoryId,
     pub project_id: ProjectId,

--- a/crates/comando-types/tests/fixtures.rs
+++ b/crates/comando-types/tests/fixtures.rs
@@ -16,11 +16,11 @@ use comando_types::error::{NativeError, NativeErrorCode};
 use comando_types::events::all_events;
 use comando_types::fs::NativeFsReadFileResult;
 use comando_types::git::{
-    NativeGitBranchSummary, NativeGitChangeEntry, NativeGitCommitDetail, NativeGitDiffStatRecord,
-    NativeGitFileDiff, NativeGitHistoryListResult, NativeGitOperationResult, NativeGitOriginalFile,
-    NativeGitRemoteSummary, NativeGitRepositoryInvalidation, NativeGitRepositoryResolution,
-    NativeGitRepositorySnapshot, NativeGitStatusSnapshot, NativeGitWorktreeDiffResult,
-    NativeGitWorktreeSummary,
+    NativeGitBranchDiffResult, NativeGitBranchSummary, NativeGitChangeEntry, NativeGitCommitDetail,
+    NativeGitDiffStatRecord, NativeGitFileDiff, NativeGitHistoryListResult,
+    NativeGitOperationResult, NativeGitOriginalFile, NativeGitRemoteSummary,
+    NativeGitRepositoryInvalidation, NativeGitRepositoryResolution, NativeGitRepositorySnapshot,
+    NativeGitStatusSnapshot, NativeGitWorktreeDiffResult, NativeGitWorktreeSummary,
 };
 use comando_types::index::{
     NativeIndexStatusResult, NativeIndexedProjectEntry, NativeProjectEntrySearchResult,
@@ -278,6 +278,8 @@ fn local_domain_fixtures_deserialize() {
     assert_eq!(commit_detail.changed_file_count, 1);
     let worktree_diff: NativeGitWorktreeDiffResult = fixture("git/worktree.diff.json");
     assert_eq!(worktree_diff.sections.len(), 1);
+    let branch_diff: NativeGitBranchDiffResult = fixture("git/branch.diff.json");
+    assert_eq!(branch_diff.base_ref.as_deref(), Some("origin/main"));
     let invalidation: NativeGitRepositoryInvalidation = fixture("git/repository.invalidation.json");
     assert_eq!(invalidation.reason, "status");
     let operation: NativeGitOperationResult = fixture("git/operation.result.json");
@@ -332,6 +334,7 @@ fn key_dtos_roundtrip_without_losing_required_fields() {
     assert_typed_roundtrip::<NativeGitHistoryListResult>("git/history.list.json");
     assert_typed_roundtrip::<NativeGitCommitDetail>("git/commit.detail.json");
     assert_typed_roundtrip::<NativeGitWorktreeDiffResult>("git/worktree.diff.json");
+    assert_typed_roundtrip::<NativeGitBranchDiffResult>("git/branch.diff.json");
     assert_typed_roundtrip::<NativeGitRepositoryInvalidation>("git/repository.invalidation.json");
     assert_typed_roundtrip::<NativeGitOperationResult>("git/operation.result.json");
     assert_typed_roundtrip::<NativeIndexStatusResult>("index/index.status.json");

--- a/fixtures/native-backend/git/branch.diff.json
+++ b/fixtures/native-backend/git/branch.diff.json
@@ -1,0 +1,61 @@
+{
+  "projectId": "project_1",
+  "worktreeId": "worktree_1",
+  "baseRef": "origin/main",
+  "headRef": "feature/review",
+  "files": [
+    {
+      "additions": 1,
+      "deletions": 1,
+      "diff": {
+        "path": "src/main.ts",
+        "previousPath": null,
+        "kind": "update",
+        "staged": false,
+        "isBinary": false,
+        "isText": true,
+        "isTooLarge": false,
+        "oldText": null,
+        "newText": null,
+        "raw": "diff --git a/src/main.ts b/src/main.ts\n@@ -1 +1 @@\n-old\n+new\n",
+        "summary": {
+          "insertions": 1,
+          "deletions": 1
+        },
+        "hunks": [
+          {
+            "id": "src/main.ts:0",
+            "header": "@@ -1 +1 @@",
+            "oldStart": 1,
+            "oldCount": 1,
+            "newStart": 1,
+            "newCount": 1,
+            "lines": [
+              {
+                "id": "src/main.ts:0:0",
+                "type": "remove",
+                "text": "old",
+                "oldLineNumber": 1,
+                "newLineNumber": null
+              },
+              {
+                "id": "src/main.ts:0:1",
+                "type": "add",
+                "text": "new",
+                "oldLineNumber": null,
+                "newLineNumber": 1
+              }
+            ]
+          }
+        ]
+      },
+      "error": null,
+      "isBinary": false,
+      "kind": "modified",
+      "path": "src/main.ts",
+      "previousPath": null
+    }
+  ],
+  "unavailableReason": null,
+  "updatedAt": "2026-07-26T00:00:00.000Z"
+}

--- a/fixtures/native-backend/protocol/capabilities.v1.json
+++ b/fixtures/native-backend/protocol/capabilities.v1.json
@@ -82,6 +82,7 @@
       "git_list_remotes",
       "git_get_diff_stats",
       "git_list_worktree_diff",
+      "git_list_branch_diff",
       "git_init_repository",
       "git_clone_repository",
       "git_stage_paths",

--- a/fixtures/native-backend/protocol/registry.commands.json
+++ b/fixtures/native-backend/protocol/registry.commands.json
@@ -58,6 +58,7 @@
   "git_list_remotes",
   "git_get_diff_stats",
   "git_list_worktree_diff",
+  "git_list_branch_diff",
   "git_init_repository",
   "git_clone_repository",
   "git_stage_paths",

--- a/src/main/git/service.ts
+++ b/src/main/git/service.ts
@@ -1,6 +1,7 @@
 import type { GitRemoteSummary } from "@shared/ipc";
 
 import type {
+    GitBranchDiffResult,
     GitBranchSummary,
     GitCommitDetail,
     GitDiffStatRecord,
@@ -38,6 +39,7 @@ export interface GitGateway {
         inputPath: string,
         options?: GitWorktreeDiffOptions,
     ): Promise<GitWorktreeDiffResult>;
+    listBranchDiff(inputPath: string): Promise<GitBranchDiffResult>;
     getFileText(
         inputPath: string,
         relativePath: string,

--- a/src/main/git/types.ts
+++ b/src/main/git/types.ts
@@ -185,6 +185,25 @@ export interface GitWorktreeDiffOptions {
     readonly scopes?: readonly GitChangeScope[];
 }
 
+export interface GitBranchDiffFile {
+    readonly additions: number | null;
+    readonly deletions: number | null;
+    readonly diff: GitFileDiff | null;
+    readonly error: string | null;
+    readonly isBinary: boolean;
+    readonly kind: GitChangeKind;
+    readonly path: string;
+    readonly previousPath: string | null;
+}
+
+export interface GitBranchDiffResult {
+    readonly baseRef: string | null;
+    readonly headRef: string;
+    readonly files: readonly GitBranchDiffFile[];
+    readonly unavailableReason: string | null;
+    readonly updatedAt: string;
+}
+
 export type GitFileTextReference = "head" | "index";
 
 export interface GitListBranchesOptions {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -48,6 +48,9 @@ import {
     type NativeContextMenuInput,
     type MoveWorkspaceContextInput,
     type EnqueueAiPromptInput,
+    type GitBranchDiffFile,
+    type GitBranchDiffInput,
+    type GitBranchDiffResult,
     type GitBranchListInput,
     type GitBranchSummary as SharedGitBranchSummary,
     type GitChangeEntry as SharedGitChangeEntry,
@@ -322,6 +325,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.listGitChanges);
     ipcMain.removeHandler(IPC_CHANNELS.listGitHistory);
     ipcMain.removeHandler(IPC_CHANNELS.listGitWorktreeDiff);
+    ipcMain.removeHandler(IPC_CHANNELS.listGitBranchDiff);
     ipcMain.removeHandler(IPC_CHANNELS.getGitDiff);
     ipcMain.removeHandler(IPC_CHANNELS.getGitOriginalFile);
     ipcMain.removeHandler(IPC_CHANNELS.getGitCommitDetail);
@@ -998,6 +1002,18 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             input: GitWorktreeDiffInput,
         ): Promise<GitWorktreeDiffResult | null> =>
             buildSharedGitWorktreeDiff(
+                options.projectService,
+                options.gitService,
+                input,
+            ),
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.listGitBranchDiff,
+        async (
+            _event,
+            input: GitBranchDiffInput,
+        ): Promise<GitBranchDiffResult | null> =>
+            buildSharedGitBranchDiff(
                 options.projectService,
                 options.gitService,
                 input,
@@ -2991,6 +3007,8 @@ type MainGitWorktreeDiffResult = Awaited<
 >;
 type MainGitWorktreeDiffFile =
     MainGitWorktreeDiffResult["sections"][number]["files"][number];
+type MainGitBranchDiffResult = Awaited<ReturnType<GitGateway["listBranchDiff"]>>;
+type MainGitBranchDiffFile = MainGitBranchDiffResult["files"][number];
 type DiffStatEntry = { additions: number; deletions: number };
 type DiffStatMap = Map<string, DiffStatEntry>;
 
@@ -3262,6 +3280,49 @@ function adaptGitWorktreeDiffFile(
     };
 }
 
+async function buildSharedGitBranchDiff(
+    projectService: ProjectService,
+    gitService: GitGateway,
+    input: GitBranchDiffInput,
+): Promise<GitBranchDiffResult | null> {
+    const scope = resolveGitScope(projectService, input);
+    const snapshot = await gitService.getRepositorySnapshot(scope.rootPath);
+    if (snapshot.resolution.state !== "ready") {
+        return null;
+    }
+
+    const result = await gitService.listBranchDiff(scope.rootPath);
+    return {
+        baseRef: result.baseRef,
+        files: result.files.map(adaptGitBranchDiffFile),
+        headRef: result.headRef,
+        projectId: input.projectId,
+        unavailableReason: result.unavailableReason,
+        updatedAt: result.updatedAt,
+        worktreeId: scope.worktreeId,
+    };
+}
+
+function adaptGitBranchDiffFile(file: MainGitBranchDiffFile): GitBranchDiffFile {
+    return {
+        additions: file.additions,
+        deletions: file.deletions,
+        diff: file.diff
+            ? adaptReadOnlyGitFileDiff(
+                  file.diff,
+                  file.kind,
+                  `branch:${file.diff.changedPath}`,
+                  false,
+              )
+            : null,
+        error: file.error,
+        isBinary: file.isBinary,
+        kind: mapSharedChangeKind(file.kind),
+        path: file.path,
+        previousPath: file.previousPath,
+    };
+}
+
 function adaptGitWorktreeDiffFileDiff(
     file: MainGitWorktreeDiffFile,
 ): SharedGitFileDiff {
@@ -3270,7 +3331,23 @@ function adaptGitWorktreeDiffFileDiff(
         throw new Error("Cannot adapt an empty worktree diff file.");
     }
 
-    const idPrefix = `${file.scope}:${diff.changedPath}`;
+    return adaptReadOnlyGitFileDiff(
+        diff,
+        file.kind,
+        `${file.scope}:${diff.changedPath}`,
+        !file.isConflicted,
+    );
+}
+
+function adaptReadOnlyGitFileDiff(
+    diff: MainGitWorktreeDiffFile["diff"],
+    kind: MainGitWorktreeDiffFile["kind"],
+    idPrefix: string,
+    reversible: boolean,
+): SharedGitFileDiff {
+    if (!diff) {
+        throw new Error("Cannot adapt an empty git file diff.");
+    }
 
     return {
         hunks: diff.hunks.map((hunk, hunkIndex) => ({
@@ -3286,12 +3363,12 @@ function adaptGitWorktreeDiffFileDiff(
             oldStart: hunk.oldStart,
         })),
         isText: !diff.isBinary,
-        kind: mapDiffKind(file.kind),
+        kind: mapDiffKind(kind),
         newText: null,
         oldText: null,
         path: diff.changedPath,
         previousPath: diff.previousPath,
-        reversible: !file.isConflicted,
+        reversible,
     };
 }
 

--- a/src/main/native-backend/git.test.ts
+++ b/src/main/native-backend/git.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import type {
+    NativeGitBranchDiffResult,
     NativeGitCommitDetail,
     NativeGitDiffStatRecord,
     NativeGitFileDiff,
@@ -196,6 +197,25 @@ describe("NativeGitGateway", () => {
             expect.objectContaining({
                 scopes: ["unstaged"],
             }),
+        );
+    });
+
+    it("adapts native branch diffs through the native command", async () => {
+        const requestMock = vi.fn(() =>
+            fixture<NativeGitBranchDiffResult>("branch.diff.json"),
+        );
+        const gateway = gatewayWith(requestMock);
+
+        await expect(
+            gateway.listBranchDiff("/tmp/comando-project"),
+        ).resolves.toMatchObject({
+            baseRef: "origin/main",
+            files: [{ kind: "modified", path: "src/main.ts" }],
+            headRef: "feature/review",
+        });
+        expect(requestMock).toHaveBeenCalledWith(
+            "git_list_branch_diff",
+            expect.objectContaining({ rootPath: "/tmp/comando-project" }),
         );
     });
 

--- a/src/main/native-backend/git.ts
+++ b/src/main/native-backend/git.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 
 import type { GitRemoteSummary } from "@shared/ipc";
 import type {
+    NativeGitBranchDiffResult,
     NativeGitBranchSummary,
     NativeGitChangeTreeNode,
     NativeGitCommitDetail,
@@ -29,6 +30,7 @@ import type {
 
 import type { GitGateway } from "../git/service";
 import type {
+    GitBranchDiffResult,
     GitBranchSummary,
     GitChangeKind,
     GitChangeScope,
@@ -161,6 +163,17 @@ export class NativeGitGateway implements ClosableGitGateway {
                             ? [...options.scopes]
                             : null,
                 }),
+            ),
+        );
+    }
+
+    async listBranchDiff(inputPath: string): Promise<GitBranchDiffResult> {
+        return nativeBranchDiffToMain(
+            parseNativeBranchDiff(
+                await this.#client.request(
+                    "git_list_branch_diff",
+                    nativeGitScope(inputPath),
+                ),
             ),
         );
     }
@@ -609,6 +622,27 @@ function nativeWorktreeDiffToMain(
     };
 }
 
+function nativeBranchDiffToMain(
+    result: NativeGitBranchDiffResult,
+): GitBranchDiffResult {
+    return {
+        baseRef: result.baseRef,
+        files: result.files.map((file) => ({
+            additions: file.additions,
+            deletions: file.deletions,
+            diff: file.diff ? nativeFileDiffToMain(file.diff) : null,
+            error: file.error,
+            isBinary: file.isBinary,
+            kind: nativeChangeKindToMain(file.kind),
+            path: file.path,
+            previousPath: file.previousPath,
+        })),
+        headRef: result.headRef,
+        unavailableReason: result.unavailableReason,
+        updatedAt: result.updatedAt,
+    };
+}
+
 function nativeGitScope(inputPath: string): NativeGitRepositoryScope {
     const rootPath = path.resolve(inputPath);
     return {
@@ -1047,6 +1081,14 @@ function parseNativeWorktreeDiff(value: unknown): NativeGitWorktreeDiffResult {
     requireArray(record.sections, "sections");
     requireString(record.updatedAt, "updatedAt");
     return record as unknown as NativeGitWorktreeDiffResult;
+}
+
+function parseNativeBranchDiff(value: unknown): NativeGitBranchDiffResult {
+    const record = requireRecord(value, "Native git branch diff");
+    requireArray(record.files, "files");
+    requireString(record.headRef, "headRef");
+    requireString(record.updatedAt, "updatedAt");
+    return record as unknown as NativeGitBranchDiffResult;
 }
 
 function parseNativeOriginalFile(value: unknown): NativeGitOriginalFile {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -92,6 +92,8 @@ import {
     type ProjectTreeInvalidation,
     type ThemeMode,
     type WindowContextSnapshot,
+    type GitBranchDiffInput,
+    type GitBranchDiffResult,
     type GitBranchListInput,
     type GitBranchSummary,
     type GitChangesListInput,
@@ -1302,6 +1304,11 @@ const comandoApi: ComandoApi = {
             IPC_CHANNELS.listGitWorktreeDiff,
             input,
         ) as Promise<GitWorktreeDiffResult | null>,
+    listGitBranchDiff: (input: GitBranchDiffInput) =>
+        ipcRenderer.invoke(
+            IPC_CHANNELS.listGitBranchDiff,
+            input,
+        ) as Promise<GitBranchDiffResult | null>,
     getGitCommitDetail: (input: GitCommitDetailInput) =>
         ipcRenderer.invoke(
             IPC_CHANNELS.getGitCommitDetail,

--- a/src/renderer/src/app/git/presentation.test.tsx
+++ b/src/renderer/src/app/git/presentation.test.tsx
@@ -1,9 +1,14 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import type { GitChangeEntry, GitWorktreeDiffResult } from "@shared/ipc";
+import type {
+    GitBranchDiffResult,
+    GitChangeEntry,
+    GitWorktreeDiffResult,
+} from "@shared/ipc";
 
 import {
+    buildGitBranchDiffSections,
     buildGitChangeGroups,
     buildGitDiffFileId,
     buildGitWorktreeDiffSections,
@@ -84,6 +89,40 @@ describe("buildGitChangeGroups", () => {
 
         expect(markup).toContain("+6");
         expect(markup).toContain("-0");
+    });
+});
+
+describe("buildGitBranchDiffSections", () => {
+    it("exposes only the read-only open action", () => {
+        const result: GitBranchDiffResult = {
+            baseRef: "main",
+            files: [
+                {
+                    additions: 1,
+                    deletions: 0,
+                    diff: null,
+                    error: null,
+                    isBinary: false,
+                    kind: "modified",
+                    path: "src/example.ts",
+                    previousPath: null,
+                },
+            ],
+            headRef: "feature",
+            projectId: "project-1",
+            unavailableReason: null,
+            updatedAt: "2026-07-26T00:00:00.000Z",
+            worktreeId: null,
+        };
+
+        const sections = buildGitBranchDiffSections(result, {
+            onOpenFile: () => undefined,
+        });
+
+        expect(sections[0].files[0].actions?.map((action) => action.label)).toEqual([
+            "Open",
+        ]);
+        expect(sections[0].files[0].reversible).toBe(false);
     });
 });
 

--- a/src/renderer/src/app/git/presentation.tsx
+++ b/src/renderer/src/app/git/presentation.tsx
@@ -1,4 +1,6 @@
 import type {
+    GitBranchDiffFile,
+    GitBranchDiffResult,
     GitChangeEntry,
     GitDiffScope,
     GitFileDiff as SharedGitFileDiff,
@@ -23,7 +25,7 @@ export interface GitWorktreeDiffPresentationSection {
     readonly additions: number;
     readonly deletions: number;
     readonly files: readonly GitDiffFile[];
-    readonly id: GitDiffScope;
+    readonly id: GitDiffScope | "branch";
     readonly title: string;
 }
 
@@ -132,20 +134,23 @@ export function buildGitDiffFiles(
     });
 }
 
-export function buildGitDiffFileId(scope: GitDiffScope, path: string): string {
+export function buildGitDiffFileId(
+    scope: GitDiffScope | "branch",
+    path: string,
+): string {
     return `${scope}:${encodeURIComponent(path)}`;
 }
 
 export function parseGitDiffFileId(
     fileId: string,
-): { readonly path: string; readonly scope: GitDiffScope } | null {
+): { readonly path: string; readonly scope: GitDiffScope | "branch" } | null {
     const separatorIndex = fileId.indexOf(":");
     if (separatorIndex < 0) {
         return null;
     }
 
     const scope = fileId.slice(0, separatorIndex);
-    if (!isGitDiffScope(scope)) {
+    if (!isGitDiffScope(scope) && scope !== "branch") {
         return null;
     }
 
@@ -186,6 +191,37 @@ export function buildGitWorktreeDiffSections(
             title: formatWorktreeDiffSectionTitle(section.scope),
         };
     });
+}
+
+export function buildGitBranchDiffSections(
+    result: GitBranchDiffResult | null,
+    actions: {
+        readonly onOpenFile: (file: GitBranchDiffFile) => void;
+    },
+): readonly GitWorktreeDiffPresentationSection[] {
+    if (!result) {
+        return [];
+    }
+
+    const files = result.files.map((file) =>
+        convertBranchDiffFile(file, [
+            {
+                id: `${buildGitDiffFileId("branch", file.path)}:open`,
+                label: "Open",
+                onClick: () => actions.onOpenFile(file),
+            },
+        ]),
+    );
+    const totals = sumWorktreeDiffStats(result.files);
+    return [
+        {
+            additions: totals.additions,
+            deletions: totals.deletions,
+            files,
+            id: "branch",
+            title: "Branch Changes",
+        },
+    ];
 }
 
 export function summarizeGitRepository(
@@ -526,6 +562,35 @@ function convertWorktreeDiffFile(
     };
 }
 
+function convertBranchDiffFile(
+    file: GitBranchDiffFile,
+    actions: readonly GitAction[],
+): GitDiffFile {
+    const id = buildGitDiffFileId("branch", file.path);
+    const shared = file.diff ? convertSharedGitDiff(file.diff, null) : null;
+    return {
+        ...(shared ?? {
+            hunks: [],
+            newText: null,
+            oldText: null,
+        }),
+        actions,
+        emptyState: file.error
+            ? file.error
+            : file.isBinary
+              ? "This file is binary, so Comando can show metadata but not a textual diff."
+              : "No hunks were produced for this file.",
+        id,
+        isText: !file.isBinary,
+        kind: mapSharedChangeKindToDiffKind(file.kind),
+        path: file.path,
+        previousPath: file.previousPath,
+        reversible: false,
+        statusLabel: file.error ? "error" : formatSharedChangeKind(file.kind),
+        summary: formatGitCountLabel(file.additions, file.deletions),
+    };
+}
+
 function buildWorktreeDiffFileActions(
     file: GitWorktreeDiffFile,
     actions: {
@@ -712,7 +777,9 @@ function isGitDiffScope(value: string): value is GitDiffScope {
     );
 }
 
-function sumWorktreeDiffStats(files: readonly GitWorktreeDiffFile[]): {
+function sumWorktreeDiffStats(
+    files: readonly (GitWorktreeDiffFile | GitBranchDiffFile)[],
+): {
     readonly additions: number;
     readonly deletions: number;
 } {

--- a/src/renderer/src/app/git/worktree-diff-patch.test.ts
+++ b/src/renderer/src/app/git/worktree-diff-patch.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import type { GitWorktreeDiffResult } from "@shared/ipc";
+import type { GitBranchDiffResult, GitWorktreeDiffResult } from "@shared/ipc";
 
-import { serializeWorktreeDiffToPatch } from "./worktree-diff-patch";
+import {
+    serializeBranchDiffToPatch,
+    serializeWorktreeDiffToPatch,
+} from "./worktree-diff-patch";
 
 function buildResult(
     overrides: Partial<GitWorktreeDiffResult> = {},
@@ -67,6 +70,36 @@ function buildResult(
         ...overrides,
     };
 }
+
+describe("serializeBranchDiffToPatch", () => {
+    it("serializes branch files and binary placeholders", () => {
+        const result: GitBranchDiffResult = {
+            baseRef: "main",
+            files: [
+                {
+                    additions: null,
+                    deletions: null,
+                    diff: null,
+                    error: null,
+                    isBinary: true,
+                    kind: "added",
+                    path: "assets/logo.png",
+                    previousPath: null,
+                },
+            ],
+            headRef: "feature",
+            projectId: "project-1",
+            unavailableReason: null,
+            updatedAt: "2026-07-26T00:00:00.000Z",
+            worktreeId: null,
+        };
+
+        expect(serializeBranchDiffToPatch(result)).toContain(
+            "Binary files a/assets/logo.png and b/assets/logo.png differ",
+        );
+        expect(serializeBranchDiffToPatch(null)).toBe("");
+    });
+});
 
 describe("serializeWorktreeDiffToPatch", () => {
     it("returns an empty string when there is no result", () => {

--- a/src/renderer/src/app/git/worktree-diff-patch.ts
+++ b/src/renderer/src/app/git/worktree-diff-patch.ts
@@ -1,4 +1,6 @@
 import type {
+    GitBranchDiffFile,
+    GitBranchDiffResult,
     GitDiffLineType,
     GitWorktreeDiffFile,
     GitWorktreeDiffResult,
@@ -16,7 +18,9 @@ function linePrefix(type: GitDiffLineType): string {
     return " ";
 }
 
-function serializeFileDiff(file: GitWorktreeDiffFile): string | null {
+function serializeFileDiff(
+    file: GitWorktreeDiffFile | GitBranchDiffFile,
+): string | null {
     const path = file.path;
     const previousPath = file.previousPath ?? file.diff?.previousPath ?? null;
     const headerPath = previousPath ?? path;
@@ -85,4 +89,18 @@ export function serializeWorktreeDiffToPatch(
     }
 
     return blocks.join("");
+}
+
+/** Serializes the committed branch range without reading the working tree. */
+export function serializeBranchDiffToPatch(
+    result: GitBranchDiffResult | null,
+): string {
+    if (!result) {
+        return "";
+    }
+
+    return result.files
+        .map(serializeFileDiff)
+        .filter((block): block is string => block !== null)
+        .join("");
 }

--- a/src/renderer/src/app/store/git-store.test.ts
+++ b/src/renderer/src/app/store/git-store.test.ts
@@ -356,6 +356,7 @@ function stubComando(api: Record<string, unknown>): void {
 
 function resetGitStoreForTests(): void {
     useGitStore.setState({
+        activeDiffModesByContext: {},
         branchDiffErrorsByContext: {},
         branchDiffRequestKeysByContext: {},
         branchDiffsByContext: {},

--- a/src/renderer/src/app/store/git-store.test.ts
+++ b/src/renderer/src/app/store/git-store.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type {
+    GitBranchDiffResult,
     GitRepositorySnapshot,
     GitWorktreeDiffResult,
     GitWorktreeSummary,
@@ -70,6 +71,67 @@ describe("git-store history", () => {
                 createWorktree("project-1:primary", "main", true),
                 createWorktree("worktree-2", "feature/new"),
             ]);
+    });
+});
+
+describe("git-store branch diff cache", () => {
+    afterEach(() => {
+        resetGitStoreForTests();
+        vi.unstubAllGlobals();
+    });
+
+    it("keeps branch and worktree resources isolated", async () => {
+        const branchResult = createBranchDiffResult();
+        const listGitBranchDiff = vi.fn().mockResolvedValue(branchResult);
+        const listGitWorktreeDiff = vi.fn().mockResolvedValue(createWorktreeDiffResult());
+        stubComando({ listGitBranchDiff, listGitWorktreeDiff });
+
+        await useGitStore.getState().refreshBranchDiff("project-1", null);
+
+        expect(useGitStore.getState().branchDiffsByContext["project-1::primary"]).toBe(
+            branchResult,
+        );
+        expect(useGitStore.getState().worktreeDiffsByContext).toEqual({});
+        expect(listGitWorktreeDiff).not.toHaveBeenCalled();
+    });
+
+    it("ignores an older branch response after a newer request", async () => {
+        let resolveFirst: (result: GitBranchDiffResult) => void;
+        const newer = createBranchDiffResult({ headRef: "newer" });
+        const listGitBranchDiff = vi
+            .fn()
+            .mockImplementationOnce(
+                () =>
+                    new Promise<GitBranchDiffResult>((resolve) => {
+                        resolveFirst = resolve;
+                    }),
+            )
+            .mockResolvedValueOnce(newer);
+        stubComando({ listGitBranchDiff });
+
+        const first = useGitStore.getState().refreshBranchDiff("project-1", null);
+        await useGitStore.getState().refreshBranchDiff("project-1", null);
+        resolveFirst!(createBranchDiffResult({ headRef: "older" }));
+        await first;
+
+        expect(
+            useGitStore.getState().branchDiffsByContext["project-1::primary"],
+        ).toBe(newer);
+    });
+
+    it("marks both cached diff modes stale after a snapshot", () => {
+        const contextKey = "project-1::primary";
+        useGitStore.setState({
+            branchDiffsByContext: { [contextKey]: createBranchDiffResult() },
+            worktreeDiffsByContext: { [contextKey]: createWorktreeDiffResult() },
+        });
+
+        useGitStore.getState().ingestSnapshot(
+            createSnapshot({ changedPaths: ["src/changed.ts"] }),
+        );
+
+        expect(useGitStore.getState().staleBranchDiffContexts[contextKey]).toBe(true);
+        expect(useGitStore.getState().staleWorktreeDiffContexts[contextKey]).toBe(true);
     });
 });
 
@@ -259,6 +321,21 @@ function createWorktree(
     };
 }
 
+function createBranchDiffResult(
+    overrides: Partial<GitBranchDiffResult> = {},
+): GitBranchDiffResult {
+    return {
+        baseRef: "main",
+        files: [],
+        headRef: "feature",
+        projectId: "project-1",
+        unavailableReason: null,
+        updatedAt: "2026-07-14T12:00:00.000Z",
+        worktreeId: null,
+        ...overrides,
+    };
+}
+
 function createWorktreeDiffResult(
     overrides: Partial<GitWorktreeDiffResult> = {},
 ): GitWorktreeDiffResult {
@@ -279,6 +356,14 @@ function stubComando(api: Record<string, unknown>): void {
 
 function resetGitStoreForTests(): void {
     useGitStore.setState({
+        branchDiffErrorsByContext: {},
+        branchDiffRequestKeysByContext: {},
+        branchDiffsByContext: {},
+        collapsedBranchDiffFileIds: {},
+        failedBranchDiffContexts: {},
+        loadingBranchDiffContexts: {},
+        selectedBranchDiffFileIds: {},
+        staleBranchDiffContexts: {},
         activeWorktreeIds: {},
         branchesByProject: {},
         changeExpandedPaths: {},

--- a/src/renderer/src/app/store/git-store.ts
+++ b/src/renderer/src/app/store/git-store.ts
@@ -53,6 +53,8 @@ type GitPushRepositoryOptions = {
     readonly setUpstream?: boolean;
 };
 
+export type GitDiffMode = "branch" | "worktree";
+
 type GitHistorySearchOptions = {
     readonly caseSensitive?: boolean;
     readonly query?: string;
@@ -65,6 +67,7 @@ type GitHistorySearchState = {
 };
 
 interface GitStoreState {
+    readonly activeDiffModesByContext: Record<string, GitDiffMode>;
     readonly branchDiffErrorsByContext: Record<string, string | null>;
     readonly branchDiffRequestKeysByContext: Record<string, string>;
     readonly branchDiffsByContext: Record<string, GitBranchDiffResult | null>;
@@ -260,6 +263,11 @@ interface GitStoreState {
         fileIds: readonly string[],
         worktreeId?: string | null,
     ) => void;
+    setActiveDiffMode: (
+        projectId: string,
+        mode: GitDiffMode,
+        worktreeId?: string | null,
+    ) => void;
     setActiveWorktree: (
         projectId: string,
         worktreeId: string | null,
@@ -310,6 +318,7 @@ interface GitStoreState {
 }
 
 export const useGitStore = create<GitStoreState>((set, get) => ({
+    activeDiffModesByContext: {},
     branchDiffErrorsByContext: {},
     branchDiffRequestKeysByContext: {},
     branchDiffsByContext: {},
@@ -1337,6 +1346,14 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
             },
         })),
 
+    setActiveDiffMode: (projectId, mode, worktreeId = null) =>
+        set((state) => ({
+            activeDiffModesByContext: {
+                ...state.activeDiffModesByContext,
+                [getContextKey(projectId, worktreeId)]: mode,
+            },
+        })),
+
     setActiveWorktree: (projectId, worktreeId) => {
         set((state) => ({
             activeWorktreeIds: {
@@ -1815,10 +1832,12 @@ function refreshCachedWorktreeDiff(
     projectId: string,
     worktreeId: string | null,
 ): void {
-    // Explicit Git mutations refresh immediately; filesystem invalidations
-    // only mark the cached diff stale.
+    // Only the visible resource refreshes immediately; the other cache remains stale.
     const contextKey = getContextKey(projectId, worktreeId);
-    if (hasOwn(get().worktreeDiffsByContext, contextKey)) {
+    if (
+        get().activeDiffModesByContext[contextKey] === "worktree" &&
+        hasOwn(get().worktreeDiffsByContext, contextKey)
+    ) {
         void get().refreshWorktreeDiff(projectId, worktreeId);
     }
 }

--- a/src/renderer/src/app/store/git-store.ts
+++ b/src/renderer/src/app/store/git-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 import type {
+    GitBranchDiffResult,
     GitBranchSummary,
     GitCommitDetail,
     GitCommitInput,
@@ -64,6 +65,14 @@ type GitHistorySearchState = {
 };
 
 interface GitStoreState {
+    readonly branchDiffErrorsByContext: Record<string, string | null>;
+    readonly branchDiffRequestKeysByContext: Record<string, string>;
+    readonly branchDiffsByContext: Record<string, GitBranchDiffResult | null>;
+    readonly collapsedBranchDiffFileIds: Record<string, readonly string[]>;
+    readonly failedBranchDiffContexts: Record<string, boolean>;
+    readonly loadingBranchDiffContexts: Record<string, boolean>;
+    readonly selectedBranchDiffFileIds: Record<string, string | null>;
+    readonly staleBranchDiffContexts: Record<string, boolean>;
     readonly activeWorktreeIds: Record<string, string | null>;
     readonly branchesByProject: Record<string, readonly GitBranchSummary[]>;
     readonly changeExpandedPaths: Record<string, readonly string[]>;
@@ -148,6 +157,10 @@ interface GitStoreState {
         commitSha: string,
         worktreeId?: string | null,
     ) => Promise<GitCommitDetail | null>;
+    ensureBranchDiff: (
+        projectId: string,
+        worktreeId?: string | null,
+    ) => Promise<GitBranchDiffResult | null>;
     ensureWorktreeDiff: (
         projectId: string,
         worktreeId?: string | null,
@@ -185,6 +198,10 @@ interface GitStoreState {
         projectId: string,
         preferredWorktreeId?: string | null,
     ) => Promise<GitRepositorySnapshot | null>;
+    refreshBranchDiff: (
+        projectId: string,
+        worktreeId?: string | null,
+    ) => Promise<GitBranchDiffResult | null>;
     refreshWorktreeDiff: (
         projectId: string,
         worktreeId?: string | null,
@@ -223,9 +240,19 @@ interface GitStoreState {
         path: string | null,
         worktreeId?: string | null,
     ) => Promise<void>;
+    selectBranchDiffFile: (
+        projectId: string,
+        fileId: string | null,
+        worktreeId?: string | null,
+    ) => void;
     selectWorktreeDiffFile: (
         projectId: string,
         fileId: string | null,
+        worktreeId?: string | null,
+    ) => void;
+    setBranchDiffCollapsedFileIds: (
+        projectId: string,
+        fileIds: readonly string[],
         worktreeId?: string | null,
     ) => void;
     setWorktreeDiffCollapsedFileIds: (
@@ -263,6 +290,11 @@ interface GitStoreState {
         path: string,
         worktreeId?: string | null,
     ) => void;
+    toggleBranchDiffFileCollapse: (
+        projectId: string,
+        fileId: string,
+        worktreeId?: string | null,
+    ) => void;
     toggleWorktreeDiffFileCollapse: (
         projectId: string,
         fileId: string,
@@ -278,6 +310,14 @@ interface GitStoreState {
 }
 
 export const useGitStore = create<GitStoreState>((set, get) => ({
+    branchDiffErrorsByContext: {},
+    branchDiffRequestKeysByContext: {},
+    branchDiffsByContext: {},
+    collapsedBranchDiffFileIds: {},
+    failedBranchDiffContexts: {},
+    loadingBranchDiffContexts: {},
+    selectedBranchDiffFileIds: {},
+    staleBranchDiffContexts: {},
     activeWorktreeIds: {},
     branchesByProject: {},
     changeExpandedPaths: {},
@@ -479,6 +519,26 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
             }));
             return null;
         }
+    },
+
+    ensureBranchDiff: async (projectId, worktreeId = null) => {
+        const contextKey = getContextKey(projectId, worktreeId);
+        const state = get();
+        const cachedResult = state.branchDiffsByContext[contextKey] ?? null;
+        if (
+            hasOwn(state.branchDiffsByContext, contextKey) &&
+            state.staleBranchDiffContexts[contextKey] !== true
+        ) {
+            return cachedResult;
+        }
+        if (
+            state.loadingBranchDiffContexts[contextKey] === true ||
+            state.failedBranchDiffContexts[contextKey] === true
+        ) {
+            return cachedResult;
+        }
+
+        return get().refreshBranchDiff(projectId, worktreeId);
     },
 
     ensureWorktreeDiff: async (projectId, worktreeId = null) => {
@@ -900,6 +960,109 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
         }
     },
 
+    refreshBranchDiff: async (projectId, worktreeId = null) => {
+        const contextKey = getContextKey(projectId, worktreeId);
+        const requestKey = `${Date.now()}:${Math.random()}`;
+
+        set((state) => ({
+            branchDiffErrorsByContext: {
+                ...state.branchDiffErrorsByContext,
+                [contextKey]: null,
+            },
+            branchDiffRequestKeysByContext: {
+                ...state.branchDiffRequestKeysByContext,
+                [contextKey]: requestKey,
+            },
+            failedBranchDiffContexts: {
+                ...state.failedBranchDiffContexts,
+                [contextKey]: false,
+            },
+            loadingBranchDiffContexts: {
+                ...state.loadingBranchDiffContexts,
+                [contextKey]: true,
+            },
+            // Preserve invalidations that arrive while this request is running.
+            staleBranchDiffContexts: {
+                ...state.staleBranchDiffContexts,
+                [contextKey]: false,
+            },
+        }));
+
+        try {
+            const result = await getComandoApi().listGitBranchDiff({
+                projectId,
+                worktreeId,
+            });
+            set((state) => {
+                if (state.branchDiffRequestKeysByContext[contextKey] !== requestKey) {
+                    return {};
+                }
+
+                const nextFileIds = collectBranchDiffFileIds(result);
+                const nextFileIdSet = new Set(nextFileIds);
+                const previousSelectedFileId =
+                    state.selectedBranchDiffFileIds[contextKey] ?? null;
+                return {
+                    branchDiffErrorsByContext: {
+                        ...state.branchDiffErrorsByContext,
+                        [contextKey]: null,
+                    },
+                    branchDiffsByContext: {
+                        ...state.branchDiffsByContext,
+                        [contextKey]: result,
+                    },
+                    collapsedBranchDiffFileIds: {
+                        ...state.collapsedBranchDiffFileIds,
+                        [contextKey]: (
+                            state.collapsedBranchDiffFileIds[contextKey] ?? []
+                        ).filter((fileId) => nextFileIdSet.has(fileId)),
+                    },
+                    loadingBranchDiffContexts: {
+                        ...state.loadingBranchDiffContexts,
+                        [contextKey]: false,
+                    },
+                    selectedBranchDiffFileIds: {
+                        ...state.selectedBranchDiffFileIds,
+                        [contextKey]:
+                            previousSelectedFileId &&
+                            nextFileIdSet.has(previousSelectedFileId)
+                                ? previousSelectedFileId
+                                : (nextFileIds[0] ?? null),
+                    },
+                };
+            });
+            return result;
+        } catch (error) {
+            set((state) => {
+                if (state.branchDiffRequestKeysByContext[contextKey] !== requestKey) {
+                    return {};
+                }
+                return {
+                    branchDiffErrorsByContext: {
+                        ...state.branchDiffErrorsByContext,
+                        [contextKey]:
+                            error instanceof Error
+                                ? error.message
+                                : "Could not load branch changes.",
+                    },
+                    failedBranchDiffContexts: {
+                        ...state.failedBranchDiffContexts,
+                        [contextKey]: true,
+                    },
+                    loadingBranchDiffContexts: {
+                        ...state.loadingBranchDiffContexts,
+                        [contextKey]: false,
+                    },
+                    staleBranchDiffContexts: {
+                        ...state.staleBranchDiffContexts,
+                        [contextKey]: true,
+                    },
+                };
+            });
+            return null;
+        }
+    },
+
     refreshWorktreeDiff: async (projectId, worktreeId = null) => {
         const contextKey = getContextKey(projectId, worktreeId);
         const requestKey = `${Date.now()}:${Math.random()}`;
@@ -1158,6 +1321,14 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
         }
     },
 
+    selectBranchDiffFile: (projectId, fileId, worktreeId = null) =>
+        set((state) => ({
+            selectedBranchDiffFileIds: {
+                ...state.selectedBranchDiffFileIds,
+                [getContextKey(projectId, worktreeId)]: fileId,
+            },
+        })),
+
     selectWorktreeDiffFile: (projectId, fileId, worktreeId = null) =>
         set((state) => ({
             selectedWorktreeDiffFileIds: {
@@ -1193,6 +1364,18 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
             panelTabs: {
                 ...state.panelTabs,
                 [getContextKey(projectId, worktreeId)]: tab,
+            },
+        })),
+
+    setBranchDiffCollapsedFileIds: (
+        projectId,
+        fileIds,
+        worktreeId = null,
+    ) =>
+        set((state) => ({
+            collapsedBranchDiffFileIds: {
+                ...state.collapsedBranchDiffFileIds,
+                [getContextKey(projectId, worktreeId)]: fileIds,
             },
         })),
 
@@ -1260,6 +1443,23 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
                     [contextKey]: isExpanded
                         ? currentPaths.filter((entry) => entry !== path)
                         : [...currentPaths, path],
+                },
+            };
+        }),
+
+    toggleBranchDiffFileCollapse: (projectId, fileId, worktreeId = null) =>
+        set((state) => {
+            const contextKey = getContextKey(projectId, worktreeId);
+            const currentFileIds =
+                state.collapsedBranchDiffFileIds[contextKey] ?? [];
+            const isCollapsed = currentFileIds.includes(fileId);
+
+            return {
+                collapsedBranchDiffFileIds: {
+                    ...state.collapsedBranchDiffFileIds,
+                    [contextKey]: isCollapsed
+                        ? currentFileIds.filter((entry) => entry !== fileId)
+                        : [...currentFileIds, fileId],
                 },
             };
         }),
@@ -1413,6 +1613,7 @@ function applySnapshotState(
                   }
                 : {}),
             ...nextWorktreeDiffState,
+            ...markBranchDiffStaleState(state, contextKey),
         };
     });
 }
@@ -1475,6 +1676,22 @@ function rfc3339TimestampToNanoseconds(timestamp: string): bigint | null {
 
     const nanoseconds = BigInt(`${fraction}000000000`.slice(0, 9));
     return BigInt(milliseconds) * 1_000_000n + nanoseconds;
+}
+
+function markBranchDiffStaleState(
+    state: GitStoreState,
+    contextKey: string,
+): Pick<GitStoreState, "failedBranchDiffContexts" | "staleBranchDiffContexts"> {
+    return {
+        failedBranchDiffContexts: {
+            ...state.failedBranchDiffContexts,
+            [contextKey]: false,
+        },
+        staleBranchDiffContexts: {
+            ...state.staleBranchDiffContexts,
+            [contextKey]: hasOwn(state.branchDiffsByContext, contextKey),
+        },
+    };
 }
 
 function clearCleanWorktreeDiffState(
@@ -1570,6 +1787,14 @@ function resolveSnapshotWorktreeId(
         snapshot.worktrees.find((worktree) => worktree.isCurrent)?.id ??
         snapshot.worktrees.find((worktree) => worktree.isPrimary)?.id ??
         null
+    );
+}
+
+function collectBranchDiffFileIds(
+    result: GitBranchDiffResult | null,
+): readonly string[] {
+    return (
+        result?.files.map((file) => buildGitDiffFileId("branch", file.path)) ?? []
     );
 }
 

--- a/src/renderer/src/components/sidebar/SidebarGitPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitPanel.tsx
@@ -412,9 +412,8 @@ export function SidebarGitPanel({
                 <div className="flex items-center gap-1">
                     <button
                         className="sidebar-toolbar-action"
-                        disabled={!hasChanges}
                         onClick={handleReviewChanges}
-                        title="Open Uncommitted Changes"
+                        title="Open Changes Review"
                         type="button"
                     >
                         Review

--- a/src/renderer/src/components/workspace/GitWorktreeDiffTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitWorktreeDiffTabView.test.tsx
@@ -9,6 +9,7 @@ import type { GitBranchDiffResult, GitWorktreeDiffResult } from "@shared/ipc";
 
 const mockGitStoreState = vi.hoisted(() => ({
     current: {
+        activeDiffModesByContext: {},
         branchDiffErrorsByContext: {},
         branchDiffsByContext: {},
         collapsedBranchDiffFileIds: {},
@@ -157,6 +158,7 @@ function createBranchDiffResult(): GitBranchDiffResult {
 }
 
 function resetStoreState() {
+    mockGitStoreState.current.activeDiffModesByContext = {};
     mockGitStoreState.current.branchDiffErrorsByContext = {};
     mockGitStoreState.current.branchDiffsByContext = {
         [CONTEXT_KEY]: createBranchDiffResult(),
@@ -215,6 +217,17 @@ describe("GitWorktreeDiffTabView", () => {
         expect(markup).toContain("worktree-file.ts");
     });
 
+    it("restores the selected branch mode after the view remounts", () => {
+        mockGitStoreState.current.activeDiffModesByContext = {
+            [CONTEXT_KEY]: "branch",
+        };
+
+        const markup = renderWorktreeMarkup();
+
+        expect(markup).toContain("branch-file.ts");
+        expect(markup).not.toContain("stage all");
+    });
+
     it("switches to read-only branch changes and back", () => {
         const container = document.createElement("div");
         document.body.appendChild(container);
@@ -233,6 +246,19 @@ describe("GitWorktreeDiffTabView", () => {
             );
         });
 
+        expect(mockGitStoreState.current.setActiveDiffMode).toHaveBeenCalledWith(
+            TAB.projectId,
+            "branch",
+            TAB.worktreeId,
+        );
+
+        mockGitStoreState.current.activeDiffModesByContext = {
+            [CONTEXT_KEY]: "branch",
+        };
+        act(() => {
+            root.render(createElement(GitWorktreeDiffTabView, { tab: TAB }));
+        });
+
         expect(container.textContent).toContain("branch-file.ts");
         expect(container.textContent).not.toContain("stage all");
         expect(container.textContent).not.toContain("unstage all");
@@ -247,6 +273,15 @@ describe("GitWorktreeDiffTabView", () => {
             worktreeTab?.dispatchEvent(
                 new MouseEvent("click", { bubbles: true }),
             );
+        });
+        expect(mockGitStoreState.current.setActiveDiffMode).toHaveBeenLastCalledWith(
+            TAB.projectId,
+            "worktree",
+            TAB.worktreeId,
+        );
+        mockGitStoreState.current.activeDiffModesByContext = {};
+        act(() => {
+            root.render(createElement(GitWorktreeDiffTabView, { tab: TAB }));
         });
         expect(container.textContent).toContain("worktree-file.ts");
         expect(container.textContent).toContain("stage all");

--- a/src/renderer/src/components/workspace/GitWorktreeDiffTabView.test.tsx
+++ b/src/renderer/src/components/workspace/GitWorktreeDiffTabView.test.tsx
@@ -1,25 +1,39 @@
-import { createElement } from "react";
+/** @vitest-environment jsdom */
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { RuntimeWorkspaceGitWorktreeDiffTab } from "@renderer/app/workspace/tree";
-import type { GitWorktreeDiffResult } from "@shared/ipc";
+import type { GitBranchDiffResult, GitWorktreeDiffResult } from "@shared/ipc";
 
 const mockGitStoreState = vi.hoisted(() => ({
     current: {
+        branchDiffErrorsByContext: {},
+        branchDiffsByContext: {},
+        collapsedBranchDiffFileIds: {},
         collapsedWorktreeDiffFileIds: {},
+        ensureBranchDiff: vi.fn(() => Promise.resolve(null)),
         discardPaths: vi.fn(() => Promise.resolve(null)),
         ensureWorktreeDiff: vi.fn(() => Promise.resolve(null)),
         errors: {},
+        loadingBranchDiffContexts: {},
         loadingWorktreeDiffContexts: {},
+        refreshBranchDiff: vi.fn(() => Promise.resolve(null)),
         refreshProject: vi.fn(() => Promise.resolve(null)),
         refreshWorktreeDiff: vi.fn(() => Promise.resolve(null)),
+        selectedBranchDiffFileIds: {},
         selectedWorktreeDiffFileIds: {},
+        selectBranchDiffFile: vi.fn(() => Promise.resolve(null)),
         selectWorktreeDiffFile: vi.fn(() => Promise.resolve(null)),
+        setActiveDiffMode: vi.fn(),
+        setBranchDiffCollapsedFileIds: vi.fn(),
         setWorktreeDiffCollapsedFileIds: vi.fn(),
         snapshots: {},
+        staleBranchDiffContexts: {},
         staleWorktreeDiffContexts: {},
         stagePaths: vi.fn(() => Promise.resolve(null)),
+        toggleBranchDiffFileCollapse: vi.fn(),
         toggleWorktreeDiffFileCollapse: vi.fn(),
         unstagePaths: vi.fn(() => Promise.resolve(null)),
         worktreeDiffsByContext: {},
@@ -69,7 +83,17 @@ vi.mock("@renderer/app/store/workspace-store", () => ({
     ) => selector(mockWorkspaceStoreState.current),
 }));
 
+vi.mock("@renderer/components/workspace/usePersistedWorkspaceScroll", () => ({
+    usePersistedWorkspaceScroll: () => ({
+        handleScroll: vi.fn(),
+        scrollRef: vi.fn(),
+    }),
+}));
+
 import { GitWorktreeDiffTabView } from "./GitWorktreeDiffTabView";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
 
 const TAB: RuntimeWorkspaceGitWorktreeDiffTab = {
     createdAt: "2026-05-21T00:00:00.000Z",
@@ -109,22 +133,59 @@ function createWorktreeDiffResult(): GitWorktreeDiffResult {
     };
 }
 
+function createBranchDiffResult(): GitBranchDiffResult {
+    return {
+        baseRef: "main",
+        files: [
+            {
+                additions: 2,
+                deletions: 1,
+                diff: null,
+                error: null,
+                isBinary: false,
+                kind: "modified",
+                path: "src/branch-file.ts",
+                previousPath: null,
+            },
+        ],
+        headRef: "feature",
+        projectId: TAB.projectId,
+        unavailableReason: null,
+        updatedAt: "2026-07-26T00:00:00.000Z",
+        worktreeId: TAB.worktreeId ?? null,
+    };
+}
+
 function resetStoreState() {
+    mockGitStoreState.current.branchDiffErrorsByContext = {};
+    mockGitStoreState.current.branchDiffsByContext = {
+        [CONTEXT_KEY]: createBranchDiffResult(),
+    };
+    mockGitStoreState.current.collapsedBranchDiffFileIds = {};
     mockGitStoreState.current.collapsedWorktreeDiffFileIds = {};
+    mockGitStoreState.current.ensureBranchDiff.mockClear();
     mockGitStoreState.current.discardPaths.mockClear();
     mockGitStoreState.current.ensureWorktreeDiff.mockClear();
     mockGitStoreState.current.errors = {};
+    mockGitStoreState.current.loadingBranchDiffContexts = {};
     mockGitStoreState.current.loadingWorktreeDiffContexts = {};
+    mockGitStoreState.current.refreshBranchDiff.mockClear();
     mockGitStoreState.current.refreshProject.mockClear();
     mockGitStoreState.current.refreshWorktreeDiff.mockClear();
+    mockGitStoreState.current.selectedBranchDiffFileIds = {};
     mockGitStoreState.current.selectedWorktreeDiffFileIds = {};
+    mockGitStoreState.current.selectBranchDiffFile.mockClear();
     mockGitStoreState.current.selectWorktreeDiffFile.mockClear();
+    mockGitStoreState.current.setActiveDiffMode.mockClear();
+    mockGitStoreState.current.setBranchDiffCollapsedFileIds.mockClear();
     mockGitStoreState.current.setWorktreeDiffCollapsedFileIds.mockClear();
     mockGitStoreState.current.snapshots = {
         [CONTEXT_KEY]: null,
     };
+    mockGitStoreState.current.staleBranchDiffContexts = {};
     mockGitStoreState.current.staleWorktreeDiffContexts = {};
     mockGitStoreState.current.stagePaths.mockClear();
+    mockGitStoreState.current.toggleBranchDiffFileCollapse.mockClear();
     mockGitStoreState.current.toggleWorktreeDiffFileCollapse.mockClear();
     mockGitStoreState.current.unstagePaths.mockClear();
     mockGitStoreState.current.worktreeDiffsByContext = {
@@ -152,5 +213,45 @@ describe("GitWorktreeDiffTabView", () => {
         );
         expect(markup).toContain('class="min-h-0 flex-1 px-2 py-2"');
         expect(markup).toContain("worktree-file.ts");
+    });
+
+    it("switches to read-only branch changes and back", () => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        act(() => {
+            root.render(createElement(GitWorktreeDiffTabView, { tab: TAB }));
+        });
+
+        const branchTab = Array.from(container.querySelectorAll("button")).find(
+            (button) => button.textContent === "Branch Changes",
+        );
+        expect(branchTab).toBeTruthy();
+        act(() => {
+            branchTab?.dispatchEvent(
+                new MouseEvent("click", { bubbles: true }),
+            );
+        });
+
+        expect(container.textContent).toContain("branch-file.ts");
+        expect(container.textContent).not.toContain("stage all");
+        expect(container.textContent).not.toContain("unstage all");
+        expect(container.textContent).not.toContain("discard all");
+        expect(container.textContent).toContain("refresh");
+        expect(container.textContent).toContain("download all");
+
+        const worktreeTab = Array.from(
+            container.querySelectorAll("button"),
+        ).find((button) => button.textContent === "Uncommitted Changes");
+        act(() => {
+            worktreeTab?.dispatchEvent(
+                new MouseEvent("click", { bubbles: true }),
+            );
+        });
+        expect(container.textContent).toContain("worktree-file.ts");
+        expect(container.textContent).toContain("stage all");
+
+        act(() => root.unmount());
+        container.remove();
     });
 });

--- a/src/renderer/src/components/workspace/GitWorktreeDiffTabView.tsx
+++ b/src/renderer/src/components/workspace/GitWorktreeDiffTabView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { getGitContextKey } from "@renderer/app/git/context-key";
 import {
@@ -26,7 +26,6 @@ import { usePersistedWorkspaceScroll } from "@renderer/components/workspace/useP
 import { IdeActionButton } from "./ide-bar";
 
 const EMPTY_COLLAPSED_FILE_IDS: readonly string[] = [];
-type DiffMode = "branch" | "worktree";
 
 function getContextKey(projectId: string, worktreeId: string | null): string {
     return getGitContextKey(projectId, worktreeId);
@@ -40,7 +39,9 @@ export function GitWorktreeDiffTabView({
     const projectId = tab.projectId;
     const worktreeId = tab.worktreeId ?? null;
     const contextKey = getContextKey(projectId, worktreeId);
-    const [mode, setMode] = useState<DiffMode>("worktree");
+    const mode = useGitStore(
+        (state) => state.activeDiffModesByContext[contextKey] ?? "worktree",
+    );
     const { handleScroll: handleDiffScroll, scrollRef: diffScrollRef } =
         usePersistedWorkspaceScroll<HTMLDivElement>({
             projectId,
@@ -362,10 +363,6 @@ export function GitWorktreeDiffTabView({
     );
 
     useEffect(() => {
-        setActiveDiffMode(projectId, mode, worktreeId);
-    }, [mode, projectId, setActiveDiffMode, worktreeId]);
-
-    useEffect(() => {
         if (!snapshot) {
             void refreshProject(projectId, worktreeId);
             return;
@@ -422,7 +419,13 @@ export function GitWorktreeDiffTabView({
                                             : "text-text-secondary hover:bg-bg-secondary hover:text-text-primary"
                                     }`}
                                     key={value}
-                                    onClick={() => setMode(value)}
+                                    onClick={() =>
+                                        setActiveDiffMode(
+                                            projectId,
+                                            value,
+                                            worktreeId,
+                                        )
+                                    }
                                     onKeyDown={(event) => {
                                         if (
                                             event.key !== "ArrowLeft" &&
@@ -433,7 +436,8 @@ export function GitWorktreeDiffTabView({
                                             return;
                                         }
                                         event.preventDefault();
-                                        setMode(
+                                        setActiveDiffMode(
+                                            projectId,
                                             event.key === "Home"
                                                 ? "worktree"
                                                 : event.key === "End"
@@ -441,6 +445,7 @@ export function GitWorktreeDiffTabView({
                                                   : value === "worktree"
                                                     ? "branch"
                                                     : "worktree",
+                                            worktreeId,
                                         );
                                     }}
                                     role="tab"

--- a/src/renderer/src/components/workspace/GitWorktreeDiffTabView.tsx
+++ b/src/renderer/src/components/workspace/GitWorktreeDiffTabView.tsx
@@ -1,23 +1,32 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { getGitContextKey } from "@renderer/app/git/context-key";
 import {
+    buildGitBranchDiffSections,
     buildGitWorktreeDiffSections,
     parseGitDiffFileId,
 } from "@renderer/app/git/presentation";
-import { serializeWorktreeDiffToPatch } from "@renderer/app/git/worktree-diff-patch";
+import {
+    serializeBranchDiffToPatch,
+    serializeWorktreeDiffToPatch,
+} from "@renderer/app/git/worktree-diff-patch";
 import { useResolvedEditorSettings } from "@renderer/app/hooks/use-resolved-editor-settings";
 import { buildEditorFontFamily } from "@renderer/app/settings/theme";
 import { useGitStore } from "@renderer/app/store/git-store";
 import { useProjectsStore } from "@renderer/app/store/projects-store";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
 import type { RuntimeWorkspaceGitWorktreeDiffTab } from "@renderer/app/workspace/tree";
-import type { GitWorktreeDiffFile, GitWorktreeDiffResult } from "@shared/ipc";
+import type {
+    GitBranchDiffFile,
+    GitWorktreeDiffFile,
+    GitWorktreeDiffResult,
+} from "@shared/ipc";
 import { GitDiffsView, GitEmptyState } from "@renderer/components/git";
 import { usePersistedWorkspaceScroll } from "@renderer/components/workspace/usePersistedWorkspaceScroll";
 import { IdeActionButton } from "./ide-bar";
 
 const EMPTY_COLLAPSED_FILE_IDS: readonly string[] = [];
+type DiffMode = "branch" | "worktree";
 
 function getContextKey(projectId: string, worktreeId: string | null): string {
     return getGitContextKey(projectId, worktreeId);
@@ -31,6 +40,7 @@ export function GitWorktreeDiffTabView({
     const projectId = tab.projectId;
     const worktreeId = tab.worktreeId ?? null;
     const contextKey = getContextKey(projectId, worktreeId);
+    const [mode, setMode] = useState<DiffMode>("worktree");
     const { handleScroll: handleDiffScroll, scrollRef: diffScrollRef } =
         usePersistedWorkspaceScroll<HTMLDivElement>({
             projectId,
@@ -45,40 +55,81 @@ export function GitWorktreeDiffTabView({
     const snapshot = useGitStore(
         (state) => state.snapshots[contextKey] ?? null,
     );
-    const result = useGitStore(
+    const worktreeResult = useGitStore(
         (state) => state.worktreeDiffsByContext[contextKey] ?? null,
     );
-    const error = useGitStore((state) => state.errors[contextKey] ?? null);
-    const isLoading = useGitStore(
+    const branchResult = useGitStore(
+        (state) => state.branchDiffsByContext[contextKey] ?? null,
+    );
+    const worktreeError = useGitStore(
+        (state) => state.errors[contextKey] ?? null,
+    );
+    const branchError = useGitStore(
+        (state) => state.branchDiffErrorsByContext[contextKey] ?? null,
+    );
+    const isWorktreeLoading = useGitStore(
         (state) => state.loadingWorktreeDiffContexts[contextKey] === true,
     );
-    const isStale = useGitStore(
+    const isBranchLoading = useGitStore(
+        (state) => state.loadingBranchDiffContexts[contextKey] === true,
+    );
+    const isWorktreeStale = useGitStore(
         (state) => state.staleWorktreeDiffContexts[contextKey] === true,
     );
-    const activeFileId = useGitStore(
+    const isBranchStale = useGitStore(
+        (state) => state.staleBranchDiffContexts[contextKey] === true,
+    );
+    const worktreeActiveFileId = useGitStore(
         (state) => state.selectedWorktreeDiffFileIds[contextKey] ?? null,
     );
-    const collapsedFileIds = useGitStore(
+    const branchActiveFileId = useGitStore(
+        (state) => state.selectedBranchDiffFileIds[contextKey] ?? null,
+    );
+    const worktreeCollapsedFileIds = useGitStore(
         (state) =>
             state.collapsedWorktreeDiffFileIds[contextKey] ??
             EMPTY_COLLAPSED_FILE_IDS,
     );
-    const ensureWorktreeDiff = useGitStore(
-        (state) => state.ensureWorktreeDiff,
+    const branchCollapsedFileIds = useGitStore(
+        (state) =>
+            state.collapsedBranchDiffFileIds[contextKey] ??
+            EMPTY_COLLAPSED_FILE_IDS,
     );
+    const ensureWorktreeDiff = useGitStore((state) => state.ensureWorktreeDiff);
+    const ensureBranchDiff = useGitStore((state) => state.ensureBranchDiff);
     const refreshProject = useGitStore((state) => state.refreshProject);
-    const refreshWorktreeDiff = useGitStore(
-        (state) => state.refreshWorktreeDiff,
-    );
+    const refreshWorktreeDiff = useGitStore((state) => state.refreshWorktreeDiff);
+    const refreshBranchDiff = useGitStore((state) => state.refreshBranchDiff);
     const selectWorktreeDiffFile = useGitStore(
         (state) => state.selectWorktreeDiffFile,
     );
+    const selectBranchDiffFile = useGitStore(
+        (state) => state.selectBranchDiffFile,
+    );
+    const setActiveDiffMode = useGitStore((state) => state.setActiveDiffMode);
     const setWorktreeDiffCollapsedFileIds = useGitStore(
         (state) => state.setWorktreeDiffCollapsedFileIds,
+    );
+    const setBranchDiffCollapsedFileIds = useGitStore(
+        (state) => state.setBranchDiffCollapsedFileIds,
     );
     const toggleWorktreeDiffFileCollapse = useGitStore(
         (state) => state.toggleWorktreeDiffFileCollapse,
     );
+    const toggleBranchDiffFileCollapse = useGitStore(
+        (state) => state.toggleBranchDiffFileCollapse,
+    );
+    const isBranchMode = mode === "branch";
+    const result = isBranchMode ? branchResult : worktreeResult;
+    const error = isBranchMode ? branchError : worktreeError;
+    const isLoading = isBranchMode ? isBranchLoading : isWorktreeLoading;
+    const isStale = isBranchMode ? isBranchStale : isWorktreeStale;
+    const activeFileId = isBranchMode
+        ? branchActiveFileId
+        : worktreeActiveFileId;
+    const collapsedFileIds = isBranchMode
+        ? branchCollapsedFileIds
+        : worktreeCollapsedFileIds;
     const stagePaths = useGitStore((state) => state.stagePaths);
     const unstagePaths = useGitStore((state) => state.unstagePaths);
     const discardPaths = useGitStore((state) => state.discardPaths);
@@ -89,7 +140,7 @@ export function GitWorktreeDiffTabView({
     const codeLineHeight = editorSettings.lineHeight;
 
     const handleOpenFile = useCallback(
-        (file: GitWorktreeDiffFile) => {
+        (file: GitWorktreeDiffFile | GitBranchDiffFile) => {
             void openFileTab(projectId, file.path, worktreeId);
         },
         [openFileTab, projectId, worktreeId],
@@ -127,18 +178,24 @@ export function GitWorktreeDiffTabView({
 
     const sections = useMemo(
         () =>
-            buildGitWorktreeDiffSections(result, {
-                onDiscardFile: handleDiscardFile,
-                onOpenFile: handleOpenFile,
-                onStageFile: handleStageFile,
-                onUnstageFile: handleUnstageFile,
-            }),
+            isBranchMode
+                ? buildGitBranchDiffSections(branchResult, {
+                      onOpenFile: handleOpenFile,
+                  })
+                : buildGitWorktreeDiffSections(worktreeResult, {
+                      onDiscardFile: handleDiscardFile,
+                      onOpenFile: handleOpenFile,
+                      onStageFile: handleStageFile,
+                      onUnstageFile: handleUnstageFile,
+                  }),
         [
+            branchResult,
             handleDiscardFile,
             handleOpenFile,
             handleStageFile,
             handleUnstageFile,
-            result,
+            isBranchMode,
+            worktreeResult,
         ],
     );
     const visibleSections = useMemo(
@@ -175,12 +232,25 @@ export function GitWorktreeDiffTabView({
     const handleRefresh = useCallback(() => {
         // Refresh metadata first so it cannot invalidate a freshly loaded full diff.
         void refreshProject(projectId, worktreeId).finally(() => {
-            void refreshWorktreeDiff(projectId, worktreeId);
+            if (isBranchMode) {
+                void refreshBranchDiff(projectId, worktreeId);
+            } else {
+                void refreshWorktreeDiff(projectId, worktreeId);
+            }
         });
-    }, [projectId, refreshProject, refreshWorktreeDiff, worktreeId]);
+    }, [
+        isBranchMode,
+        projectId,
+        refreshBranchDiff,
+        refreshProject,
+        refreshWorktreeDiff,
+        worktreeId,
+    ]);
 
     const handleDownloadAll = useCallback(() => {
-        const patch = serializeWorktreeDiffToPatch(result);
+        const patch = isBranchMode
+            ? serializeBranchDiffToPatch(branchResult)
+            : serializeWorktreeDiffToPatch(worktreeResult);
         if (!patch) {
             return;
         }
@@ -193,29 +263,32 @@ export function GitWorktreeDiffTabView({
         const url = URL.createObjectURL(blob);
         const anchor = document.createElement("a");
         anchor.href = url;
-        anchor.download = `${safeName}-uncommitted.patch`;
+        anchor.download = `${safeName}-${isBranchMode ? "branch-changes" : "uncommitted"}.patch`;
         document.body.appendChild(anchor);
         anchor.click();
         anchor.remove();
         URL.revokeObjectURL(url);
-    }, [project?.name, result]);
+    }, [branchResult, isBranchMode, project?.name, worktreeResult]);
 
     const handleStageAll = useCallback(() => {
-        const paths = collectActionPaths(result, ["unstaged", "untracked"]);
+        const paths = collectActionPaths(worktreeResult, [
+            "unstaged",
+            "untracked",
+        ]);
         if (paths.length > 0) {
             void stagePaths(projectId, paths, worktreeId);
         }
-    }, [projectId, result, stagePaths, worktreeId]);
+    }, [projectId, stagePaths, worktreeId, worktreeResult]);
 
     const handleUnstageAll = useCallback(() => {
-        const paths = collectActionPaths(result, ["staged"]);
+        const paths = collectActionPaths(worktreeResult, ["staged"]);
         if (paths.length > 0) {
             void unstagePaths(projectId, paths, worktreeId);
         }
-    }, [projectId, result, unstagePaths, worktreeId]);
+    }, [projectId, unstagePaths, worktreeId, worktreeResult]);
 
     const handleDiscardAll = useCallback(() => {
-        const paths = collectActionPaths(result, [
+        const paths = collectActionPaths(worktreeResult, [
             "staged",
             "unstaged",
             "untracked",
@@ -232,32 +305,53 @@ export function GitWorktreeDiffTabView({
         }
 
         void discardPaths(projectId, paths, worktreeId);
-    }, [discardPaths, projectId, result, worktreeId]);
+    }, [discardPaths, projectId, worktreeId, worktreeResult]);
 
     const handleToggleAll = useCallback(() => {
-        setWorktreeDiffCollapsedFileIds(
-            projectId,
-            allCollapsed ? [] : allFileIds,
-            worktreeId,
-        );
+        const setCollapsed = isBranchMode
+            ? setBranchDiffCollapsedFileIds
+            : setWorktreeDiffCollapsedFileIds;
+        setCollapsed(projectId, allCollapsed ? [] : allFileIds, worktreeId);
     }, [
         allCollapsed,
         allFileIds,
+        isBranchMode,
         projectId,
+        setBranchDiffCollapsedFileIds,
         setWorktreeDiffCollapsedFileIds,
         worktreeId,
     ]);
 
     const handleToggleFileCollapse = useCallback(
-        (fileId: string) =>
-            toggleWorktreeDiffFileCollapse(projectId, fileId, worktreeId),
-        [projectId, toggleWorktreeDiffFileCollapse, worktreeId],
+        (fileId: string) => {
+            const toggleCollapse = isBranchMode
+                ? toggleBranchDiffFileCollapse
+                : toggleWorktreeDiffFileCollapse;
+            toggleCollapse(projectId, fileId, worktreeId);
+        },
+        [
+            isBranchMode,
+            projectId,
+            toggleBranchDiffFileCollapse,
+            toggleWorktreeDiffFileCollapse,
+            worktreeId,
+        ],
     );
 
     const handleSelectFile = useCallback(
-        (file: { readonly id: string }) =>
-            selectWorktreeDiffFile(projectId, file.id, worktreeId),
-        [projectId, selectWorktreeDiffFile, worktreeId],
+        (file: { readonly id: string }) => {
+            const selectFile = isBranchMode
+                ? selectBranchDiffFile
+                : selectWorktreeDiffFile;
+            selectFile(projectId, file.id, worktreeId);
+        },
+        [
+            isBranchMode,
+            projectId,
+            selectBranchDiffFile,
+            selectWorktreeDiffFile,
+            worktreeId,
+        ],
     );
     const setDiffScrollContainer = useCallback(
         (node: HTMLDivElement | null) => {
@@ -268,18 +362,28 @@ export function GitWorktreeDiffTabView({
     );
 
     useEffect(() => {
+        setActiveDiffMode(projectId, mode, worktreeId);
+    }, [mode, projectId, setActiveDiffMode, worktreeId]);
+
+    useEffect(() => {
         if (!snapshot) {
             void refreshProject(projectId, worktreeId);
             return;
         }
 
         if (!isLoading) {
-            void ensureWorktreeDiff(projectId, worktreeId);
+            if (isBranchMode) {
+                void ensureBranchDiff(projectId, worktreeId);
+            } else {
+                void ensureWorktreeDiff(projectId, worktreeId);
+            }
         }
         // A follow-up invalidation can arrive while a diff request is in flight.
         // Watching both values schedules one catch-up only while this tab is active.
     }, [
+        ensureBranchDiff,
         ensureWorktreeDiff,
+        isBranchMode,
         isLoading,
         isStale,
         projectId,
@@ -288,24 +392,64 @@ export function GitWorktreeDiffTabView({
         worktreeId,
     ]);
 
-    if (!result && !isLoading && error) {
-        return (
-            <div className="flex h-full items-center justify-center px-6">
-                <GitEmptyState>{error}</GitEmptyState>
-            </div>
-        );
-    }
-
     return (
         <div className="flex h-full min-h-0 select-none flex-col bg-bg-primary">
             <header className="border-b border-border px-5 py-3">
                 <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="min-w-0">
-                        {/* Project and worktree are already implied by the tab
-                            context, so the header only carries the section label. */}
+                    <div className="flex min-w-0 flex-wrap items-center gap-3">
+                        {/* Project and worktree are already implied by the tab context. */}
                         <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-text-secondary">
-                            Uncommitted Changes
+                            {isBranchMode
+                                ? "Branch Changes"
+                                : "Uncommitted Changes"}
                         </p>
+                        <div
+                            aria-label="Diff source"
+                            className="flex overflow-hidden rounded border border-border"
+                            role="tablist"
+                        >
+                            {(
+                                [
+                                    ["worktree", "Uncommitted Changes"],
+                                    ["branch", "Branch Changes"],
+                                ] as const
+                            ).map(([value, label]) => (
+                                <button
+                                    aria-selected={mode === value}
+                                    className={`h-6 px-2 font-mono text-[10px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent ${
+                                        mode === value
+                                            ? "bg-bg-tertiary text-text-primary"
+                                            : "text-text-secondary hover:bg-bg-secondary hover:text-text-primary"
+                                    }`}
+                                    key={value}
+                                    onClick={() => setMode(value)}
+                                    onKeyDown={(event) => {
+                                        if (
+                                            event.key !== "ArrowLeft" &&
+                                            event.key !== "ArrowRight" &&
+                                            event.key !== "Home" &&
+                                            event.key !== "End"
+                                        ) {
+                                            return;
+                                        }
+                                        event.preventDefault();
+                                        setMode(
+                                            event.key === "Home"
+                                                ? "worktree"
+                                                : event.key === "End"
+                                                  ? "branch"
+                                                  : value === "worktree"
+                                                    ? "branch"
+                                                    : "worktree",
+                                        );
+                                    }}
+                                    role="tab"
+                                    type="button"
+                                >
+                                    {label}
+                                </button>
+                            ))}
+                        </div>
                     </div>
 
                     <div className="flex flex-wrap items-center justify-end gap-2">
@@ -319,30 +463,40 @@ export function GitWorktreeDiffTabView({
                         >
                             download all
                         </IdeActionButton>
-                        <IdeActionButton
-                            disabled={collectActionPaths(result, [
-                                "unstaged",
-                                "untracked",
-                            ]).length === 0}
-                            onClick={handleStageAll}
-                            title="Stage all visible changes"
-                        >
-                            stage all
-                        </IdeActionButton>
-                        <IdeActionButton
-                            disabled={collectActionPaths(result, ["staged"]).length === 0}
-                            onClick={handleUnstageAll}
-                            title="Unstage all staged changes"
-                        >
-                            unstage all
-                        </IdeActionButton>
-                        <IdeActionButton
-                            disabled={changedFileCount === 0}
-                            onClick={handleDiscardAll}
-                            title="Discard all changes (cannot be undone)"
-                        >
-                            discard all
-                        </IdeActionButton>
+                        {!isBranchMode ? (
+                            <>
+                                <IdeActionButton
+                                    disabled={
+                                        collectActionPaths(worktreeResult, [
+                                            "unstaged",
+                                            "untracked",
+                                        ]).length === 0
+                                    }
+                                    onClick={handleStageAll}
+                                    title="Stage all visible changes"
+                                >
+                                    stage all
+                                </IdeActionButton>
+                                <IdeActionButton
+                                    disabled={
+                                        collectActionPaths(worktreeResult, [
+                                            "staged",
+                                        ]).length === 0
+                                    }
+                                    onClick={handleUnstageAll}
+                                    title="Unstage all staged changes"
+                                >
+                                    unstage all
+                                </IdeActionButton>
+                                <IdeActionButton
+                                    disabled={changedFileCount === 0}
+                                    onClick={handleDiscardAll}
+                                    title="Discard all changes (cannot be undone)"
+                                >
+                                    discard all
+                                </IdeActionButton>
+                            </>
+                        ) : null}
                         {allFileIds.length > 0 ? (
                             <IdeActionButton
                                 onClick={handleToggleAll}
@@ -387,15 +541,23 @@ export function GitWorktreeDiffTabView({
                 onScroll={handleDiffScroll}
                 ref={setDiffScrollContainer}
             >
-                {isLoading && !result ? (
+                {!result && !isLoading && error ? (
+                    <div className="flex h-full items-center justify-center px-6">
+                        <GitEmptyState>{error}</GitEmptyState>
+                    </div>
+                ) : isLoading && !result ? (
                     <div className="flex h-full items-center justify-center text-[13px] text-text-secondary">
-                        Loading project diff...
+                        {isBranchMode
+                            ? "Loading branch changes..."
+                            : "Loading project diff..."}
                     </div>
                 ) : changedFileCount === 0 ? (
-                    // Borderless, centered label reads cleaner than a boxed empty
-                    // state when the worktree is clean.
+                    // Borderless, centered label reads cleaner than a boxed empty state.
                     <div className="flex h-full items-center justify-center text-[13px] text-text-secondary">
-                        No uncommitted changes in this worktree.
+                        {isBranchMode
+                            ? (branchResult?.unavailableReason ??
+                              "No branch changes against the resolved base.")
+                            : "No uncommitted changes in this worktree."}
                     </div>
                 ) : (
                     <div className="space-y-5">

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -59,6 +59,7 @@ export const IPC_CHANNELS = {
     listGitChanges: "git:list-changes",
     listGitHistory: "git:list-history",
     listGitWorktreeDiff: "git:list-worktree-diff",
+    listGitBranchDiff: "git:list-branch-diff",
     getGitDiff: "git:get-diff",
     getGitOriginalFile: "git:get-original-file",
     getGitCommitDetail: "git:get-commit-detail",
@@ -1110,6 +1111,29 @@ export interface GitWorktreeDiffResult {
     readonly projectId: string;
     readonly worktreeId: string | null;
     readonly sections: readonly GitWorktreeDiffSection[];
+    readonly updatedAt: string;
+}
+
+export type GitBranchDiffInput = GitRepositoryScopeInput;
+
+export interface GitBranchDiffFile {
+    readonly additions: number | null;
+    readonly deletions: number | null;
+    readonly diff: GitFileDiff | null;
+    readonly error: string | null;
+    readonly isBinary: boolean;
+    readonly kind: GitChangeKind;
+    readonly path: string;
+    readonly previousPath: string | null;
+}
+
+export interface GitBranchDiffResult {
+    readonly projectId: string;
+    readonly worktreeId: string | null;
+    readonly baseRef: string | null;
+    readonly headRef: string;
+    readonly files: readonly GitBranchDiffFile[];
+    readonly unavailableReason: string | null;
     readonly updatedAt: string;
 }
 
@@ -3649,6 +3673,9 @@ export interface ComandoApi {
     listGitWorktreeDiff: (
         input: GitWorktreeDiffInput,
     ) => Promise<GitWorktreeDiffResult | null>;
+    listGitBranchDiff: (
+        input: GitBranchDiffInput,
+    ) => Promise<GitBranchDiffResult | null>;
     getGitDiff: (input: GitDiffInput) => Promise<GitFileDiff | null>;
     getGitOriginalFile: (
         input: GitOriginalFileInput,

--- a/src/shared/native-backend/commands.ts
+++ b/src/shared/native-backend/commands.ts
@@ -73,6 +73,7 @@ export const NATIVE_GIT_COMMANDS = [
     "git_list_remotes",
     "git_get_diff_stats",
     "git_list_worktree_diff",
+    "git_list_branch_diff",
     "git_init_repository",
     "git_clone_repository",
     "git_stage_paths",

--- a/src/shared/native-backend/fixtures.test.ts
+++ b/src/shared/native-backend/fixtures.test.ts
@@ -32,6 +32,7 @@ import type {
 } from "./ai";
 import type { NativeBackendErrorPayload } from "./errors";
 import type {
+    NativeGitBranchDiffResult,
     NativeGitBranchSummary,
     NativeGitChangeEntry,
     NativeGitCommitDetail,
@@ -746,6 +747,9 @@ describe("native backend fixtures", () => {
             fixture<NativeGitWorktreeDiffResult>("git/worktree.diff.json")
                 .sections,
         ).toHaveLength(1);
+        expect(
+            fixture<NativeGitBranchDiffResult>("git/branch.diff.json").baseRef,
+        ).toBe("origin/main");
         expect(
             fixture<NativeGitRepositoryInvalidation>(
                 "git/repository.invalidation.json",

--- a/src/shared/native-backend/git.ts
+++ b/src/shared/native-backend/git.ts
@@ -262,6 +262,27 @@ export type NativeGitWorktreeDiffResult = {
     readonly updatedAt: string;
 };
 
+export type NativeGitBranchDiffFile = {
+    readonly additions: number | null;
+    readonly deletions: number | null;
+    readonly diff: NativeGitFileDiff | null;
+    readonly error: string | null;
+    readonly isBinary: boolean;
+    readonly kind: string;
+    readonly path: string;
+    readonly previousPath: string | null;
+};
+
+export type NativeGitBranchDiffResult = {
+    readonly projectId: NativeProjectId;
+    readonly worktreeId: NativeWorktreeId | null;
+    readonly baseRef: string | null;
+    readonly headRef: string;
+    readonly files: readonly NativeGitBranchDiffFile[];
+    readonly unavailableReason: string | null;
+    readonly updatedAt: string;
+};
+
 export type NativeGitRepositorySnapshot = {
     readonly repositoryId: NativeRepositoryId;
     readonly projectId: NativeProjectId;


### PR DESCRIPTION
## Summary

- Add a selector to switch between `Uncommitted Changes` and `Branch Changes` in the existing Git diff tab.
- Load committed branch changes against a safely resolved base using merge-base semantics.
- Keep branch and worktree diff state, loading, errors, selection, and collapsed files isolated.
- Preserve the selected diff mode when the view remounts during the current workspace session.

## Details

- Resolve the comparison base from:
  1. `branch.<current>.gh-merge-base`
  2. the primary remote's default branch
  3. its local equivalent
  4. available `main` or `master` fallbacks
- Compare the resolved base against `HEAD` using the equivalent of `git diff <base>...HEAD`.
- Return explicit unavailable states for detached HEAD, missing bases, invalid configured bases, and repositories without a merge-base.
- Keep uncommitted, staged, untracked, and conflicted files out of `Branch Changes`.
- Keep branch diff operations strictly read-only.
- Expose only refresh, download, open, and collapse/expand actions in branch mode.
- Download branch patches using the `<project>-branch-changes.patch` filename.
- Support keyboard navigation and accessible selected state in the mode selector.

## Testing

- `cargo test --workspace`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm test`
- `pnpm run build:ci`

All tests pass: 2,626 passed and 1 skipped.
