### PR TITLE
fix(deps): resolve fast-uri and PostCSS advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   dompurify: 3.4.12
   js-yaml: 4.3.0
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   esbuild@0.27.7: 0.28.1
   '@babel/core@7.29.0': 7.29.6
   form-data@4.0.5: 4.0.6
@@ -17,7 +17,7 @@ overrides:
   undici@7.25.0: 7.29.0
   undici@7.27.2: 7.29.0
   '@xmldom/xmldom': 0.8.13
-  postcss: 8.5.18
+  postcss: 8.5.23
   brace-expansion@<1.1.16: 1.1.16
   brace-expansion@>=2.0.0 <2.1.2: 2.1.2
   brace-expansion@>=3.0.0 <5.0.7: 5.0.7
@@ -2097,8 +2097,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2808,8 +2808,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2937,8 +2937,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -4922,7 +4922,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5729,7 +5729,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -6669,7 +6669,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -6802,9 +6802,9 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7310,7 +7310,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.1.4
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ onlyBuiltDependencies:
 overrides:
   dompurify: 3.4.12
   js-yaml: 4.3.0
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   "esbuild@0.27.7": 0.28.1
   "@babel/core@7.29.0": 7.29.6
   "form-data@4.0.5": 4.0.6
@@ -18,7 +18,7 @@ overrides:
   "undici@7.25.0": 7.29.0
   "undici@7.27.2": 7.29.0
   "@xmldom/xmldom": 0.8.13
-  postcss: 8.5.18
+  postcss: 8.5.23
   "brace-expansion@<1.1.16": 1.1.16
   "brace-expansion@>=2.0.0 <2.1.2": 2.1.2
   "brace-expansion@>=3.0.0 <5.0.7": 5.0.7


### PR DESCRIPTION
## Summary

- upgrade `fast-uri` from 3.1.4 to 3.1.5 to prevent host confusion through backslash authority introducers
- upgrade `postcss` from 8.5.18 to 8.5.23 to prevent untrusted source map paths from reading arbitrary `.map` files
- resolve GHSA-7p8r-x3mc-p8w7 and GHSA-fxqj-rqcc-2cmp
- regenerate the pnpm lockfile with the patched transitive dependencies

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm test` (2,889 passed, 1 skipped)
- `pnpm audit --json` reports zero advisories for `fast-uri` and `postcss`