### PR TITLE
Prepare 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [0.2.1] - 2026-07-30
+
+### Added
+
+- Configurable custom ACP runtimes, including validation, isolated launches, lifecycle recovery, and settings management.
+- Mermaid diagram previews with theme-aware rendering, zoom, panning, resizing, and persistent viewport state.
+- Global workspace switching and live workspace transfers across application windows.
+- A unified Git changes view for reviewing uncommitted work and full branch changes against their base.
+- Native context-menu actions for image previews and file tabs, including copying a file's full path.
+
+### Changed
+
+- Rebuilt chat transcript storage and rendering around durable blocks, paged hydration, bounded payload caches, and virtualization for responsive long-running sessions.
+- Migrated read-only Git diffs to Pierre with virtualized files, sticky headers, syntax themes, and side-by-side layouts.
+- Moved AI review diff materialization to the native backend and reduced refresh work during large bursts of agent file changes.
+- Routed sidebar actions, shortcuts, quick open, and context menus through the active workspace surface.
+- Improved Markdown table previews with constrained layouts and horizontal scrolling for wide content.
+- Updated the bundled Claude ACP runtime to 0.63.0 and refreshed security-sensitive dependencies.
+
+### Fixed
+
+- Made transcript migration and recovery durable across interrupted writes, legacy histories, runtime failures, tab changes, and application restarts.
+- Preserved chat scroll anchors, activity details, review expansion, plan collapse state, and visible diffs while streaming or restoring sessions.
+- Prevented stale file reloads and watcher events from overwriting editor state after saves, tab switches, or worktree removal.
+- Stabilized workspace navigation, settings refreshes, native context-menu focus and layering, and transfers involving retained contexts.
+- Corrected agent session titles and sidebar visibility, full branch names in workspace tabs, pinned tab sizing, and elapsed times longer than one hour.
+- Restored macOS release signing and hardened runtime preparation and packaging.
+
 ## [0.2.0] - 2026-07-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "comando-ai"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "agent-client-protocol",
  "comando-diff",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "comando-diff"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "imara-diff",
  "serde",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "comando-fs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "comando-types",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "comando-git"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "comando-types",
  "serde_json",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "comando-index"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "comando-fs",
  "comando-types",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "comando-native-backend"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "comando-ai",
  "comando-diff",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "comando-persistence"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "comando-types",
  "rusqlite",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "comando-projects"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "comando-persistence",
  "comando-types",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "comando-settings"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "comando-types",
  "keyring",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "comando-terminal"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "comando-types",
  "portable-pty",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "comando-types"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [workspace.dependencies]

--- a/apps/native-backend/tests/jsonl_contract.rs
+++ b/apps/native-backend/tests/jsonl_contract.rs
@@ -114,7 +114,7 @@ fn reports_capabilities() {
     assert_eq!(response["id"], "caps");
     assert_eq!(response["ok"], true);
     assert_eq!(response["result"]["protocolVersion"], 1);
-    assert_eq!(response["result"]["backendVersion"], "0.2.0");
+    assert_eq!(response["result"]["backendVersion"], "0.2.1");
     assert_eq!(response["result"]["rustVersion"], "1.96");
     assert_eq!(
         response["result"]["capabilities"]["features"],

--- a/fixtures/native-backend/protocol/capabilities.v1.json
+++ b/fixtures/native-backend/protocol/capabilities.v1.json
@@ -1,6 +1,6 @@
 {
   "backendName": "comando-native-backend",
-  "backendVersion": "0.2.0",
+  "backendVersion": "0.2.1",
   "rustVersion": "1.96",
   "protocolVersion": 1,
   "minimumClientProtocolVersion": 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "comando",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "private": true,
     "description": "Workspace local-first para programar con IA.",
     "author": "José Gurruchaga",


### PR DESCRIPTION
## Summary

- add user-facing release notes for version 0.2.1
- align Electron and Rust workspace versions with the release
- refresh native backend capability fixtures and contract expectations

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run lint` (passes with two existing React warnings)
- `pnpm run test`
- `pnpm run build:ci`
- `cargo check --workspace`
- `cargo test --workspace`
- release notes extraction and release body generation for `v0.2.1`