### PR TITLE
Fix live agent sidebar synchronization

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -187,6 +187,7 @@ import {
     type WorkspaceScopeActivationRequest,
     type WorkspaceSurfaceDragEvent,
     type WorkspaceSurfaceLeaseReport,
+    type WorkspaceSurfaceAgentPresenceState,
     type WorkspaceSurfaceRuntimeBinding,
     type WorkspaceSurfaceRuntimeResync,
     type WorkspaceSurfaceRegistrySnapshot,
@@ -262,6 +263,7 @@ import { workspaceSurfaceManager } from "@main/workspace/surface-manager";
 import { workspaceRuntimeOwnership } from "@main/workspace/runtime-ownership-coordinator";
 import {
     isWorkspaceSurfaceActiveFileState,
+    isWorkspaceSurfaceAgentPresenceState,
     isWorkspaceSurfaceActionRequest,
     isWorkspaceSurfaceActionCompletion,
     isWorkspaceSurfaceFileRevealRequest,
@@ -2300,6 +2302,18 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
                 throw new Error("A valid workspace surface active file is required.");
             }
             return workspaceSurfaceManager.publishSurfaceActiveFile(
+                event.sender,
+                input,
+            );
+        },
+    );
+    ipcMain.handle(
+        IPC_CHANNELS.publishWorkspaceSurfaceAgentPresence,
+        (event, input: WorkspaceSurfaceAgentPresenceState) => {
+            if (!isWorkspaceSurfaceAgentPresenceState(input)) {
+                throw new Error("A valid workspace surface agent presence is required.");
+            }
+            return workspaceSurfaceManager.publishSurfaceAgentPresence(
                 event.sender,
                 input,
             );

--- a/src/main/workspace/surface-actions.test.ts
+++ b/src/main/workspace/surface-actions.test.ts
@@ -4,11 +4,13 @@ import type {
     PersistedWorkspaceContext,
     WorkspaceSurfaceActionRequest,
     WorkspaceSurfaceActiveFileState,
+    WorkspaceSurfaceAgentPresenceState,
     WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
 import {
     doesWorkspaceSurfaceActionMatchContext,
     isWorkspaceSurfaceActiveFileState,
+    isWorkspaceSurfaceAgentPresenceState,
     isWorkspaceSurfaceFileRevealRequest,
     isWorkspaceSurfaceActionRequest,
 } from "./surface-actions";
@@ -144,6 +146,39 @@ describe("workspace surface actions", () => {
                 projectId: context.projectId,
                 relativePath: request.relativePath,
                 worktreeId: null,
+            }),
+        ).toBe(false);
+    });
+
+    it("accepts compact, scoped agent presence without transcript data", () => {
+        const presence: WorkspaceSurfaceAgentPresenceState = {
+            ...context,
+            activeSessionId: "session-1",
+            sessions: [
+                {
+                    createdAt: "2026-08-04T12:00:00.000Z",
+                    parentSessionId: null,
+                    runtimeId: "codex",
+                    runtimeSessionId: "runtime-1",
+                    sessionId: "session-1",
+                    status: "streaming",
+                    title: "Live session",
+                    updatedAt: "2026-08-04T12:00:01.000Z",
+                },
+            ],
+        };
+
+        expect(isWorkspaceSurfaceAgentPresenceState(presence)).toBe(true);
+        expect(
+            isWorkspaceSurfaceAgentPresenceState({
+                ...presence,
+                sessions: [{ ...presence.sessions[0], title: "" }],
+            }),
+        ).toBe(false);
+        expect(
+            isWorkspaceSurfaceAgentPresenceState({
+                ...presence,
+                sessions: Array.from({ length: 101 }, () => presence.sessions[0]),
             }),
         ).toBe(false);
     });

--- a/src/main/workspace/surface-actions.test.ts
+++ b/src/main/workspace/surface-actions.test.ts
@@ -50,6 +50,13 @@ describe("workspace surface actions", () => {
             { ...context, kind: "chat-history" },
             { ...context, kind: "new-chat", runtimeId: "claude" },
             { ...context, kind: "focus-terminal", terminalId: "terminal-1" },
+            {
+                ...context,
+                kind: "rename-terminal",
+                terminalId: "terminal-1",
+                title: "Claude Code",
+            },
+            { ...context, kind: "close-terminal", terminalId: "terminal-1" },
             { ...context, kind: "new-claude-terminal" },
             {
                 ...context,
@@ -157,6 +164,7 @@ describe("workspace surface actions", () => {
             sessions: [
                 {
                     createdAt: "2026-08-04T12:00:00.000Z",
+                    kind: "ai",
                     parentSessionId: null,
                     runtimeId: "codex",
                     runtimeSessionId: "runtime-1",
@@ -181,6 +189,25 @@ describe("workspace surface actions", () => {
                 sessions: Array.from({ length: 101 }, () => presence.sessions[0]),
             }),
         ).toBe(false);
+        expect(
+            isWorkspaceSurfaceAgentPresenceState({
+                ...presence,
+                sessions: [
+                    {
+                        createdAt: "2026-08-04T12:00:00.000Z",
+                        kind: "terminal",
+                        preview: null,
+                        runtimeId: "claude-code-terminal",
+                        runtimeSessionId: "terminal-session-1",
+                        sessionId: "claude-code-terminal:terminal-1",
+                        status: null,
+                        terminalId: "terminal-1",
+                        title: "Claude Code",
+                        updatedAt: "2026-08-04T12:00:01.000Z",
+                    },
+                ],
+            }),
+        ).toBe(true);
     });
 
     it("accepts active file updates and an explicit clear", () => {

--- a/src/main/workspace/surface-actions.ts
+++ b/src/main/workspace/surface-actions.ts
@@ -48,7 +48,13 @@ export function isWorkspaceSurfaceActionRequest(
         case "new-chat":
             return isKnownAiRuntimeId(input.runtimeId);
         case "focus-terminal":
+        case "close-terminal":
             return isNonEmptyString(input.terminalId, MAX_SHORT_TEXT_LENGTH);
+        case "rename-terminal":
+            return (
+                isNonEmptyString(input.terminalId, MAX_SHORT_TEXT_LENGTH) &&
+                isNonEmptyString(input.title, MAX_SHORT_TEXT_LENGTH)
+            );
         case "github-list":
             return (
                 (input.listKind === "issues" ||
@@ -133,18 +139,7 @@ export function isWorkspaceSurfaceAgentPresenceState(
         return false;
     }
 
-    return input.sessions.every(
-        (session) =>
-            isRecord(session) &&
-            isNonEmptyString(session.sessionId, MAX_SHORT_TEXT_LENGTH) &&
-            isKnownAiRuntimeId(session.runtimeId) &&
-            isNonEmptyString(session.title, MAX_SHORT_TEXT_LENGTH) &&
-            isNonEmptyString(session.createdAt, MAX_SHORT_TEXT_LENGTH) &&
-            isNonEmptyString(session.updatedAt, MAX_SHORT_TEXT_LENGTH) &&
-            isNullableString(session.parentSessionId, MAX_SHORT_TEXT_LENGTH) &&
-            isNullableString(session.runtimeSessionId, MAX_SHORT_TEXT_LENGTH) &&
-            isAiSessionStatusOrNull(session.status),
-    );
+    return input.sessions.every(isWorkspaceSurfaceAgentPresence);
 }
 
 export function isWorkspaceSurfaceActionCompletion(
@@ -198,6 +193,35 @@ function isAiSessionStatusOrNull(input: unknown): boolean {
         input === "waiting_permission" ||
         input === "waiting_user_input" ||
         input === "error"
+    );
+}
+
+function isWorkspaceSurfaceAgentPresence(input: unknown): boolean {
+    if (
+        !isRecord(input) ||
+        !isNonEmptyString(input.sessionId, MAX_SHORT_TEXT_LENGTH) ||
+        !isNonEmptyString(input.title, MAX_SHORT_TEXT_LENGTH) ||
+        !isNonEmptyString(input.createdAt, MAX_SHORT_TEXT_LENGTH) ||
+        !isNonEmptyString(input.updatedAt, MAX_SHORT_TEXT_LENGTH) ||
+        !isNullableString(input.runtimeSessionId, MAX_SHORT_TEXT_LENGTH)
+    ) {
+        return false;
+    }
+
+    if (input.kind === "ai") {
+        return (
+            isKnownAiRuntimeId(input.runtimeId) &&
+            isNullableString(input.parentSessionId, MAX_SHORT_TEXT_LENGTH) &&
+            isAiSessionStatusOrNull(input.status)
+        );
+    }
+
+    return (
+        input.kind === "terminal" &&
+        input.runtimeId === "claude-code-terminal" &&
+        input.status === null &&
+        isNonEmptyString(input.terminalId, MAX_SHORT_TEXT_LENGTH) &&
+        isNullableString(input.preview, MAX_SHORT_TEXT_LENGTH)
     );
 }
 

--- a/src/main/workspace/surface-actions.ts
+++ b/src/main/workspace/surface-actions.ts
@@ -6,6 +6,7 @@ import type {
     WorkspaceSurfaceActionContext,
     WorkspaceSurfaceActionCompletion,
     WorkspaceSurfaceActiveFileState,
+    WorkspaceSurfaceAgentPresenceState,
     WorkspaceSurfaceFileRevealRequest,
 } from "@shared/ipc";
 
@@ -116,6 +117,36 @@ export function isWorkspaceSurfaceActiveFileState(
     );
 }
 
+export function isWorkspaceSurfaceAgentPresenceState(
+    input: unknown,
+): input is WorkspaceSurfaceAgentPresenceState {
+    if (!isRecord(input) || !hasValidContext(input)) {
+        return false;
+    }
+    if (
+        input.activeSessionId !== null &&
+        !isNonEmptyString(input.activeSessionId, MAX_SHORT_TEXT_LENGTH)
+    ) {
+        return false;
+    }
+    if (!Array.isArray(input.sessions) || input.sessions.length > MAX_ACTION_ITEMS) {
+        return false;
+    }
+
+    return input.sessions.every(
+        (session) =>
+            isRecord(session) &&
+            isNonEmptyString(session.sessionId, MAX_SHORT_TEXT_LENGTH) &&
+            isKnownAiRuntimeId(session.runtimeId) &&
+            isNonEmptyString(session.title, MAX_SHORT_TEXT_LENGTH) &&
+            isNonEmptyString(session.createdAt, MAX_SHORT_TEXT_LENGTH) &&
+            isNonEmptyString(session.updatedAt, MAX_SHORT_TEXT_LENGTH) &&
+            isNullableString(session.parentSessionId, MAX_SHORT_TEXT_LENGTH) &&
+            isNullableString(session.runtimeSessionId, MAX_SHORT_TEXT_LENGTH) &&
+            isAiSessionStatusOrNull(session.status),
+    );
+}
+
 export function isWorkspaceSurfaceActionCompletion(
     input: unknown,
 ): input is WorkspaceSurfaceActionCompletion {
@@ -155,6 +186,18 @@ function hasValidContext(input: Record<string, unknown>): boolean {
         isNonEmptyString(input.contextKey, MAX_SHORT_TEXT_LENGTH) &&
         isNonEmptyString(input.projectId, MAX_SHORT_TEXT_LENGTH) &&
         isNullableString(input.worktreeId, MAX_SHORT_TEXT_LENGTH)
+    );
+}
+
+function isAiSessionStatusOrNull(input: unknown): boolean {
+    return (
+        input === null ||
+        input === "idle" ||
+        input === "starting" ||
+        input === "streaming" ||
+        input === "waiting_permission" ||
+        input === "waiting_user_input" ||
+        input === "error"
     );
 }
 

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -22,6 +22,7 @@ import type {
     WorkspaceSurfaceActionRequest,
     WorkspaceSurfaceActionStatus,
     WorkspaceSurfaceActiveFileState,
+    WorkspaceSurfaceAgentPresenceState,
     WorkspaceSurfaceActivationResult,
     WorkspaceSurfaceEnvironmentDiagnostic,
     WorkspaceSurfaceCloseResult,
@@ -649,6 +650,17 @@ export class WorkspaceSurfaceManager {
             webContents,
             state,
             IPC_EVENTS.workspaceSurfaceActiveFileChanged,
+        );
+    }
+
+    publishSurfaceAgentPresence(
+        webContents: WebContents,
+        state: WorkspaceSurfaceAgentPresenceState,
+    ): WorkspaceSurfaceActionDeliveryResult {
+        return this.#forwardActiveSurfaceContextEvent(
+            webContents,
+            state,
+            IPC_EVENTS.workspaceSurfaceAgentPresenceChanged,
         );
     }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -201,6 +201,7 @@ import {
     type WorkspaceSurfaceActionCompletion,
     type WorkspaceSurfaceActionEnvelope,
     type WorkspaceSurfaceActiveFileState,
+    type WorkspaceSurfaceAgentPresenceState,
     type WorkspaceSurfaceFileRevealRequest,
     type WorkspaceSurfaceActionStatus,
     type WorkspaceSurfaceContentInsets,
@@ -1099,6 +1100,22 @@ const comandoApi: ComandoApi = {
             );
         };
     },
+    onWorkspaceSurfaceAgentPresenceChanged: (listener) => {
+        const handleEvent = (
+            _event: Electron.IpcRendererEvent,
+            state: WorkspaceSurfaceAgentPresenceState,
+        ) => listener(state);
+        ipcRenderer.on(
+            IPC_EVENTS.workspaceSurfaceAgentPresenceChanged,
+            handleEvent,
+        );
+        return () => {
+            ipcRenderer.removeListener(
+                IPC_EVENTS.workspaceSurfaceAgentPresenceChanged,
+                handleEvent,
+            );
+        };
+    },
     onWorkspaceSurfaceFileRevealRequested: (listener) => {
         const handleEvent = (
             _event: Electron.IpcRendererEvent,
@@ -1337,6 +1354,11 @@ const comandoApi: ComandoApi = {
     publishWorkspaceSurfaceActiveFile: (state) =>
         ipcRenderer.invoke(
             IPC_CHANNELS.publishWorkspaceSurfaceActiveFile,
+            state,
+        ),
+    publishWorkspaceSurfaceAgentPresence: (state) =>
+        ipcRenderer.invoke(
+            IPC_CHANNELS.publishWorkspaceSurfaceAgentPresence,
             state,
         ),
     revealWorkspaceSurfaceFileInHostTree: (request) =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -24,6 +24,7 @@ import type {
     SettingsWindowCategory,
     SettingsSnapshot,
     WorkspaceSurfaceActionRequest,
+    WorkspaceSurfaceAgentPresenceState,
     WorkspaceSurfaceFileRevealRequest,
     WorkspaceInspectorView,
 } from "@shared/ipc";
@@ -304,6 +305,12 @@ export function WorkspaceHostApp() {
         (workspaceNavigationHydrated ? null : persistedActiveProjectId);
     const [workspaceSurfaceActionError, setWorkspaceSurfaceActionError] =
         useState<string | null>(null);
+    const [agentPresenceByContext, setAgentPresenceByContext] = useState<
+        Readonly<Record<string, WorkspaceSurfaceAgentPresenceState>>
+    >({});
+    const activeAgentPresence = workspaceActiveContextKey
+        ? (agentPresenceByContext[workspaceActiveContextKey] ?? null)
+        : null;
     const workspaceSurfaceActionErrorTimerRef = useRef<number | null>(null);
     const workspaceSurfaceDragBindingRef = useRef<{
         readonly contextKey: string;
@@ -941,6 +948,27 @@ export function WorkspaceHostApp() {
             );
         });
     }, [reportWorkspaceSurfaceActionError]);
+
+    useEffect(() => {
+        if (!isWorkspaceHostRenderer) {
+            return;
+        }
+        const api = getComandoApi();
+        if (!api) {
+            return;
+        }
+        return api.onWorkspaceSurfaceAgentPresenceChanged((presence) => {
+            setAgentPresenceByContext((current) => {
+                if (current[presence.contextKey] === presence) {
+                    return current;
+                }
+                return {
+                    ...current,
+                    [presence.contextKey]: presence,
+                };
+            });
+        });
+    }, []);
 
     useEffect(() => {
         if (!isWorkspaceHostRenderer) {
@@ -4094,6 +4122,7 @@ export function WorkspaceHostApp() {
             panels={{
                 agents: (
                     <SidebarAgentsPanel
+                        agentPresence={activeAgentPresence}
                         filter={agentsFilter}
                         onRequestWorkspaceAction={requestWorkspaceSurfaceAction}
                         projectId={activeProjectId}

--- a/src/renderer/src/WorkspaceSurfaceApp.tsx
+++ b/src/renderer/src/WorkspaceSurfaceApp.tsx
@@ -50,6 +50,12 @@ import { WorkspaceView } from "./components/workspace/WorkspaceView";
 import { findPaneById } from "./app/workspace/tree";
 import { WorkspaceTerminalHost } from "./features/terminal/WorkspaceTerminalHost";
 import { useTerminalRuntimeStore } from "./features/terminal/terminalRuntimeStore";
+import {
+    getClaudeCodeSidebarSessions,
+    reconcileClaudeCodeSidebarSessions,
+    refreshClaudeCodeSidebarSessionTranscript,
+    subscribeClaudeCodeSidebarSessions,
+} from "./features/terminal/claudeCodeSidebarSession";
 import { getAiSessionDisplayTitle } from "@shared/ai-session-title";
 
 const descriptor = parseWorkspaceSurfaceRendererDescriptor(
@@ -174,6 +180,9 @@ export function WorkspaceSurfaceApp() {
     const activePaneId = useWorkspaceStore((state) => state.activePaneId);
     const rootNode = useWorkspaceStore((state) => state.rootNode);
     const tabsById = useWorkspaceStore((state) => state.tabsById);
+    const [terminalAgentSessions, setTerminalAgentSessions] = useState(() =>
+        getClaudeCodeSidebarSessions(),
+    );
     const activeContext = useWorkspaceStore((state) =>
         state.activeContextKey
             ? (state.contextsByKey[state.activeContextKey] ?? null)
@@ -217,11 +226,17 @@ export function WorkspaceSurfaceApp() {
                 return null;
             }
 
+            const terminalSessionsByTerminalId = new Map(
+                terminalAgentSessions.map((session) => [
+                    session.terminalId,
+                    session,
+                ]),
+            );
             const activePane = findPaneById(rootNode, activePaneId);
             const activeTab = activePane?.activeTabId
                 ? tabsById[activePane.activeTabId]
                 : null;
-            const sessions = Object.values(tabsById).flatMap((tab) => {
+            const aiSessionsInTabs = Object.values(tabsById).flatMap((tab) => {
                 if (tab.kind !== "chat" && tab.kind !== "review") {
                     return [];
                 }
@@ -229,6 +244,7 @@ export function WorkspaceSurfaceApp() {
                 return [
                     {
                         createdAt: tab.createdAt,
+                        kind: "ai" as const,
                         parentSessionId: snapshot?.parentSessionId ?? null,
                         runtimeId: snapshot?.runtimeId ?? tab.runtimeId,
                         runtimeSessionId: snapshot?.runtimeSessionId ?? null,
@@ -241,15 +257,31 @@ export function WorkspaceSurfaceApp() {
                     },
                 ];
             });
+            const terminalSessions = terminalAgentSessions.map((session) => ({
+                createdAt: session.createdAt,
+                kind: "terminal" as const,
+                preview: session.preview,
+                runtimeId: session.runtimeId,
+                runtimeSessionId: session.runtimeSessionId ?? null,
+                sessionId: session.sessionId,
+                status: null,
+                terminalId: session.terminalId,
+                title: session.title,
+                updatedAt: session.updatedAt,
+            }));
 
             return {
                 activeSessionId:
                     activeTab?.kind === "chat" || activeTab?.kind === "review"
                         ? activeTab.sessionId
+                        : activeTab?.kind === "terminal"
+                          ? (terminalSessionsByTerminalId.get(
+                                activeTab.terminalId,
+                            )?.sessionId ?? null)
                         : null,
                 contextKey: activeContext.key,
                 projectId: activeProjectId,
-                sessions,
+                sessions: [...aiSessionsInTabs, ...terminalSessions],
                 worktreeId: activeWorktreeId,
             };
         },
@@ -261,6 +293,7 @@ export function WorkspaceSurfaceApp() {
             aiSessions,
             rootNode,
             tabsById,
+            terminalAgentSessions,
         ],
     );
     const publishedAgentPresenceSignatureRef = useRef("");
@@ -569,6 +602,35 @@ export function WorkspaceSurfaceApp() {
             unsubscribeGitMenu();
         };
     }, [surfaceLifecycle]);
+
+    useEffect(() => {
+        return subscribeClaudeCodeSidebarSessions(() => {
+            setTerminalAgentSessions(getClaudeCodeSidebarSessions());
+        });
+    }, []);
+
+    useEffect(() => {
+        reconcileClaudeCodeSidebarSessions(Object.values(tabsById));
+    }, [tabsById]);
+
+    useEffect(() => {
+        if (terminalAgentSessions.length === 0) {
+            return;
+        }
+
+        const refresh = () => {
+            for (const session of getClaudeCodeSidebarSessions()) {
+                void refreshClaudeCodeSidebarSessionTranscript(session).catch(
+                    () => undefined,
+                );
+            }
+        };
+        refresh();
+        const intervalId = window.setInterval(refresh, 4_000);
+        return () => {
+            window.clearInterval(intervalId);
+        };
+    }, [terminalAgentSessions]);
 
     useEffect(() => {
         if (surfaceStatus !== "ready" || !agentPresence) {

--- a/src/renderer/src/WorkspaceSurfaceApp.tsx
+++ b/src/renderer/src/WorkspaceSurfaceApp.tsx
@@ -599,7 +599,10 @@ export function WorkspaceSurfaceApp() {
     }, [tabsById]);
 
     useEffect(() => {
-        if (terminalAgentSessions.length === 0) {
+        if (
+            surfaceLifecycle !== "visible" ||
+            terminalAgentSessions.length === 0
+        ) {
             return;
         }
 
@@ -615,7 +618,7 @@ export function WorkspaceSurfaceApp() {
         return () => {
             window.clearInterval(intervalId);
         };
-    }, [terminalAgentSessions]);
+    }, [surfaceLifecycle, terminalAgentSessions]);
 
     useEffect(() => {
         if (surfaceStatus !== "ready" || !agentPresence) {

--- a/src/renderer/src/WorkspaceSurfaceApp.tsx
+++ b/src/renderer/src/WorkspaceSurfaceApp.tsx
@@ -31,6 +31,7 @@ import {
     resolveCommittedProjectWorktreeId,
 } from "./app/git/context-key";
 import { executeWorkspaceSurfaceAction } from "./app/workspace/surface-actions";
+import { collectWorkspaceSurfaceAiAgentPresence } from "./app/workspace/surface-agent-presence";
 import { resolveWorkspaceSurfaceActiveFileState } from "./app/workspace/surface-active-file";
 import { isWorkspaceSurfaceLifecycleCurrent } from "./app/workspace/surface-presentation-lifecycle";
 import {
@@ -56,7 +57,6 @@ import {
     refreshClaudeCodeSidebarSessionTranscript,
     subscribeClaudeCodeSidebarSessions,
 } from "./features/terminal/claudeCodeSidebarSession";
-import { getAiSessionDisplayTitle } from "@shared/ai-session-title";
 
 const descriptor = parseWorkspaceSurfaceRendererDescriptor(
     window.location.search,
@@ -236,26 +236,11 @@ export function WorkspaceSurfaceApp() {
             const activeTab = activePane?.activeTabId
                 ? tabsById[activePane.activeTabId]
                 : null;
-            const aiSessionsInTabs = Object.values(tabsById).flatMap((tab) => {
-                if (tab.kind !== "chat" && tab.kind !== "review") {
-                    return [];
-                }
-                const snapshot = aiSessions[tab.sessionId]?.snapshot ?? null;
-                return [
-                    {
-                        createdAt: tab.createdAt,
-                        kind: "ai" as const,
-                        parentSessionId: snapshot?.parentSessionId ?? null,
-                        runtimeId: snapshot?.runtimeId ?? tab.runtimeId,
-                        runtimeSessionId: snapshot?.runtimeSessionId ?? null,
-                        sessionId: tab.sessionId,
-                        status: snapshot?.status ?? null,
-                        title: snapshot
-                            ? getAiSessionDisplayTitle(snapshot)
-                            : tab.title,
-                        updatedAt: snapshot?.updatedAt ?? tab.createdAt,
-                    },
-                ];
+            const aiSessionPresence = collectWorkspaceSurfaceAiAgentPresence({
+                aiSessions,
+                projectId: activeProjectId,
+                tabsById,
+                worktreeId: activeWorktreeId,
             });
             const terminalSessions = terminalAgentSessions.map((session) => ({
                 createdAt: session.createdAt,
@@ -281,7 +266,7 @@ export function WorkspaceSurfaceApp() {
                         : null,
                 contextKey: activeContext.key,
                 projectId: activeProjectId,
-                sessions: [...aiSessionsInTabs, ...terminalSessions],
+                sessions: [...aiSessionPresence, ...terminalSessions],
                 worktreeId: activeWorktreeId,
             };
         },

--- a/src/renderer/src/WorkspaceSurfaceApp.tsx
+++ b/src/renderer/src/WorkspaceSurfaceApp.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import type {
+    WorkspaceSurfaceAgentPresenceState,
     WorkspaceSurfaceActionEnvelope,
     WorkspaceSurfaceHardLease,
     WorkspaceSurfaceLifecycleState,
@@ -49,6 +50,7 @@ import { WorkspaceView } from "./components/workspace/WorkspaceView";
 import { findPaneById } from "./app/workspace/tree";
 import { WorkspaceTerminalHost } from "./features/terminal/WorkspaceTerminalHost";
 import { useTerminalRuntimeStore } from "./features/terminal/terminalRuntimeStore";
+import { getAiSessionDisplayTitle } from "@shared/ai-session-title";
 
 const descriptor = parseWorkspaceSurfaceRendererDescriptor(
     window.location.search,
@@ -154,6 +156,7 @@ export function WorkspaceSurfaceApp() {
     const applyAiPromptQueueSnapshot = useAiStore(
         (state) => state.applyPromptQueueSnapshot,
     );
+    const aiSessions = useAiStore((state) => state.sessions);
     const hydrateProjects = useProjectsStore((state) => state.hydrate);
     const projects = useProjectsStore((state) => state.projects);
     const addProjects = useProjectsStore((state) => state.addProjects);
@@ -169,6 +172,8 @@ export function WorkspaceSurfaceApp() {
     );
     const openFileTab = useWorkspaceStore((state) => state.openFileTab);
     const activePaneId = useWorkspaceStore((state) => state.activePaneId);
+    const rootNode = useWorkspaceStore((state) => state.rootNode);
+    const tabsById = useWorkspaceStore((state) => state.tabsById);
     const activeContext = useWorkspaceStore((state) =>
         state.activeContextKey
             ? (state.contextsByKey[state.activeContextKey] ?? null)
@@ -206,6 +211,59 @@ export function WorkspaceSurfaceApp() {
               activeContext?.worktreeId ?? descriptor?.worktreeId ?? null,
           )
         : null;
+    const agentPresence = useMemo<WorkspaceSurfaceAgentPresenceState | null>(
+        () => {
+            if (!activeContext || !activeProjectId) {
+                return null;
+            }
+
+            const activePane = findPaneById(rootNode, activePaneId);
+            const activeTab = activePane?.activeTabId
+                ? tabsById[activePane.activeTabId]
+                : null;
+            const sessions = Object.values(tabsById).flatMap((tab) => {
+                if (tab.kind !== "chat" && tab.kind !== "review") {
+                    return [];
+                }
+                const snapshot = aiSessions[tab.sessionId]?.snapshot ?? null;
+                return [
+                    {
+                        createdAt: tab.createdAt,
+                        parentSessionId: snapshot?.parentSessionId ?? null,
+                        runtimeId: snapshot?.runtimeId ?? tab.runtimeId,
+                        runtimeSessionId: snapshot?.runtimeSessionId ?? null,
+                        sessionId: tab.sessionId,
+                        status: snapshot?.status ?? null,
+                        title: snapshot
+                            ? getAiSessionDisplayTitle(snapshot)
+                            : tab.title,
+                        updatedAt: snapshot?.updatedAt ?? tab.createdAt,
+                    },
+                ];
+            });
+
+            return {
+                activeSessionId:
+                    activeTab?.kind === "chat" || activeTab?.kind === "review"
+                        ? activeTab.sessionId
+                        : null,
+                contextKey: activeContext.key,
+                projectId: activeProjectId,
+                sessions,
+                worktreeId: activeWorktreeId,
+            };
+        },
+        [
+            activeContext,
+            activePaneId,
+            activeProjectId,
+            activeWorktreeId,
+            aiSessions,
+            rootNode,
+            tabsById,
+        ],
+    );
+    const publishedAgentPresenceSignatureRef = useRef("");
     const runtimeBinding = useMemo<WorkspaceSurfaceRuntimeBinding | null>(
         () =>
             descriptor
@@ -511,6 +569,25 @@ export function WorkspaceSurfaceApp() {
             unsubscribeGitMenu();
         };
     }, [surfaceLifecycle]);
+
+    useEffect(() => {
+        if (surfaceStatus !== "ready" || !agentPresence) {
+            return;
+        }
+        const signature = JSON.stringify(agentPresence);
+        if (publishedAgentPresenceSignatureRef.current === signature) {
+            return;
+        }
+        // Keep the host informed without duplicating message or transcript payloads.
+        void window.comando
+            .publishWorkspaceSurfaceAgentPresence(agentPresence)
+            .then((result) => {
+                if (result.delivered) {
+                    publishedAgentPresenceSignatureRef.current = signature;
+                }
+            })
+            .catch(() => undefined);
+    }, [agentPresence, surfaceLifecycle, surfaceStatus]);
 
     useEffect(() => {
         if (surfaceLifecycle !== "visible") {

--- a/src/renderer/src/app/workspace/surface-actions.test.ts
+++ b/src/renderer/src/app/workspace/surface-actions.test.ts
@@ -127,7 +127,7 @@ describe("executeWorkspaceSurfaceAction", () => {
         });
     });
 
-    it("focuses existing terminals and launches Claude locally", async () => {
+    it("focuses, closes, and launches terminals on the owning surface", async () => {
         const harness = createHarness({ terminal: true });
 
         await executeWorkspaceSurfaceAction(
@@ -136,6 +136,10 @@ describe("executeWorkspaceSurfaceAction", () => {
         );
         await executeWorkspaceSurfaceAction(
             { ...context, kind: "new-claude-terminal" },
+            harness.dependencies,
+        );
+        await executeWorkspaceSurfaceAction(
+            { ...context, kind: "close-terminal", terminalId: "terminal-1" },
             harness.dependencies,
         );
 
@@ -147,6 +151,7 @@ describe("executeWorkspaceSurfaceAction", () => {
             projectId: "project-1",
             worktreeId: null,
         });
+        expect(harness.workspace.closeTab).toHaveBeenCalledWith("terminal-tab-1");
     });
 
     it("adds multiple files to the best matching local chat", async () => {
@@ -287,6 +292,7 @@ function createHarness(
 
     const workspace = {
         activePaneId: "pane-1",
+        closeTab: vi.fn(() => Promise.resolve()),
         createChatTab: vi.fn(() => {
             if (!options.createChatOnDemand) return Promise.resolve();
             tabsById["created-chat"] = {

--- a/src/renderer/src/app/workspace/surface-actions.ts
+++ b/src/renderer/src/app/workspace/surface-actions.ts
@@ -17,6 +17,11 @@ import {
     createEmptyComposerParts,
 } from "@renderer/components/workspace/chat/composerParts";
 import { launchClaudeCodeTerminal } from "@renderer/features/terminal/claudeCodeTerminal";
+import {
+    closeClaudeCodeSidebarSession,
+    getClaudeCodeSidebarSessionByTerminalId,
+    renameClaudeCodeSidebarSession,
+} from "@renderer/features/terminal/claudeCodeSidebarSession";
 
 type AiState = ReturnType<typeof useAiStore.getState>;
 type WorkspaceState = ReturnType<typeof useWorkspaceStore.getState>;
@@ -88,6 +93,12 @@ export async function executeWorkspaceSurfaceAction(
         case "focus-terminal":
             await focusTerminal(request.terminalId, workspace);
             return;
+        case "rename-terminal":
+            await renameTerminal(request.terminalId, request.title);
+            return;
+        case "close-terminal":
+            await closeTerminal(request.terminalId, workspace);
+            return;
         case "new-claude-terminal":
             await dependencies.launchClaudeTerminal({
                 projectId: request.projectId,
@@ -147,6 +158,37 @@ async function focusTerminal(
     }
 
     await workspace.selectTab(pane.id, tab.id);
+}
+
+async function renameTerminal(terminalId: string, title: string): Promise<void> {
+    const session = getClaudeCodeSidebarSessionByTerminalId(terminalId);
+    if (!session) {
+        throw new Error("The requested terminal is no longer open.");
+    }
+
+    // The surface owns the terminal registry, including manual-title precedence.
+    await renameClaudeCodeSidebarSession(session, title);
+}
+
+async function closeTerminal(
+    terminalId: string,
+    workspace: WorkspaceState,
+): Promise<void> {
+    const session = getClaudeCodeSidebarSessionByTerminalId(terminalId);
+    if (session) {
+        await closeClaudeCodeSidebarSession(session);
+        return;
+    }
+
+    const tab = Object.values(workspace.tabsById).find(
+        (candidate) =>
+            candidate.kind === "terminal" &&
+            candidate.terminalId === terminalId,
+    );
+    if (!tab) {
+        throw new Error("The requested terminal is no longer open.");
+    }
+    await workspace.closeTab(tab.id);
 }
 
 async function addFilesToChat(

--- a/src/renderer/src/app/workspace/surface-agent-presence.test.ts
+++ b/src/renderer/src/app/workspace/surface-agent-presence.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import type { AiSessionSnapshot } from "@shared/ipc";
+import type { RuntimeWorkspaceChatTab } from "@renderer/app/workspace/tree";
+
+import {
+    collectWorkspaceSurfaceAiAgentPresence,
+} from "./surface-agent-presence";
+
+function createSnapshot(
+    overrides: Partial<AiSessionSnapshot> = {},
+): AiSessionSnapshot {
+    return {
+        availableCommands: [],
+        configOptions: [],
+        lastError: null,
+        messages: [],
+        modeId: null,
+        modes: [],
+        modelId: null,
+        models: [],
+        pendingPermission: null,
+        pendingUserInput: null,
+        plan: null,
+        projectId: "project-1",
+        runtimeId: "codex",
+        runtimeSessionId: "runtime-session-1",
+        sessionId: "session-1",
+        status: "idle",
+        title: "Session",
+        tokenUsage: null,
+        toolActivity: [],
+        trackedFiles: [],
+        updatedAt: "2026-08-04T12:00:00.000Z",
+        worktreeId: "worktree-1",
+        ...overrides,
+    };
+}
+
+describe("collectWorkspaceSurfaceAiAgentPresence", () => {
+    it("keeps active sessions visible after their tabs close", () => {
+        const result = collectWorkspaceSurfaceAiAgentPresence({
+            aiSessions: {
+                "closed-idle": {
+                    isDispatching: false,
+                    snapshot: createSnapshot({
+                        sessionId: "closed-idle",
+                        status: "idle",
+                    }),
+                },
+                "closed-streaming": {
+                    isDispatching: false,
+                    snapshot: createSnapshot({
+                        sessionId: "closed-streaming",
+                        status: "streaming",
+                        title: "Background task",
+                    }),
+                },
+                "other-project": {
+                    isDispatching: false,
+                    snapshot: createSnapshot({
+                        projectId: "project-2",
+                        sessionId: "other-project",
+                        status: "streaming",
+                    }),
+                },
+            },
+            projectId: "project-1",
+            tabsById: {},
+            worktreeId: "worktree-1",
+        });
+
+        expect(result).toEqual([
+            expect.objectContaining({
+                sessionId: "closed-streaming",
+                status: "streaming",
+                title: "Background task",
+            }),
+        ]);
+    });
+
+    it("keeps idle sessions visible while their chat tabs remain open", () => {
+        const chatTab: RuntimeWorkspaceChatTab = {
+            createdAt: "2026-08-04T11:00:00.000Z",
+            draft: "",
+            id: "chat-tab-1",
+            kind: "chat",
+            projectId: "project-1",
+            runtimeId: "codex",
+            sessionId: "open-idle",
+            title: "Open idle session",
+            worktreeId: "worktree-1",
+        };
+        const result = collectWorkspaceSurfaceAiAgentPresence({
+            aiSessions: {
+                "open-idle": {
+                    isDispatching: false,
+                    snapshot: createSnapshot({
+                        sessionId: "open-idle",
+                        title: "Live idle session",
+                    }),
+                },
+            },
+            projectId: "project-1",
+            tabsById: { [chatTab.id]: chatTab },
+            worktreeId: "worktree-1",
+        });
+
+        expect(result).toEqual([
+            expect.objectContaining({
+                sessionId: "open-idle",
+                status: "idle",
+                title: "Live idle session",
+            }),
+        ]);
+    });
+});

--- a/src/renderer/src/app/workspace/surface-agent-presence.ts
+++ b/src/renderer/src/app/workspace/surface-agent-presence.ts
@@ -1,0 +1,107 @@
+import type {
+    AiSessionSnapshot,
+    WorkspaceSurfaceAiAgentPresence,
+} from "@shared/ipc";
+import { getAiSessionDisplayTitle } from "@shared/ai-session-title";
+
+import { areGitWorktreeIdsEquivalent } from "@renderer/app/git/context-key";
+import type { RuntimeWorkspaceTab } from "@renderer/app/workspace/tree";
+
+export interface WorkspaceSurfaceAiSessionState {
+    readonly isDispatching: boolean;
+    readonly snapshot: AiSessionSnapshot | null;
+}
+
+export function collectWorkspaceSurfaceAiAgentPresence({
+    aiSessions,
+    projectId,
+    tabsById,
+    worktreeId,
+}: {
+    readonly aiSessions: Readonly<
+        Record<string, WorkspaceSurfaceAiSessionState>
+    >;
+    readonly projectId: string;
+    readonly tabsById: Readonly<Record<string, RuntimeWorkspaceTab>>;
+    readonly worktreeId: string | null;
+}): readonly WorkspaceSurfaceAiAgentPresence[] {
+    const presenceBySessionId = new Map<
+        string,
+        WorkspaceSurfaceAiAgentPresence
+    >();
+
+    for (const tab of Object.values(tabsById)) {
+        if (tab.kind !== "chat" && tab.kind !== "review") {
+            continue;
+        }
+        const snapshot = aiSessions[tab.sessionId]?.snapshot ?? null;
+        presenceBySessionId.set(tab.sessionId, {
+            createdAt: tab.createdAt,
+            kind: "ai",
+            parentSessionId: snapshot?.parentSessionId ?? null,
+            runtimeId: snapshot?.runtimeId ?? tab.runtimeId,
+            runtimeSessionId: snapshot?.runtimeSessionId ?? null,
+            sessionId: tab.sessionId,
+            status: snapshot?.status ?? null,
+            title: snapshot
+                ? getAiSessionDisplayTitle(snapshot)
+                : tab.title,
+            updatedAt: snapshot?.updatedAt ?? tab.createdAt,
+        });
+    }
+
+    for (const [sessionId, session] of Object.entries(aiSessions)) {
+        const snapshot = session.snapshot;
+        if (
+            !snapshot ||
+            presenceBySessionId.has(sessionId) ||
+            !isWorkspaceSurfaceAiSessionActive(session) ||
+            !isSnapshotInWorkspaceScope(snapshot, projectId, worktreeId)
+        ) {
+            continue;
+        }
+
+        // Closing a tab does not stop its runtime, so keep active work visible.
+        presenceBySessionId.set(sessionId, {
+            createdAt: snapshot.updatedAt,
+            kind: "ai",
+            parentSessionId: snapshot.parentSessionId ?? null,
+            runtimeId: snapshot.runtimeId,
+            runtimeSessionId: snapshot.runtimeSessionId,
+            sessionId,
+            status: snapshot.status,
+            title: getAiSessionDisplayTitle(snapshot),
+            updatedAt: snapshot.updatedAt,
+        });
+    }
+
+    return [...presenceBySessionId.values()];
+}
+
+function isWorkspaceSurfaceAiSessionActive(
+    session: WorkspaceSurfaceAiSessionState,
+): boolean {
+    const status = session.snapshot?.status;
+    return (
+        session.isDispatching ||
+        status === "starting" ||
+        status === "streaming" ||
+        status === "waiting_permission" ||
+        status === "waiting_user_input"
+    );
+}
+
+function isSnapshotInWorkspaceScope(
+    snapshot: AiSessionSnapshot,
+    projectId: string,
+    worktreeId: string | null,
+): boolean {
+    return (
+        snapshot.projectId === projectId &&
+        areGitWorktreeIdsEquivalent(
+            projectId,
+            snapshot.worktreeId ?? null,
+            worktreeId,
+        )
+    );
+}

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
@@ -9,6 +9,7 @@ import type {
     AiSessionSnapshot,
     ComandoApi,
     WorkspaceChatTab,
+    WorkspaceSurfaceAgentPresenceState,
 } from "@shared/ipc";
 import {
     registerClaudeCodeSidebarSession,
@@ -144,6 +145,7 @@ async function mountSidebarAgentsPanel(
         readonly onRequestWorkspaceAction?: Parameters<
             typeof SidebarAgentsPanel
         >[0]["onRequestWorkspaceAction"];
+        readonly agentPresence?: WorkspaceSurfaceAgentPresenceState;
         readonly workspaceContextKey?: string;
     } = {},
 ): Promise<HTMLDivElement> {
@@ -175,6 +177,7 @@ async function mountSidebarAgentsPanel(
     await act(async () => {
         root.render(
             <SidebarAgentsPanel
+                agentPresence={options.agentPresence}
                 onRequestWorkspaceAction={options.onRequestWorkspaceAction}
                 projectId="project-1"
                 workspaceContextKey={options.workspaceContextKey}
@@ -381,6 +384,46 @@ describe("SidebarAgentsPanel history cache", () => {
                 '.sidebar-agents-row[title="Open Session"]',
             ),
         ).not.toBeNull();
+    });
+
+    it("uses live surface presence for titles, open state, and activity", async () => {
+        const container = await mountSidebarAgentsPanel(
+            [
+                createSummary({ title: "Stale title" }),
+                createSummary({
+                    sessionId: "closed-session",
+                    title: "Closed session",
+                }),
+            ],
+            {
+                agentPresence: {
+                    activeSessionId: "session-1",
+                    contextKey: "project-1::worktree-1",
+                    projectId: "project-1",
+                    sessions: [
+                        {
+                            createdAt: "2026-04-19T09:00:00.000Z",
+                            parentSessionId: null,
+                            runtimeId: "codex",
+                            runtimeSessionId: "runtime-session-1",
+                            sessionId: "session-1",
+                            status: "streaming",
+                            title: "Live title",
+                            updatedAt: "2026-04-19T10:05:00.000Z",
+                        },
+                    ],
+                    worktreeId: "worktree-1",
+                },
+            },
+        );
+
+        const row = container.querySelector<HTMLElement>(
+            '.sidebar-agents-row[title="Live title"]',
+        );
+        expect(row).not.toBeNull();
+        expect(row?.dataset.active).toBe("true");
+        expect(row?.textContent).toContain("Working…");
+        expect(container.textContent).toContain("Open");
     });
 
     it("queries the canonical primary worktree supplied by the host", async () => {

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.test.tsx
@@ -8,13 +8,8 @@ import type {
     AiHistorySessionSummary,
     AiSessionSnapshot,
     ComandoApi,
-    WorkspaceChatTab,
     WorkspaceSurfaceAgentPresenceState,
 } from "@shared/ipc";
-import {
-    registerClaudeCodeSidebarSession,
-    resetClaudeCodeSidebarSessionsForTests,
-} from "@renderer/features/terminal/claudeCodeSidebarSession";
 import {
     resetAiStoreRuntimeBuffersForTests,
     useAiStore,
@@ -323,7 +318,6 @@ function dispatchPointerEvent(
 describe("SidebarAgentsPanel history cache", () => {
     beforeEach(() => {
         clearSidebarAgentsHistoryCache();
-        resetClaudeCodeSidebarSessionsForTests();
         resetAiStoreRuntimeBuffersForTests();
         useAiStore.setState((state) => ({
             ...state,
@@ -358,26 +352,28 @@ describe("SidebarAgentsPanel history cache", () => {
         expect(markup).not.toContain("Loading...");
     });
 
-    it("renders an open chat even before it appears in history", async () => {
-        const openTab: WorkspaceChatTab = {
-            createdAt: "2026-04-19T11:00:00.000Z",
-            draft: "",
-            id: "open-tab",
-            kind: "chat",
-            projectId: "project-1",
-            runtimeId: "claude",
-            sessionId: "open-session",
-            title: "Open Session",
-            worktreeId: "worktree-1",
-        };
-        useWorkspaceStore.setState((state) => ({
-            ...state,
-            tabsById: {
-                [openTab.id]: openTab,
+    it("renders an open chat from surface presence before it appears in history", async () => {
+        const container = await mountSidebarAgentsPanel([], {
+            agentPresence: {
+                activeSessionId: "open-session",
+                contextKey: "project-1::worktree-1",
+                projectId: "project-1",
+                sessions: [
+                    {
+                        createdAt: "2026-04-19T11:00:00.000Z",
+                        kind: "ai",
+                        parentSessionId: null,
+                        runtimeId: "claude",
+                        runtimeSessionId: null,
+                        sessionId: "open-session",
+                        status: "idle",
+                        title: "Open Session",
+                        updatedAt: "2026-04-19T11:00:00.000Z",
+                    },
+                ],
+                worktreeId: "worktree-1",
             },
-        }));
-
-        const container = await mountSidebarAgentsPanel([]);
+        });
 
         expect(
             container.querySelector(
@@ -403,6 +399,7 @@ describe("SidebarAgentsPanel history cache", () => {
                     sessions: [
                         {
                             createdAt: "2026-04-19T09:00:00.000Z",
+                            kind: "ai",
                             parentSessionId: null,
                             runtimeId: "codex",
                             runtimeSessionId: "runtime-session-1",
@@ -731,7 +728,7 @@ describe("SidebarAgentsPanel history cache", () => {
         ).not.toBeNull();
     });
 
-    it("renders live Claude Code terminal agents alongside real history", () => {
+    it("renders centralized Claude Code terminal presence alongside real history", () => {
         writeSidebarAgentsHistoryCache(
             "project-1",
             "worktree-1",
@@ -744,18 +741,28 @@ describe("SidebarAgentsPanel history cache", () => {
             ],
             100,
         );
-        registerClaudeCodeSidebarSession({
-            cwd: "/workspace",
-            projectId: "project-1",
-            terminalId: "terminal-1",
-            terminalTabId: "terminal-tab-1",
-            title: "Claude Code 1",
-            transcriptSessionId: null,
-            worktreeId: "worktree-1",
-        });
-
         const markup = renderToStaticMarkup(
             <SidebarAgentsPanel
+                agentPresence={{
+                    activeSessionId: null,
+                    contextKey: "project-1::worktree-1",
+                    projectId: "project-1",
+                    sessions: [
+                        {
+                            createdAt: "2026-04-19T09:00:00.000Z",
+                            kind: "terminal",
+                            preview: null,
+                            runtimeId: "claude-code-terminal",
+                            runtimeSessionId: null,
+                            sessionId: "claude-code-terminal:terminal-1",
+                            status: null,
+                            terminalId: "terminal-1",
+                            title: "Claude Code 1",
+                            updatedAt: "2026-04-19T10:00:00.000Z",
+                        },
+                    ],
+                    worktreeId: "worktree-1",
+                }}
                 projectId="project-1"
                 worktreeId="worktree-1"
             />,
@@ -771,7 +778,6 @@ describe("SidebarAgentsPanel history cache", () => {
 describe("SidebarAgentsPanel folders", () => {
     beforeEach(() => {
         clearSidebarAgentsHistoryCache();
-        resetClaudeCodeSidebarSessionsForTests();
         resetAiStoreRuntimeBuffersForTests();
         useAiStore.setState((state) => ({
             ...state,

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -22,12 +22,9 @@ import type {
 import {
     BUILT_IN_AI_RUNTIME_CATALOG,
 } from "@shared/ai-runtimes";
-import { getAiSessionDisplayTitle } from "@shared/ai-session-title";
 
 import { useAiStore } from "@renderer/app/store/ai-store";
-import { areGitWorktreeIdsEquivalent } from "@renderer/app/git/context-key";
 import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
-import { collectPaneNodes } from "@renderer/app/workspace/tree";
 import {
     checkClaudeCodeInstalled,
     launchClaudeCodeTerminal,
@@ -36,13 +33,8 @@ import {
     CLAUDE_CODE_TERMINAL_RUNTIME_ID,
     closeClaudeCodeSidebarSession,
     focusClaudeCodeSidebarSession,
-    getClaudeCodeSidebarSessionByTerminalId,
-    getClaudeCodeSidebarSessions,
     isClaudeCodeSidebarSession,
-    reconcileClaudeCodeSidebarSessions,
-    refreshClaudeCodeSidebarSessionTranscript,
     renameClaudeCodeSidebarSession,
-    subscribeClaudeCodeSidebarSessions,
     type SidebarAgentSessionSummary,
 } from "@renderer/features/terminal/claudeCodeSidebarSession";
 
@@ -75,10 +67,8 @@ import { releaseScopedToolUiStateStore } from "@renderer/components/workspace/ch
 import { releaseCachedChatTimeline } from "@renderer/components/workspace/chat/chatTimelineCache";
 
 import {
-    applySessionUpdateToSidebarHistory,
     mergeOpenSessionFallbacks,
     SIDEBAR_AGENTS_HISTORY_LIMIT,
-    type SidebarAgentsHistoryUnknownSessionSeed,
 } from "./sidebarAgentsHistory";
 import {
     getSidebarAgentsHistoryCacheKey,
@@ -197,29 +187,8 @@ export function SidebarAgentsPanel({
     const updateSessionTabTitles = useWorkspaceStore(
         (state) => state.updateSessionTabTitles,
     );
-    const tabsById = useWorkspaceStore((state) => state.tabsById);
     const aiSessions = useAiStore((state) => state.sessions);
-    const activePaneSessionId = useWorkspaceStore((state) => {
-        const activePane = collectPaneNodes(state.rootNode).find(
-            (pane) => pane.id === state.activePaneId,
-        );
-        const activeTab = activePane?.activeTabId
-            ? state.tabsById[activePane.activeTabId]
-            : null;
-
-        if (activeTab?.kind === "chat" || activeTab?.kind === "review") {
-            return activeTab.sessionId;
-        }
-        if (activeTab?.kind === "terminal") {
-            return (
-                getClaudeCodeSidebarSessionByTerminalId(activeTab.terminalId)
-                    ?.sessionId ?? null
-            );
-        }
-        return null;
-    });
-    const activeSessionId =
-        agentPresence?.activeSessionId ?? activePaneSessionId;
+    const activeSessionId = agentPresence?.activeSessionId ?? null;
     const historyScopeKey = useMemo(
         () => getSidebarAgentsHistoryCacheKey(projectId, worktreeId),
         [projectId, worktreeId],
@@ -231,9 +200,6 @@ export function SidebarAgentsPanel({
 
     const [sessions, setSessions] = useState<readonly AiHistorySessionSummary[]>(
         () => readSidebarAgentsHistoryCache(projectId, worktreeId)?.sessions ?? [],
-    );
-    const [terminalAgentSessions, setTerminalAgentSessions] = useState(
-        () => getClaudeCodeSidebarSessions(),
     );
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -281,6 +247,7 @@ export function SidebarAgentsPanel({
     );
     const requestIdRef = useRef(0);
     const refreshTimerRef = useRef<number | null>(null);
+    const previousPresenceSessionIdsRef = useRef<ReadonlySet<string>>(new Set());
     const deletedSessionIdsRef = useRef<Set<string>>(new Set());
     const normalizedFilter = (filter ?? "").trim().toLowerCase();
     const hasQuery = normalizedFilter.length > 0;
@@ -311,93 +278,32 @@ export function SidebarAgentsPanel({
         loadedHistoryScopeKey === historyScopeKey
             ? sessions
             : pendingHistoryCache?.sessions ?? EMPTY_AGENTS_SESSIONS;
-    const localOpenSessionFallbacks = useMemo(() => {
-        const fallbacks = new Map<string, AiHistorySessionSummary>();
-        const sourceKinds = new Map<string, "chat" | "review">();
-
-        for (const tab of Object.values(tabsById)) {
-            if (tab.kind !== "chat" && tab.kind !== "review") {
-                continue;
-            }
-            const tabWorktreeId = tab.worktreeId ?? null;
-            const isInScope =
-                tab.projectId === projectId &&
-                (projectId
-                    ? areGitWorktreeIdsEquivalent(
-                          projectId,
-                          tabWorktreeId,
-                          worktreeId ?? null,
-                      )
-                    : tabWorktreeId === (worktreeId ?? null));
-            if (!isInScope) {
-                continue;
-            }
-
-            const existingKind = sourceKinds.get(tab.sessionId);
-            if (
-                existingKind === "chat" ||
-                (existingKind === "review" && tab.kind === "review")
-            ) {
-                continue;
-            }
-
-            const snapshot = aiSessions[tab.sessionId]?.snapshot ?? null;
-            const snapshotTitle = snapshot
-                ? getAiSessionDisplayTitle(snapshot).trim()
-                : "";
-            const title = snapshotTitle || tab.title.trim() || "AI Session";
-            fallbacks.set(tab.sessionId, {
-                createdAt: tab.createdAt,
-                messageCount: snapshot?.messages.length ?? 0,
-                parentSessionId: snapshot?.parentSessionId ?? null,
-                pinnedAt: null,
-                preview: null,
-                projectId: tab.projectId,
-                runtimeId: snapshot?.runtimeId ?? tab.runtimeId,
-                runtimeSessionId: snapshot?.runtimeSessionId ?? null,
-                sessionId: tab.sessionId,
-                title,
-                updatedAt: snapshot?.updatedAt ?? tab.createdAt,
-                worktreeId: tabWorktreeId,
-            });
-            sourceKinds.set(tab.sessionId, tab.kind);
-        }
-
-        return [...fallbacks.values()];
-    }, [aiSessions, projectId, tabsById, worktreeId]);
     const presenceOpenSessionFallbacks = useMemo(() => {
         if (!agentPresence) {
             return [];
         }
-        return agentPresence.sessions.map((session) => ({
-            createdAt: session.createdAt,
-            messageCount: 0,
-            parentSessionId: session.parentSessionId,
-            pinnedAt: null,
-            preview: null,
-            projectId: agentPresence.projectId,
-            runtimeId: session.runtimeId,
-            runtimeSessionId: session.runtimeSessionId,
-            sessionId: session.sessionId,
-            title: session.title,
-            updatedAt: session.updatedAt,
-            worktreeId: agentPresence.worktreeId,
-        }));
-    }, [agentPresence]);
-    const openSessionFallbacks = useMemo(() => {
-        const sessionsById = new Map<string, AiHistorySessionSummary>(
-            presenceOpenSessionFallbacks.map((session) => [
-                session.sessionId,
-                session,
-            ]),
-        );
-        for (const session of localOpenSessionFallbacks) {
-            if (!sessionsById.has(session.sessionId)) {
-                sessionsById.set(session.sessionId, session);
+        return agentPresence.sessions.flatMap((session) => {
+            if (session.kind !== "ai") {
+                return [];
             }
-        }
-        return [...sessionsById.values()];
-    }, [localOpenSessionFallbacks, presenceOpenSessionFallbacks]);
+            return [
+                {
+                    createdAt: session.createdAt,
+                    messageCount: 0,
+                    parentSessionId: session.parentSessionId,
+                    pinnedAt: null,
+                    preview: null,
+                    projectId: agentPresence.projectId,
+                    runtimeId: session.runtimeId,
+                    runtimeSessionId: session.runtimeSessionId,
+                    sessionId: session.sessionId,
+                    title: session.title,
+                    updatedAt: session.updatedAt,
+                    worktreeId: agentPresence.worktreeId,
+                },
+            ];
+        });
+    }, [agentPresence]);
     const agentPresenceStatusBySessionId = useMemo(
         () =>
             new Map<string, AiSessionStatus | null>(
@@ -435,42 +341,45 @@ export function SidebarAgentsPanel({
         () =>
             mergeOpenSessionFallbacks(
                 historySessionsWithLivePresence,
-                openSessionFallbacks.filter(
+                presenceOpenSessionFallbacks.filter(
                     (session) =>
                         !deletedSessionIdsRef.current.has(session.sessionId),
                 ),
             ),
-        [historySessionsWithLivePresence, openSessionFallbacks],
+        [historySessionsWithLivePresence, presenceOpenSessionFallbacks],
     );
-    const scopedTerminalAgentSessions = useMemo(
-        () =>
-            terminalAgentSessions.filter(
-                (session) =>
-                    session.projectId === projectId &&
-                    (projectId
-                        ? areGitWorktreeIdsEquivalent(
-                              projectId,
-                              session.worktreeId ?? null,
-                              worktreeId ?? null,
-                          )
-                        : (session.worktreeId ?? null) ===
-                          (worktreeId ?? null)),
-        ),
-        [projectId, terminalAgentSessions, worktreeId],
-    );
-    const terminalAgentSessionByTerminalId = useMemo(
-        () =>
-            new Map(
-                terminalAgentSessions.map((session) => [
-                    session.terminalId,
-                    session,
-                ]),
-            ),
-        [terminalAgentSessions],
-    );
+    const visibleTerminalAgentSessions = useMemo<
+        readonly SidebarAgentSessionSummary[]
+    >(() => {
+        const presence = agentPresence;
+        if (!presence) {
+            return [];
+        }
+        return presence.sessions.flatMap((session) =>
+            session.kind === "terminal"
+                ? [
+                      {
+                          createdAt: session.createdAt,
+                          isTerminalAgent: true as const,
+                          messageCount: 0,
+                          pinnedAt: null,
+                          preview: session.preview,
+                          projectId: presence.projectId,
+                          runtimeId: session.runtimeId,
+                          runtimeSessionId: session.runtimeSessionId,
+                          sessionId: session.sessionId,
+                          terminalId: session.terminalId,
+                          title: session.title,
+                          updatedAt: session.updatedAt,
+                          worktreeId: presence.worktreeId,
+                      },
+                  ]
+                : [],
+        );
+    }, [agentPresence]);
     const visibleSessions = useMemo<readonly SidebarAgentSessionSummary[]>(
-        () => [...scopedTerminalAgentSessions, ...visibleHistorySessions],
-        [scopedTerminalAgentSessions, visibleHistorySessions],
+        () => [...visibleTerminalAgentSessions, ...visibleHistorySessions],
+        [visibleHistorySessions, visibleTerminalAgentSessions],
     );
     const visibleError =
         loadedHistoryScopeKey === historyScopeKey ? error : null;
@@ -626,97 +535,17 @@ export function SidebarAgentsPanel({
     }, [folderScopeKey, projectId, worktreeId]);
 
     useEffect(() => {
-        return subscribeClaudeCodeSidebarSessions(() => {
-            setTerminalAgentSessions(getClaudeCodeSidebarSessions());
-        });
-    }, []);
-
-    useEffect(() => {
-        reconcileClaudeCodeSidebarSessions(Object.values(tabsById));
-    }, [tabsById]);
-
-    useEffect(() => {
-        const refreshableSessions = terminalAgentSessions.filter(
-            (session) => session.cwd && session.transcriptSessionId,
+        const currentIds = new Set(
+            (agentPresence?.sessions ?? []).map((session) => session.sessionId),
         );
-        if (refreshableSessions.length === 0) {
-            return;
+        const previousIds = previousPresenceSessionIdsRef.current;
+        previousPresenceSessionIdsRef.current = currentIds;
+
+        if ([...previousIds].some((sessionId) => !currentIds.has(sessionId))) {
+            // A closed live session becomes history after the surface stops reporting it.
+            scheduleReload();
         }
-
-        const refresh = () => {
-            for (const session of getClaudeCodeSidebarSessions()) {
-                if (!session.cwd || !session.transcriptSessionId) {
-                    continue;
-                }
-                void refreshClaudeCodeSidebarSessionTranscript(session).catch(
-                    () => undefined,
-                );
-            }
-        };
-        refresh();
-        const intervalId = window.setInterval(refresh, 4_000);
-        return () => {
-            window.clearInterval(intervalId);
-        };
-    }, [terminalAgentSessions]);
-
-    useEffect(() => {
-        const api = getComandoApi();
-        if (!api) {
-            return;
-        }
-
-        const unsubscribe = api.onAiSessionSnapshot((update) => {
-            let needsReload = false;
-
-            setLoadedHistoryScopeKey(historyScopeKey);
-            setSessions((current) => {
-                const currentScopeSessions =
-                    loadedHistoryScopeKey === historyScopeKey
-                        ? current
-                        : readSidebarAgentsHistoryCache(projectId, worktreeId)
-                              ?.sessions ?? EMPTY_AGENTS_SESSIONS;
-                const result = applySessionUpdateToSidebarHistory({
-                    deletedSessionIds: deletedSessionIdsRef.current,
-                    limit: SIDEBAR_AGENTS_HISTORY_LIMIT,
-                    scope: {
-                        projectId,
-                        worktreeId: worktreeId ?? null,
-                    },
-                    sessions: currentScopeSessions,
-                    unknownSessionSeed:
-                        update.kind === "patch"
-                            ? buildUnknownSessionSeed(
-                                  useAiStore.getState().sessions[
-                                      update.patch.sessionId
-                                  ],
-                              )
-                            : null,
-                    update,
-                });
-                needsReload = result.needsReload;
-                writeSidebarAgentsHistoryCache(
-                    projectId,
-                    worktreeId,
-                    result.sessions,
-                );
-                return result.sessions;
-            });
-
-            if (needsReload) {
-                scheduleReload();
-            }
-        });
-        return () => {
-            unsubscribe();
-        };
-    }, [
-        historyScopeKey,
-        loadedHistoryScopeKey,
-        projectId,
-        scheduleReload,
-        worktreeId,
-    ]);
+    }, [agentPresence, scheduleReload]);
 
     const handleOpenSession = useCallback(
         (session: SidebarAgentSessionSummary) => {
@@ -980,7 +809,21 @@ export function SidebarAgentsPanel({
         }
 
         if (isClaudeCodeSidebarSession(session)) {
-            await renameClaudeCodeSidebarSession(session, trimmedTitle);
+            if (onRequestWorkspaceAction) {
+                if (!projectId || !workspaceContextKey) {
+                    return;
+                }
+                onRequestWorkspaceAction({
+                    contextKey: workspaceContextKey,
+                    kind: "rename-terminal",
+                    projectId,
+                    terminalId: session.terminalId,
+                    title: trimmedTitle,
+                    worktreeId,
+                });
+            } else {
+                await renameClaudeCodeSidebarSession(session, trimmedTitle);
+            }
             return;
         }
 
@@ -1020,15 +863,32 @@ export function SidebarAgentsPanel({
     }, [
         renameDraft,
         renamingSessionId,
+        onRequestWorkspaceAction,
+        projectId,
         setSessionsAndCache,
         updateSessionTabTitles,
         visibleSessions,
+        workspaceContextKey,
+        worktreeId,
     ]);
 
     const handleDelete = useCallback(
         async (session: SidebarAgentSessionSummary) => {
             if (isClaudeCodeSidebarSession(session)) {
-                await closeClaudeCodeSidebarSession(session);
+                if (onRequestWorkspaceAction) {
+                    if (!projectId || !workspaceContextKey) {
+                        return;
+                    }
+                    onRequestWorkspaceAction({
+                        contextKey: workspaceContextKey,
+                        kind: "close-terminal",
+                        projectId,
+                        terminalId: session.terminalId,
+                        worktreeId,
+                    });
+                } else {
+                    await closeClaudeCodeSidebarSession(session);
+                }
                 updateFolderState((current) =>
                     removeSidebarAgentSessionFolderAssignment(
                         current,
@@ -1108,9 +968,13 @@ export function SidebarAgentsPanel({
         },
         [
             closeTab,
+            onRequestWorkspaceAction,
+            projectId,
             setSessionsAndCache,
             updateFolderState,
             visibleHistorySessions,
+            workspaceContextKey,
+            worktreeId,
         ],
     );
 
@@ -1392,23 +1256,10 @@ export function SidebarAgentsPanel({
     ]);
 
     const openSessionIds = useMemo(() => {
-        const ids = new Set(
+        return new Set(
             (agentPresence?.sessions ?? []).map((session) => session.sessionId),
         );
-        for (const tab of Object.values(tabsById)) {
-            if (tab.kind === "chat" || tab.kind === "review") {
-                ids.add(tab.sessionId);
-            } else if (tab.kind === "terminal") {
-                const terminalSession = terminalAgentSessionByTerminalId.get(
-                    tab.terminalId,
-                );
-                if (terminalSession) {
-                    ids.add(terminalSession.sessionId);
-                }
-            }
-        }
-        return ids;
-    }, [agentPresence, tabsById, terminalAgentSessionByTerminalId]);
+    }, [agentPresence]);
 
     const workingOrderRef = useRef<Map<string, number>>(new Map());
     const workingCounterRef = useRef(0);
@@ -2788,31 +2639,6 @@ function isSessionWorking(
             : null,
     });
     return indicator?.tone === "working";
-}
-
-function buildUnknownSessionSeed(
-    entry: ReturnType<typeof useAiStore.getState>["sessions"][string] | undefined,
-): SidebarAgentsHistoryUnknownSessionSeed | null {
-    if (!entry) {
-        return null;
-    }
-
-    const title = entry.snapshot
-        ? getAiSessionDisplayTitle(entry.snapshot)
-        : entry.meta?.title ?? "";
-    if (title.trim().length === 0) {
-        return null;
-    }
-
-    return {
-        messages: entry.snapshot?.messages ?? null,
-        parentSessionId: entry.snapshot?.parentSessionId ?? null,
-        pinnedAt: null,
-        projectId: entry.snapshot?.projectId ?? entry.meta?.projectId ?? null,
-        title,
-        updatedAt: entry.snapshot?.updatedAt ?? null,
-        worktreeId: entry.snapshot?.worktreeId ?? entry.meta?.worktreeId ?? null,
-    };
 }
 
 function isSessionPinned(session: SidebarAgentSessionSummary): boolean {

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -14,7 +14,9 @@ import type {
     AiHistorySessionSummary,
     AiRuntimeDescriptor,
     AiRuntimeId,
+    AiSessionStatus,
     ComandoApi,
+    WorkspaceSurfaceAgentPresenceState,
     WorkspaceSurfaceActionRequest,
 } from "@shared/ipc";
 import {
@@ -155,6 +157,7 @@ const CLAUDE_CODE_NOT_FOUND_MESSAGE =
     "The claude command was not found in Comando's PATH. Your shell may still resolve it.";
 
 export function SidebarAgentsPanel({
+    agentPresence,
     filter,
     onRequestWorkspaceAction,
     projectId,
@@ -164,6 +167,7 @@ export function SidebarAgentsPanel({
     workspaceContextKey,
     worktreeId,
 }: {
+    readonly agentPresence?: WorkspaceSurfaceAgentPresenceState | null;
     readonly filter?: string;
     readonly onRequestWorkspaceAction?: (
         request: WorkspaceSurfaceActionRequest,
@@ -214,6 +218,8 @@ export function SidebarAgentsPanel({
         }
         return null;
     });
+    const activeSessionId =
+        agentPresence?.activeSessionId ?? activePaneSessionId;
     const historyScopeKey = useMemo(
         () => getSidebarAgentsHistoryCacheKey(projectId, worktreeId),
         [projectId, worktreeId],
@@ -305,7 +311,7 @@ export function SidebarAgentsPanel({
         loadedHistoryScopeKey === historyScopeKey
             ? sessions
             : pendingHistoryCache?.sessions ?? EMPTY_AGENTS_SESSIONS;
-    const openSessionFallbacks = useMemo(() => {
+    const localOpenSessionFallbacks = useMemo(() => {
         const fallbacks = new Map<string, AiHistorySessionSummary>();
         const sourceKinds = new Map<string, "chat" | "review">();
 
@@ -359,16 +365,82 @@ export function SidebarAgentsPanel({
 
         return [...fallbacks.values()];
     }, [aiSessions, projectId, tabsById, worktreeId]);
+    const presenceOpenSessionFallbacks = useMemo(() => {
+        if (!agentPresence) {
+            return [];
+        }
+        return agentPresence.sessions.map((session) => ({
+            createdAt: session.createdAt,
+            messageCount: 0,
+            parentSessionId: session.parentSessionId,
+            pinnedAt: null,
+            preview: null,
+            projectId: agentPresence.projectId,
+            runtimeId: session.runtimeId,
+            runtimeSessionId: session.runtimeSessionId,
+            sessionId: session.sessionId,
+            title: session.title,
+            updatedAt: session.updatedAt,
+            worktreeId: agentPresence.worktreeId,
+        }));
+    }, [agentPresence]);
+    const openSessionFallbacks = useMemo(() => {
+        const sessionsById = new Map<string, AiHistorySessionSummary>(
+            presenceOpenSessionFallbacks.map((session) => [
+                session.sessionId,
+                session,
+            ]),
+        );
+        for (const session of localOpenSessionFallbacks) {
+            if (!sessionsById.has(session.sessionId)) {
+                sessionsById.set(session.sessionId, session);
+            }
+        }
+        return [...sessionsById.values()];
+    }, [localOpenSessionFallbacks, presenceOpenSessionFallbacks]);
+    const agentPresenceStatusBySessionId = useMemo(
+        () =>
+            new Map<string, AiSessionStatus | null>(
+                (agentPresence?.sessions ?? []).map((session) => [
+                    session.sessionId,
+                    session.status,
+                ]),
+            ),
+        [agentPresence],
+    );
+    const historySessionsWithLivePresence = useMemo(() => {
+        const liveSessionsById = new Map(
+            presenceOpenSessionFallbacks.map((session) => [
+                session.sessionId,
+                session,
+            ]),
+        );
+        return cachedHistorySessions.map((session) => {
+            const liveSession = liveSessionsById.get(session.sessionId);
+            if (!liveSession) {
+                return session;
+            }
+            // The active surface has newer title and hierarchy metadata than history.
+            return {
+                ...session,
+                parentSessionId: liveSession.parentSessionId,
+                runtimeId: liveSession.runtimeId,
+                runtimeSessionId: liveSession.runtimeSessionId,
+                title: liveSession.title,
+                updatedAt: liveSession.updatedAt,
+            };
+        });
+    }, [cachedHistorySessions, presenceOpenSessionFallbacks]);
     const visibleHistorySessions = useMemo(
         () =>
             mergeOpenSessionFallbacks(
-                cachedHistorySessions,
+                historySessionsWithLivePresence,
                 openSessionFallbacks.filter(
                     (session) =>
                         !deletedSessionIdsRef.current.has(session.sessionId),
                 ),
             ),
-        [cachedHistorySessions, openSessionFallbacks],
+        [historySessionsWithLivePresence, openSessionFallbacks],
     );
     const scopedTerminalAgentSessions = useMemo(
         () =>
@@ -1320,7 +1392,9 @@ export function SidebarAgentsPanel({
     ]);
 
     const openSessionIds = useMemo(() => {
-        const ids = new Set<string>();
+        const ids = new Set(
+            (agentPresence?.sessions ?? []).map((session) => session.sessionId),
+        );
         for (const tab of Object.values(tabsById)) {
             if (tab.kind === "chat" || tab.kind === "review") {
                 ids.add(tab.sessionId);
@@ -1334,7 +1408,7 @@ export function SidebarAgentsPanel({
             }
         }
         return ids;
-    }, [tabsById, terminalAgentSessionByTerminalId]);
+    }, [agentPresence, tabsById, terminalAgentSessionByTerminalId]);
 
     const workingOrderRef = useRef<Map<string, number>>(new Map());
     const workingCounterRef = useRef(0);
@@ -1373,8 +1447,12 @@ export function SidebarAgentsPanel({
         const map = workingOrderRef.current;
         let changed = false;
 
-        for (const [sessionId, entry] of Object.entries(aiSessions)) {
-            const working = isSessionWorking(entry);
+        for (const session of visibleSessions) {
+            const sessionId = session.sessionId;
+            const working = isSessionWorking(
+                aiSessions[sessionId],
+                agentPresenceStatusBySessionId.get(sessionId),
+            );
             const tracked = map.has(sessionId);
             if (working && !tracked) {
                 workingCounterRef.current += 1;
@@ -1387,7 +1465,7 @@ export function SidebarAgentsPanel({
         }
 
         for (const trackedId of Array.from(map.keys())) {
-            if (!(trackedId in aiSessions)) {
+            if (!visibleSessions.some((session) => session.sessionId === trackedId)) {
                 map.delete(trackedId);
                 changed = true;
             }
@@ -1396,7 +1474,7 @@ export function SidebarAgentsPanel({
         if (changed) {
             setWorkingOrderRevision((value) => value + 1);
         }
-    }, [aiSessions]);
+    }, [agentPresenceStatusBySessionId, aiSessions, visibleSessions]);
 
     useEffect(() => {
         if (hasQuery || loadedHistoryScopeKey !== historyScopeKey) {
@@ -1708,7 +1786,8 @@ export function SidebarAgentsPanel({
                         onRenameDraftChange={setRenameDraft}
                         onToggleCollapsed={handleToggleCollapsed}
                         onTogglePinned={handleTogglePinned}
-                        activeSessionId={activePaneSessionId}
+                        activeSessionId={activeSessionId}
+                        activityStatusBySessionId={agentPresenceStatusBySessionId}
                         collapsedSessionIds={collapsedSessionIds}
                         collapseEnabled={!hasQuery}
                         renameDraft={renameDraft}
@@ -1731,7 +1810,8 @@ export function SidebarAgentsPanel({
                         onRenameDraftChange={setRenameDraft}
                         onToggleCollapsed={handleToggleCollapsed}
                         onTogglePinned={handleTogglePinned}
-                        activeSessionId={activePaneSessionId}
+                        activeSessionId={activeSessionId}
+                        activityStatusBySessionId={agentPresenceStatusBySessionId}
                         collapsedSessionIds={collapsedSessionIds}
                         collapseEnabled={!hasQuery}
                         renameDraft={renameDraft}
@@ -1761,7 +1841,8 @@ export function SidebarAgentsPanel({
                         onToggleFolder={handleToggleFolder}
                         renderFolderContents={(folder) => (
                             <SidebarAgentsSection
-                                activeSessionId={activePaneSessionId}
+                                activeSessionId={activeSessionId}
+                                activityStatusBySessionId={agentPresenceStatusBySessionId}
                                 cancelRename={cancelRename}
                                 collapsedSessionIds={collapsedSessionIds}
                                 collapseEnabled={!hasQuery}
@@ -1806,7 +1887,8 @@ export function SidebarAgentsPanel({
                             onRenameDraftChange={setRenameDraft}
                             onToggleCollapsed={handleToggleCollapsed}
                             onTogglePinned={handleTogglePinned}
-                            activeSessionId={activePaneSessionId}
+                            activeSessionId={activeSessionId}
+                            activityStatusBySessionId={agentPresenceStatusBySessionId}
                             collapsedSessionIds={collapsedSessionIds}
                             collapseEnabled={!hasQuery}
                             renameDraft={renameDraft}
@@ -1884,6 +1966,7 @@ export function buildSidebarAgentsNewAgentMenuEntries({
 
 function SidebarAgentsSection({
     activeSessionId,
+    activityStatusBySessionId,
     cancelRename,
     collapsedSessionIds,
     collapseEnabled,
@@ -1903,6 +1986,10 @@ function SidebarAgentsSection({
     title,
 }: {
     readonly activeSessionId: string | null;
+    readonly activityStatusBySessionId: ReadonlyMap<
+        string,
+        AiSessionStatus | null
+    >;
     readonly cancelRename: () => void;
     readonly collapsedSessionIds: ReadonlySet<string>;
     readonly collapseEnabled: boolean;
@@ -1971,6 +2058,9 @@ function SidebarAgentsSection({
                             }
                         >
                             <SidebarAgentsItem
+                                activityStatus={activityStatusBySessionId.get(
+                                    row.session.sessionId,
+                                )}
                                 depth={row.depth}
                                 hasChildren={row.hasChildren}
                                 isActive={
@@ -2017,6 +2107,7 @@ function SidebarAgentsSection({
 }
 
 function SidebarAgentsItem({
+    activityStatus,
     depth,
     hasChildren,
     isActive,
@@ -2037,6 +2128,7 @@ function SidebarAgentsItem({
     renameDraft,
     session,
 }: {
+    readonly activityStatus: AiSessionStatus | null | undefined;
     readonly depth: number;
     readonly hasChildren: boolean;
     readonly isActive: boolean;
@@ -2078,7 +2170,10 @@ function SidebarAgentsItem({
     const isPinned = isSessionPinned(session);
     const isTerminalAgent = isClaudeCodeSidebarSession(session);
     const canOpenInPane = !isTerminalAgent;
-    const activityState = useAgentActivityIndicator(session.sessionId);
+    const activityState = useAgentActivityIndicator(
+        session.sessionId,
+        activityStatus,
+    );
     const activity = activityState?.indicator ?? null;
     const indentStyle =
         depth > 0
@@ -2542,13 +2637,15 @@ function getSidebarAgentInternalDropTargetAtPoint(
 
 function useAgentActivityIndicator(
     sessionId: string,
+    liveStatus: AiSessionStatus | null | undefined,
 ): SidebarAgentActivity {
     const localError = useAiStore(
         (state) => state.sessions[sessionId]?.localError ?? null,
     );
-    const status = useAiStore(
+    const storedStatus = useAiStore(
         (state) => state.sessions[sessionId]?.snapshot?.status ?? null,
     );
+    const status = liveStatus ?? storedStatus;
     return useMemo(
         () => {
             const indicator = resolveWorkspaceChatTabActivityIndicator({
@@ -2679,13 +2776,16 @@ function PinIcon({ active }: { readonly active: boolean }) {
 
 function isSessionWorking(
     entry: ReturnType<typeof useAiStore.getState>["sessions"][string] | undefined,
+    liveStatus: AiSessionStatus | null | undefined,
 ): boolean {
-    if (!entry) {
+    if (!entry && liveStatus === undefined) {
         return false;
     }
     const indicator = resolveWorkspaceChatTabActivityIndicator({
-        localError: entry.localError ?? null,
-        snapshot: entry.snapshot ? { status: entry.snapshot.status } : null,
+        localError: entry?.localError ?? null,
+        snapshot: (liveStatus ?? entry?.snapshot?.status)
+            ? { status: liveStatus ?? entry?.snapshot?.status ?? "idle" }
+            : null,
     });
     return indicator?.tone === "working";
 }

--- a/src/renderer/src/features/terminal/claudeCodeSidebarSession.ts
+++ b/src/renderer/src/features/terminal/claudeCodeSidebarSession.ts
@@ -24,15 +24,19 @@ export type SidebarAgentSessionSummary = Omit<
 
 export interface ClaudeCodeSidebarSessionSummary
     extends Omit<AiHistorySessionSummary, "runtimeId"> {
-    readonly cwd: string;
-    readonly defaultTitle: string;
     readonly isTerminalAgent: true;
     readonly runtimeId: typeof CLAUDE_CODE_TERMINAL_RUNTIME_ID;
     readonly terminalId: string;
-    readonly terminalTabId: string;
     readonly transcriptMtimeMs: number | null;
-    readonly transcriptSessionId: string | null;
 }
+
+type MutableClaudeCodeSidebarSession = ClaudeCodeSidebarSessionSummary & {
+    readonly cwd: string;
+    readonly customTitle: string | null;
+    readonly defaultTitle: string;
+    readonly terminalTabId: string;
+    readonly transcriptSessionId: string | null;
+};
 
 export interface RegisterClaudeCodeSidebarSessionInput {
     readonly cwd: string;
@@ -42,10 +46,6 @@ export interface RegisterClaudeCodeSidebarSessionInput {
     readonly title: string;
     readonly transcriptSessionId: string | null;
     readonly worktreeId: string | null;
-}
-
-type MutableClaudeCodeSidebarSession = ClaudeCodeSidebarSessionSummary & {
-    readonly customTitle: string | null;
 };
 
 const sessionsByTerminalId = new Map<string, MutableClaudeCodeSidebarSession>();
@@ -201,12 +201,8 @@ export function reconcileClaudeCodeSidebarSessions(
 export async function refreshClaudeCodeSidebarSessionTranscript(
     session: ClaudeCodeSidebarSessionSummary,
 ): Promise<void> {
-    if (!session.transcriptSessionId || !session.cwd) {
-        return;
-    }
-
     const current = sessionsByTerminalId.get(session.terminalId);
-    if (!current) {
+    if (!current?.transcriptSessionId || !current.cwd) {
         return;
     }
 
@@ -217,7 +213,7 @@ export async function refreshClaudeCodeSidebarSessionTranscript(
 
     const result = await api.readClaudeCodeTranscript({
         cwd: current.cwd,
-        sessionId: session.transcriptSessionId,
+        sessionId: current.transcriptSessionId,
         sinceMtimeMs: current.transcriptMtimeMs,
     });
     if (!result.found || !result.changed) {
@@ -261,12 +257,15 @@ export function resetClaudeCodeSidebarSessionsForTests(): void {
 function findTerminalTabForSession(
     session: ClaudeCodeSidebarSessionSummary,
 ): RuntimeWorkspaceTerminalTab | null {
+    const terminalTabId = sessionsByTerminalId.get(
+        session.terminalId,
+    )?.terminalTabId;
     const tabs = Object.values(useWorkspaceStore.getState().tabsById);
     return (
         tabs.find(
             (tab): tab is RuntimeWorkspaceTerminalTab =>
                 tab.kind === "terminal" &&
-                (tab.id === session.terminalTabId ||
+                (tab.id === terminalTabId ||
                     tab.terminalId === session.terminalId),
         ) ?? null
     );
@@ -287,8 +286,19 @@ function notifyClaudeCodeSidebarSessionListeners(): void {
 function toPublicSession(
     session: MutableClaudeCodeSidebarSession,
 ): ClaudeCodeSidebarSessionSummary {
-    const { customTitle, ...publicSession } = session;
+    const {
+        cwd,
+        customTitle,
+        defaultTitle,
+        terminalTabId,
+        transcriptSessionId,
+        ...publicSession
+    } = session;
+    void cwd;
     void customTitle;
+    void defaultTitle;
+    void terminalTabId;
+    void transcriptSessionId;
     return publicSession;
 }
 

--- a/src/renderer/src/features/terminal/claudeCodeSidebarSession.ts
+++ b/src/renderer/src/features/terminal/claudeCodeSidebarSession.ts
@@ -24,18 +24,18 @@ export type SidebarAgentSessionSummary = Omit<
 
 export interface ClaudeCodeSidebarSessionSummary
     extends Omit<AiHistorySessionSummary, "runtimeId"> {
+    readonly cwd: string;
+    readonly defaultTitle: string;
     readonly isTerminalAgent: true;
     readonly runtimeId: typeof CLAUDE_CODE_TERMINAL_RUNTIME_ID;
     readonly terminalId: string;
+    readonly terminalTabId: string;
     readonly transcriptMtimeMs: number | null;
+    readonly transcriptSessionId: string | null;
 }
 
 type MutableClaudeCodeSidebarSession = ClaudeCodeSidebarSessionSummary & {
-    readonly cwd: string;
     readonly customTitle: string | null;
-    readonly defaultTitle: string;
-    readonly terminalTabId: string;
-    readonly transcriptSessionId: string | null;
 };
 
 export interface RegisterClaudeCodeSidebarSessionInput {
@@ -286,19 +286,8 @@ function notifyClaudeCodeSidebarSessionListeners(): void {
 function toPublicSession(
     session: MutableClaudeCodeSidebarSession,
 ): ClaudeCodeSidebarSessionSummary {
-    const {
-        cwd,
-        customTitle,
-        defaultTitle,
-        terminalTabId,
-        transcriptSessionId,
-        ...publicSession
-    } = session;
-    void cwd;
+    const { customTitle, ...publicSession } = session;
     void customTitle;
-    void defaultTitle;
-    void terminalTabId;
-    void transcriptSessionId;
     return publicSession;
 }
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -2677,8 +2677,9 @@ export interface WorkspaceSurfaceActiveFileState
  * A small live projection sent to the host so its inspector can reflect tabs
  * that live inside an isolated workspace surface without receiving transcripts.
  */
-export interface WorkspaceSurfaceAgentPresence {
+export interface WorkspaceSurfaceAiAgentPresence {
     readonly createdAt: string;
+    readonly kind: "ai";
     readonly parentSessionId: string | null;
     readonly runtimeId: AiRuntimeId;
     readonly runtimeSessionId: string | null;
@@ -2687,6 +2688,23 @@ export interface WorkspaceSurfaceAgentPresence {
     readonly title: string;
     readonly updatedAt: string;
 }
+
+export interface WorkspaceSurfaceTerminalAgentPresence {
+    readonly createdAt: string;
+    readonly kind: "terminal";
+    readonly preview: string | null;
+    readonly runtimeId: "claude-code-terminal";
+    readonly runtimeSessionId: string | null;
+    readonly sessionId: string;
+    readonly status: null;
+    readonly terminalId: string;
+    readonly title: string;
+    readonly updatedAt: string;
+}
+
+export type WorkspaceSurfaceAgentPresence =
+    | WorkspaceSurfaceAiAgentPresence
+    | WorkspaceSurfaceTerminalAgentPresence;
 
 export interface WorkspaceSurfaceAgentPresenceState
     extends WorkspaceSurfaceActionContext {
@@ -2727,6 +2745,15 @@ export type WorkspaceSurfaceActionRequest = WorkspaceSurfaceActionContext &
           }
         | {
               readonly kind: "focus-terminal";
+              readonly terminalId: string;
+          }
+        | {
+              readonly kind: "rename-terminal";
+              readonly terminalId: string;
+              readonly title: string;
+          }
+        | {
+              readonly kind: "close-terminal";
               readonly terminalId: string;
           }
         | {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -168,6 +168,8 @@ export const IPC_CHANNELS = {
     resyncWorkspaceSurfaceRuntime: "workspace:resync-surface-runtime",
     publishWorkspaceSurfaceActiveFile:
         "workspace:publish-surface-active-file",
+    publishWorkspaceSurfaceAgentPresence:
+        "workspace:publish-surface-agent-presence",
     revealWorkspaceSurfaceFileInHostTree:
         "workspace:reveal-surface-file-in-host-tree",
     notifyWorkspaceSurfaceFocused: "workspace:notify-surface-focused",
@@ -258,6 +260,8 @@ export const IPC_EVENTS = {
     workspaceSurfaceActionStatus: "workspace:surface-action-status",
     workspaceSurfaceActiveFileChanged:
         "workspace:surface-active-file-changed",
+    workspaceSurfaceAgentPresenceChanged:
+        "workspace:surface-agent-presence-changed",
     workspaceSurfaceFileRevealRequested:
         "workspace:surface-file-reveal-requested",
     workspaceSurfaceGitScopeMenuRequested:
@@ -2669,6 +2673,27 @@ export interface WorkspaceSurfaceActiveFileState
     readonly relativePath: string | null;
 }
 
+/**
+ * A small live projection sent to the host so its inspector can reflect tabs
+ * that live inside an isolated workspace surface without receiving transcripts.
+ */
+export interface WorkspaceSurfaceAgentPresence {
+    readonly createdAt: string;
+    readonly parentSessionId: string | null;
+    readonly runtimeId: AiRuntimeId;
+    readonly runtimeSessionId: string | null;
+    readonly sessionId: string;
+    readonly status: AiSessionStatus | null;
+    readonly title: string;
+    readonly updatedAt: string;
+}
+
+export interface WorkspaceSurfaceAgentPresenceState
+    extends WorkspaceSurfaceActionContext {
+    readonly activeSessionId: string | null;
+    readonly sessions: readonly WorkspaceSurfaceAgentPresence[];
+}
+
 export interface WorkspaceSurfaceGitHubComposerItem {
     readonly number: number;
     readonly title: string;
@@ -4259,6 +4284,9 @@ export interface ComandoApi {
     publishWorkspaceSurfaceActiveFile: (
         state: WorkspaceSurfaceActiveFileState,
     ) => Promise<WorkspaceSurfaceActionDeliveryResult>;
+    publishWorkspaceSurfaceAgentPresence: (
+        state: WorkspaceSurfaceAgentPresenceState,
+    ) => Promise<WorkspaceSurfaceActionDeliveryResult>;
     revealWorkspaceSurfaceFileInHostTree: (
         request: WorkspaceSurfaceFileRevealRequest,
     ) => Promise<WorkspaceSurfaceActionDeliveryResult>;
@@ -4447,6 +4475,9 @@ export interface ComandoApi {
     ) => () => void;
     onWorkspaceSurfaceActiveFileChanged: (
         listener: (state: WorkspaceSurfaceActiveFileState) => void,
+    ) => () => void;
+    onWorkspaceSurfaceAgentPresenceChanged: (
+        listener: (state: WorkspaceSurfaceAgentPresenceState) => void,
     ) => () => void;
     onWorkspaceSurfaceFileRevealRequested: (
         listener: (request: WorkspaceSurfaceFileRevealRequest) => void,


### PR DESCRIPTION
## Summary

- restore live agent titles, open state, and working indicators after moving the sidebar to the host window
- publish compact agent presence from workspace surfaces to the host without duplicating transcript payloads
- centralize chat, review, and Claude Code terminal presence, including terminal focus, rename, and close actions
- reload history when a live session leaves the active surface

## Validation

- `pnpm run typecheck`
- focused Vitest suite (52 tests)
- focused ESLint checks