### PR TITLE
fix(deps): resolve undici security advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,9 +13,9 @@ overrides:
   form-data@4.0.5: 4.0.6
   tar: 7.5.19
   tmp@0.2.5: 0.2.7
-  undici@6.25.0: 6.27.0
-  undici@7.25.0: 7.28.0
-  undici@7.27.2: 7.28.0
+  undici@6.25.0: 6.28.0
+  undici@7.25.0: 7.29.0
+  undici@7.27.2: 7.29.0
   '@xmldom/xmldom': 0.8.13
   postcss: 8.5.18
   brace-expansion@<1.1.16: 1.1.16
@@ -3332,12 +3332,12 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -3952,7 +3952,7 @@ snapshots:
       semver: 7.8.4
       sumchecker: 3.0.1
     optionalDependencies:
-      undici: 7.28.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6093,7 +6093,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6691,7 +6691,7 @@ snapshots:
       semver: 7.8.4
       tar: 7.5.19
       tinyglobby: 0.2.17
-      undici: 6.27.0
+      undici: 6.28.0
       which: 6.0.1
 
   node-int64@0.4.0: {}
@@ -7231,9 +7231,9 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@6.27.0: {}
+  undici@6.28.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,9 +14,9 @@ overrides:
   "form-data@4.0.5": 4.0.6
   tar: 7.5.19
   "tmp@0.2.5": 0.2.7
-  "undici@6.25.0": 6.27.0
-  "undici@7.25.0": 7.28.0
-  "undici@7.27.2": 7.28.0
+  "undici@6.25.0": 6.28.0
+  "undici@7.25.0": 7.29.0
+  "undici@7.27.2": 7.29.0
   "@xmldom/xmldom": 0.8.13
   postcss: 8.5.18
   "brace-expansion@<1.1.16": 1.1.16


### PR DESCRIPTION
## Summary

- upgrade transitive Undici 6.x resolutions from 6.27.0 to 6.28.0
- upgrade transitive Undici 7.x resolutions from 7.28.0 to 7.29.0
- resolve GHSA-4cwx-7wf7-3272, GHSA-jr45-8vmc-qm54, GHSA-v3r7-h72x-cjcm, GHSA-8xcm-r25x-g524, and GHSA-m8rv-5g2x-5cg5
- regenerate the pnpm lockfile with the patched versions

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm test` (2,889 passed, 1 skipped)
- `pnpm audit --json` reports zero Undici advisories