### PR TITLE
Optimize warm workspace switching

### DIFF
--- a/src/main/workspace/activation-coordinator.ts
+++ b/src/main/workspace/activation-coordinator.ts
@@ -31,7 +31,7 @@ export interface WorkspaceActivationAdapter {
     readonly commitActiveScope: (
         scopeKey: string | null,
         generation: string | null,
-    ) => Promise<void>;
+    ) => Promise<void> | void;
     readonly destroy: (scopeKey: string, generation: string) => Promise<void> | void;
     readonly prepareHibernate: (
         scopeKey: string,

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -255,6 +255,35 @@ describe("WorkspaceSurfaceManager action routing", () => {
         ).not.toBeNull();
     });
 
+    it("waits before retrying failed background navigation persistence", async () => {
+        vi.useFakeTimers();
+        try {
+            const manager = createTestManager();
+            manager.syncWorkspaceRegistry(
+                createHostWindow().window,
+                createHostContext(),
+                createSnapshot(),
+            );
+            await finishActiveSurface(manager, "host-1", "project-a::__primary__");
+            const commitActiveScope = vi.fn(() =>
+                Promise.reject(new Error("durable navigation is unavailable")),
+            );
+            manager.setLifecycleHandlers({ commitActiveScope });
+
+            const activation = manager.activate("host-1", "project-b::__primary__");
+            await finishActiveSurface(manager, "host-1", "project-b::__primary__");
+            await activation;
+            vi.runAllTicks();
+            expect(commitActiveScope).toHaveBeenCalledTimes(1);
+            expect(vi.getTimerCount()).toBe(1);
+
+            await vi.advanceTimersToNextTimerAsync();
+            expect(commitActiveScope).toHaveBeenCalledTimes(2);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it("delegates workspace shortcuts from the surface to singleton navigation", () => {
         const manager = createTestManager();
         const host = createHostWindow();

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -192,6 +192,69 @@ describe("WorkspaceSurfaceManager action routing", () => {
         );
     });
 
+    it("reveals a warm workspace without waiting for navigation persistence", async () => {
+        const manager = createTestManager();
+        manager.syncWorkspaceRegistry(
+            createHostWindow().window,
+            createHostContext(),
+            createSnapshot(),
+        );
+        await finishActiveSurface(manager, "host-1", "project-a::__primary__");
+        const activateBackground = manager.activate(
+            "host-1",
+            "project-b::__primary__",
+        );
+        await finishActiveSurface(manager, "host-1", "project-b::__primary__");
+        await activateBackground;
+
+        let resolvePersistence: (() => void) | undefined;
+        const persistence = new Promise<void>((resolve) => {
+            resolvePersistence = resolve;
+        });
+        const commitActiveScope = vi.fn(() => persistence);
+        manager.setLifecycleHandlers({ commitActiveScope });
+
+        await expect(
+            manager.activate("host-1", "project-a::__primary__"),
+        ).resolves.toMatchObject({ status: "activated", warm: true });
+        await vi.waitFor(() =>
+            expect(commitActiveScope).toHaveBeenCalledWith(
+                "host-1",
+                "project-a::__primary__",
+            ),
+        );
+        expect(
+            manager.getSurfaceDiagnostics("host-1").activeScopeKey,
+        ).toBe("project-a::__primary__");
+
+        resolvePersistence?.();
+    });
+
+    it("keeps the active surface when clearing durable navigation fails", async () => {
+        const manager = createTestManager();
+        manager.syncWorkspaceRegistry(
+            createHostWindow().window,
+            createHostContext(),
+            createSnapshot(),
+        );
+        await finishActiveSurface(manager, "host-1", "project-a::__primary__");
+        manager.setLifecycleHandlers({
+            commitActiveScope: () =>
+                Promise.reject(new Error("durable navigation is unavailable")),
+            prepareSurfaceHibernate: () => Promise.resolve(),
+        });
+
+        await expect(
+            manager.closeWorkspaceSurface("host-1", "project-a::__primary__"),
+        ).resolves.toMatchObject({ status: "failed" });
+        expect(
+            manager.getSurfaceDiagnostics("host-1").activeScopeKey,
+        ).toBe("project-a::__primary__");
+        expect(
+            manager.getSurfaceWebContents("host-1", "project-a::__primary__"),
+        ).not.toBeNull();
+    });
+
     it("delegates workspace shortcuts from the surface to singleton navigation", () => {
         const manager = createTestManager();
         const host = createHostWindow();

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -268,7 +268,10 @@ describe("WorkspaceSurfaceManager action routing", () => {
             const commitActiveScope = vi.fn(() =>
                 Promise.reject(new Error("durable navigation is unavailable")),
             );
-            manager.setLifecycleHandlers({ commitActiveScope });
+            manager.setLifecycleHandlers({
+                commitActiveScope,
+                prepareSurfaceHibernate: () => Promise.resolve(),
+            });
 
             const activation = manager.activate("host-1", "project-b::__primary__");
             await finishActiveSurface(manager, "host-1", "project-b::__primary__");
@@ -279,6 +282,51 @@ describe("WorkspaceSurfaceManager action routing", () => {
 
             await vi.advanceTimersToNextTimerAsync();
             expect(commitActiveScope).toHaveBeenCalledTimes(2);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("invalidates a failed background retry when its active workspace closes", async () => {
+        vi.useFakeTimers();
+        try {
+            const manager = createTestManager();
+            manager.syncWorkspaceRegistry(
+                createHostWindow().window,
+                createHostContext(),
+                createSnapshot(),
+            );
+            await finishActiveSurface(manager, "host-1", "project-a::__primary__");
+            const activateBackground = manager.activate(
+                "host-1",
+                "project-b::__primary__",
+            );
+            await finishActiveSurface(manager, "host-1", "project-b::__primary__");
+            await activateBackground;
+
+            let rejectFirstCommit: ((error: Error) => void) | undefined;
+            const firstCommit = new Promise<void>((_resolve, reject) => {
+                rejectFirstCommit = reject;
+            });
+            const commitActiveScope = vi
+                .fn()
+                .mockImplementationOnce(() => firstCommit)
+                .mockResolvedValue(undefined);
+            manager.setLifecycleHandlers({
+                commitActiveScope,
+                prepareSurfaceHibernate: () => Promise.resolve(),
+            });
+
+            await manager.activate("host-1", "project-a::__primary__");
+            const close = manager.closeWorkspaceSurface(
+                "host-1",
+                "project-a::__primary__",
+            );
+            rejectFirstCommit?.(new Error("durable navigation is unavailable"));
+
+            await expect(close).resolves.toMatchObject({ status: "closed" });
+            expect(commitActiveScope).toHaveBeenCalledTimes(2);
+            expect(vi.getTimerCount()).toBe(0);
         } finally {
             vi.useRealTimers();
         }

--- a/src/main/workspace/surface-manager.actions.test.ts
+++ b/src/main/workspace/surface-manager.actions.test.ts
@@ -332,6 +332,35 @@ describe("WorkspaceSurfaceManager action routing", () => {
         }
     });
 
+    it("does not retry persistence owned by a disposed host", async () => {
+        vi.useFakeTimers();
+        try {
+            const manager = createTestManager();
+            const host = createHostWindow();
+            manager.syncWorkspaceRegistry(host.window, createHostContext(), createSnapshot());
+            await finishActiveSurface(manager, "host-1", "project-a::__primary__");
+            let rejectCommit: ((error: Error) => void) | undefined;
+            const commit = new Promise<void>((_resolve, reject) => {
+                rejectCommit = reject;
+            });
+            const commitActiveScope = vi.fn(() => commit);
+            manager.setLifecycleHandlers({ commitActiveScope });
+
+            const activation = manager.activate("host-1", "project-b::__primary__");
+            await finishActiveSurface(manager, "host-1", "project-b::__primary__");
+            await activation;
+            manager.disposeHost("host-1", host.window);
+            rejectCommit?.(new Error("durable navigation is unavailable"));
+            await Promise.resolve();
+
+            expect(vi.getTimerCount()).toBe(0);
+            await vi.runAllTimersAsync();
+            expect(commitActiveScope).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it("delegates workspace shortcuts from the surface to singleton navigation", () => {
         const manager = createTestManager();
         const host = createHostWindow();

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -96,6 +96,7 @@ interface WorkspaceSurfaceHostRecord {
     readonly environment: WorkspaceSurfaceEnvironmentDiagnostic;
     contentInsets: WorkspaceSurfaceContentInsets;
     durableScopeCommit: Promise<void> | null;
+    durableScopeEpoch: number;
     hasPendingDurableScopeCommit: boolean;
     disposalScheduled: boolean;
     readonly hostWindow: BrowserWindow;
@@ -1113,6 +1114,7 @@ export class WorkspaceSurfaceManager {
                 top: DESKTOP_TITLE_BAR_HEIGHT,
             },
             durableScopeCommit: null,
+            durableScopeEpoch: 0,
             durableScopeRetryTimer: null,
             disposalScheduled: false,
             hostWindow,
@@ -1139,11 +1141,17 @@ export class WorkspaceSurfaceManager {
     #scheduleDurableScopeCommit(
         host: WorkspaceSurfaceHostRecord,
         scopeKey: string | null,
+        epoch?: number,
     ): void {
+        const commitEpoch = epoch ?? host.durableScopeEpoch + 1;
+        if (commitEpoch < host.durableScopeEpoch) {
+            return;
+        }
         if (host.durableScopeRetryTimer !== null) {
             clearTimeout(host.durableScopeRetryTimer);
             host.durableScopeRetryTimer = null;
         }
+        host.durableScopeEpoch = commitEpoch;
         host.pendingDurableScopeKey = scopeKey;
         host.hasPendingDurableScopeCommit = true;
         if (host.durableScopeCommit) {
@@ -1154,6 +1162,7 @@ export class WorkspaceSurfaceManager {
             while (host.hasPendingDurableScopeCommit) {
                 host.hasPendingDurableScopeCommit = false;
                 const pendingScopeKey = host.pendingDurableScopeKey;
+                const pendingEpoch = host.durableScopeEpoch;
                 try {
                     // Navigation persistence must not delay a resident surface swap.
                     await this.#lifecycleHandlers.commitActiveScope?.(
@@ -1166,13 +1175,15 @@ export class WorkspaceSurfaceManager {
                         "[workspace] Failed to persist active workspace navigation",
                         error,
                     );
-                    host.pendingDurableScopeKey = pendingScopeKey;
-                    host.hasPendingDurableScopeCommit = true;
+                    if (host.durableScopeEpoch !== pendingEpoch) {
+                        continue;
+                    }
                     host.durableScopeRetryTimer ??= setTimeout(() => {
                         host.durableScopeRetryTimer = null;
                         this.#scheduleDurableScopeCommit(
                             host,
                             host.pendingDurableScopeKey,
+                            pendingEpoch,
                         );
                     }, 1_000);
                     // The retry timer owns the next attempt; continuing here
@@ -1207,6 +1218,8 @@ export class WorkspaceSurfaceManager {
             clearTimeout(host.durableScopeRetryTimer);
             host.durableScopeRetryTimer = null;
         }
+        host.durableScopeEpoch += 1;
+        host.pendingDurableScopeKey = scopeKey;
         host.hasPendingDurableScopeCommit = false;
         await host.durableScopeCommit;
         // A close must not leave durable navigation pointing to a renderer

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -104,6 +104,7 @@ interface WorkspaceSurfaceHostRecord {
     context: WindowContextSnapshot;
     isClosing: boolean;
     hostOverlayVisible: boolean;
+    isDisposed: boolean;
     pendingLayoutTimer: NodeJS.Timeout | null;
     pendingDurableScopeKey: string | null;
     durableScopeRetryTimer: NodeJS.Timeout | null;
@@ -928,6 +929,8 @@ export class WorkspaceSurfaceManager {
     }
 
     #disposeHostNow(host: WorkspaceSurfaceHostRecord): void {
+        host.isDisposed = true;
+        host.durableScopeEpoch += 1;
         const isCurrentHost =
             this.#hostsByWindowId.get(host.hostWindowId) === host;
         if (isCurrentHost) {
@@ -1123,6 +1126,7 @@ export class WorkspaceSurfaceManager {
             hasPendingDurableScopeCommit: false,
             context: hostContext,
             isClosing: false,
+            isDisposed: false,
             pendingLayoutTimer: null,
             pendingDurableScopeKey: null,
             performance: surfacePerformance,
@@ -1143,6 +1147,9 @@ export class WorkspaceSurfaceManager {
         scopeKey: string | null,
         epoch?: number,
     ): void {
+        if (host.isDisposed) {
+            return;
+        }
         const commitEpoch = epoch ?? host.durableScopeEpoch + 1;
         if (commitEpoch < host.durableScopeEpoch) {
             return;
@@ -1159,7 +1166,7 @@ export class WorkspaceSurfaceManager {
         }
 
         const commit = (async () => {
-            while (host.hasPendingDurableScopeCommit) {
+            while (!host.isDisposed && host.hasPendingDurableScopeCommit) {
                 host.hasPendingDurableScopeCommit = false;
                 const pendingScopeKey = host.pendingDurableScopeKey;
                 const pendingEpoch = host.durableScopeEpoch;
@@ -1170,6 +1177,10 @@ export class WorkspaceSurfaceManager {
                         pendingScopeKey,
                     );
                 } catch (error) {
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Disposal can race the rejected async commit.
+                    if (host.isDisposed) {
+                        return;
+                    }
                     host.performance.recordFailure();
                     console.error(
                         "[workspace] Failed to persist active workspace navigation",
@@ -1180,6 +1191,9 @@ export class WorkspaceSurfaceManager {
                     }
                     host.durableScopeRetryTimer ??= setTimeout(() => {
                         host.durableScopeRetryTimer = null;
+                        if (host.isDisposed) {
+                            return;
+                        }
                         this.#scheduleDurableScopeCommit(
                             host,
                             host.pendingDurableScopeKey,
@@ -1199,6 +1213,7 @@ export class WorkspaceSurfaceManager {
             }
             host.durableScopeCommit = null;
             if (
+                !host.isDisposed &&
                 host.hasPendingDurableScopeCommit &&
                 host.durableScopeRetryTimer === null
             ) {

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -95,6 +95,8 @@ interface WorkspaceSurfaceHostRecord {
     activeScopeKey: string | null;
     readonly environment: WorkspaceSurfaceEnvironmentDiagnostic;
     contentInsets: WorkspaceSurfaceContentInsets;
+    durableScopeCommit: Promise<void> | null;
+    hasPendingDurableScopeCommit: boolean;
     disposalScheduled: boolean;
     readonly hostWindow: BrowserWindow;
     readonly hostWindowId: string;
@@ -102,6 +104,8 @@ interface WorkspaceSurfaceHostRecord {
     isClosing: boolean;
     hostOverlayVisible: boolean;
     pendingLayoutTimer: NodeJS.Timeout | null;
+    pendingDurableScopeKey: string | null;
+    durableScopeRetryTimer: NodeJS.Timeout | null;
     readonly recentOperations: WorkspaceSurfaceOperationDiagnostic[];
     readonly performance: WorkspaceSurfacePerformanceMonitor;
     readonly surfacePool: WorkspaceSurfacePool;
@@ -890,7 +894,7 @@ export class WorkspaceSurfaceManager {
             return Promise.resolve();
         }
         host.isClosing = true;
-        return Promise.resolve();
+        return this.#flushDurableScopeCommit(host, host.activeScopeKey);
     }
 
     cancelHostClose(hostWindowId: string, hostWindow?: BrowserWindow): void {
@@ -930,6 +934,9 @@ export class WorkspaceSurfaceManager {
         }
         if (host.pendingLayoutTimer) {
             clearTimeout(host.pendingLayoutTimer);
+        }
+        if (host.durableScopeRetryTimer) {
+            clearTimeout(host.durableScopeRetryTimer);
         }
         for (const surfaceId of [...host.surfaceIdsByContextKey.values()]) {
             this.#destroySurface(host, surfaceId);
@@ -999,14 +1006,10 @@ export class WorkspaceSurfaceManager {
                         reused: false,
                     });
                 },
-                commitActiveScope: async (scopeKey, generation) => {
+                commitActiveScope: (scopeKey, generation) => {
                     if (host.isClosing) {
                         throw new Error("The workspace host is closing.");
                     }
-                    await this.#lifecycleHandlers.commitActiveScope?.(
-                        host.hostWindowId,
-                        scopeKey,
-                    );
                     if (
                         scopeKey &&
                         (!generation ||
@@ -1030,6 +1033,10 @@ export class WorkspaceSurfaceManager {
                     };
                     this.#rejectInactiveActions(host);
                     this.#applyVisibility(host, { focusActive: Boolean(scopeKey) });
+                    if (scopeKey === null) {
+                        return this.#flushDurableScopeCommit(host, null);
+                    }
+                    this.#scheduleDurableScopeCommit(host, scopeKey);
                 },
                 destroy: (scopeKey, generation) => {
                     if (host.surfaceIdsByContextKey.get(scopeKey) === generation) {
@@ -1105,13 +1112,17 @@ export class WorkspaceSurfaceManager {
                 right: 0,
                 top: DESKTOP_TITLE_BAR_HEIGHT,
             },
+            durableScopeCommit: null,
+            durableScopeRetryTimer: null,
             disposalScheduled: false,
             hostWindow,
             hostWindowId: hostContext.windowId,
             hostOverlayVisible: false,
+            hasPendingDurableScopeCommit: false,
             context: hostContext,
             isClosing: false,
             pendingLayoutTimer: null,
+            pendingDurableScopeKey: null,
             performance: surfacePerformance,
             recentOperations: [],
             registry: {
@@ -1123,6 +1134,80 @@ export class WorkspaceSurfaceManager {
             warmingContextKey: null,
         });
         return host;
+    }
+
+    #scheduleDurableScopeCommit(
+        host: WorkspaceSurfaceHostRecord,
+        scopeKey: string | null,
+    ): void {
+        host.pendingDurableScopeKey = scopeKey;
+        host.hasPendingDurableScopeCommit = true;
+        if (host.durableScopeCommit) {
+            return;
+        }
+
+        const commit = (async () => {
+            while (host.hasPendingDurableScopeCommit) {
+                host.hasPendingDurableScopeCommit = false;
+                const pendingScopeKey = host.pendingDurableScopeKey;
+                try {
+                    // Navigation persistence must not delay a resident surface swap.
+                    await this.#lifecycleHandlers.commitActiveScope?.(
+                        host.hostWindowId,
+                        pendingScopeKey,
+                    );
+                } catch (error) {
+                    host.performance.recordFailure();
+                    console.error(
+                        "[workspace] Failed to persist active workspace navigation",
+                        error,
+                    );
+                    host.pendingDurableScopeKey = pendingScopeKey;
+                    host.hasPendingDurableScopeCommit = true;
+                    host.durableScopeRetryTimer ??= setTimeout(() => {
+                        host.durableScopeRetryTimer = null;
+                        this.#scheduleDurableScopeCommit(
+                            host,
+                            host.pendingDurableScopeKey,
+                        );
+                    }, 1_000);
+                }
+            }
+        })();
+        host.durableScopeCommit = commit;
+        void commit.finally(() => {
+            if (host.durableScopeCommit !== commit) {
+                return;
+            }
+            host.durableScopeCommit = null;
+            if (
+                host.hasPendingDurableScopeCommit &&
+                host.durableScopeRetryTimer === null
+            ) {
+                this.#scheduleDurableScopeCommit(
+                    host,
+                    host.pendingDurableScopeKey,
+                );
+            }
+        });
+    }
+
+    async #flushDurableScopeCommit(
+        host: WorkspaceSurfaceHostRecord,
+        scopeKey: string | null,
+    ): Promise<void> {
+        if (host.durableScopeRetryTimer) {
+            clearTimeout(host.durableScopeRetryTimer);
+            host.durableScopeRetryTimer = null;
+        }
+        host.hasPendingDurableScopeCommit = false;
+        await host.durableScopeCommit;
+        // A close must not leave durable navigation pointing to a renderer
+        // that is about to be destroyed.
+        await this.#lifecycleHandlers.commitActiveScope?.(
+            host.hostWindowId,
+            scopeKey,
+        );
     }
 
     #waitUntilSurfaceReady(

--- a/src/main/workspace/surface-manager.ts
+++ b/src/main/workspace/surface-manager.ts
@@ -935,7 +935,7 @@ export class WorkspaceSurfaceManager {
         if (host.pendingLayoutTimer) {
             clearTimeout(host.pendingLayoutTimer);
         }
-        if (host.durableScopeRetryTimer) {
+        if (host.durableScopeRetryTimer !== null) {
             clearTimeout(host.durableScopeRetryTimer);
         }
         for (const surfaceId of [...host.surfaceIdsByContextKey.values()]) {
@@ -1140,6 +1140,10 @@ export class WorkspaceSurfaceManager {
         host: WorkspaceSurfaceHostRecord,
         scopeKey: string | null,
     ): void {
+        if (host.durableScopeRetryTimer !== null) {
+            clearTimeout(host.durableScopeRetryTimer);
+            host.durableScopeRetryTimer = null;
+        }
         host.pendingDurableScopeKey = scopeKey;
         host.hasPendingDurableScopeCommit = true;
         if (host.durableScopeCommit) {
@@ -1171,6 +1175,9 @@ export class WorkspaceSurfaceManager {
                             host.pendingDurableScopeKey,
                         );
                     }, 1_000);
+                    // The retry timer owns the next attempt; continuing here
+                    // would turn a durable outage into a busy loop.
+                    break;
                 }
             }
         })();
@@ -1196,7 +1203,7 @@ export class WorkspaceSurfaceManager {
         host: WorkspaceSurfaceHostRecord,
         scopeKey: string | null,
     ): Promise<void> {
-        if (host.durableScopeRetryTimer) {
+        if (host.durableScopeRetryTimer !== null) {
             clearTimeout(host.durableScopeRetryTimer);
             host.durableScopeRetryTimer = null;
         }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -598,10 +598,9 @@ export function WorkspaceHostApp() {
             const contextKey = await useWorkspaceStore
                 .getState()
                 .registerWorkspaceScope(workspace.projectId, workspace.worktreeId);
-            await comandoApi.initializeWorkspaceSurfaces(
-                useWorkspaceStore.getState().getWorkspaceSurfaceRegistry(),
-            );
-            const result = await comandoApi.activateWorkspaceSurface(contextKey);
+            const result = await useWorkspaceStore
+                .getState()
+                .activateWorkspaceSurface(contextKey);
             if (result.status === "failed") {
                 throw new Error(result.message);
             }
@@ -882,7 +881,6 @@ export function WorkspaceHostApp() {
             useWorkspaceStore.getState().getWorkspaceSurfaceRegistry(),
         );
     }, [
-        workspaceActiveContextKey,
         workspaceNavigationHydrated,
         workspaceSurfaceTopologyKey,
     ]);
@@ -919,10 +917,7 @@ export function WorkspaceHostApp() {
                         { emptyLayout: true },
                     );
                 }
-                await api.initializeWorkspaceSurfaces(
-                    useWorkspaceStore.getState().getWorkspaceSurfaceRegistry(),
-                );
-                const result = await api.activateWorkspaceSurface(contextKey);
+                const result = await store.activateWorkspaceSurface(contextKey);
                 if (result.status === "failed") {
                     throw new Error(result.message);
                 }
@@ -1179,10 +1174,9 @@ export function WorkspaceHostApp() {
                 const contextKey = await useWorkspaceStore
                     .getState()
                     .registerWorkspaceScope(payload.projectId, requestedWorktreeId);
-                await comandoApi.initializeWorkspaceSurfaces(
-                    useWorkspaceStore.getState().getWorkspaceSurfaceRegistry(),
-                );
-                await comandoApi.activateWorkspaceSurface(contextKey);
+                await useWorkspaceStore
+                    .getState()
+                    .activateWorkspaceSurface(contextKey);
 
                 if (payload.branchName !== undefined) {
                     selectGitBranch(
@@ -3882,10 +3876,9 @@ export function WorkspaceHostApp() {
             const contextKey = await useWorkspaceStore
                 .getState()
                 .registerWorkspaceScope(projectId, worktreeId);
-            await api.initializeWorkspaceSurfaces(
-                useWorkspaceStore.getState().getWorkspaceSurfaceRegistry(),
-            );
-            const result = await api.activateWorkspaceSurface(contextKey);
+            const result = await useWorkspaceStore
+                .getState()
+                .activateWorkspaceSurface(contextKey);
             if (result.status === "failed") {
                 throw new Error(result.message);
             }

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -19,6 +19,7 @@ import type {
     WorkspaceReviewTab,
     WorkspaceSurfaceNavigationState,
     WorkspaceSurfaceRegistrySnapshot,
+    WorkspaceSurfaceActivationResult,
 } from "@shared/ipc";
 import {
     getAiRuntimeDisplayName,
@@ -147,6 +148,9 @@ interface WorkspaceStore extends WorkspaceTreeState {
     readonly contextsByKey: Record<string, RuntimeWorkspaceLayout>;
     readonly deferredPaneIds: ReadonlySet<string>;
     getWorkspaceSurfaceRegistry: () => WorkspaceSurfaceRegistrySnapshot;
+    activateWorkspaceSurface: (
+        contextKey: string,
+    ) => Promise<WorkspaceSurfaceActivationResult>;
     applyWorkspaceSurfaceNavigation: (
         navigation: WorkspaceSurfaceNavigationState,
     ) => void;
@@ -436,6 +440,26 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     scopeEpoch: 0,
 
     getWorkspaceSurfaceRegistry: () => workspaceStoreToSurfaceRegistry(get()),
+
+    activateWorkspaceSurface: async (contextKey) => {
+        const api = getComandoApi();
+        if (!api) {
+            throw new Error("The desktop bridge is unavailable.");
+        }
+
+        let result = await api.activateWorkspaceSurface(contextKey);
+        if (
+            result.status === "failed" &&
+            result.message === "The workspace is not available in this host."
+        ) {
+            // A new scope may race React's topology-sync effect on its first open.
+            await api.initializeWorkspaceSurfaces(
+                get().getWorkspaceSurfaceRegistry(),
+            );
+            result = await api.activateWorkspaceSurface(contextKey);
+        }
+        return result;
+    },
 
     applyWorkspaceSurfaceNavigation: (navigation) => {
         const { activeScopeKey, projectId, worktreeId } = navigation;

--- a/src/renderer/src/components/workspace-navigator/WorkspaceNavigatorPanel.tsx
+++ b/src/renderer/src/components/workspace-navigator/WorkspaceNavigatorPanel.tsx
@@ -64,12 +64,10 @@ export function WorkspaceNavigatorPanel({
             const contextKey = await useWorkspaceStore
                 .getState()
                 .registerWorkspaceScope(workspace.projectId, workspace.worktreeId);
-            // Main receives the compatibility context before activation, while
-            // selection remains committed to the previous surface until ready.
-            await api.initializeWorkspaceSurfaces(
-                useWorkspaceStore.getState().getWorkspaceSurfaceRegistry(),
-            );
-            const result = await api.activateWorkspaceSurface(contextKey);
+            // New scopes synchronize only when main cannot activate them yet.
+            const result = await useWorkspaceStore
+                .getState()
+                .activateWorkspaceSurface(contextKey);
             if (result.status === "failed") {
                 throw new Error(result.message);
             }


### PR DESCRIPTION
## Summary

- Avoid full workspace-registry synchronization when activating a workspace surface that is already known by the host.
- Reveal and focus warm workspace surfaces before durable navigation persistence completes.
- Coalesce background navigation writes and retry failed writes without blocking workspace switching.
- Preserve consistency when closing an active workspace: navigation must be durably cleared before its surface can be destroyed.
- Flush pending navigation persistence during host shutdown.

## Validation

- `pnpm run typecheck`
- `pnpm exec vitest run src/main/workspace/activation-coordinator.test.ts src/main/workspace/surface-manager.actions.test.ts src/renderer/src/app/store/workspace-store.test.ts src/renderer/src/components/workspace-navigator/WorkspaceNavigator.test.tsx`
- `pnpm exec eslint src/main/workspace src/renderer/src/app/store/workspace-store.ts src/renderer/src/components/workspace-navigator/WorkspaceNavigatorPanel.tsx`
- `pnpm run build:ci`