### PR TITLE
Fix Git History refreshes in workspace surfaces

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -38,7 +38,10 @@ import {
     buildHierarchicalGitTreeNodesFromProjectEntries,
     findProjectTreeNodeByPath,
 } from "./app/projects/git-tree";
-import { createGitProjectRefreshScheduler } from "./app/git/refresh-scheduler";
+import {
+    createGitProjectRefreshScheduler,
+    gitInvalidationAffectsHistory,
+} from "./app/git/refresh-scheduler";
 import { revalidateVisibleGitDiffs } from "./app/git/visible-diff-revalidation";
 import {
     areGitWorktreeIdsEquivalent,
@@ -1212,6 +1215,7 @@ export function WorkspaceHostApp() {
             useGitStore.getState().activeWorktreeIds[projectId] ??
             null;
         const projectRefreshScheduler = createGitProjectRefreshScheduler({
+            refreshHistory: refreshGitHistory,
             refreshProject: async (projectId, worktreeId) => {
                 const snapshot = await refreshGitProject(projectId, worktreeId);
                 if (snapshot) {
@@ -1232,18 +1236,8 @@ export function WorkspaceHostApp() {
                 projectRefreshScheduler.schedule(
                     payload.projectId,
                     preferredWorktreeId,
+                    { refreshHistory: gitInvalidationAffectsHistory(payload.reason) },
                 );
-                if (
-                    payload.reason === "branch" ||
-                    payload.reason === "remote" ||
-                    payload.reason === "worktree" ||
-                    payload.reason === "unknown"
-                ) {
-                    void refreshGitHistory(
-                        payload.projectId,
-                        preferredWorktreeId,
-                    );
-                }
             },
         );
         const unsubscribeSnapshot = comandoApi.onGitRepositorySnapshotUpdated(

--- a/src/renderer/src/WorkspaceSurfaceApp.tsx
+++ b/src/renderer/src/WorkspaceSurfaceApp.tsx
@@ -11,7 +11,10 @@ import type {
 import { useSystemTheme } from "./app/hooks/use-system-theme";
 import { parseWorkspaceSurfaceRendererDescriptor } from "./app/renderer-mode";
 import { setCachedAppEditorSettings } from "./app/settings/client";
-import { createGitProjectRefreshScheduler } from "./app/git/refresh-scheduler";
+import {
+    createGitProjectRefreshScheduler,
+    gitInvalidationAffectsHistoryForScope,
+} from "./app/git/refresh-scheduler";
 import { revalidateVisibleGitDiffs } from "./app/git/visible-diff-revalidation";
 import { useAiStore } from "./app/store/ai-store";
 import { useAppStore } from "./app/store/app-store";
@@ -156,6 +159,7 @@ export function WorkspaceSurfaceApp() {
     const addProjects = useProjectsStore((state) => state.addProjects);
     const gitHydrate = useGitStore((state) => state.hydrate);
     const ingestGitSnapshot = useGitStore((state) => state.ingestSnapshot);
+    const refreshGitHistory = useGitStore((state) => state.refreshHistory);
     const refreshGitProject = useGitStore((state) => state.refreshProject);
     const hydrateSurfaceLayout = useWorkspaceStore(
         (state) => state.hydrateSurfaceLayout,
@@ -535,6 +539,7 @@ export function WorkspaceSurfaceApp() {
                 workspace: useWorkspaceStore.getState(),
             });
         const projectRefreshScheduler = createGitProjectRefreshScheduler({
+            refreshHistory: refreshGitHistory,
             refreshProject: async (projectId, worktreeId) => {
                 const snapshot = await refreshGitProject(projectId, worktreeId);
                 if (snapshot) {
@@ -565,6 +570,13 @@ export function WorkspaceSurfaceApp() {
                 projectRefreshScheduler.schedule(
                     payload.projectId,
                     payload.worktreeId ?? activeWorktreeId,
+                    {
+                        // One surface represents one scope, so avoid redundant history loads.
+                        refreshHistory: gitInvalidationAffectsHistoryForScope(
+                            payload,
+                            activeWorktreeId,
+                        ),
+                    },
                 );
             },
         );
@@ -600,6 +612,7 @@ export function WorkspaceSurfaceApp() {
         activeWorktreeId,
         hydrateProjects,
         ingestGitSnapshot,
+        refreshGitHistory,
         refreshGitProject,
         refreshProjectTabs,
         surfaceLifecycle,

--- a/src/renderer/src/app/git/refresh-scheduler.test.ts
+++ b/src/renderer/src/app/git/refresh-scheduler.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createGitProjectRefreshScheduler } from "./refresh-scheduler";
+import {
+    createGitProjectRefreshScheduler,
+    gitInvalidationAffectsHistory,
+    gitInvalidationAffectsHistoryForScope,
+} from "./refresh-scheduler";
 
 describe("createGitProjectRefreshScheduler", () => {
     afterEach(() => {
@@ -80,5 +84,63 @@ describe("createGitProjectRefreshScheduler", () => {
         await Promise.resolve();
 
         expect(refreshProject).toHaveBeenCalledTimes(2);
+    });
+
+    it("coalesces history refreshes with the project refresh", async () => {
+        vi.useFakeTimers();
+        const refreshHistory = vi.fn().mockResolvedValue(undefined);
+        const refreshProject = vi.fn().mockResolvedValue(undefined);
+        const scheduler = createGitProjectRefreshScheduler({
+            refreshHistory,
+            refreshProject,
+        });
+
+        scheduler.schedule("project-1", "worktree-1", {
+            refreshHistory: true,
+        });
+        scheduler.schedule("project-1", "worktree-1");
+        vi.runAllTimers();
+        await Promise.resolve();
+
+        expect(refreshProject).toHaveBeenCalledTimes(1);
+        expect(refreshHistory).toHaveBeenCalledTimes(1);
+        expect(refreshHistory).toHaveBeenCalledWith("project-1", "worktree-1");
+    });
+
+    it("does not invalidate history for status-only changes", () => {
+        expect(gitInvalidationAffectsHistory("status")).toBe(false);
+        expect(gitInvalidationAffectsHistory("branch")).toBe(true);
+        expect(gitInvalidationAffectsHistory("remote")).toBe(true);
+        expect(gitInvalidationAffectsHistory("worktree")).toBe(true);
+        expect(gitInvalidationAffectsHistory("unknown")).toBe(true);
+    });
+
+    it("refreshes History only in the invalidated workspace scope", () => {
+        const invalidation = {
+            occurredAt: "2026-08-03T12:00:00.000Z",
+            projectId: "project-1",
+            reason: "branch" as const,
+            rootPath: "/tmp/project-worktree",
+            worktreeId: "project-1:worktree:feature",
+        };
+
+        expect(
+            gitInvalidationAffectsHistoryForScope(
+                invalidation,
+                "project-1:worktree:feature",
+            ),
+        ).toBe(true);
+        expect(
+            gitInvalidationAffectsHistoryForScope(
+                invalidation,
+                "project-1:primary",
+            ),
+        ).toBe(false);
+        expect(
+            gitInvalidationAffectsHistoryForScope(
+                { ...invalidation, worktreeId: null },
+                "project-1:primary",
+            ),
+        ).toBe(true);
     });
 });

--- a/src/renderer/src/app/git/refresh-scheduler.ts
+++ b/src/renderer/src/app/git/refresh-scheduler.ts
@@ -1,9 +1,17 @@
+import type { GitRepositoryInvalidation } from "@shared/ipc";
+
+import { areGitWorktreeIdsEquivalent } from "./context-key";
+
 export const GIT_INVALIDATION_REFRESH_DEBOUNCE_MS = 50;
 
 type TimeoutHandle = ReturnType<typeof setTimeout>;
 
 type GitProjectRefreshSchedulerOptions = {
     readonly delayMs?: number;
+    readonly refreshHistory?: (
+        projectId: string,
+        worktreeId: string | null,
+    ) => Promise<unknown>;
     readonly refreshProject: (
         projectId: string,
         worktreeId: string | null,
@@ -15,11 +23,46 @@ type GitProjectRefreshSchedulerOptions = {
 export type GitProjectRefreshScheduler = {
     readonly cancel: (projectId: string, worktreeId: string | null) => void;
     readonly clear: () => void;
-    readonly schedule: (projectId: string, worktreeId: string | null) => void;
+    readonly schedule: (
+        projectId: string,
+        worktreeId: string | null,
+        options?: GitProjectRefreshOptions,
+    ) => void;
 };
+
+export type GitProjectRefreshOptions = {
+    readonly refreshHistory?: boolean;
+};
+
+export function gitInvalidationAffectsHistory(
+    reason: GitRepositoryInvalidation["reason"],
+): boolean {
+    return (
+        reason === "branch" ||
+        reason === "remote" ||
+        reason === "worktree" ||
+        reason === "unknown"
+    );
+}
+
+export function gitInvalidationAffectsHistoryForScope(
+    invalidation: GitRepositoryInvalidation,
+    activeWorktreeId: string | null,
+): boolean {
+    return (
+        gitInvalidationAffectsHistory(invalidation.reason) &&
+        (invalidation.worktreeId === null ||
+            areGitWorktreeIdsEquivalent(
+                invalidation.projectId,
+                invalidation.worktreeId,
+                activeWorktreeId,
+            ))
+    );
+}
 
 export function createGitProjectRefreshScheduler({
     delayMs = GIT_INVALIDATION_REFRESH_DEBOUNCE_MS,
+    refreshHistory,
     refreshProject,
     setTimeoutFn = setTimeout,
     clearTimeoutFn = clearTimeout,
@@ -27,6 +70,7 @@ export function createGitProjectRefreshScheduler({
     const pendingRefreshes = new Map<string, TimeoutHandle>();
     const activeRefreshes = new Map<string, Promise<void>>();
     const refreshAgain = new Set<string>();
+    const historyRefreshes = new Set<string>();
 
     const run = (projectId: string, worktreeId: string | null): void => {
         const contextKey = getGitSchedulerContextKey(projectId, worktreeId);
@@ -36,13 +80,21 @@ export function createGitProjectRefreshScheduler({
             return;
         }
 
-        const refresh = refreshProject(projectId, worktreeId).finally(() => {
+        const projectRefresh = refreshProject(projectId, worktreeId);
+        const refresh =
+            historyRefreshes.delete(contextKey) && refreshHistory
+                ? Promise.all([
+                      projectRefresh,
+                      refreshHistory(projectId, worktreeId),
+                  ]).then(() => undefined)
+                : projectRefresh;
+        const trackedRefresh = refresh.finally(() => {
             activeRefreshes.delete(contextKey);
             if (refreshAgain.delete(contextKey)) {
                 run(projectId, worktreeId);
             }
         });
-        activeRefreshes.set(contextKey, refresh);
+        activeRefreshes.set(contextKey, trackedRefresh);
     };
 
     const cancel = (projectId: string, worktreeId: string | null): void => {
@@ -53,6 +105,15 @@ export function createGitProjectRefreshScheduler({
             pendingRefreshes.delete(contextKey);
         }
         refreshAgain.delete(contextKey);
+        historyRefreshes.delete(contextKey);
+    };
+
+    const clearPendingTimeout = (contextKey: string): void => {
+        const timeout = pendingRefreshes.get(contextKey);
+        if (timeout !== undefined) {
+            clearTimeoutFn(timeout);
+            pendingRefreshes.delete(contextKey);
+        }
     };
 
     return {
@@ -63,10 +124,15 @@ export function createGitProjectRefreshScheduler({
             }
             pendingRefreshes.clear();
             refreshAgain.clear();
+            historyRefreshes.clear();
         },
-        schedule: (projectId, worktreeId) => {
+        schedule: (projectId, worktreeId, options = {}) => {
             const contextKey = getGitSchedulerContextKey(projectId, worktreeId);
-            cancel(projectId, worktreeId);
+            // Preserve a history request when a later status event extends the debounce.
+            clearPendingTimeout(contextKey);
+            if (options.refreshHistory) {
+                historyRefreshes.add(contextKey);
+            }
             const timeout = setTimeoutFn(() => {
                 pendingRefreshes.delete(contextKey);
                 run(projectId, worktreeId);


### PR DESCRIPTION
## Summary
- refresh Git History for branch, remote, worktree, and unknown invalidations in workspace surfaces
- coalesce History refreshes with the existing per-worktree Git refresh scheduler
- avoid redundant History reloads for status-only or unrelated worktree events

## Validation
- pnpm exec vitest run src/renderer/src/app/git/refresh-scheduler.test.ts
- pnpm exec tsc --noEmit -p tsconfig.web.json
- pnpm exec eslint src/renderer/src/app/git/refresh-scheduler.ts src/renderer/src/app/git/refresh-scheduler.test.ts src/renderer/src/WorkspaceSurfaceApp.tsx