### PR TITLE
fix(security): update PostCSS to 8.5.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   undici@7.25.0: 7.28.0
   undici@7.27.2: 7.28.0
   '@xmldom/xmldom': 0.8.13
-  postcss: 8.5.15
+  postcss: 8.5.18
   brace-expansion@<1.1.16: 1.1.16
   brace-expansion@>=2.0.0 <2.1.2: 2.1.2
   brace-expansion@>=3.0.0 <5.0.7: 5.0.7
@@ -2937,8 +2937,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -6802,7 +6802,7 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss@8.5.15:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -7310,7 +7310,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
       rolldown: 1.1.4
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ overrides:
   "undici@7.25.0": 7.28.0
   "undici@7.27.2": 7.28.0
   "@xmldom/xmldom": 0.8.13
-  postcss: 8.5.15
+  postcss: 8.5.18
   "brace-expansion@<1.1.16": 1.1.16
   "brace-expansion@>=2.0.0 <2.1.2": 2.1.2
   "brace-expansion@>=3.0.0 <5.0.7": 5.0.7


### PR DESCRIPTION
## Summary
- update the workspace PostCSS override from 8.5.15 to 8.5.18
- regenerate the pnpm lockfile to resolve the patched transitive dependency

## Security
Addresses Dependabot alert #39 (GHSA-r28c-9q8g-f849).

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm test`