### PR TITLE
Add Copy Full Path to file tab context menus

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -29,6 +29,7 @@ import { resolveEditorLanguage } from "@shared/editor-language";
 
 import { useSystemTheme } from "./app/hooks/use-system-theme";
 import { writeClipboardText } from "./app/utils/clipboard";
+import { joinProjectPath } from "./app/utils/projectPath";
 import { setCachedAppEditorSettings } from "./app/settings/client";
 import {
     buildGitTreeNodesFromProjectTree,
@@ -5511,17 +5512,6 @@ function getSettingsUpdateMenuLabel(state: AppUpdateState): string | null {
     }
 
     return null;
-}
-
-function joinProjectPath(rootPath: string, relativePath: string): string {
-    if (!relativePath) {
-        return rootPath;
-    }
-
-    const separator = rootPath.includes("\\") ? "\\" : "/";
-    return `${rootPath.replace(/[\\/]+$/, "")}${separator}${relativePath
-        .split("/")
-        .join(separator)}`;
 }
 
 function normalizeFileTreeClipboardWorktreeId(

--- a/src/renderer/src/app/utils/projectPath.test.ts
+++ b/src/renderer/src/app/utils/projectPath.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { joinProjectPath, resolveProjectFileFullPath } from "./projectPath";
+
+describe("project paths", () => {
+    it("joins POSIX project paths", () => {
+        expect(joinProjectPath("/projects/comando/", "src/App.tsx")).toBe(
+            "/projects/comando/src/App.tsx",
+        );
+    });
+
+    it("joins Windows project paths with native separators", () => {
+        expect(joinProjectPath("C:\\projects\\comando\\", "src/App.tsx")).toBe(
+            "C:\\projects\\comando\\src\\App.tsx",
+        );
+    });
+
+    it("prefers the loaded document path over the project root", () => {
+        expect(
+            resolveProjectFileFullPath({
+                absolutePath: "/worktrees/feature/src/App.tsx",
+                relativePath: "src/App.tsx",
+                rootPath: "/projects/comando",
+            }),
+        ).toBe("/worktrees/feature/src/App.tsx");
+    });
+
+    it("resolves unloaded tabs from their project or worktree root", () => {
+        expect(
+            resolveProjectFileFullPath({
+                absolutePath: null,
+                relativePath: "src/App.tsx",
+                rootPath: "/worktrees/feature",
+            }),
+        ).toBe("/worktrees/feature/src/App.tsx");
+    });
+
+    it("returns null when an unloaded tab has no resolvable root", () => {
+        expect(
+            resolveProjectFileFullPath({
+                absolutePath: null,
+                relativePath: "src/App.tsx",
+                rootPath: null,
+            }),
+        ).toBeNull();
+    });
+});

--- a/src/renderer/src/app/utils/projectPath.ts
+++ b/src/renderer/src/app/utils/projectPath.ts
@@ -1,0 +1,28 @@
+export function joinProjectPath(
+    rootPath: string,
+    relativePath: string,
+): string {
+    if (!relativePath) {
+        return rootPath;
+    }
+
+    const separator = rootPath.includes("\\") ? "\\" : "/";
+    return `${rootPath.replace(/[\\/]+$/, "")}${separator}${relativePath
+        .split("/")
+        .join(separator)}`;
+}
+
+export function resolveProjectFileFullPath(input: {
+    readonly absolutePath?: string | null;
+    readonly relativePath: string;
+    readonly rootPath: string | null;
+}): string | null {
+    // Loaded documents are authoritative, especially when the tab belongs to a worktree.
+    if (input.absolutePath) {
+        return input.absolutePath;
+    }
+
+    return input.rootPath
+        ? joinProjectPath(input.rootPath, input.relativePath)
+        : null;
+}

--- a/src/renderer/src/components/workspace/WorkspaceView.tsx
+++ b/src/renderer/src/components/workspace/WorkspaceView.tsx
@@ -211,11 +211,13 @@ import {
     type ContextMenuEntry,
     type ContextMenuState,
 } from "@renderer/components/context-menu/ContextMenu";
+import { writeClipboardText } from "@renderer/app/utils/clipboard";
 import {
     getViewportSafeMenuPosition,
     getViewportSafeSubmenuPosition,
     type MenuAnchorRect,
 } from "@renderer/app/utils/menu-position";
+import { resolveProjectFileFullPath } from "@renderer/app/utils/projectPath";
 import type { WorkspaceQuickCreateAction } from "@renderer/app/store/workspace-store";
 import {
     SIDEBAR_AGENT_DRAG_EVENT,
@@ -1291,6 +1293,7 @@ function WorkspaceNodeView({
 function useWorkspaceProjectRootPath(
     projectId: string | null,
     worktreeId: string | null,
+    fallbackToProjectRoot = true,
 ): string | null {
     const projectRootPath = useProjectsStore(
         useCallback(
@@ -1325,7 +1328,11 @@ function useWorkspaceProjectRootPath(
         ),
     );
 
-    return worktreeRootPath ?? projectRootPath;
+    // A worktree path must not silently resolve against the primary checkout.
+    return (
+        worktreeRootPath ??
+        (!worktreeId || fallbackToProjectRoot ? projectRootPath : null)
+    );
 }
 
 function areWorkspacePaneDropTargetsEqual(
@@ -1984,6 +1991,30 @@ function WorkspacePaneView({
             [contextTabId],
         ),
     );
+    const contextFileTab = contextTab?.kind === "file" ? contextTab : null;
+    const contextFileRootPath = useWorkspaceProjectRootPath(
+        contextFileTab?.projectId ?? null,
+        contextFileTab?.worktreeId ?? null,
+        false,
+    );
+    const contextFileFullPath = contextFileTab
+        ? resolveProjectFileFullPath({
+              absolutePath: contextFileTab.document?.absolutePath,
+              relativePath: contextFileTab.relativePath,
+              rootPath: contextFileRootPath,
+          })
+        : null;
+    const copyContextFileFullPath = useCallback(async () => {
+        if (!contextFileFullPath) {
+            return;
+        }
+
+        try {
+            await writeClipboardText(contextFileFullPath);
+        } catch {
+            window.alert("Could not copy the file path.");
+        }
+    }, [contextFileFullPath]);
     const activeTab = paneActiveTabId
         ? (paneTabs.find((tab) => tab.id === paneActiveTabId) ?? null)
         : null;
@@ -2205,6 +2236,11 @@ function WorkspacePaneView({
             const ext = contextTab.relativePath.split(".").pop() ?? null;
             entries.push(
                 { type: "separator" },
+                {
+                    label: "Copy Full Path",
+                    action: () => void copyContextFileFullPath(),
+                    disabled: !contextFileFullPath,
+                },
                 {
                     label: "Add to Chat",
                     action: () => {


### PR DESCRIPTION
## Summary

- add a **Copy Full Path** action to file tab context menus
- resolve paths from loaded documents or project/worktree roots for restored tabs
- share cross-platform project path handling with the file tree
- add coverage for POSIX, Windows, loaded, restored, and unresolved paths

## Testing

- `pnpm run typecheck`
- `pnpm exec eslint src/renderer/src/components/workspace/WorkspaceView.tsx src/renderer/src/app/utils/projectPath.ts src/renderer/src/app/utils/projectPath.test.ts`
- `pnpm exec vitest run src/renderer/src/components/workspace/WorkspaceView.quick-create.test.ts src/renderer/src/app/utils/projectPath.test.ts`