### PR TITLE
fix(chat): defer syntax highlighting until code fences close

### DIFF
--- a/src/renderer/src/app/editor/codeLanguage.ts
+++ b/src/renderer/src/app/editor/codeLanguage.ts
@@ -1220,16 +1220,12 @@ export function resolveCodeLanguageKeyFromPath(
     return resolveCodeLanguageKey(filePath, null, probeContent);
 }
 
-const noMarkdownLanguageSupportPromise: Promise<LanguageSupport | null> =
-    Promise.resolve(null);
-
-export function loadMarkdownCodeLanguageSupport(
+export async function loadMarkdownCodeLanguageSupport(
     info: string,
 ): Promise<LanguageSupport | null> {
     const key = resolveMarkdownCodeLanguageKey(info);
     if (!key) {
-        // Suspense requires a stable promise even when the fence has no grammar.
-        return noMarkdownLanguageSupportPromise;
+        return null;
     }
     return loadCachedLanguageByKey(key);
 }

--- a/src/renderer/src/app/editor/staticCodeHighlight.tsx
+++ b/src/renderer/src/app/editor/staticCodeHighlight.tsx
@@ -9,9 +9,6 @@ type HighlightSegment = {
     readonly className: string | null;
 };
 
-const FALLBACK_CODE_TOKEN_RE =
-    /\/\*[\s\S]*?\*\/|\/\/[^\n]*|#[^\n]*|`(?:\\.|[^`\\])*`|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\b\d+(?:\.\d+)?\b|\b(?:class|const|else|enum|export|for|from|function|if|import|in|let|namespace|new|private|protected|public|return|static|switch|template|throw|try|using|while)\b|\b(?:auto|bool|char|double|float|int|long|short|string|void)\b/g;
-
 const staticTokenHighlighter = tagHighlighter([
     {
         tag: [
@@ -199,43 +196,6 @@ function buildLanguageHighlightSegments(
     return segments;
 }
 
-function buildFallbackHighlightSegments(text: string): HighlightSegment[] {
-    const segments: HighlightSegment[] = [];
-    let cursor = 0;
-
-    for (const match of text.matchAll(FALLBACK_CODE_TOKEN_RE)) {
-        const token = match[0];
-        const from = match.index ?? cursor;
-        if (from > cursor) {
-            segments.push({ text: text.slice(cursor, from), className: null });
-        }
-
-        const className = token.startsWith("//") ||
-            token.startsWith("/*") ||
-            token.startsWith("#")
-            ? "cm-static-token-comment"
-            : token.startsWith('"') ||
-                token.startsWith("'") ||
-                token.startsWith("`")
-              ? "cm-static-token-string"
-              : /^\d/.test(token)
-                ? "cm-static-token-number"
-                : /^(?:auto|bool|char|double|float|int|long|short|string|void)$/.test(
-                      token,
-                  )
-                  ? "cm-static-token-type"
-                  : "cm-static-token-keyword";
-        segments.push({ text: token, className });
-        cursor = from + token.length;
-    }
-
-    if (cursor < text.length) {
-        segments.push({ text: text.slice(cursor), className: null });
-    }
-
-    return segments;
-}
-
 function renderHighlightSegments(
     segments: readonly HighlightSegment[],
     keyPrefix: string,
@@ -252,30 +212,29 @@ function renderHighlightSegments(
 }
 
 export function HighlightedCodeText({
-    fallbackHighlighting = false,
+    deferHighlighting = false,
     text,
     language,
     segmentKeyPrefix = "cm-static",
 }: {
-    /** Gives a loading streaming parser an immediate lightweight token pass. */
-    readonly fallbackHighlighting?: boolean;
+    /** Keeps an open streaming fence responsive until its syntax is sealed. */
+    readonly deferHighlighting?: boolean;
     readonly text: string;
     readonly language: LanguageSupport | Language | null;
     readonly segmentKeyPrefix?: string;
 }) {
     const segments = useMemo(
         () =>
-            language
-                ? buildHighlightSegments(text, toLanguage(language))
-                : fallbackHighlighting
-                  ? buildFallbackHighlightSegments(text)
-                  : [{ className: null, text }],
-        [fallbackHighlighting, language, text],
+            deferHighlighting
+                ? [{ className: null, text }]
+                : buildHighlightSegments(text, toLanguage(language)),
+        [deferHighlighting, language, text],
     );
 
     return (
         <span
             className="cm-static-code"
+            data-code-highlight-deferred={deferHighlighting ? "true" : undefined}
         >
             {renderHighlightSegments(segments, segmentKeyPrefix)}
         </span>

--- a/src/renderer/src/components/workspace/MarkdownContent.test.ts
+++ b/src/renderer/src/components/workspace/MarkdownContent.test.ts
@@ -14,8 +14,6 @@ import {
     readChatPerformanceCounters,
     resetChatPerformanceCounters,
 } from "@renderer/app/debug/chatPerformanceCounters";
-import { loadMarkdownCodeLanguageSupport } from "@renderer/app/editor/codeLanguage";
-
 import {
     MarkdownContent,
     parseMarkdownBlocksProgressively,
@@ -59,24 +57,6 @@ function renderInteractiveMarkdownContent(
 
     act(() => {
         root.render(createElement(MarkdownContent, props));
-    });
-
-    return container;
-}
-
-async function renderInteractiveMarkdownContentAsync(
-    props: Parameters<typeof MarkdownContent>[0],
-): Promise<HTMLElement> {
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-
-    const root = createRoot(container);
-    mountedRoots.push(root);
-    mountedContainers.push(container);
-
-    await act(async () => {
-        root.render(createElement(MarkdownContent, props));
-        await Promise.resolve();
     });
 
     return container;
@@ -194,8 +174,8 @@ describe("MarkdownContent", () => {
         expect(next.stableBlocks.at(-1)).toBe(completed.stableBlocks.at(-1));
     });
 
-    it("seals a closed fence and highlights an open fence while streaming", async () => {
-        const openFence = "Before the fence.\n\n```cpp\nint answer = 42;";
+    it("seals a closed fence and defers highlighting only while it is open", () => {
+        const openFence = "Before the fence.\n\n```ts\nconst answer = 42;";
         const streamingMarkup = renderToStaticMarkup(
             createElement(MarkdownContent, {
                 content: openFence,
@@ -213,19 +193,10 @@ describe("MarkdownContent", () => {
             (block) => block.type === "code",
         );
 
-        expect(streamingMarkup).toContain("cm-static-token-type");
-        const container = await renderInteractiveMarkdownContentAsync({
-            content: openFence,
-            live: true,
-        });
-        await act(async () => {
-            await loadMarkdownCodeLanguageSupport("cpp");
-            await new Promise((resolve) => window.setTimeout(resolve, 0));
-        });
-
-        expect(
-            container.querySelector("span[class*='cm-static-token-']"),
-        ).not.toBeNull();
+        expect(streamingMarkup).toContain(
+            'data-code-highlight-deferred="true"',
+        );
+        expect(streamingMarkup).not.toContain("cm-static-token-");
         expect(completedFence?.isMutable).toBe(false);
         expect(next.stableBlocks.find((block) => block.type === "code")).toBe(
             completedFence,

--- a/src/renderer/src/components/workspace/MarkdownContent.tsx
+++ b/src/renderer/src/components/workspace/MarkdownContent.tsx
@@ -1,7 +1,5 @@
 import {
     memo,
-    Suspense,
-    use,
     useCallback,
     useEffect,
     useMemo,
@@ -26,7 +24,7 @@ import {
     type MarkdownListItem,
 } from "../../app/editor/markdownLists";
 import { HighlightedCodeText } from "../../app/editor/staticCodeHighlight";
-import { loadMarkdownCodeLanguageSupport } from "../../app/editor/codeLanguage";
+import { useMarkdownCodeLanguageSupport } from "../../app/editor/useCodeLanguageSupport";
 import {
     ContextMenu,
     type ContextMenuEntry,
@@ -1674,35 +1672,16 @@ function parseList(
 
 /* ─── Code block ─── */
 
-function ResolvedHighlightedCodeText({
-    block,
-}: {
-    readonly block: MarkdownBlock;
-}) {
-    // The language promise is cached by grammar, allowing Suspense to resume
-    // an open fence as soon as its parser finishes loading.
-    const languageSupport = use(loadMarkdownCodeLanguageSupport(block.info));
-
-    return (
-        <HighlightedCodeText
-            text={block.content}
-            language={languageSupport}
-            segmentKeyPrefix={`chat-code:${block.id}`}
-        />
-    );
-}
-
 const CodeBlock = memo(function CodeBlock({
     block,
     chatFontSize = 14,
+    live,
 }: {
     readonly block: MarkdownBlock;
     readonly chatFontSize?: number;
+    readonly live: boolean;
 }) {
-    useEffect(() => {
-        // Preload the precise parser without delaying the mutable fence fallback.
-        void loadMarkdownCodeLanguageSupport(block.info);
-    }, [block.info]);
+    const languageSupport = useMarkdownCodeLanguageSupport(block.info);
     const languageToken = extractFenceLanguageToken(block.info ?? "");
     const isDiffBlock =
         languageToken?.toLowerCase() === "diff" ||
@@ -1761,27 +1740,12 @@ const CodeBlock = memo(function CodeBlock({
                             wordBreak: "inherit",
                         }}
                     >
-                        {block.isMutable ? (
-                            <HighlightedCodeText
-                                fallbackHighlighting
-                                text={block.content}
-                                language={null}
-                                segmentKeyPrefix={`chat-code:${block.id}`}
-                            />
-                        ) : (
-                            <Suspense
-                                fallback={
-                                    <HighlightedCodeText
-                                        fallbackHighlighting
-                                        text={block.content}
-                                        language={null}
-                                        segmentKeyPrefix={`chat-code:${block.id}`}
-                                    />
-                                }
-                            >
-                                <ResolvedHighlightedCodeText block={block} />
-                            </Suspense>
-                        )}
+                        <HighlightedCodeText
+                            deferHighlighting={live && block.isMutable}
+                            text={block.content}
+                            language={languageSupport}
+                            segmentKeyPrefix={`chat-code:${block.id}`}
+                        />
                     </code>
                 )}
             </pre>
@@ -2167,6 +2131,7 @@ export const MarkdownContent = memo(function MarkdownContent({
                         block={block}
                         chatFontSize={chatFontSize}
                         key={block.id}
+                        live={live}
                     />
                 ) : (
                     <TextBlock


### PR DESCRIPTION
## Summary

- keep mutable streaming code fences unhighlighted until they close
- apply the complete parser-based highlighting after the fence is sealed
- remove the partial regex fallback and streaming Suspense path

## Testing

- pnpm exec vitest run src/renderer/src/components/workspace/MarkdownContent.test.ts src/renderer/src/app/editor/codeLanguage.test.ts
- pnpm run typecheck
- pnpm exec eslint src/renderer/src/app/editor/codeLanguage.ts src/renderer/src/app/editor/staticCodeHighlight.tsx src/renderer/src/components/workspace/MarkdownContent.tsx src/renderer/src/components/workspace/MarkdownContent.test.ts