### PR TITLE
Sync active files with the workspace inspector

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -261,6 +261,7 @@ import { windowRegistry } from "@main/windows/registry";
 import { workspaceSurfaceManager } from "@main/workspace/surface-manager";
 import { workspaceRuntimeOwnership } from "@main/workspace/runtime-ownership-coordinator";
 import {
+    isWorkspaceSurfaceActiveFileState,
     isWorkspaceSurfaceActionRequest,
     isWorkspaceSurfaceActionCompletion,
     isWorkspaceSurfaceFileRevealRequest,
@@ -453,6 +454,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     ipcMain.removeHandler(IPC_CHANNELS.notifyWorkspaceSurfaceRestoreFailed);
     ipcMain.removeHandler(IPC_CHANNELS.reportWorkspaceSurfaceLeases);
     ipcMain.removeHandler(IPC_CHANNELS.resyncWorkspaceSurfaceRuntime);
+    ipcMain.removeHandler(IPC_CHANNELS.publishWorkspaceSurfaceActiveFile);
     ipcMain.removeHandler(IPC_CHANNELS.revealWorkspaceSurfaceFileInHostTree);
     ipcMain.removeHandler(IPC_CHANNELS.notifyWorkspaceSurfaceFocused);
     ipcMain.removeHandler(IPC_CHANNELS.requestWorkspaceScopeActivation);
@@ -2288,6 +2290,18 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
             workspaceSurfaceManager.completeSurfaceAction(
                 event.sender,
                 completion,
+            );
+        },
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.publishWorkspaceSurfaceActiveFile,
+        (event, input) => {
+            if (!isWorkspaceSurfaceActiveFileState(input)) {
+                throw new Error("A valid workspace surface active file is required.");
+            }
+            return workspaceSurfaceManager.publishSurfaceActiveFile(
+                event.sender,
+                input,
             );
         },
     );

--- a/src/main/workspace/surface-actions.test.ts
+++ b/src/main/workspace/surface-actions.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from "vitest";
 import type {
     PersistedWorkspaceContext,
     WorkspaceSurfaceActionRequest,
+    WorkspaceSurfaceActiveFileState,
     WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
 import {
     doesWorkspaceSurfaceActionMatchContext,
+    isWorkspaceSurfaceActiveFileState,
     isWorkspaceSurfaceFileRevealRequest,
     isWorkspaceSurfaceActionRequest,
 } from "./surface-actions";
@@ -141,6 +143,34 @@ describe("workspace surface actions", () => {
             isWorkspaceSurfaceFileRevealRequest({
                 projectId: context.projectId,
                 relativePath: request.relativePath,
+                worktreeId: null,
+            }),
+        ).toBe(false);
+    });
+
+    it("accepts active file updates and an explicit clear", () => {
+        const state: WorkspaceSurfaceActiveFileState = {
+            ...context,
+            relativePath: "src/index.ts",
+        };
+
+        expect(isWorkspaceSurfaceActiveFileState(state)).toBe(true);
+        expect(
+            isWorkspaceSurfaceActiveFileState({
+                ...state,
+                relativePath: null,
+            }),
+        ).toBe(true);
+        expect(
+            isWorkspaceSurfaceActiveFileState({
+                ...state,
+                relativePath: "",
+            }),
+        ).toBe(false);
+        expect(
+            isWorkspaceSurfaceActiveFileState({
+                projectId: context.projectId,
+                relativePath: state.relativePath,
                 worktreeId: null,
             }),
         ).toBe(false);

--- a/src/main/workspace/surface-actions.ts
+++ b/src/main/workspace/surface-actions.ts
@@ -5,6 +5,7 @@ import type {
     WorkspaceSurfaceActionRequest,
     WorkspaceSurfaceActionContext,
     WorkspaceSurfaceActionCompletion,
+    WorkspaceSurfaceActiveFileState,
     WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
 
@@ -101,6 +102,17 @@ export function isWorkspaceSurfaceFileRevealRequest(
         isRecord(input) &&
         hasValidContext(input) &&
         isNonEmptyString(input.relativePath, MAX_PATH_OR_URL_LENGTH)
+    );
+}
+
+export function isWorkspaceSurfaceActiveFileState(
+    input: unknown,
+): input is WorkspaceSurfaceActiveFileState {
+    return (
+        isRecord(input) &&
+        hasValidContext(input) &&
+        (input.relativePath === null ||
+            isNonEmptyString(input.relativePath, MAX_PATH_OR_URL_LENGTH))
     );
 }
 

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -8,6 +8,7 @@ import type {
     WorkspaceSurfaceEnvironmentDiagnostic,
     WorkspaceSurfaceRegistrySnapshot,
     WorkspaceSurfaceActionRequest,
+    WorkspaceSurfaceActiveFileState,
     WorkspaceSurfaceDragEvent,
     WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
@@ -1283,6 +1284,41 @@ describe("WorkspaceSurfaceManager action routing", () => {
         ).toEqual({ delivered: true });
     });
 
+    it("publishes and clears the active file through the current host context", () => {
+        const manager = createTestManager();
+        const host = createHostWindow();
+        manager.syncWorkspaceRegistry(host.window, createHostContext(), createSnapshot());
+        const [surfaceA] = electronMocks.views;
+        const activeFile = createActiveFileState(
+            "project-a::__primary__",
+            "project-a",
+            "src/index.ts",
+        );
+
+        expect(
+            manager.publishSurfaceActiveFile(
+                asWebContents(surfaceA.webContents),
+                activeFile,
+            ),
+        ).toEqual({ delivered: true });
+        expect(host.send).toHaveBeenCalledWith(
+            IPC_EVENTS.workspaceSurfaceActiveFileChanged,
+            activeFile,
+        );
+
+        const clearedFile = { ...activeFile, relativePath: null };
+        expect(
+            manager.publishSurfaceActiveFile(
+                asWebContents(surfaceA.webContents),
+                clearedFile,
+            ),
+        ).toEqual({ delivered: true });
+        expect(host.send).toHaveBeenLastCalledWith(
+            IPC_EVENTS.workspaceSurfaceActiveFileChanged,
+            clearedFile,
+        );
+    });
+
 
 });
 
@@ -1484,6 +1520,19 @@ function createFileRevealRequest(
         contextKey,
         projectId,
         relativePath: "README.md",
+        worktreeId: null,
+    };
+}
+
+function createActiveFileState(
+    contextKey: string,
+    projectId: string,
+    relativePath: string | null,
+): WorkspaceSurfaceActiveFileState {
+    return {
+        contextKey,
+        projectId,
+        relativePath,
         worktreeId: null,
     };
 }

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -21,6 +21,7 @@ import type {
     WorkspaceSurfaceActionEnvelope,
     WorkspaceSurfaceActionRequest,
     WorkspaceSurfaceActionStatus,
+    WorkspaceSurfaceActiveFileState,
     WorkspaceSurfaceActivationResult,
     WorkspaceSurfaceEnvironmentDiagnostic,
     WorkspaceSurfaceCloseResult,
@@ -633,6 +634,29 @@ export class WorkspaceSurfaceManager {
         webContents: WebContents,
         request: WorkspaceSurfaceFileRevealRequest,
     ): WorkspaceSurfaceActionDeliveryResult {
+        return this.#forwardActiveSurfaceContextEvent(
+            webContents,
+            request,
+            IPC_EVENTS.workspaceSurfaceFileRevealRequested,
+        );
+    }
+
+    publishSurfaceActiveFile(
+        webContents: WebContents,
+        state: WorkspaceSurfaceActiveFileState,
+    ): WorkspaceSurfaceActionDeliveryResult {
+        return this.#forwardActiveSurfaceContextEvent(
+            webContents,
+            state,
+            IPC_EVENTS.workspaceSurfaceActiveFileChanged,
+        );
+    }
+
+    #forwardActiveSurfaceContextEvent(
+        webContents: WebContents,
+        payload: WorkspaceSurfaceActionContext,
+        eventName: string,
+    ): WorkspaceSurfaceActionDeliveryResult {
         const surface = this.#getSurfaceByWebContents(webContents);
         const host = surface
             ? this.#hostsByWindowId.get(surface.hostWindowId)
@@ -640,16 +664,16 @@ export class WorkspaceSurfaceManager {
         if (!surface || !host || surface.webContents.isDestroyed()) {
             return { delivered: false, reason: "missing-surface" };
         }
-        if (host.activeScopeKey !== request.contextKey) {
+        if (host.activeScopeKey !== payload.contextKey) {
             return { delivered: false, reason: "inactive-context" };
         }
         const activeWorkspace = host.registry.workspaces.find(
             (workspace) => workspace.scopeKey === host.activeScopeKey,
         );
         if (
-            surface.contextKey !== request.contextKey ||
+            surface.contextKey !== payload.contextKey ||
             !activeWorkspace ||
-            !doesWorkspaceSurfaceContextMatchContext(request, {
+            !doesWorkspaceSurfaceContextMatchContext(payload, {
                 key: activeWorkspace.scopeKey,
                 projectId: activeWorkspace.projectId,
                 worktreeId: activeWorkspace.worktreeId,
@@ -661,10 +685,7 @@ export class WorkspaceSurfaceManager {
             return { delivered: false, reason: "missing-surface" };
         }
 
-        host.hostWindow.webContents.send(
-            IPC_EVENTS.workspaceSurfaceFileRevealRequested,
-            request,
-        );
+        host.hostWindow.webContents.send(eventName, payload);
         return { delivered: true };
     }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -200,6 +200,7 @@ import {
     type WriteTerminalInput,
     type WorkspaceSurfaceActionCompletion,
     type WorkspaceSurfaceActionEnvelope,
+    type WorkspaceSurfaceActiveFileState,
     type WorkspaceSurfaceFileRevealRequest,
     type WorkspaceSurfaceActionStatus,
     type WorkspaceSurfaceContentInsets,
@@ -1082,6 +1083,22 @@ const comandoApi: ComandoApi = {
             );
         };
     },
+    onWorkspaceSurfaceActiveFileChanged: (listener) => {
+        const handleEvent = (
+            _event: Electron.IpcRendererEvent,
+            state: WorkspaceSurfaceActiveFileState,
+        ) => listener(state);
+        ipcRenderer.on(
+            IPC_EVENTS.workspaceSurfaceActiveFileChanged,
+            handleEvent,
+        );
+        return () => {
+            ipcRenderer.removeListener(
+                IPC_EVENTS.workspaceSurfaceActiveFileChanged,
+                handleEvent,
+            );
+        };
+    },
     onWorkspaceSurfaceFileRevealRequested: (listener) => {
         const handleEvent = (
             _event: Electron.IpcRendererEvent,
@@ -1316,6 +1333,11 @@ const comandoApi: ComandoApi = {
                 IPC_CHANNELS.resyncWorkspaceSurfaceRuntime,
                 binding,
             ),
+        ),
+    publishWorkspaceSurfaceActiveFile: (state) =>
+        ipcRenderer.invoke(
+            IPC_CHANNELS.publishWorkspaceSurfaceActiveFile,
+            state,
         ),
     revealWorkspaceSurfaceFileInHostTree: (request) =>
         ipcRenderer.invoke(

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -47,7 +47,6 @@ import {
 } from "./app/git/context-key";
 import {
     reconcileFileTreeSelection,
-    resolveActiveFileTreePath,
     resolveFileTreeNodeClickSelection,
 } from "./app/projects/file-tree-selection";
 import {
@@ -105,9 +104,10 @@ import {
     useWorkspaceStore,
 } from "./app/store/workspace-store";
 import {
-    findPaneById,
-    type RuntimeWorkspaceTab,
-} from "./app/workspace/tree";
+    updateWorkspaceActiveFilePaths,
+    type WorkspaceActiveFilePaths,
+} from "./app/workspace/surface-active-file";
+import { findPaneById } from "./app/workspace/tree";
 import {
     compactGitTreeEntriesByAncestor,
     compactGitTreeEntriesForDeletion,
@@ -255,17 +255,6 @@ function resolveStateAction<T>(action: SetStateAction<T>, current: T): T {
     return typeof action === "function"
         ? (action as (value: T) => T)(current)
         : action;
-}
-
-function selectActiveWorkspaceTab(
-    state: ReturnType<typeof useWorkspaceStore.getState>,
-): RuntimeWorkspaceTab | null {
-    const activePane = findPaneById(state.rootNode, state.activePaneId);
-    if (!activePane?.activeTabId) {
-        return null;
-    }
-
-    return state.tabsById[activePane.activeTabId] ?? null;
 }
 
 export function WorkspaceHostApp() {
@@ -528,7 +517,6 @@ export function WorkspaceHostApp() {
         (state) => state.renameTabsForProjectPath,
     );
     const workspaceError = useWorkspaceStore((state) => state.error);
-    const activeWorkspaceTab = useWorkspaceStore(selectActiveWorkspaceTab);
 
     const activeSurface = useShellStore((state) => state.activeSurface);
     const focusSurface = useShellStore((state) => state.focusSurface);
@@ -709,8 +697,12 @@ export function WorkspaceHostApp() {
     >(null);
     const [pendingFileTreeReveal, setPendingFileTreeReveal] =
         useState<PendingFileTreeReveal | null>(null);
-    const [revealedFilePathsByContext, setRevealedFilePathsByContext] =
-        useState<Record<string, string>>({});
+    const [fileTreeRevealTarget, setFileTreeRevealTarget] = useState<{
+        readonly relativePath: string;
+        readonly requestId: number;
+    } | null>(null);
+    const [activeFilePathsByContext, setActiveFilePathsByContext] =
+        useState<WorkspaceActiveFilePaths>({});
     const fileTreeRevealRequestIdRef = useRef(0);
     const fileTreeSearchInputRef = useRef<HTMLInputElement | null>(null);
     const fileTreeInlineSubmitPendingRef = useRef(false);
@@ -2034,24 +2026,9 @@ export function WorkspaceHostApp() {
     const isProjectRootExpanded =
         projectRootExpandedByContext[activeProjectContextKey] ?? true;
     void renameTabsForProjectPath;
-    const revealedActiveFilePath = workspaceActiveContextKey
-        ? (revealedFilePathsByContext[workspaceActiveContextKey] ?? null)
+    const activeFilePath = workspaceActiveContextKey
+        ? (activeFilePathsByContext[workspaceActiveContextKey] ?? null)
         : null;
-    const activeFilePath = useMemo(
-        () =>
-            revealedActiveFilePath ??
-            resolveActiveFileTreePath({
-                activeProjectId,
-                activeWorkspaceTab,
-                activeWorktreeId,
-            }),
-        [
-            activeProjectId,
-            activeWorkspaceTab,
-            activeWorktreeId,
-            revealedActiveFilePath,
-        ],
-    );
     const activeGitError = activeGitContextKey
         ? (gitErrors[activeGitContextKey] ?? null)
         : null;
@@ -3768,16 +3745,11 @@ export function WorkspaceHostApp() {
                 ...currentState,
                 [targetProjectContextKey]: true,
             }));
-            // The host cannot read the surface's selected tab, so retain the IPC
-            // path until the tree has rendered and scrolled to the requested row.
-            setRevealedFilePathsByContext((currentPaths) =>
-                currentPaths[request.contextKey] === request.relativePath
-                    ? currentPaths
-                    : {
-                          ...currentPaths,
-                          [request.contextKey]: request.relativePath,
-                      },
-            );
+            // Keep scrolling independent from the passive active-file highlight.
+            setFileTreeRevealTarget({
+                relativePath: request.relativePath,
+                requestId,
+            });
             setPendingFileTreeReveal({ ...request, requestId });
         },
         [setRightCollapsed, setSidebarView],
@@ -3816,6 +3788,11 @@ export function WorkspaceHostApp() {
             .catch((error) => {
                 if (!cancelled) {
                     console.error("[workspace-host] file reveal failed", error);
+                    setFileTreeRevealTarget((currentTarget) =>
+                        currentTarget?.requestId === reveal.requestId
+                            ? null
+                            : currentTarget,
+                    );
                 }
             });
 
@@ -3827,6 +3804,17 @@ export function WorkspaceHostApp() {
         revealPathInTree,
         workspaceActiveContextKey,
     ]);
+
+    useEffect(() => {
+        if (!isWorkspaceHostRenderer) {
+            return;
+        }
+        return getComandoApi()?.onWorkspaceSurfaceActiveFileChanged((state) => {
+            setActiveFilePathsByContext((currentPaths) =>
+                updateWorkspaceActiveFilePaths(currentPaths, state),
+            );
+        });
+    }, []);
 
     useEffect(() => {
         if (!isWorkspaceHostRenderer) {
@@ -4216,8 +4204,9 @@ export function WorkspaceHostApp() {
                             void handleMoveTreeNode(dragData, destinationNode);
                         }}
                         onScroll={handleFileTreeScroll}
-                        onScrollToActivePathConsumed={() => {
+                        onScrollToPathConsumed={() => {
                             setFileTreeRevealSignal(null);
+                            setFileTreeRevealTarget(null);
                         }}
                         onToggleDirectory={(node) => {
                             if (node.isProjectRoot) {
@@ -4244,6 +4233,7 @@ export function WorkspaceHostApp() {
                             }
                         }}
                         project={activeProject}
+                        revealPath={fileTreeRevealTarget?.relativePath ?? null}
                         revealSignal={fileTreeRevealSignal}
                         scrollRef={setFileTreeScrollElement}
                         selectedPaths={selectedFileTreePathSet}

--- a/src/renderer/src/WorkspaceSurfaceApp.tsx
+++ b/src/renderer/src/WorkspaceSurfaceApp.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
 
 import type {
     WorkspaceSurfaceActionEnvelope,
@@ -26,6 +27,7 @@ import {
     resolveCommittedProjectWorktreeId,
 } from "./app/git/context-key";
 import { executeWorkspaceSurfaceAction } from "./app/workspace/surface-actions";
+import { resolveWorkspaceSurfaceActiveFileState } from "./app/workspace/surface-active-file";
 import { isWorkspaceSurfaceLifecycleCurrent } from "./app/workspace/surface-presentation-lifecycle";
 import {
     collectWorkspaceSurfaceStateLeases,
@@ -167,6 +169,16 @@ export function WorkspaceSurfaceApp() {
         state.activeContextKey
             ? (state.contextsByKey[state.activeContextKey] ?? null)
             : null,
+    );
+    const activeFileState = useWorkspaceStore(
+        useShallow((state) => {
+            const context = state.activeContextKey
+                ? (state.contextsByKey[state.activeContextKey] ?? null)
+                : null;
+            return context
+                ? resolveWorkspaceSurfaceActiveFileState(state, context)
+                : null;
+        }),
     );
     const workspaceError = useWorkspaceStore((state) => state.error);
     const projectsError = useProjectsStore((state) => state.error);
@@ -362,6 +374,34 @@ export function WorkspaceSurfaceApp() {
             unsubscribeRegistry();
         };
     }, [runtimeBinding]);
+
+    useEffect(() => {
+        if (
+            surfaceStatus !== "ready" ||
+            surfaceLifecycle !== "visible" ||
+            !activeFileState
+        ) {
+            return;
+        }
+
+        // The host owns the inspector, so publish only the minimal state it cannot derive.
+        void window.comando
+            .publishWorkspaceSurfaceActiveFile(activeFileState)
+            .then((result) => {
+                if (!result.delivered) {
+                    console.warn(
+                        "[workspace-surface] active file delivery failed",
+                        result,
+                    );
+                }
+            })
+            .catch((error: unknown) => {
+                console.error(
+                    "[workspace-surface] active file delivery failed",
+                    error,
+                );
+            });
+    }, [activeFileState, surfaceLifecycle, surfaceStatus]);
 
     useEffect(() => {
         const api = window.comando;

--- a/src/renderer/src/app/workspace/surface-active-file.test.ts
+++ b/src/renderer/src/app/workspace/surface-active-file.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+    RuntimeWorkspaceFileTab,
+    RuntimeWorkspaceTab,
+    WorkspaceTreeState,
+} from "./tree";
+import {
+    resolveWorkspaceSurfaceActiveFileState,
+    updateWorkspaceActiveFilePaths,
+} from "./surface-active-file";
+
+const context = {
+    key: "project-1::__primary__",
+    projectId: "project-1",
+    worktreeId: null,
+} as const;
+
+describe("workspace surface active file", () => {
+    it("follows the active pane and clears for a non-file tab", () => {
+        const leftFile = createFileTab("file-left", "src/left.ts");
+        const rightFile = createFileTab("file-right", "src/right.ts");
+        const chat = createChatTab("chat-right");
+        const workspace = createSplitWorkspace(leftFile, rightFile, chat);
+
+        expect(
+            resolveWorkspaceSurfaceActiveFileState(workspace, context),
+        ).toEqual({
+            contextKey: context.key,
+            projectId: context.projectId,
+            relativePath: leftFile.relativePath,
+            worktreeId: null,
+        });
+
+        const focusedRight = { ...workspace, activePaneId: "pane-right" };
+        expect(
+            resolveWorkspaceSurfaceActiveFileState(focusedRight, context)
+                .relativePath,
+        ).toBe(rightFile.relativePath);
+
+        if (focusedRight.rootNode.type !== "split") {
+            throw new Error("Expected a split workspace.");
+        }
+        const chatFocused: WorkspaceTreeState = {
+            ...focusedRight,
+            rootNode: {
+                ...focusedRight.rootNode,
+                children: [
+                    focusedRight.rootNode.children[0],
+                    {
+                        activeTabId: chat.id,
+                        id: "pane-right",
+                        tabIds: [rightFile.id, chat.id],
+                        type: "pane",
+                    },
+                ],
+            },
+        };
+        expect(
+            resolveWorkspaceSurfaceActiveFileState(chatFocused, context)
+                .relativePath,
+        ).toBeNull();
+    });
+
+    it("ignores a file from another project and updates host state by context", () => {
+        const foreignFile = createFileTab(
+            "foreign-file",
+            "src/foreign.ts",
+            "project-2",
+        );
+        const workspace: WorkspaceTreeState = {
+            activePaneId: "pane-root",
+            rootNode: {
+                activeTabId: foreignFile.id,
+                id: "pane-root",
+                tabIds: [foreignFile.id],
+                type: "pane",
+            },
+            tabsById: { [foreignFile.id]: foreignFile },
+        };
+        const cleared = resolveWorkspaceSurfaceActiveFileState(workspace, context);
+
+        expect(cleared.relativePath).toBeNull();
+        const current = { [context.key]: "src/old.ts" };
+        const updated = updateWorkspaceActiveFilePaths(current, cleared);
+        expect(updated).toEqual({ [context.key]: null });
+        expect(updateWorkspaceActiveFilePaths(updated, cleared)).toBe(updated);
+    });
+});
+
+function createSplitWorkspace(
+    leftFile: RuntimeWorkspaceFileTab,
+    rightFile: RuntimeWorkspaceFileTab,
+    chat: RuntimeWorkspaceTab,
+): WorkspaceTreeState {
+    return {
+        activePaneId: "pane-left",
+        rootNode: {
+            axis: "horizontal",
+            children: [
+                {
+                    activeTabId: leftFile.id,
+                    id: "pane-left",
+                    tabIds: [leftFile.id],
+                    type: "pane",
+                },
+                {
+                    activeTabId: rightFile.id,
+                    id: "pane-right",
+                    tabIds: [rightFile.id, chat.id],
+                    type: "pane",
+                },
+            ],
+            id: "split-root",
+            sizes: [0.5, 0.5],
+            type: "split",
+        },
+        tabsById: {
+            [chat.id]: chat,
+            [leftFile.id]: leftFile,
+            [rightFile.id]: rightFile,
+        },
+    };
+}
+
+function createChatTab(id: string): RuntimeWorkspaceTab {
+    return {
+        createdAt: "2026-08-03T00:00:00.000Z",
+        draft: "",
+        id,
+        kind: "chat",
+        projectId: "project-1",
+        runtimeId: "codex",
+        sessionId: `session-${id}`,
+        title: "Chat",
+        worktreeId: null,
+    };
+}
+
+function createFileTab(
+    id: string,
+    relativePath: string,
+    projectId = "project-1",
+): RuntimeWorkspaceFileTab {
+    return {
+        createdAt: "2026-08-03T00:00:00.000Z",
+        document: null,
+        draftContent: "",
+        hasExternalChange: false,
+        id,
+        isDirty: false,
+        isLoading: false,
+        isSaving: false,
+        kind: "file",
+        loadError: null,
+        projectId,
+        relativePath,
+        reviewContext: null,
+        saveError: null,
+        savedContent: "",
+        title: relativePath,
+        worktreeId: null,
+    };
+}

--- a/src/renderer/src/app/workspace/surface-active-file.ts
+++ b/src/renderer/src/app/workspace/surface-active-file.ts
@@ -1,0 +1,56 @@
+import type { WorkspaceSurfaceActiveFileState } from "@shared/ipc";
+
+import { resolveActiveFileTreePath } from "../projects/file-tree-selection";
+import {
+    findPaneById,
+    type WorkspaceTreeState,
+} from "./tree";
+
+interface WorkspaceSurfaceContext {
+    readonly key: string;
+    readonly projectId: string;
+    readonly worktreeId: string | null;
+}
+
+export type WorkspaceActiveFilePaths = Readonly<
+    Record<string, string | null>
+>;
+
+export function updateWorkspaceActiveFilePaths(
+    current: WorkspaceActiveFilePaths,
+    state: WorkspaceSurfaceActiveFileState,
+): WorkspaceActiveFilePaths {
+    if (current[state.contextKey] === state.relativePath) {
+        return current;
+    }
+
+    return {
+        ...current,
+        [state.contextKey]: state.relativePath,
+    };
+}
+
+export function resolveWorkspaceSurfaceActiveFileState(
+    workspace: WorkspaceTreeState,
+    context: WorkspaceSurfaceContext,
+): WorkspaceSurfaceActiveFileState {
+    const activePane = findPaneById(
+        workspace.rootNode,
+        workspace.activePaneId,
+    );
+    const activeWorkspaceTab = activePane?.activeTabId
+        ? (workspace.tabsById[activePane.activeTabId] ?? null)
+        : null;
+
+    return {
+        contextKey: context.key,
+        projectId: context.projectId,
+        // Publish null for non-file tabs so the host clears only the active highlight.
+        relativePath: resolveActiveFileTreePath({
+            activeProjectId: context.projectId,
+            activeWorkspaceTab,
+            activeWorktreeId: context.worktreeId,
+        }),
+        worktreeId: context.worktreeId,
+    };
+}

--- a/src/renderer/src/components/git/GitTreeView.tsx
+++ b/src/renderer/src/components/git/GitTreeView.tsx
@@ -418,10 +418,11 @@ export function GitTreeView({
     onNodeClick,
     onNodeDrop,
     onNodeDragStart,
-    onScrollToActivePathConsumed,
+    onScrollToPathConsumed,
     onToggleDirectory,
     renderNodeMeta,
-    scrollToActivePathSignal,
+    scrollToPath = null,
+    scrollToPathSignal,
     selectedPaths,
     showStatusIndicator = true,
     stickyFolderPaths,
@@ -787,42 +788,45 @@ export function GitTreeView({
     }, [flatRows.length, refreshVirtualizationTarget]);
 
     useEffect(() => {
-        if (scrollToActivePathSignal === undefined || !activePath) {
+        const targetPath = scrollToPath ?? activePath;
+        if (scrollToPathSignal === undefined || !targetPath) {
             return;
         }
 
         const frameId = window.requestAnimationFrame(() => {
-            const activeIndex = flatRows.findIndex(
-                (row) => row.node.path === activePath,
+            const targetIndex = flatRows.findIndex(
+                (row) => row.node.path === targetPath,
             );
 
-            if (activeIndex >= 0 && shouldVirtualize) {
-                virtualListRef.current?.scrollToIndex(activeIndex, {
+            if (targetIndex >= 0 && shouldVirtualize) {
+                virtualListRef.current?.scrollToIndex(targetIndex, {
                     align: "center",
                     offset: treeScrollOffsetRef.current,
                 });
             }
 
-            const activeRow =
-                containerRef.current?.querySelector<HTMLElement>(
-                    '[data-active="true"]',
-                ) ?? null;
-            activeRow?.scrollIntoView({
+            const targetRow =
+                targetIndex >= 0
+                    ? document.getElementById(`${treeId}-row-${targetIndex}`)
+                    : null;
+            targetRow?.scrollIntoView({
                 block: "nearest",
                 inline: "nearest",
             });
-            onScrollToActivePathConsumed?.();
+            onScrollToPathConsumed?.();
         });
 
         return () => {
             window.cancelAnimationFrame(frameId);
         };
     }, [
-        activePath,
         flatRows,
-        onScrollToActivePathConsumed,
-        scrollToActivePathSignal,
+        onScrollToPathConsumed,
+        scrollToPath,
+        scrollToPathSignal,
         shouldVirtualize,
+        treeId,
+        activePath,
     ]);
 
     if (nodes.length === 0) {

--- a/src/renderer/src/components/git/types.ts
+++ b/src/renderer/src/components/git/types.ts
@@ -193,10 +193,11 @@ export interface GitTreeViewProps {
     readonly onEditingCancel?: () => void;
     readonly onEditingDraftNameChange?: (value: string) => void;
     readonly onEditingSubmit?: () => void;
-    readonly onScrollToActivePathConsumed?: () => void;
+    readonly onScrollToPathConsumed?: () => void;
     readonly onToggleDirectory?: (node: GitTreeNode) => void;
     readonly renderNodeMeta?: (node: GitTreeNode) => ReactNode;
-    readonly scrollToActivePathSignal?: number;
+    readonly scrollToPath?: string | null;
+    readonly scrollToPathSignal?: number;
     readonly showStatusIndicator?: boolean;
     readonly stickyFolderPaths?: ReadonlySet<string>;
     readonly suppressKeyboardCursor?: boolean;

--- a/src/renderer/src/components/workspace-inspector/FileExplorerPanel.tsx
+++ b/src/renderer/src/components/workspace-inspector/FileExplorerPanel.tsx
@@ -43,11 +43,12 @@ interface FileExplorerPanelProps {
     >;
     readonly onNodeDrop: NonNullable<GitTreeViewProps["onNodeDrop"]>;
     readonly onScroll: UIEventHandler<HTMLDivElement>;
-    readonly onScrollToActivePathConsumed: () => void;
+    readonly onScrollToPathConsumed: () => void;
     readonly onToggleDirectory: NonNullable<
         GitTreeViewProps["onToggleDirectory"]
     >;
     readonly project: ProjectSummary | null;
+    readonly revealPath: string | null;
     readonly revealSignal: number | null;
     readonly scrollRef: RefCallback<HTMLDivElement>;
     readonly selectedPaths: ReadonlySet<string>;
@@ -76,9 +77,10 @@ export function FileExplorerPanel({
     onNodeDragStart,
     onNodeDrop,
     onScroll,
-    onScrollToActivePathConsumed,
+    onScrollToPathConsumed,
     onToggleDirectory,
     project,
+    revealPath,
     revealSignal,
     scrollRef,
     selectedPaths,
@@ -143,13 +145,12 @@ export function FileExplorerPanel({
                         onNodeContextMenu={onNodeContextMenu}
                         onNodeDragStart={onNodeDragStart}
                         onNodeDrop={onNodeDrop}
-                        onScrollToActivePathConsumed={
-                            onScrollToActivePathConsumed
-                        }
+                        onScrollToPathConsumed={onScrollToPathConsumed}
                         onToggleDirectory={
                             isFiltering ? undefined : onToggleDirectory
                         }
-                        scrollToActivePathSignal={revealSignal ?? undefined}
+                        scrollToPath={revealPath}
+                        scrollToPathSignal={revealSignal ?? undefined}
                         selectedPaths={selectedPaths}
                         showStatusIndicator={false}
                         stickyFolderPaths={stickyFolderPaths}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -166,6 +166,8 @@ export const IPC_CHANNELS = {
         "workspace:notify-surface-restore-failed",
     reportWorkspaceSurfaceLeases: "workspace:report-surface-leases",
     resyncWorkspaceSurfaceRuntime: "workspace:resync-surface-runtime",
+    publishWorkspaceSurfaceActiveFile:
+        "workspace:publish-surface-active-file",
     revealWorkspaceSurfaceFileInHostTree:
         "workspace:reveal-surface-file-in-host-tree",
     notifyWorkspaceSurfaceFocused: "workspace:notify-surface-focused",
@@ -254,6 +256,8 @@ export const IPC_EVENTS = {
     workspaceSurfaceDrag: "workspace:surface-drag",
     workspaceSurfaceActionRequested: "workspace:surface-action-requested",
     workspaceSurfaceActionStatus: "workspace:surface-action-status",
+    workspaceSurfaceActiveFileChanged:
+        "workspace:surface-active-file-changed",
     workspaceSurfaceFileRevealRequested:
         "workspace:surface-file-reveal-requested",
     workspaceSurfaceGitScopeMenuRequested:
@@ -2659,6 +2663,12 @@ export interface WorkspaceSurfaceFileRevealRequest
     readonly relativePath: string;
 }
 
+/** The active file published by a surface; null clears the host highlight. */
+export interface WorkspaceSurfaceActiveFileState
+    extends WorkspaceSurfaceActionContext {
+    readonly relativePath: string | null;
+}
+
 export interface WorkspaceSurfaceGitHubComposerItem {
     readonly number: number;
     readonly title: string;
@@ -4229,6 +4239,9 @@ export interface ComandoApi {
     resyncWorkspaceSurfaceRuntime: (
         binding: WorkspaceSurfaceRuntimeBinding,
     ) => Promise<WorkspaceSurfaceRuntimeResync>;
+    publishWorkspaceSurfaceActiveFile: (
+        state: WorkspaceSurfaceActiveFileState,
+    ) => Promise<WorkspaceSurfaceActionDeliveryResult>;
     revealWorkspaceSurfaceFileInHostTree: (
         request: WorkspaceSurfaceFileRevealRequest,
     ) => Promise<WorkspaceSurfaceActionDeliveryResult>;
@@ -4414,6 +4427,9 @@ export interface ComandoApi {
     ) => () => void;
     onWorkspaceSurfaceActionStatus: (
         listener: (status: WorkspaceSurfaceActionStatus) => void,
+    ) => () => void;
+    onWorkspaceSurfaceActiveFileChanged: (
+        listener: (state: WorkspaceSurfaceActiveFileState) => void,
     ) => () => void;
     onWorkspaceSurfaceFileRevealRequested: (
         listener: (request: WorkspaceSurfaceFileRevealRequest) => void,


### PR DESCRIPTION
## Summary

- publish the active file from each visible workspace surface to the host inspector
- keep active-file highlighting independent from manual tree selection and reveal scrolling
- validate and route active-file updates through the existing workspace surface boundary
- clear the highlight when a non-file tab becomes active
- rename the tree scroll API to describe explicit path targets

## Testing

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build:ci`