### PR TITLE
Fix: center embedded settings content

### DIFF
--- a/src/renderer/src/components/settings/SettingsWindow.test.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.test.tsx
@@ -158,6 +158,15 @@ describe("SettingsWindow terminal settings", () => {
         expect(markup).not.toContain('height:100vh');
     });
 
+    it("centers the settings content inside the main-window pane", () => {
+        const markup = renderToStaticMarkup(
+            <SettingsWindow {...createSettingsWindowProps()} embedded />,
+        );
+
+        expect(markup).toContain("margin-inline:auto");
+        expect(markup).toContain("max-width:600px");
+    });
+
     it("warns when the autosave delay can overlap with agent edits", () => {
         const highDelayMarkup = renderToStaticMarkup(
             <SettingsWindow

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -828,7 +828,13 @@ export function SettingsWindow({
                             padding: "8px 48px 48px",
                         }}
                     >
-                        <div style={{ maxWidth: 600 }}>
+                        <div
+                            style={{
+                                marginInline: "auto",
+                                maxWidth: 600,
+                                width: "100%",
+                            }}
+                        >
                             {filteredCategories.length === 0 && hasSearch ? (
                                 <EmptySettingsSearch search={search} />
                             ) : null}


### PR DESCRIPTION
## Summary
- center the settings control panel within the embedded main-window content pane
- preserve the existing 600px reading width and responsive behavior
- add coverage for the centered layout

## Validation
- pnpm exec vitest run src/renderer/src/components/settings/SettingsWindow.test.tsx
- pnpm exec eslint src/renderer/src/components/settings/SettingsWindow.tsx src/renderer/src/components/settings/SettingsWindow.test.tsx
- git diff --check