### PR TITLE
Move the Git context picker to the window chrome

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -158,7 +158,6 @@ import {
 import { DesktopWindowChrome } from "./components/DesktopWindowChrome";
 import { GitContextTrigger } from "./components/git/GitContextTrigger";
 import { WorkspaceSwitcher } from "./components/WorkspaceSwitcher";
-import { SidebarGitScopePicker } from "./components/sidebar/SidebarGitScopePicker";
 import { WorkspaceNavigatorPanel } from "./components/workspace-navigator/WorkspaceNavigatorPanel";
 import {
     FileExplorerPanel,
@@ -4087,26 +4086,11 @@ export function WorkspaceHostApp() {
                 : sidebarView === "pull_requests"
                   ? pullRequestsFilter
                   : agentsFilter;
-    const inspectorOverlayBounds = useMemo(
-        () => ({
-            left: shellViewportWidth - rightEffectiveWidth,
-            width: rightEffectiveWidth,
-        }),
-        [rightEffectiveWidth, shellViewportWidth],
-    );
     const workspaceInspectorContent = (
         <WorkspaceInspector
             activeView={sidebarView}
             error={projectsError}
             filter={sidebarSearchValue}
-            gitScopePicker={
-                <SidebarGitScopePicker
-                    onOpenWorkspace={openWorkspaceFromInspector}
-                    overlayBounds={inspectorOverlayBounds}
-                    projectId={activeProjectId}
-                    worktreeId={activeWorktreeId}
-                />
-            }
             hasCommittedWorkspace={Boolean(
                 workspaceActiveContextKey && activeProjectId,
             )}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -156,6 +156,7 @@ import {
     closeWorkspaceTabsWithConfirmation,
 } from "./components/workspace/workspaceCloseGuard";
 import { DesktopWindowChrome } from "./components/DesktopWindowChrome";
+import { GitContextTrigger } from "./components/git/GitContextTrigger";
 import { WorkspaceSwitcher } from "./components/WorkspaceSwitcher";
 import { SidebarGitScopePicker } from "./components/sidebar/SidebarGitScopePicker";
 import { WorkspaceNavigatorPanel } from "./components/workspace-navigator/WorkspaceNavigatorPanel";
@@ -4337,6 +4338,14 @@ export function WorkspaceHostApp() {
     );
     const desktopWindowChrome = (
         <DesktopWindowChrome
+            gitContextControl={
+                <GitContextTrigger
+                    onOpenWorkspace={openWorkspaceFromInspector}
+                    projectId={activeProjectId}
+                    titlebarContextKey={workspaceActiveContextKey}
+                    worktreeId={activeWorktreeId}
+                />
+            }
             inspectorControlsId={
                 shellResponsive.right.overlay
                     ? "workspace-inspector-drawer"

--- a/src/renderer/src/components/DesktopWindowChrome.test.tsx
+++ b/src/renderer/src/components/DesktopWindowChrome.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { DesktopWindowChrome } from "./DesktopWindowChrome";
 
 describe("DesktopWindowChrome", () => {
-    it("keeps the center empty and exposes only the two shell controls", () => {
+    it("keeps a draggable center region for optional context controls", () => {
         const markup = renderToStaticMarkup(
             <DesktopWindowChrome
                 inspectorControlsId="workspace-inspector"
@@ -27,5 +27,25 @@ describe("DesktopWindowChrome", () => {
         expect(markup).toContain('aria-expanded="false"');
         expect(markup).not.toContain('role="tablist"');
         expect(markup).not.toContain("breadcrumb");
+    });
+
+    it("renders a context control inside the reserved chrome region", () => {
+        const markup = renderToStaticMarkup(
+            <DesktopWindowChrome
+                gitContextControl={<button type="button">Git context</button>}
+                inspectorControlsId="workspace-inspector"
+                inspectorExpanded={false}
+                navigatorControlsId="workspace-navigator"
+                navigatorExpanded
+                onToggleInspector={vi.fn()}
+                onToggleNavigator={vi.fn()}
+                platform="darwin"
+            />,
+        );
+
+        expect(markup).toContain("Git context");
+        expect(markup).toContain(
+            'class="desktop-window-chrome__reserved" data-window-chrome-reserved="true"',
+        );
     });
 });

--- a/src/renderer/src/components/DesktopWindowChrome.tsx
+++ b/src/renderer/src/components/DesktopWindowChrome.tsx
@@ -1,6 +1,7 @@
-import type { RefObject } from "react";
+import type { ReactNode, RefObject } from "react";
 
 interface DesktopWindowChromeProps {
+    readonly gitContextControl?: ReactNode;
     readonly inspectorControlsId: string;
     readonly inspectorExpanded: boolean;
     readonly navigatorControlsId: string;
@@ -13,6 +14,7 @@ interface DesktopWindowChromeProps {
 }
 
 export function DesktopWindowChrome({
+    gitContextControl,
     inspectorControlsId,
     inspectorExpanded,
     navigatorControlsId,
@@ -44,12 +46,14 @@ export function DesktopWindowChrome({
                 toggleRef={navigatorToggleRef}
                 side="left"
             />
-            {/* This draggable region is deliberately empty and reserved for future shell UI. */}
+            {/* The wrapper remains draggable; interactive context controls opt out locally. */}
             <div
-                aria-hidden="true"
+                aria-hidden={gitContextControl ? undefined : true}
                 className="desktop-window-chrome__reserved"
                 data-window-chrome-reserved="true"
-            />
+            >
+                {gitContextControl}
+            </div>
             <ChromePanelToggle
                 controlsId={inspectorControlsId}
                 expanded={inspectorExpanded}

--- a/src/renderer/src/components/git/GitContextTrigger.tsx
+++ b/src/renderer/src/components/git/GitContextTrigger.tsx
@@ -1,0 +1,37 @@
+import { SidebarGitScopePicker } from "@renderer/components/sidebar/SidebarGitScopePicker";
+
+interface GitContextTriggerProps {
+    readonly onOpenWorkspace: (
+        projectId: string,
+        worktreeId: string | null,
+        options?: { readonly emptyLayout?: boolean },
+    ) => Promise<void>;
+    readonly projectId: string | null;
+    readonly titlebarContextKey: string | null;
+    readonly worktreeId: string | null;
+}
+
+/**
+ * Uses the existing Git scope behavior while keeping the title bar's anchor
+ * small enough to leave a predictable draggable window region.
+ */
+export function GitContextTrigger({
+    onOpenWorkspace,
+    projectId,
+    titlebarContextKey,
+    worktreeId,
+}: GitContextTriggerProps) {
+    if (!projectId) {
+        return null;
+    }
+
+    return (
+        <SidebarGitScopePicker
+            onOpenWorkspace={onOpenWorkspace}
+            projectId={projectId}
+            titlebarContextKey={titlebarContextKey ?? undefined}
+            triggerVariant="titlebar"
+            worktreeId={worktreeId}
+        />
+    );
+}

--- a/src/renderer/src/components/git/GitContextTrigger.tsx
+++ b/src/renderer/src/components/git/GitContextTrigger.tsx
@@ -27,6 +27,11 @@ export function GitContextTrigger({
 
     return (
         <SidebarGitScopePicker
+            onTitlebarMenuRequest={(anchor) => {
+                // The workspace is a separate WebContentsView above the host
+                // renderer, so its surface must own the visible popover.
+                void window.comando.openWorkspaceSurfaceGitScopeMenu(anchor);
+            }}
             onOpenWorkspace={onOpenWorkspace}
             projectId={projectId}
             titlebarContextKey={titlebarContextKey ?? undefined}

--- a/src/renderer/src/components/git/GitScopePickerContent.test.tsx
+++ b/src/renderer/src/components/git/GitScopePickerContent.test.tsx
@@ -1,0 +1,72 @@
+/** @vitest-environment jsdom */
+import { act, createRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GitScopePickerContent } from "./GitScopePickerContent";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+    act(() => root?.unmount());
+    container?.remove();
+    root = null;
+    container = null;
+});
+
+describe("GitScopePickerContent", () => {
+    it("renders through a portal and delegates Escape to its host", () => {
+        const onRequestClose = vi.fn();
+        const onKeyDown = vi.fn();
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        root = createRoot(container);
+
+        act(() => {
+            root?.render(
+                <GitScopePickerContent
+                    actionError="Could not switch branches."
+                    animationState="open"
+                    isBusy={false}
+                    isMounted
+                    isOpen
+                    menuPosition={{
+                        height: 320,
+                        placement: "below",
+                        width: 300,
+                        x: 24,
+                        y: 40,
+                    }}
+                    menuRef={createRef<HTMLDivElement>()}
+                    onAnimationEnd={() => undefined}
+                    onKeyDown={onKeyDown}
+                    onRequestClose={onRequestClose}
+                    onResizeStart={() => undefined}
+                >
+                    <button type="button">Checkout</button>
+                </GitScopePickerContent>,
+            );
+        });
+
+        const menu = document.body.querySelector<HTMLElement>(
+            ".sidebar-git-scope-menu",
+        );
+        expect(menu?.parentElement).toBe(document.body);
+        expect(menu?.textContent).toContain("Checkout");
+        expect(menu?.textContent).toContain("Could not switch branches.");
+        expect(menu?.dataset.placement).toBe("below");
+
+        act(() => {
+            menu?.dispatchEvent(
+                new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }),
+            );
+        });
+
+        expect(onRequestClose).toHaveBeenCalledOnce();
+        expect(onKeyDown).not.toHaveBeenCalled();
+    });
+});

--- a/src/renderer/src/components/git/GitScopePickerContent.tsx
+++ b/src/renderer/src/components/git/GitScopePickerContent.tsx
@@ -58,6 +58,7 @@ export function GitScopePickerContent({
             data-animation-state={animationState}
             data-placement={menuPosition?.placement ?? "below"}
             inert={!isOpen}
+            aria-label="Git branches and worktrees"
             onAnimationEnd={onAnimationEnd}
             onKeyDown={(event) => {
                 if (event.key === "Escape") {
@@ -68,6 +69,7 @@ export function GitScopePickerContent({
                 onKeyDown(event);
             }}
             ref={menuRef}
+            role="dialog"
             style={{
                 height: menuPosition?.height,
                 left: menuPosition?.x ?? 8,

--- a/src/renderer/src/components/git/GitScopePickerContent.tsx
+++ b/src/renderer/src/components/git/GitScopePickerContent.tsx
@@ -1,0 +1,101 @@
+import type {
+    AnimationEvent,
+    KeyboardEvent,
+    PointerEvent,
+    ReactNode,
+    RefObject,
+} from "react";
+import { createPortal } from "react-dom";
+
+export interface GitScopePickerMenuPosition {
+    readonly height: number;
+    readonly placement: "above" | "below";
+    readonly width: number;
+    readonly x: number;
+    readonly y: number;
+}
+
+interface GitScopePickerContentProps {
+    readonly actionError: string | null;
+    readonly animationState: "closing" | "open" | "opening";
+    readonly children: ReactNode;
+    readonly isBusy: boolean;
+    readonly isMounted: boolean;
+    readonly isOpen: boolean;
+    readonly menuPosition: GitScopePickerMenuPosition | null;
+    readonly menuRef: RefObject<HTMLDivElement | null>;
+    readonly onAnimationEnd: (event: AnimationEvent<HTMLDivElement>) => void;
+    readonly onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
+    readonly onRequestClose: () => void;
+    readonly onResizeStart: (event: PointerEvent<HTMLDivElement>) => void;
+}
+
+/**
+ * Keeps the Git scope surface independent from the trigger that opens it so
+ * the same menu can be anchored in the sidebar or the window chrome.
+ */
+export function GitScopePickerContent({
+    actionError,
+    animationState,
+    children,
+    isBusy,
+    isMounted,
+    isOpen,
+    menuPosition,
+    menuRef,
+    onAnimationEnd,
+    onKeyDown,
+    onRequestClose,
+    onResizeStart,
+}: GitScopePickerContentProps) {
+    if (!isMounted) {
+        return null;
+    }
+
+    return createPortal(
+        <div
+            className="sidebar-git-scope-menu"
+            data-animation-state={animationState}
+            data-placement={menuPosition?.placement ?? "below"}
+            inert={!isOpen}
+            onAnimationEnd={onAnimationEnd}
+            onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                    event.preventDefault();
+                    onRequestClose();
+                    return;
+                }
+                onKeyDown(event);
+            }}
+            ref={menuRef}
+            style={{
+                height: menuPosition?.height,
+                left: menuPosition?.x ?? 8,
+                top: menuPosition?.y ?? 8,
+                width: menuPosition?.width ?? 280,
+            }}
+        >
+            {children}
+
+            {actionError ? (
+                <div className="sidebar-git-scope-menu__status sidebar-git-scope-menu__status--error">
+                    {actionError}
+                </div>
+            ) : null}
+
+            {isBusy ? (
+                <div className="sidebar-git-scope-menu__status">
+                    Updating git scope…
+                </div>
+            ) : null}
+
+            <div
+                aria-hidden="true"
+                className="sidebar-git-scope-menu__resize-handle"
+                onPointerDown={onResizeStart}
+                title="Resize"
+            />
+        </div>,
+        document.body,
+    );
+}

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -937,10 +937,15 @@ export function SidebarGitScopePicker({
         }
 
         lastExternalMenuRequestIdRef.current = externalMenuRequest.id;
-        setIsOpen(true);
+        if (isOpen) {
+            requestMenuClose();
+            return;
+        }
+
         setActionError(null);
         setQuery("");
-    }, [externalMenuRequest]);
+        setIsOpen(true);
+    }, [externalMenuRequest, isOpen, requestMenuClose]);
 
     const finishMenuAnimation = useCallback(() => {
         if (menuAnimationState === "opening" && isOpen) {

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -2333,8 +2333,10 @@ export function SidebarGitScopePicker({
             ref={containerRef}
         >
             <button
-                aria-selected={
-                    triggerVariant === "titlebar" ? true : undefined
+                aria-expanded={isOpen}
+                aria-haspopup={triggerVariant === "titlebar" ? "dialog" : undefined}
+                aria-current={
+                    triggerVariant === "titlebar" ? "page" : undefined
                 }
                 className={[
                     "sidebar-git-scope-trigger",
@@ -2370,8 +2372,6 @@ export function SidebarGitScopePicker({
                 }}
                 onKeyDown={onTitlebarKeyDown}
                 ref={buttonRef}
-                role={triggerVariant === "titlebar" ? "tab" : undefined}
-                tabIndex={triggerVariant === "titlebar" ? 0 : undefined}
                 style={
                     triggerHidden
                         ? {

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -12,7 +12,6 @@ import {
     type MouseEvent as ReactMouseEvent,
     type PointerEvent as ReactPointerEvent,
 } from "react";
-import { createPortal } from "react-dom";
 
 import type {
     GitBranchSummary,
@@ -42,6 +41,7 @@ import {
     MeasuredVirtualList,
     type MeasuredVirtualListHandle,
 } from "@renderer/components/virtual/MeasuredVirtualList";
+import { GitScopePickerContent } from "@renderer/components/git/GitScopePickerContent";
 
 import { SidebarNodeRow, type SidebarBadge } from "./SidebarNodeRow";
 import {
@@ -2313,6 +2313,13 @@ export function SidebarGitScopePicker({
         ],
     );
 
+    const handleContentRequestClose = useCallback(() => {
+        setIsOpen(false);
+        setQuery("");
+        setActionError(null);
+        setFocusIndex(-1);
+    }, []);
+
     return (
         <div
             className={[
@@ -2411,25 +2418,19 @@ export function SidebarGitScopePicker({
                 <ChevronIcon open={isOpen} />
             </button>
 
-            {isMenuMounted
-                ? createPortal(
-                      <div
-                          className="sidebar-git-scope-menu"
-                          data-animation-state={menuAnimationState}
-                          data-placement={
-                              menuPosition?.placement ?? "below"
-                          }
-                          inert={!isOpen}
-                          onAnimationEnd={handleMenuAnimationEnd}
-                          onKeyDown={handleListKeyDown}
-                          ref={menuRef}
-                          style={{
-                              height: menuPosition?.height,
-                              left: menuPosition?.x ?? 8,
-                              top: menuPosition?.y ?? 8,
-                              width: menuPosition?.width ?? 280,
-                          }}
-                      >
+            <GitScopePickerContent
+                actionError={actionError}
+                animationState={menuAnimationState}
+                isBusy={isBusy}
+                isMounted={isMenuMounted}
+                isOpen={isOpen}
+                menuPosition={menuPosition}
+                menuRef={menuRef}
+                onAnimationEnd={handleMenuAnimationEnd}
+                onKeyDown={handleListKeyDown}
+                onRequestClose={handleContentRequestClose}
+                onResizeStart={handleMenuResizeStart}
+            >
                           <div className="sidebar-git-scope-menu__header">
                               <div className="sidebar-git-scope-menu__title">
                                   <span className="truncate">
@@ -2586,28 +2587,7 @@ export function SidebarGitScopePicker({
                               )}
                           </div>
 
-                          {actionError ? (
-                              <div className="sidebar-git-scope-menu__status sidebar-git-scope-menu__status--error">
-                                  {actionError}
-                              </div>
-                          ) : null}
-
-                          {isBusy ? (
-                              <div className="sidebar-git-scope-menu__status">
-                                  Updating git scope…
-                              </div>
-                          ) : null}
-
-                          <div
-                              aria-hidden="true"
-                              className="sidebar-git-scope-menu__resize-handle"
-                              onPointerDown={handleMenuResizeStart}
-                              title="Resize"
-                          />
-                      </div>,
-                      document.body,
-                  )
-                : null}
+            </GitScopePickerContent>
 
             {itemContextMenu && !overlayBounds ? (
                 <ContextMenu

--- a/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGitScopePicker.tsx
@@ -357,6 +357,15 @@ export function SidebarGitScopePicker({
     const pendingMenuSizeRef = useRef<GitScopeMenuSize | null>(null);
     const menuResizeEndRef = useRef<(() => void) | null>(null);
     const lastExternalMenuRequestIdRef = useRef(0);
+    const restoreTriggerFocusRef = useRef(false);
+
+    const requestMenuClose = useCallback(() => {
+        restoreTriggerFocusRef.current = true;
+        setIsOpen(false);
+        setQuery("");
+        setActionError(null);
+        setFocusIndex(-1);
+    }, []);
 
     const project = useProjectsStore((state) =>
         projectId
@@ -1121,17 +1130,12 @@ export function SidebarGitScopePicker({
             ) {
                 return;
             }
-            setIsOpen(false);
-            setQuery("");
-            setActionError(null);
+            requestMenuClose();
         };
 
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === "Escape") {
-                setIsOpen(false);
-                setQuery("");
-                setActionError(null);
-                setFocusIndex(-1);
+                requestMenuClose();
             }
         };
 
@@ -1141,6 +1145,15 @@ export function SidebarGitScopePicker({
             document.removeEventListener("mousedown", handlePointerDown);
             window.removeEventListener("keydown", handleKeyDown);
         };
+    }, [isOpen, requestMenuClose]);
+
+    useEffect(() => {
+        if (isOpen || !restoreTriggerFocusRef.current) {
+            return;
+        }
+
+        restoreTriggerFocusRef.current = false;
+        buttonRef.current?.focus();
     }, [isOpen]);
 
     useEffect(() => {
@@ -1213,9 +1226,7 @@ export function SidebarGitScopePicker({
                     normalizedWorktreeId,
                 )
             ) {
-                setIsOpen(false);
-                setQuery("");
-                setActionError(null);
+                requestMenuClose();
                 return;
             }
 
@@ -1226,8 +1237,7 @@ export function SidebarGitScopePicker({
                 await (onOpenWorkspace
                     ? onOpenWorkspace(projectId, normalizedWorktreeId)
                     : requestWorkspaceNavigation(projectId, normalizedWorktreeId));
-                setIsOpen(false);
-                setQuery("");
+                requestMenuClose();
             } catch (error) {
                 setActionError(
                     error instanceof Error
@@ -1243,6 +1253,7 @@ export function SidebarGitScopePicker({
             onOpenWorkspace,
             projectId,
             snapshot?.worktrees,
+            requestMenuClose,
             requestWorkspaceNavigation,
             worktreeId,
         ],
@@ -1295,9 +1306,7 @@ export function SidebarGitScopePicker({
             }
 
             if (targetBranch.name === snapshot?.branch?.name) {
-                setIsOpen(false);
-                setQuery("");
-                setActionError(null);
+                requestMenuClose();
                 return;
             }
 
@@ -1324,8 +1333,7 @@ export function SidebarGitScopePicker({
                     snapshot?.currentWorktreeId ??
                     null;
                 await refreshProjectTree(projectId, nextWorktreeId);
-                setIsOpen(false);
-                setQuery("");
+                requestMenuClose();
             } catch (error) {
                 setActionError(
                     error instanceof Error
@@ -1343,6 +1351,7 @@ export function SidebarGitScopePicker({
             isBusy,
             projectId,
             refreshProjectTree,
+            requestMenuClose,
             snapshot,
             worktreeId,
         ],
@@ -1386,8 +1395,7 @@ export function SidebarGitScopePicker({
                           emptyLayout: true,
                       }));
 
-                setIsOpen(false);
-                setQuery("");
+                requestMenuClose();
             } catch (error) {
                 setActionError(
                     error instanceof Error
@@ -1403,6 +1411,7 @@ export function SidebarGitScopePicker({
             createWorktree,
             isBusy,
             onOpenWorkspace,
+            requestMenuClose,
             requestWorkspaceNavigation,
             project,
             projectId,
@@ -1497,8 +1506,7 @@ export function SidebarGitScopePicker({
                     projectId,
                     result.currentWorktreeId ?? activeWorktreeId,
                 );
-                setIsOpen(false);
-                setQuery("");
+                requestMenuClose();
                 setBranchCreationDraft(null);
                 setBranchCreationName("");
                 setBranchCreationBaseName("");
@@ -1525,6 +1533,7 @@ export function SidebarGitScopePicker({
             isBusy,
             projectId,
             refreshProjectTree,
+            requestMenuClose,
             snapshot?.currentWorktreeId,
             worktreeId,
         ],
@@ -1703,8 +1712,7 @@ export function SidebarGitScopePicker({
                         nextSnapshot.currentWorktreeId ?? null,
                     ),
                 ]);
-                setIsOpen(false);
-                setQuery("");
+                requestMenuClose();
             } catch (error) {
                 setActionError(
                     error instanceof Error
@@ -1721,6 +1729,7 @@ export function SidebarGitScopePicker({
             refreshGitHistory,
             refreshGitProject,
             refreshProjectTree,
+            requestMenuClose,
             removeWorktreeTabs,
             removeWorktree,
             snapshot?.currentWorktreeId,
@@ -1742,8 +1751,7 @@ export function SidebarGitScopePicker({
                 projectId,
                 nextSnapshot.currentWorktreeId ?? worktreeId ?? null,
             );
-            setIsOpen(false);
-            setQuery("");
+            requestMenuClose();
         } catch (error) {
             setActionError(
                 error instanceof Error
@@ -1759,6 +1767,7 @@ export function SidebarGitScopePicker({
         isBusy,
         projectId,
         refreshProjectTree,
+        requestMenuClose,
         worktreeId,
     ]);
 
@@ -2313,13 +2322,6 @@ export function SidebarGitScopePicker({
         ],
     );
 
-    const handleContentRequestClose = useCallback(() => {
-        setIsOpen(false);
-        setQuery("");
-        setActionError(null);
-        setFocusIndex(-1);
-    }, []);
-
     return (
         <div
             className={[
@@ -2428,7 +2430,7 @@ export function SidebarGitScopePicker({
                 menuRef={menuRef}
                 onAnimationEnd={handleMenuAnimationEnd}
                 onKeyDown={handleListKeyDown}
-                onRequestClose={handleContentRequestClose}
+                onRequestClose={requestMenuClose}
                 onResizeStart={handleMenuResizeStart}
             >
                           <div className="sidebar-git-scope-menu__header">

--- a/src/renderer/src/components/workspace-inspector/WorkspaceInspector.test.tsx
+++ b/src/renderer/src/components/workspace-inspector/WorkspaceInspector.test.tsx
@@ -107,12 +107,11 @@ describe("WorkspaceInspector", () => {
         expect(container?.textContent).not.toContain("Files panel");
     });
 
-    it("renders the Git scope control only in the committed Git view", () => {
+    it("does not reserve sidebar space for the Git scope control", () => {
         mountInspector({ activeView: "git" });
         expect(
-            container?.querySelector("[data-workspace-inspector-git-scope]")
-                ?.textContent,
-        ).toContain("Scope picker");
+            container?.querySelector("[data-workspace-inspector-git-scope]"),
+        ).toBeNull();
     });
 });
 
@@ -149,7 +148,6 @@ function mountInspector({
                 activeView={activeView}
                 error={error}
                 filter={filter}
-                gitScopePicker={<button>Scope picker</button>}
                 hasCommittedWorkspace={hasCommittedWorkspace}
                 loading={loading}
                 onChangeFilter={onChangeFilter}

--- a/src/renderer/src/components/workspace-inspector/WorkspaceInspector.tsx
+++ b/src/renderer/src/components/workspace-inspector/WorkspaceInspector.tsx
@@ -54,7 +54,6 @@ interface WorkspaceInspectorProps {
     readonly activeView: WorkspaceInspectorView;
     readonly error: string | null;
     readonly filter: string;
-    readonly gitScopePicker?: ReactNode;
     readonly hasCommittedWorkspace: boolean;
     readonly loading: boolean;
     readonly onChangeFilter: (value: string) => void;
@@ -66,7 +65,6 @@ export function WorkspaceInspector({
     activeView,
     error,
     filter,
-    gitScopePicker,
     hasCommittedWorkspace,
     loading,
     onChangeFilter,
@@ -171,12 +169,6 @@ export function WorkspaceInspector({
                         );
                     })}
                 </div>
-
-                {activeView === "git" && hasCommittedWorkspace ? (
-                    <div className="mt-1" data-workspace-inspector-git-scope>
-                        {gitScopePicker}
-                    </div>
-                ) : null}
 
                 <div className="sidebar-search app-no-drag mt-1">
                     <span aria-hidden="true" className="sidebar-search-icon">

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -415,6 +415,8 @@
 }
 
 .desktop-window-chrome__reserved {
+    display: flex;
+    align-items: stretch;
     min-width: 0;
     height: 100%;
     flex: 1 1 auto;
@@ -2724,7 +2726,8 @@ button {
 .sidebar-git-scope-picker--titlebar {
     display: flex;
     min-width: 0;
-    flex: 1;
+    width: min(360px, 44vw);
+    flex: 0 1 360px;
     align-self: stretch;
 }
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2726,15 +2726,18 @@ button {
 .sidebar-git-scope-picker--titlebar {
     display: flex;
     min-width: 0;
-    width: min(360px, 44vw);
-    flex: 0 1 360px;
+    width: fit-content;
+    max-width: min(360px, 44vw);
+    flex: 0 1 auto;
     align-self: stretch;
 }
 
 .sidebar-git-scope-trigger--titlebar {
     min-width: 0;
+    width: fit-content;
+    max-width: 100%;
     height: 100%;
-    flex: 1;
+    flex: 0 1 auto;
     gap: 2px;
     border: 0;
     border-radius: inherit;
@@ -2758,7 +2761,10 @@ button {
 .sidebar-git-scope-trigger__titlebar-copy {
     display: block;
     min-width: 0;
-    flex: 1;
+    max-width: min(300px, 38vw);
+    flex: 0 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- add a compact Git branch/worktree trigger to the window chrome
- render the picker popover in the active workspace surface so it layers above the WebContentsView
- remove the redundant Git scope picker from the sidebar
- improve popover focus, dismissal, viewport positioning, and long-branch truncation

## Validation
- `pnpm exec tsc --noEmit -p tsconfig.web.json`
- focused ESLint checks
- focused Vitest suites for the Git picker, window chrome, and workspace inspector