### PR TITLE
Fix workspace layout persistence conflicts

### DIFF
--- a/src/renderer/src/app/store/workspace-store.test.ts
+++ b/src/renderer/src/app/store/workspace-store.test.ts
@@ -2683,7 +2683,7 @@ describe("workspace file opening", () => {
         errorSpy.mockRestore();
     });
 
-    it("flushes split resize immediately when the drag is committed", async () => {
+    it("defers split resize persistence until the workspace is idle", async () => {
         useWorkspaceStore.setState((state) => ({
             ...state,
             activePaneId: "pane-left",
@@ -2713,6 +2713,10 @@ describe("workspace file opening", () => {
         await useWorkspaceStore
             .getState()
             .resizeSplit("split-root", [0.68, 0.32]);
+
+        expect(persistWorkspaceLayoutMock).not.toHaveBeenCalled();
+
+        await flushWorkspacePersistenceForTests();
 
         expect(persistWorkspaceLayoutMock).toHaveBeenCalledTimes(1);
         const persistedSnapshot =

--- a/src/renderer/src/app/store/workspace-store.ts
+++ b/src/renderer/src/app/store/workspace-store.ts
@@ -2119,7 +2119,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
             error: null,
             rootNode: resizeSplit(state.rootNode, splitId, nextSizes),
         }));
-        await flushWorkspacePersistence(get, { force: true });
+        await persistWorkspaceState(get);
     },
 
     restartTerminalTab: async (tabId) => {
@@ -2549,7 +2549,7 @@ if (import.meta.hot) {
 
 type WorkspaceSetState = typeof useWorkspaceStore.setState;
 
-const WORKSPACE_PERSIST_DEBOUNCE_MS = 180;
+const WORKSPACE_PERSIST_DEBOUNCE_MS = 10_000;
 const MAX_RECENTLY_CLOSED_TABS = 20;
 
 let pendingWorkspacePersistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -2557,6 +2557,7 @@ let workspacePersistDirty = false;
 let workspacePersistGet: GetWorkspaceState | null = null;
 let workspacePersistInFlight: Promise<void> | null = null;
 let workspacePersistFailureCount = 0;
+let workspacePersistBlocked = false;
 const pendingFileDocumentLoads = new Map<string, Promise<ProjectFileDocument>>();
 const latestFileLoadRequestIds = new Map<string, number>();
 
@@ -3733,6 +3734,7 @@ export function resetWorkspacePersistenceForTests(): void {
     workspacePersistGet = null;
     workspacePersistInFlight = null;
     workspacePersistFailureCount = 0;
+    workspacePersistBlocked = false;
     pendingFileDocumentLoads.clear();
     latestFileLoadRequestIds.clear();
 }
@@ -3742,6 +3744,7 @@ function scheduleWorkspacePersistence(get: GetWorkspaceState): void {
     workspacePersistDirty = true;
 
     if (
+        workspacePersistBlocked ||
         pendingWorkspacePersistTimer !== null ||
         workspacePersistInFlight !== null
     ) {
@@ -3773,6 +3776,7 @@ async function flushWorkspacePersistence(
 
     if (options.force) {
         workspacePersistDirty = true;
+        workspacePersistBlocked = false;
     }
 
     if (pendingWorkspacePersistTimer !== null) {
@@ -3832,6 +3836,7 @@ async function persistWorkspaceStateNow(get: GetWorkspaceState): Promise<void> {
             );
         }
         workspacePersistFailureCount = 0;
+        workspacePersistBlocked = false;
     } catch (error) {
         // Workspace persistence failure silently loses layout/tabs on restart;
         // surface it at error level so diagnostics don't start from scratch.
@@ -3841,15 +3846,9 @@ async function persistWorkspaceStateNow(get: GetWorkspaceState): Promise<void> {
         );
         workspacePersistDirty = true;
         workspacePersistFailureCount += 1;
-        if (
-            pendingWorkspacePersistTimer === null &&
-            workspacePersistFailureCount <= 3
-        ) {
-            pendingWorkspacePersistTimer = setTimeout(() => {
-                pendingWorkspacePersistTimer = null;
-                void flushWorkspacePersistence();
-            }, Math.min(1_000 * workspacePersistFailureCount, 3_000));
-        }
+        // A stale revision cannot recover by retrying the same snapshot. Keep
+        // the change for an explicit close flush or a future surface hydrate.
+        workspacePersistBlocked = true;
     }
 }
 

--- a/src/renderer/src/app/workspace/workspace-layout-coordinator.test.ts
+++ b/src/renderer/src/app/workspace/workspace-layout-coordinator.test.ts
@@ -160,4 +160,73 @@ describe("WorkspaceLayoutCoordinator", () => {
         );
         expect(store.getState().binding.revision).toBe(5);
     });
+
+    it("reloads the revision and retries once after a durable revision conflict", async () => {
+        const conflict = new Error(
+            "The durable workspace revision changed (expected 4, actual 5).",
+        );
+        const save = vi
+            .fn<WorkspaceLayoutAdapter["save"]>()
+            .mockRejectedValueOnce(conflict)
+            .mockImplementationOnce((requestedBinding, requestedLayout, lastActivatedAt) =>
+                Promise.resolve({
+                    ...requestedBinding,
+                    lastActivatedAt,
+                    layout: requestedLayout,
+                    revision: 6,
+                }),
+            );
+        const load = vi.fn<WorkspaceLayoutAdapter["load"]>(() =>
+                Promise.resolve({
+                    ...binding,
+                    lastActivatedAt: "2026-07-31T12:00:00.000Z",
+                    layout,
+                    revision: 5,
+                }),
+            );
+        const adapter: WorkspaceLayoutAdapter = {
+            load,
+            save,
+        };
+        const store = createWorkspaceLayoutStore(binding);
+        const coordinator = new WorkspaceLayoutCoordinator(store, adapter);
+
+        await expect(coordinator.persist(layout)).resolves.toBe(true);
+
+        expect(load).toHaveBeenCalledWith(binding);
+        expect(save).toHaveBeenNthCalledWith(1, binding, layout, expect.any(String));
+        expect(save).toHaveBeenNthCalledWith(
+            2,
+            { ...binding, revision: 5 },
+            layout,
+            expect.any(String),
+        );
+        expect(store.getState().binding.revision).toBe(6);
+    });
+
+    it("stops after the single conflict recovery retry fails", async () => {
+        const conflict = new Error(
+            "The durable workspace revision changed (expected 4, actual 5).",
+        );
+        const save = vi
+            .fn<WorkspaceLayoutAdapter["save"]>()
+            .mockRejectedValue(conflict);
+        const load = vi.fn<WorkspaceLayoutAdapter["load"]>(() =>
+            Promise.resolve({
+                ...binding,
+                lastActivatedAt: "2026-07-31T12:00:00.000Z",
+                layout,
+                revision: 5,
+            }),
+        );
+        const coordinator = new WorkspaceLayoutCoordinator(
+            createWorkspaceLayoutStore(binding),
+            { load, save },
+        );
+
+        await expect(coordinator.persist(layout)).rejects.toBe(conflict);
+
+        expect(load).toHaveBeenCalledTimes(1);
+        expect(save).toHaveBeenCalledTimes(2);
+    });
 });

--- a/src/renderer/src/app/workspace/workspace-layout-coordinator.ts
+++ b/src/renderer/src/app/workspace/workspace-layout-coordinator.ts
@@ -70,7 +70,7 @@ export class WorkspaceLayoutCoordinator {
         this.#store.setState({ error: null, status: "saving" });
 
         try {
-            const record = await this.#adapter.save(
+            const record = await this.#saveWithConflictRecovery(
                 binding,
                 layout,
                 lastActivatedAt,
@@ -108,6 +108,33 @@ export class WorkspaceLayoutCoordinator {
         this.#operation += 1;
     }
 
+    async #saveWithConflictRecovery(
+        binding: WorkspaceLayoutBinding,
+        layout: WorkspaceLayoutSnapshot,
+        lastActivatedAt: string,
+    ): Promise<WorkspaceLayoutRecord> {
+        try {
+            return await this.#adapter.save(binding, layout, lastActivatedAt);
+        } catch (error) {
+            if (!isWorkspaceRevisionConflict(error)) {
+                throw error;
+            }
+
+            // Refresh the CAS token before one retry so a completed save from
+            // a previous surface lifecycle cannot leave this renderer stale.
+            const current = await this.#adapter.load(binding);
+            this.#assertRecordMatchesBinding(current, binding);
+            return await this.#adapter.save(
+                {
+                    ...binding,
+                    revision: current.revision,
+                },
+                layout,
+                lastActivatedAt,
+            );
+        }
+    }
+
     #assertRecordMatchesBinding(
         record: WorkspaceLayoutRecord,
         binding: WorkspaceLayoutBinding,
@@ -136,4 +163,11 @@ export class WorkspaceLayoutCoordinator {
             current.revision === binding.revision
         );
     }
+}
+
+function isWorkspaceRevisionConflict(error: unknown): boolean {
+    return (
+        error instanceof Error &&
+        error.message.includes("The durable workspace revision changed")
+    );
 }


### PR DESCRIPTION
## Summary
- debounce durable workspace layout saves for 10 seconds and stop forcing a save after split resize
- recover once from an optimistic revision conflict by refreshing the durable revision
- stop automatic retries after a persistence failure while preserving explicit close/hibernate flushes

## Validation
- pnpm exec vitest run src/renderer/src/app/workspace/workspace-layout-coordinator.test.ts src/renderer/src/app/store/workspace-store.test.ts
- pnpm exec eslint src/renderer/src/app/workspace/workspace-layout-coordinator.ts src/renderer/src/app/store/workspace-store.ts src/renderer/src/app/workspace/workspace-layout-coordinator.test.ts src/renderer/src/app/store/workspace-store.test.ts
- pnpm run typecheck