### PR TITLE
Fix Grok CLI authentication persistence

### DIFF
--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -13,7 +13,7 @@ use comando_ai::history::{
     AiHistoryMigrationMode, AiHistoryMigrationOptions, AiHistoryMigrator, AiHistoryStore,
     LegacyAiHistoryReader,
 };
-use comando_ai::runtime_setup::invalidate_runtime_auth_on_error;
+use comando_ai::runtime_setup::{invalidate_runtime_auth_on_error, reconcile_grok_auth};
 use comando_fs::{FsError, ProjectFsService, ProjectRoot};
 use comando_git::{
     GitBranchListScope, GitError, GitFileDiffRequest, GitRunOptions, GitRunner, checkout_branch,
@@ -461,6 +461,12 @@ impl NativeBackend {
                 let runtime_setup_store = RuntimeSetupStore::new(
                     store.app_data_dir().join("ai").join("runtime-setup.json"),
                 );
+                if let Err(error) = reconcile_grok_auth(&runtime_setup_store) {
+                    // Runtime auth recovery is best-effort and must not block application storage.
+                    crate::logging::diagnostic(format!(
+                        "Native Grok auth reconciliation failed: {error}"
+                    ));
+                }
                 if let Err(error) = self
                     .ai_engine
                     .set_runtime_setup_store(Some(runtime_setup_store.clone()))

--- a/crates/comando-ai/src/runtime_setup.rs
+++ b/crates/comando-ai/src/runtime_setup.rs
@@ -68,6 +68,10 @@ pub fn runtime_status(
     Ok(status_from_parts(definition, &setup, &command, &auth))
 }
 
+pub fn reconcile_grok_auth(store: &RuntimeSetupStore) -> AiResult<bool> {
+    reconcile_grok_auth_at(store, grok_auth_file_path(), grok_auth_dir_path())
+}
+
 pub fn prepare_runtime_launch(
     store: &RuntimeSetupStore,
     definition: &RuntimeDefinition,
@@ -923,21 +927,13 @@ fn grok_auth_state(store: &RuntimeSetupStore, setup: &RuntimeSetupState) -> Runt
         normalize_auth_method(setup.auth_method.as_deref(), &["grok-login", "xai-api-key"]);
     let auth_invalidated = setup.auth_invalidated_at_ms.is_some();
     let login_ready = grok_login_auth_available(setup.auth_invalidated_at_ms);
-    let method = if env_ready && !auth_invalidated {
-        Some("xai-api-key".to_string())
-    } else if selected.as_deref() == Some("xai-api-key") && stored_ready && !auth_invalidated {
-        selected
-    } else if selected.as_deref() == Some("grok-login") && !auth_invalidated {
-        Some("grok-login".to_string())
-    } else if selected.is_some() {
-        None
-    } else if stored_ready && !auth_invalidated {
-        Some("xai-api-key".to_string())
-    } else if login_ready {
-        Some("grok-login".to_string())
-    } else {
-        None
-    };
+    let method = resolve_grok_auth_method(
+        env_ready,
+        stored_ready,
+        selected.as_deref(),
+        auth_invalidated,
+        login_ready,
+    );
     let can_logout = method.as_deref() == Some("grok-login");
     RuntimeAuthState {
         ready: method.is_some(),
@@ -960,6 +956,30 @@ fn grok_auth_state(store: &RuntimeSetupStore, setup: &RuntimeSetupState) -> Runt
             || setup.auth_invalidated_at_ms.is_some()
             || login_ready,
         can_logout,
+    }
+}
+
+fn resolve_grok_auth_method(
+    env_ready: bool,
+    stored_ready: bool,
+    selected: Option<&str>,
+    auth_invalidated: bool,
+    login_ready: bool,
+) -> Option<String> {
+    if env_ready && !auth_invalidated {
+        Some("xai-api-key".to_string())
+    } else if selected == Some("xai-api-key") && stored_ready && !auth_invalidated {
+        Some("xai-api-key".to_string())
+    } else if selected == Some("grok-login") && (!auth_invalidated || login_ready) {
+        Some("grok-login".to_string())
+    } else if selected.is_some() {
+        None
+    } else if stored_ready && !auth_invalidated {
+        Some("xai-api-key".to_string())
+    } else if login_ready {
+        Some("grok-login".to_string())
+    } else {
+        None
     }
 }
 
@@ -2074,6 +2094,34 @@ fn grok_login_auth_available_at(
         || external_auth_dir_available(auth_dir_path, invalidated_at_ms)
 }
 
+fn reconcile_grok_auth_at(
+    store: &RuntimeSetupStore,
+    auth_file_path: Option<PathBuf>,
+    auth_dir_path: Option<PathBuf>,
+) -> AiResult<bool> {
+    let setup = load_runtime_setup(store, "grok")?;
+    let Some(invalidated_at_ms) = setup.auth_invalidated_at_ms else {
+        return Ok(false);
+    };
+    if setup.auth_method.as_deref() == Some("xai-api-key")
+        || !grok_login_auth_available_at(auth_file_path, auth_dir_path, Some(invalidated_at_ms))
+    {
+        return Ok(false);
+    }
+
+    // A newer CLI credential supersedes the persisted failure marker.
+    store
+        .update_runtime("grok", |state| {
+            if state.auth_invalidated_at_ms == Some(invalidated_at_ms) {
+                state.auth_invalidated_at_ms = None;
+            }
+        })
+        .map_err(|error| {
+            AiError::Internal(format!("Native Grok auth reconciliation failed: {error}"))
+        })?;
+    Ok(true)
+}
+
 fn kilo_auth_file_path() -> Option<PathBuf> {
     xdg_data_dir().map(|base| base.join("kilo").join("auth.json"))
 }
@@ -2542,6 +2590,69 @@ mod tests {
             Some(temp.path().join(".grok").join("auth")),
             Some(u64::MAX),
         ));
+    }
+
+    #[test]
+    fn selected_grok_login_accepts_credentials_renewed_after_invalidation() {
+        assert_eq!(
+            resolve_grok_auth_method(false, false, Some("grok-login"), true, true).as_deref(),
+            Some("grok-login")
+        );
+        assert_eq!(
+            resolve_grok_auth_method(false, false, Some("grok-login"), true, false),
+            None
+        );
+    }
+
+    #[test]
+    fn grok_auth_reconciliation_clears_only_obsolete_invalidation() {
+        let temp = tempdir().expect("temp");
+        let store = RuntimeSetupStore::in_memory_for_tests(temp.path().join("runtime-setup.json"));
+        store
+            .update_runtime("grok", |state| {
+                state.auth_method = Some("grok-login".to_string());
+                state.auth_invalidated_at_ms = Some(1);
+            })
+            .expect("setup");
+        let auth_file = temp.path().join(".grok").join("auth.json");
+        write_file(&auth_file, r#"{"token":"test"}"#);
+
+        assert!(
+            reconcile_grok_auth_at(
+                &store,
+                Some(auth_file.clone()),
+                Some(temp.path().join(".grok").join("auth")),
+            )
+            .expect("reconcile")
+        );
+        assert_eq!(
+            store
+                .load_runtime("grok")
+                .expect("setup")
+                .auth_invalidated_at_ms,
+            None
+        );
+
+        store
+            .update_runtime("grok", |state| {
+                state.auth_invalidated_at_ms = Some(u64::MAX);
+            })
+            .expect("setup");
+        assert!(
+            !reconcile_grok_auth_at(
+                &store,
+                Some(auth_file),
+                Some(temp.path().join(".grok").join("auth")),
+            )
+            .expect("reconcile")
+        );
+        assert_eq!(
+            store
+                .load_runtime("grok")
+                .expect("setup")
+                .auth_invalidated_at_ms,
+            Some(u64::MAX)
+        );
     }
 
     #[test]

--- a/crates/comando-ai/src/runtime_setup.rs
+++ b/crates/comando-ai/src/runtime_setup.rs
@@ -966,9 +966,7 @@ fn resolve_grok_auth_method(
     auth_invalidated: bool,
     login_ready: bool,
 ) -> Option<String> {
-    if env_ready && !auth_invalidated {
-        Some("xai-api-key".to_string())
-    } else if selected == Some("xai-api-key") && stored_ready && !auth_invalidated {
+    if !auth_invalidated && (env_ready || (selected == Some("xai-api-key") && stored_ready)) {
         Some("xai-api-key".to_string())
     } else if selected == Some("grok-login") && (!auth_invalidated || login_ready) {
         Some("grok-login".to_string())

--- a/src/main/ai/grok/setup.test.ts
+++ b/src/main/ai/grok/setup.test.ts
@@ -336,28 +336,54 @@ describe("Grok setup", () => {
         }
     });
 
-    it("detects Grok login from ~/.grok/auth and respects invalidation", () => {
+    it("detects Grok login from ~/.grok/auth.json and respects invalidation", () => {
         const tempDir = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-grok-auth-store-"),
         );
 
         try {
-            writeGrokAuthStore(tempDir);
+            writeGrokAuthFile(tempDir);
             process.env.HOME = tempDir;
             delete process.env.USERPROFILE;
 
             const readySettings = createEmptyGrokSettings();
+            const renewedSelectedSettings = createEmptyGrokSettings({
+                authInvalidatedAtMs: Date.now() - 60_000,
+                authMethod: "grok-login",
+            });
             const invalidatedSettings = createEmptyGrokSettings({
                 authInvalidatedAtMs: Date.now() + 60_000,
+                authMethod: "grok-login",
             });
 
             expect(detectGrokAuthMethod(readySettings)).toBe("grok-login");
+            expect(detectGrokAuthMethod(renewedSelectedSettings)).toBe(
+                "grok-login",
+            );
             expect(detectGrokAuthMethod(invalidatedSettings)).toBeNull();
             expect(markGrokAuthInvalidated(readySettings)).toMatchObject({
                 authMethod: null,
                 binaryPath: null,
                 hasXaiApiKey: false,
             });
+        } finally {
+            fs.rmSync(tempDir, { force: true, recursive: true });
+        }
+    });
+
+    it("keeps compatibility with the legacy ~/.grok/auth directory", () => {
+        const tempDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "comando-grok-legacy-auth-store-"),
+        );
+
+        try {
+            writeLegacyGrokAuthStore(tempDir);
+            process.env.HOME = tempDir;
+            delete process.env.USERPROFILE;
+
+            expect(detectGrokAuthMethod(createEmptyGrokSettings())).toBe(
+                "grok-login",
+            );
         } finally {
             fs.rmSync(tempDir, { force: true, recursive: true });
         }
@@ -427,7 +453,17 @@ function platformExecutableName(command: string): string {
     return process.platform === "win32" ? `${command}.CMD` : command;
 }
 
-function writeGrokAuthStore(homeDir: string): void {
+function writeGrokAuthFile(homeDir: string): void {
+    const grokDir = path.join(homeDir, ".grok");
+    fs.mkdirSync(grokDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(grokDir, "auth.json"),
+        '{"token":"cached-token"}',
+        "utf8",
+    );
+}
+
+function writeLegacyGrokAuthStore(homeDir: string): void {
     const authDir = path.join(homeDir, ".grok", "auth");
     fs.mkdirSync(authDir, { recursive: true });
     fs.writeFileSync(path.join(authDir, "token"), "cached-token", "utf8");

--- a/src/main/ai/grok/setup.ts
+++ b/src/main/ai/grok/setup.ts
@@ -158,7 +158,8 @@ export function detectGrokAuthMethod(
 
     if (
         selectedAuthMethod === GROK_LOGIN_METHOD_ID &&
-        settings.authInvalidatedAtMs === null
+        (settings.authInvalidatedAtMs === null ||
+            grokLoginAvailable(settings))
     ) {
         return GROK_LOGIN_METHOD_ID;
     }
@@ -433,25 +434,76 @@ function grokLoginAvailable(settings: GrokRuntimeSettings): boolean {
 }
 
 function getGrokAuthStoreStatus(): GrokAuthStoreStatus | null {
-    const authDir = getGrokAuthStorePath();
-    if (!authDir || !isDirectory(authDir)) {
+    const paths = getGrokAuthStorePaths();
+    if (!paths) {
         return null;
     }
 
-    return readGrokAuthStoreStatus(authDir);
+    const statuses = [
+        readGrokAuthFileStatus(paths.authFile),
+        readGrokAuthDirectoryStatus(paths.authDir),
+    ].filter((status): status is GrokAuthStoreStatus => status !== null);
+    if (statuses.length === 0) {
+        return null;
+    }
+
+    return {
+        hasActiveAuth: statuses.some((status) => status.hasActiveAuth),
+        modifiedAtMs: statuses.reduce<number | null>(
+            (newest, status) =>
+                status.modifiedAtMs === null
+                    ? newest
+                    : Math.max(newest ?? 0, status.modifiedAtMs),
+            null,
+        ),
+    };
 }
 
-function getGrokAuthStorePath(): string | null {
+function getGrokAuthStorePaths(): {
+    readonly authDir: string;
+    readonly authFile: string;
+} | null {
     const homeDir =
         process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || "";
     if (!homeDir) {
         return null;
     }
 
-    return path.join(homeDir, ".grok", "auth");
+    const grokDir = path.join(homeDir, ".grok");
+    return {
+        authDir: path.join(grokDir, "auth"),
+        authFile: path.join(grokDir, "auth.json"),
+    };
 }
 
-function readGrokAuthStoreStatus(authDir: string): GrokAuthStoreStatus {
+function readGrokAuthFileStatus(
+    authFile: string,
+): GrokAuthStoreStatus | null {
+    try {
+        const stat = fs.statSync(authFile);
+        if (!stat.isFile()) {
+            return null;
+        }
+
+        return {
+            hasActiveAuth: stat.size > 0,
+            modifiedAtMs: stat.mtimeMs,
+        };
+    } catch (error) {
+        if (!isMissingFileError(error)) {
+            debugBenignError("ai.grok.readAuthFileStatus", error);
+        }
+        return null;
+    }
+}
+
+function readGrokAuthDirectoryStatus(
+    authDir: string,
+): GrokAuthStoreStatus | null {
+    if (!isDirectory(authDir)) {
+        return null;
+    }
+
     try {
         const entries = fs.readdirSync(authDir, { withFileTypes: true });
         let hasActiveAuth = false;
@@ -481,6 +533,14 @@ function readGrokAuthStoreStatus(authDir: string): GrokAuthStoreStatus {
             modifiedAtMs: getFileModifiedAtMs(authDir),
         };
     }
+}
+
+function isMissingFileError(error: unknown): boolean {
+    return (
+        error instanceof Error &&
+        "code" in error &&
+        (error as NodeJS.ErrnoException).code === "ENOENT"
+    );
 }
 
 function envSecretPresent(env: NodeJS.ProcessEnv, key: typeof XAI_API_KEY_ENV) {

--- a/src/main/ai/service.grok.test.ts
+++ b/src/main/ai/service.grok.test.ts
@@ -118,9 +118,13 @@ describe("AiService Grok branch", () => {
         const tempDir = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-grok-pending-login-"),
         );
+        const originalHome = process.env.HOME;
+        const originalUserProfile = process.env.USERPROFILE;
 
         try {
             const binaryPath = writeExecutable(tempDir, "grok");
+            process.env.HOME = tempDir;
+            delete process.env.USERPROFILE;
             let savedSettings: GrokRuntimeSettings | null = null;
             const service = createService({
                 settingsService: createSettingsService({
@@ -160,6 +164,8 @@ describe("AiService Grok branch", () => {
                 runtimeId: "grok",
             });
         } finally {
+            restoreEnv("HOME", originalHome);
+            restoreEnv("USERPROFILE", originalUserProfile);
             fs.rmSync(tempDir, { force: true, recursive: true });
         }
     });
@@ -168,9 +174,13 @@ describe("AiService Grok branch", () => {
         const tempDir = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-grok-env-login-"),
         );
+        const originalHome = process.env.HOME;
+        const originalUserProfile = process.env.USERPROFILE;
 
         try {
             const binaryPath = writeExecutable(tempDir, "grok");
+            process.env.HOME = tempDir;
+            delete process.env.USERPROFILE;
             process.env.XAI_API_KEY = "env-xai-key";
             let savedSettings: GrokRuntimeSettings | null = null;
             const service = createService({
@@ -205,6 +215,8 @@ describe("AiService Grok branch", () => {
                 runtimeId: "grok",
             });
         } finally {
+            restoreEnv("HOME", originalHome);
+            restoreEnv("USERPROFILE", originalUserProfile);
             fs.rmSync(tempDir, { force: true, recursive: true });
         }
     });
@@ -463,10 +475,15 @@ describe("AiService Grok branch", () => {
         const tempDir = fs.mkdtempSync(
             path.join(os.tmpdir(), "comando-grok-prepare-native-status-"),
         );
+        const originalHome = process.env.HOME;
+        const originalUserProfile = process.env.USERPROFILE;
 
         try {
             const binaryPath = writeExecutable(tempDir, "grok");
-            const invalidatedAtMs = Date.now();
+            const invalidatedAtMs = Date.now() - 60_000;
+            writeCurrentGrokAuthFile(tempDir);
+            process.env.HOME = tempDir;
+            delete process.env.USERPROFILE;
             const grokSettings = createGrokSettings({
                 authInvalidatedAtMs: invalidatedAtMs,
                 authMethod: "grok-login",
@@ -503,11 +520,13 @@ describe("AiService Grok branch", () => {
                 prepareSession,
                 saveRuntimeSettings,
             });
+            const saveGrokRuntimeSettings = vi.fn();
 
             const service = createService({
                 nativeAi,
                 settingsService: createSettingsService({
                     loadGrokRuntimeSettings: vi.fn(() => grokSettings),
+                    saveGrokRuntimeSettings,
                 }),
             });
 
@@ -526,10 +545,14 @@ describe("AiService Grok branch", () => {
                 runtimeId: "grok",
                 secretPatches: [],
                 settings: {
-                    authInvalidatedAtMs: invalidatedAtMs,
+                    authInvalidatedAtMs: null,
                     authMethod: "grok-login",
                     binaryPath,
                 },
+            });
+            expect(saveGrokRuntimeSettings).toHaveBeenCalledWith({
+                ...grokSettings,
+                authInvalidatedAtMs: null,
             });
             expect(getRuntimeStatus).toHaveBeenCalledWith("grok");
             expect(
@@ -541,6 +564,8 @@ describe("AiService Grok branch", () => {
                     .onboardingRequired,
             ).toBe(false);
         } finally {
+            restoreEnv("HOME", originalHome);
+            restoreEnv("USERPROFILE", originalUserProfile);
             fs.rmSync(tempDir, { force: true, recursive: true });
         }
     });
@@ -865,6 +890,16 @@ function writeGrokAuthStore(homeDir: string): void {
     const authDir = path.join(homeDir, ".grok", "auth");
     fs.mkdirSync(authDir, { recursive: true });
     fs.writeFileSync(path.join(authDir, "token"), "cached-token", "utf8");
+}
+
+function writeCurrentGrokAuthFile(homeDir: string): void {
+    const grokDir = path.join(homeDir, ".grok");
+    fs.mkdirSync(grokDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(grokDir, "auth.json"),
+        '{"token":"cached-token"}',
+        "utf8",
+    );
 }
 
 function restoreEnv(name: string, value: string | undefined): void {

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -2670,7 +2670,19 @@ export class AiService {
                 };
             }
             case "grok": {
-                const settings = this.#settingsService.loadGrokRuntimeSettings();
+                let settings = this.#settingsService.loadGrokRuntimeSettings();
+                if (
+                    settings.authInvalidatedAtMs !== null &&
+                    settings.authMethod !== "xai-api-key" &&
+                    isGrokExternalCredentialReady(settings)
+                ) {
+                    // Keep legacy and native stores aligned after the CLI renews its login.
+                    settings = {
+                        ...settings,
+                        authInvalidatedAtMs: null,
+                    };
+                    this.#settingsService.saveGrokRuntimeSettings(settings);
+                }
                 return {
                     runtimeId,
                     settings: {


### PR DESCRIPTION
## Summary

- detect the current `~/.grok/auth.json` credential store while preserving the legacy directory fallback
- accept Grok CLI credentials renewed after a persisted authentication invalidation
- reconcile stale invalidation state across native and legacy runtime settings during startup
- isolate Grok authentication tests from the developer machine and cover restart-related regressions

## Validation

- `pnpm exec vitest run src/main/ai/grok/setup.test.ts src/main/ai/service.grok.test.ts`
- `cargo test -p comando-ai --lib`
- `cargo test -p comando-native-backend --lib`
- `pnpm run typecheck`
- targeted ESLint checks
- `cargo fmt --all -- --check`
- `git diff --check`