### PR TITLE
feat: add configurable chat content width

### DIFF
--- a/src/main/native-backend/app-data.ts
+++ b/src/main/native-backend/app-data.ts
@@ -8,6 +8,10 @@ import { APP_ZOOM_FACTOR_DEFAULT } from "@shared/app-zoom";
 import { AGENTS_SIDEBAR_SCALE_DEFAULT } from "@shared/agents-sidebar-scale";
 import { FILE_TREE_SCALE_DEFAULT } from "@shared/file-tree-scale";
 import {
+    CHAT_CONTENT_WIDTH_DEFAULT,
+    clampChatContentWidth,
+} from "@shared/chat-content-width";
+import {
     DEFAULT_APP_TERMINAL_SETTINGS,
     normalizeWindowsTerminalShell,
 } from "@shared/terminal-settings";
@@ -1454,6 +1458,9 @@ function createLegacySettingsSnapshot(
                     settings,
                     "appearance.boost_code_contrast",
                 ) ?? defaults.appearance.boostCodeContrast,
+            chatContentWidth:
+                readLegacyNumberSetting(settings, "appearance.chat_content_width") ??
+                defaults.appearance.chatContentWidth,
             fileTreeScale:
                 readLegacyNumberSetting(settings, "appearance.file_tree_scale") ??
                 defaults.appearance.fileTreeScale,
@@ -2139,6 +2146,7 @@ function createDefaultSettingsSnapshot(): CompleteSettingsSnapshot {
         appearance: {
             agentsSidebarScale: AGENTS_SIDEBAR_SCALE_DEFAULT,
             boostCodeContrast: true,
+            chatContentWidth: CHAT_CONTENT_WIDTH_DEFAULT,
             chromeTransparency: 45,
             fileTreeScale: FILE_TREE_SCALE_DEFAULT,
             stickyFoldersEnabled: true,
@@ -2188,6 +2196,10 @@ function normalizeSettingsSnapshot(snapshot: SettingsSnapshot): SettingsSnapshot
         appearance: {
             ...defaults.appearance,
             ...(snapshot.appearance ?? {}),
+            chatContentWidth: clampChatContentWidth(
+                snapshot.appearance?.chatContentWidth ??
+                    defaults.appearance.chatContentWidth,
+            ),
         },
         customAcpRuntimes: normalizeCustomAcpRuntimesSettings(
             snapshot.customAcpRuntimes,

--- a/src/main/settings/window-zoom.test.ts
+++ b/src/main/settings/window-zoom.test.ts
@@ -50,6 +50,7 @@ describe("broadcastSettingsUpdated", () => {
             {
                 agentsSidebarScale: 1,
                 boostCodeContrast: true,
+                chatContentWidth: 600,
                 chromeTransparency: 45,
                 fileTreeScale: 1,
                 stickyFoldersEnabled: true,
@@ -99,6 +100,7 @@ describe("broadcastSettingsUpdated", () => {
             appearance: {
                 agentsSidebarScale: 1,
                 boostCodeContrast: true,
+                chatContentWidth: 600,
                 chromeTransparency: 45,
                 fileTreeScale: 1,
                 stickyFoldersEnabled: true,

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -489,6 +489,13 @@ export function SettingsApp({
         commitAppAppearance(nextAppearance);
     };
 
+    const handleAppChatContentWidthChange = (chatContentWidth: number) => {
+        commitAppAppearance({
+            ...appAppearance,
+            chatContentWidth,
+        });
+    };
+
     const handleAppFileTreeScaleChange = (fileTreeScale: number) => {
         const nextAppearance = {
             ...appAppearance,
@@ -932,12 +939,14 @@ export function SettingsApp({
             appAppearance={{
                 agentsSidebarScale: appAppearance.agentsSidebarScale,
                 boostCodeContrast: appAppearance.boostCodeContrast,
+                chatContentWidth: appAppearance.chatContentWidth,
                 chromeTransparency: appAppearance.chromeTransparency,
                 fileTreeScale: appAppearance.fileTreeScale,
                 mode: appAppearance.themeMode,
                 onAgentsSidebarScaleChange:
                     handleAppAgentsSidebarScaleChange,
                 onBoostCodeContrastChange: handleAppBoostCodeContrastChange,
+                onChatContentWidthChange: handleAppChatContentWidthChange,
                 onChromeTransparencyChange: handleAppChromeTransparencyChange,
                 onFileTreeScaleChange: handleAppFileTreeScaleChange,
                 onModeChange: handleAppThemeModeChange,

--- a/src/renderer/src/app/settings/client.test.ts
+++ b/src/renderer/src/app/settings/client.test.ts
@@ -37,6 +37,7 @@ function createAppearanceSettings(
     return {
         agentsSidebarScale: 1,
         boostCodeContrast: true,
+        chatContentWidth: 600,
         chromeTransparency: 45,
         fileTreeScale: 1,
         stickyFoldersEnabled: true,

--- a/src/renderer/src/app/settings/theme.ts
+++ b/src/renderer/src/app/settings/theme.ts
@@ -15,6 +15,10 @@ import {
     FILE_TREE_SCALE_DEFAULT,
     clampFileTreeScale,
 } from "@shared/file-tree-scale";
+import {
+    CHAT_CONTENT_WIDTH_DEFAULT,
+    clampChatContentWidth,
+} from "@shared/chat-content-width";
 import type {
     AppAiChatSettings,
     AppAppearanceSettings,
@@ -1757,6 +1761,7 @@ export function getDefaultAppAppearance(): AppAppearanceSettings {
     return {
         agentsSidebarScale: AGENTS_SIDEBAR_SCALE_DEFAULT,
         boostCodeContrast: true,
+        chatContentWidth: CHAT_CONTENT_WIDTH_DEFAULT,
         chromeTransparency: CHROME_TRANSPARENCY_DEFAULT,
         fileTreeScale: FILE_TREE_SCALE_DEFAULT,
         stickyFoldersEnabled: true,
@@ -1823,6 +1828,9 @@ export function resolveAppearance(
         ),
         boostCodeContrast:
             appAppearance?.boostCodeContrast ?? defaults.boostCodeContrast,
+        chatContentWidth: clampChatContentWidth(
+            appAppearance?.chatContentWidth ?? defaults.chatContentWidth,
+        ),
         chromeTransparency: clampChromeTransparency(
             appAppearance?.chromeTransparency ?? defaults.chromeTransparency,
         ),

--- a/src/renderer/src/app/store/settings-store.test.ts
+++ b/src/renderer/src/app/store/settings-store.test.ts
@@ -38,6 +38,7 @@ function createAppearanceSettings(
     return {
         agentsSidebarScale: 1,
         boostCodeContrast: true,
+        chatContentWidth: 600,
         chromeTransparency: 45,
         fileTreeScale: 1,
         stickyFoldersEnabled: true,

--- a/src/renderer/src/components/settings/SettingsWindow.test.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.test.tsx
@@ -50,6 +50,7 @@ function createSettingsWindowProps(
         },
         appAppearance: {
             boostCodeContrast: false,
+            chatContentWidth: 600,
             chromeTransparency: 45,
             mode: "system",
             presetId: "default",

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -27,6 +27,11 @@ import {
     formatFileTreeScalePercent,
 } from "@shared/file-tree-scale";
 import {
+    CHAT_CONTENT_WIDTH_MAX,
+    CHAT_CONTENT_WIDTH_MIN,
+    CHAT_CONTENT_WIDTH_STEP,
+} from "@shared/chat-content-width";
+import {
     AI_CHAT_FONT_SIZE_MAX,
     AI_CHAT_FONT_SIZE_MIN,
     AI_COMPOSER_FONT_SIZE_MAX,
@@ -144,6 +149,8 @@ const STATIC_CATEGORY_SEARCH_VALUES: Record<Category, readonly SearchValue[]> = 
         "Scale text and rows in the Agents, Issues, and Pull Requests sidebars.",
         "Sticky folders",
         "Keep parent folders pinned while scrolling the file tree.",
+        "Chat content width",
+        "Set the maximum width of AI chat messages and composer.",
         "Window transparency",
         "Use native acrylic transparency on Windows and vibrancy on macOS.",
         "Mode",
@@ -1742,6 +1749,22 @@ function AppearanceContent({
                         onChange={(v) =>
                             state.onAgentsSidebarScaleChange?.(v)
                         }
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Workspace"
+                label="Chat content width"
+                description="Set the maximum width of AI chat messages and composer."
+                control={
+                    <SliderField
+                        value={state.chatContentWidth}
+                        min={CHAT_CONTENT_WIDTH_MIN}
+                        max={CHAT_CONTENT_WIDTH_MAX}
+                        step={CHAT_CONTENT_WIDTH_STEP}
+                        onChange={(v) => state.onChatContentWidthChange?.(v)}
+                        formatValue={(v) => `${v}px`}
                     />
                 }
             />

--- a/src/renderer/src/components/settings/settings-types.ts
+++ b/src/renderer/src/components/settings/settings-types.ts
@@ -32,6 +32,7 @@ export interface ThemePresetOption {
 export interface SettingsThemeControlState {
     readonly agentsSidebarScale?: number;
     readonly boostCodeContrast: boolean;
+    readonly chatContentWidth: number;
     readonly chromeTransparency: number;
     readonly fileTreeScale?: number;
     readonly mode: ThemeMode;
@@ -43,6 +44,7 @@ export interface SettingsThemeControlState {
     readonly disabled?: boolean;
     readonly onAgentsSidebarScaleChange?: (agentsSidebarScale: number) => void;
     readonly onBoostCodeContrastChange?: (enabled: boolean) => void;
+    readonly onChatContentWidthChange?: (chatContentWidth: number) => void;
     readonly onChromeTransparencyChange?: (chromeTransparency: number) => void;
     readonly onFileTreeScaleChange?: (fileTreeScale: number) => void;
     readonly onModeChange?: (mode: ThemeMode) => void;

--- a/src/renderer/src/components/workspace/chat/ChatContentColumn.tsx
+++ b/src/renderer/src/components/workspace/chat/ChatContentColumn.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, type CSSProperties, type ReactNode } from "react";
 
 import { CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
+import { useSettingsStore } from "@renderer/app/store/settings-store";
 
 export { CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
 
@@ -14,6 +15,10 @@ export const ChatContentColumn = forwardRef<
     HTMLDivElement,
     ChatContentColumnProps
 >(function ChatContentColumn({ children, className, style }, ref) {
+    const chatContentWidth = useSettingsStore(
+        (state) => state.appearance.chatContentWidth,
+    );
+
     return (
         <div
             ref={ref}
@@ -21,7 +26,8 @@ export const ChatContentColumn = forwardRef<
             data-chat-content-column="true"
             style={{
                 marginInline: "auto",
-                maxWidth: CHAT_CONTENT_MAX_WIDTH_PX,
+                // `width: 100%` keeps narrow panes responsive below this user-selected limit.
+                maxWidth: chatContentWidth ?? CHAT_CONTENT_MAX_WIDTH_PX,
                 width: "100%",
                 ...style,
             }}

--- a/src/renderer/src/components/workspace/chat/chatContentLayout.ts
+++ b/src/renderer/src/components/workspace/chat/chatContentLayout.ts
@@ -1,1 +1,1 @@
-export const CHAT_CONTENT_MAX_WIDTH_PX = 600;
+export { CHAT_CONTENT_WIDTH_DEFAULT as CHAT_CONTENT_MAX_WIDTH_PX } from "@shared/chat-content-width";

--- a/src/shared/chat-content-width.ts
+++ b/src/shared/chat-content-width.ts
@@ -1,0 +1,15 @@
+export const CHAT_CONTENT_WIDTH_DEFAULT = 600;
+export const CHAT_CONTENT_WIDTH_MIN = 480;
+export const CHAT_CONTENT_WIDTH_MAX = 1_200;
+export const CHAT_CONTENT_WIDTH_STEP = 20;
+
+export function clampChatContentWidth(width: number): number {
+    if (!Number.isFinite(width)) {
+        return CHAT_CONTENT_WIDTH_DEFAULT;
+    }
+
+    return Math.min(
+        CHAT_CONTENT_WIDTH_MAX,
+        Math.max(CHAT_CONTENT_WIDTH_MIN, Math.round(width / CHAT_CONTENT_WIDTH_STEP) * CHAT_CONTENT_WIDTH_STEP),
+    );
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -336,6 +336,7 @@ export interface AppAiChatSettings {
 export interface AppAppearanceSettings {
     readonly agentsSidebarScale: number;
     readonly boostCodeContrast: boolean;
+    readonly chatContentWidth: number;
     readonly chromeTransparency: number;
     readonly fileTreeScale: number;
     readonly stickyFoldersEnabled: boolean;


### PR DESCRIPTION
## Summary
- add a persisted Appearance slider for AI chat content width
- default new and existing users to 600px, with responsive behavior below the selected maximum
- validate and normalize the setting across renderer and native persistence

## Validation
- npm run typecheck
- npm run lint
- npm test -- --run src/renderer/src/components/settings/SettingsWindow.test.tsx src/renderer/src/components/workspace/chat/ChatContentColumn.test.tsx src/renderer/src/app/store/settings-store.test.ts src/main/settings/window-zoom.test.ts