### PR TITLE
Enforce chat history retention settings

### DIFF
--- a/apps/native-backend/src/commands.rs
+++ b/apps/native-backend/src/commands.rs
@@ -248,6 +248,7 @@ impl NativeBackend {
             | "ai_list_session_runtime_mappings"
             | "ai_set_session_pinned"
             | "ai_delete_session"
+            | "ai_prune_session_history"
             | "ai_migrate_session_history"
             | "ai_get_history_storage_health"
             | "ai_capture_review_baseline"
@@ -407,6 +408,7 @@ impl NativeBackend {
             | "ai_list_session_runtime_mappings"
             | "ai_set_session_pinned"
             | "ai_delete_session"
+            | "ai_prune_session_history"
             | "ai_migrate_session_history"
             | "ai_get_history_storage_health"
             | "ai_capture_review_baseline"
@@ -2974,6 +2976,20 @@ impl NativeBackend {
                     Err(error) => error_only(request.id, error),
                 }
             }
+            "ai_prune_session_history" => {
+                let input =
+                    match parse_args::<native_ai::NativeAiPruneSessionHistoryInput>(&request) {
+                        Ok(input) => input,
+                        Err(error) => return error_only(request.id, error),
+                    };
+                match self.prune_ai_session_history(input) {
+                    Ok(output) => response_only(
+                        request.id,
+                        serde_json::to_value(output).expect("AI history prune output serializes"),
+                    ),
+                    Err(error) => error_only(request.id, error),
+                }
+            }
             "ai_rename_session" => {
                 let input = match parse_args::<native_ai::NativeAiRenameSessionInput>(&request) {
                     Ok(input) => input,
@@ -3286,6 +3302,89 @@ impl NativeBackend {
         store
             .delete_session(&session_id)
             .map_err(|error| error.to_native_error())
+    }
+
+    fn prune_ai_session_history(
+        &self,
+        input: native_ai::NativeAiPruneSessionHistoryInput,
+    ) -> Result<native_ai::NativeAiPruneSessionHistoryOutput, NativeError> {
+        let store = self.ai_history_store()?;
+        let persisted_retention_days = self
+            .persistence_store
+            .as_ref()
+            .and_then(|persistence_store| {
+                load_app_data_value(persistence_store, SETTINGS_SNAPSHOT_KEY).ok()
+            })
+            .and_then(|snapshot| {
+                snapshot
+                    .pointer("/aiChat/historyRetentionDays")
+                    .and_then(Value::as_u64)
+            })
+            .unwrap_or(0);
+        if persisted_retention_days != u64::from(input.retention_days) {
+            return Ok(native_ai::NativeAiPruneSessionHistoryOutput {
+                deleted_root_ids: Vec::new(),
+                deleted_session_ids: Vec::new(),
+                failed_root_ids: Vec::new(),
+                inspected_session_count: 0,
+                protected_tree_count: 0,
+                invalid_metadata_count: 0,
+                invalid_timestamp_count: 0,
+                policy_changed: true,
+            });
+        }
+        if let Some(persistence_store) = self.persistence_store.as_ref() {
+            let migrator = AiHistoryMigrator::new(
+                &store,
+                persistence_store.connection(),
+                Some(persistence_store.database_path().display().to_string()),
+            );
+            migrator
+                .copy_legacy_history_with_options(AiHistoryMigrationOptions {
+                    mode: AiHistoryMigrationMode::Copy,
+                    limit: None,
+                })
+                .map_err(|error| error.to_native_error())?;
+        }
+
+        let protected_session_ids = input
+            .protected_session_ids
+            .iter()
+            .map(|session_id| session_id.0.clone())
+            .collect::<std::collections::HashSet<_>>();
+        let candidates = store
+            .list_expired_session_trees(&input.cutoff, &protected_session_ids)
+            .map_err(|error| error.to_native_error())?;
+        let mut deleted_root_ids = Vec::new();
+        let mut deleted_session_ids = Vec::new();
+        let mut failed_root_ids = Vec::new();
+
+        for tree in candidates.trees {
+            let legacy_delete =
+                self.persistence_store
+                    .as_ref()
+                    .map_or(Ok(()), |persistence_store| {
+                        LegacyAiHistoryReader::new(persistence_store.connection())
+                            .delete_sessions(&tree.session_ids)
+                    });
+            if legacy_delete.is_err() || store.delete_session_tree(&tree.session_ids).is_err() {
+                failed_root_ids.push(tree.root_session_id);
+                continue;
+            }
+            deleted_root_ids.push(tree.root_session_id);
+            deleted_session_ids.extend(tree.session_ids);
+        }
+
+        Ok(native_ai::NativeAiPruneSessionHistoryOutput {
+            deleted_root_ids,
+            deleted_session_ids,
+            failed_root_ids,
+            inspected_session_count: candidates.inspected_session_count,
+            protected_tree_count: candidates.protected_tree_count,
+            invalid_metadata_count: candidates.invalid_metadata_count,
+            invalid_timestamp_count: candidates.invalid_timestamp_count,
+            policy_changed: false,
+        })
     }
 
     fn rename_ai_session(
@@ -5721,6 +5820,42 @@ mod tests {
         assert_eq!(
             project_response.result.as_ref().unwrap()["snapshot"]["editor"]["fontSize"],
             14
+        );
+    }
+
+    #[test]
+    fn history_pruning_revalidates_the_persisted_retention_policy() {
+        let (_temp_dir, mut backend) = backend_with_memory_runtime_setup();
+        let save_settings = backend.handle_request(request(
+            "settings_save_snapshot",
+            json!({ "snapshot": { "aiChat": { "historyRetentionDays": 7 } } }),
+        ));
+        assert!(only_response(&save_settings).ok);
+
+        let stale_prune = backend.handle_request(request(
+            "ai_prune_session_history",
+            json!({
+                "cutoff": "2026-08-01T12:00:00.000Z",
+                "protectedSessionIds": [],
+                "retentionDays": 30,
+            }),
+        ));
+        assert_eq!(
+            only_response(&stale_prune).result.as_ref().unwrap()["policyChanged"],
+            true
+        );
+
+        let current_prune = backend.handle_request(request(
+            "ai_prune_session_history",
+            json!({
+                "cutoff": "2026-08-01T12:00:00.000Z",
+                "protectedSessionIds": [],
+                "retentionDays": 7,
+            }),
+        ));
+        assert_eq!(
+            only_response(&current_prune).result.as_ref().unwrap()["policyChanged"],
+            false
         );
     }
 

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -5,6 +5,8 @@ use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
 use comando_types::ai::{
     AI_TRANSCRIPT_BLOCK_CAPABILITY_VERSION, AI_TRANSCRIPT_PAYLOAD_BATCH_MAX_REFS,
     NativeAiCheckpointOpenTranscriptTailInput, NativeAiHistorySessionSummary,
@@ -63,6 +65,21 @@ pub struct AiHistoryStore {
     legacy_transcript_backfill_indexes: Arc<Mutex<HashMap<String, AiTranscriptIndex>>>,
     work_metrics: Arc<StorageWorkMetrics>,
     durable_operation_interceptor: Option<DurableOperationInterceptorRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AiExpiredSessionTree {
+    pub root_session_id: SessionId,
+    pub session_ids: Vec<SessionId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AiExpiredSessionTrees {
+    pub trees: Vec<AiExpiredSessionTree>,
+    pub inspected_session_count: usize,
+    pub protected_tree_count: usize,
+    pub invalid_metadata_count: usize,
+    pub invalid_timestamp_count: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1757,8 +1774,14 @@ impl AiHistoryStore {
 
     pub fn delete_session(&self, session_id: &SessionId) -> AiResult<()> {
         let subtree_session_ids = self.collect_session_subtree_ids(session_id)?;
-        for subtree_session_id in subtree_session_ids.into_iter().rev() {
-            let session_dir = self.session_dir(&subtree_session_id);
+        self.delete_session_tree(&subtree_session_ids)
+    }
+
+    pub fn delete_session_tree(&self, session_ids: &[SessionId]) -> AiResult<()> {
+        // Retention already resolved the complete tree in one metadata scan;
+        // deleting that immutable candidate avoids rescanning all histories per root.
+        for subtree_session_id in session_ids.iter().rev() {
+            let session_dir = self.session_dir(subtree_session_id);
             if !session_dir.exists() {
                 continue;
             }
@@ -1766,6 +1789,152 @@ impl AiHistoryStore {
                 .map_err(|error| history_io("delete AI session dir", &session_dir, error))?;
         }
         Ok(())
+    }
+
+    pub fn list_expired_session_trees(
+        &self,
+        cutoff: &str,
+        protected_session_ids: &HashSet<String>,
+    ) -> AiResult<AiExpiredSessionTrees> {
+        let cutoff = OffsetDateTime::parse(cutoff, &Rfc3339).map_err(|error| {
+            AiError::InvalidInput(format!("Invalid AI history retention cutoff: {error}"))
+        })?;
+        let sessions_dir = self.sessions_dir();
+        if !sessions_dir.exists() {
+            return Ok(AiExpiredSessionTrees {
+                trees: Vec::new(),
+                inspected_session_count: 0,
+                protected_tree_count: 0,
+                invalid_metadata_count: 0,
+                invalid_timestamp_count: 0,
+            });
+        }
+
+        let mut metadata_by_id = HashMap::new();
+        let mut invalid_metadata_count = 0;
+        for entry in fs::read_dir(&sessions_dir)
+            .map_err(|error| history_io("read AI sessions dir", &sessions_dir, error))?
+        {
+            let entry = entry
+                .map_err(|error| history_io("read AI sessions dir entry", &sessions_dir, error))?;
+            if !entry
+                .file_type()
+                .map_err(|error| history_io("read AI session file type", &entry.path(), error))?
+                .is_dir()
+            {
+                continue;
+            }
+            match read_json_file::<AiHistorySessionMetadata>(&entry.path().join(SESSION_META_FILE))
+            {
+                Ok(metadata) => {
+                    let expected_dir_name = Self::storage_key(&metadata.session_id.0);
+                    if entry.file_name() != std::ffi::OsStr::new(&expected_dir_name) {
+                        invalid_metadata_count += 1;
+                        continue;
+                    }
+                    if metadata_by_id
+                        .insert(metadata.session_id.0.clone(), metadata)
+                        .is_some()
+                    {
+                        invalid_metadata_count += 1;
+                    }
+                }
+                Err(_) => invalid_metadata_count += 1,
+            }
+        }
+
+        // Unreadable metadata may hide a parent/child edge, so no tree can be
+        // proven independent until storage repair makes every record readable.
+        if invalid_metadata_count > 0 {
+            return Ok(AiExpiredSessionTrees {
+                trees: Vec::new(),
+                inspected_session_count: metadata_by_id.len(),
+                protected_tree_count: usize::from(!metadata_by_id.is_empty()),
+                invalid_metadata_count,
+                invalid_timestamp_count: 0,
+            });
+        }
+
+        let mut children_by_parent: HashMap<String, Vec<String>> = HashMap::new();
+        let mut roots = Vec::new();
+        for (session_id, metadata) in &metadata_by_id {
+            let parent_session_id = metadata
+                .subagent
+                .as_ref()
+                .map(|subagent| &subagent.parent_session_id)
+                .or(metadata.parent_session_id.as_ref())
+                .map(|parent| parent.0.clone());
+            if let Some(parent_session_id) = parent_session_id
+                && metadata_by_id.contains_key(&parent_session_id)
+            {
+                children_by_parent
+                    .entry(parent_session_id)
+                    .or_default()
+                    .push(session_id.clone());
+            } else {
+                roots.push(session_id.clone());
+            }
+        }
+        roots.sort();
+
+        let mut trees = Vec::new();
+        let mut protected_tree_count = 0;
+        let mut invalid_timestamp_count = 0;
+        let mut visited = HashSet::new();
+        for root_session_id in roots {
+            let mut pending = vec![root_session_id.clone()];
+            let mut tree_session_ids = Vec::new();
+            while let Some(session_id) = pending.pop() {
+                if !visited.insert(session_id.clone()) {
+                    continue;
+                }
+                tree_session_ids.push(session_id.clone());
+                if let Some(children) = children_by_parent.get(&session_id) {
+                    pending.extend(children.iter().cloned());
+                }
+            }
+
+            let mut eligible = true;
+            for session_id in &tree_session_ids {
+                let metadata = &metadata_by_id[session_id];
+                if protected_session_ids.contains(session_id) || metadata.pinned_at.is_some() {
+                    eligible = false;
+                    continue;
+                }
+                match OffsetDateTime::parse(&metadata.updated_at, &Rfc3339) {
+                    Ok(updated_at) if updated_at <= cutoff => {}
+                    Ok(_) => eligible = false,
+                    Err(_) => {
+                        invalid_timestamp_count += 1;
+                        eligible = false;
+                    }
+                }
+            }
+
+            if eligible {
+                tree_session_ids.sort();
+                trees.push(AiExpiredSessionTree {
+                    root_session_id: SessionId(root_session_id),
+                    session_ids: tree_session_ids.into_iter().map(SessionId).collect(),
+                });
+            } else {
+                protected_tree_count += 1;
+            }
+        }
+
+        // Cycles cannot be proven safe, so retain every disconnected malformed component.
+        if visited.len() < metadata_by_id.len() {
+            protected_tree_count += 1;
+            invalid_metadata_count += metadata_by_id.len() - visited.len();
+        }
+
+        Ok(AiExpiredSessionTrees {
+            trees,
+            inspected_session_count: metadata_by_id.len(),
+            protected_tree_count,
+            invalid_metadata_count,
+            invalid_timestamp_count,
+        })
     }
 
     fn collect_session_subtree_ids(&self, session_id: &SessionId) -> AiResult<Vec<SessionId>> {
@@ -2791,6 +2960,24 @@ impl<'a> LegacyAiHistoryReader<'a> {
             .filter(|row| row.message_count > 0 || row.parent_session_id.is_some())
             .map(summary_from_legacy_row)
             .collect())
+    }
+
+    pub fn delete_sessions(&self, session_ids: &[SessionId]) -> AiResult<()> {
+        if session_ids.is_empty() || !self.table_exists("chat_sessions")? {
+            return Ok(());
+        }
+        let transaction = self
+            .connection
+            .unchecked_transaction()
+            .map_err(|error| history_sql("start legacy AI history deletion", error))?;
+        for session_id in session_ids.iter().rev() {
+            transaction
+                .execute("DELETE FROM chat_sessions WHERE id = ?1", [&session_id.0])
+                .map_err(|error| history_sql("delete legacy AI session", error))?;
+        }
+        transaction
+            .commit()
+            .map_err(|error| history_sql("commit legacy AI history deletion", error))
     }
 
     pub fn load_transcript_page(
@@ -4904,6 +5091,134 @@ mod tests {
     }
 
     #[test]
+    fn expired_session_tree_is_eligible_at_the_cutoff_boundary() {
+        let (_temp, store) = store();
+        let mut root = metadata("expired-root");
+        root.updated_at = "2026-07-01T12:00:00.000Z".to_string();
+        store.create_session(root.clone()).unwrap();
+
+        let result = store
+            .list_expired_session_trees("2026-07-01T12:00:00.000Z", &HashSet::new())
+            .unwrap();
+
+        assert_eq!(result.inspected_session_count, 1);
+        assert_eq!(result.protected_tree_count, 0);
+        assert_eq!(result.trees.len(), 1);
+        assert_eq!(result.trees[0].root_session_id, root.session_id);
+        assert_eq!(result.trees[0].session_ids, vec![root.session_id]);
+    }
+
+    #[test]
+    fn recent_descendant_protects_the_complete_session_tree() {
+        let (_temp, store) = store();
+        let mut root = metadata("old-root");
+        root.updated_at = "2026-06-01T12:00:00.000Z".to_string();
+        store.create_session(root.clone()).unwrap();
+        let mut child = metadata("recent-child");
+        child.parent_session_id = Some(root.session_id.clone());
+        child.updated_at = "2026-07-02T12:00:00.000Z".to_string();
+        store.create_session(child).unwrap();
+
+        let result = store
+            .list_expired_session_trees("2026-07-01T12:00:00.000Z", &HashSet::new())
+            .unwrap();
+
+        assert!(result.trees.is_empty());
+        assert_eq!(result.inspected_session_count, 2);
+        assert_eq!(result.protected_tree_count, 1);
+    }
+
+    #[test]
+    fn pinned_or_live_descendant_protects_the_complete_session_tree() {
+        let (_temp, store) = store();
+        let mut pinned_root = metadata("pinned-root");
+        pinned_root.updated_at = "2026-06-01T12:00:00.000Z".to_string();
+        pinned_root.pinned_at = Some("2026-06-02T12:00:00.000Z".to_string());
+        store.create_session(pinned_root).unwrap();
+
+        let mut live_root = metadata("live-root");
+        live_root.updated_at = "2026-06-01T12:00:00.000Z".to_string();
+        store.create_session(live_root.clone()).unwrap();
+        let mut child = metadata("live-child");
+        child.parent_session_id = Some(live_root.session_id);
+        child.updated_at = "2026-06-01T12:00:00.000Z".to_string();
+        store.create_session(child.clone()).unwrap();
+
+        let result = store
+            .list_expired_session_trees(
+                "2026-07-01T12:00:00.000Z",
+                &HashSet::from([child.session_id.0]),
+            )
+            .unwrap();
+
+        assert!(result.trees.is_empty());
+        assert_eq!(result.protected_tree_count, 2);
+    }
+
+    #[test]
+    fn invalid_timestamp_is_retained_and_counted() {
+        let (_temp, store) = store();
+        let mut root = metadata("invalid-time");
+        root.updated_at = "not-a-timestamp".to_string();
+        store.create_session(root).unwrap();
+
+        let result = store
+            .list_expired_session_trees("2026-07-01T12:00:00.000Z", &HashSet::new())
+            .unwrap();
+
+        assert!(result.trees.is_empty());
+        assert_eq!(result.invalid_timestamp_count, 1);
+        assert_eq!(result.protected_tree_count, 1);
+    }
+
+    #[test]
+    fn unreadable_metadata_blocks_pruning_until_storage_is_repaired() {
+        let (_temp, store) = store();
+        let mut valid = metadata("valid-old-session");
+        valid.updated_at = "2026-06-01T12:00:00.000Z".to_string();
+        store.create_session(valid).unwrap();
+        let corrupt_dir = store.sessions_dir().join("corrupt-session");
+        fs::create_dir_all(&corrupt_dir).unwrap();
+        fs::write(corrupt_dir.join(SESSION_META_FILE), b"not-json").unwrap();
+
+        let result = store
+            .list_expired_session_trees("2026-07-01T12:00:00.000Z", &HashSet::new())
+            .unwrap();
+
+        assert!(result.trees.is_empty());
+        assert_eq!(result.invalid_metadata_count, 1);
+        assert_eq!(result.protected_tree_count, 1);
+    }
+
+    #[test]
+    fn noncanonical_duplicate_metadata_blocks_pruning() {
+        let (_temp, store) = store();
+        let mut recent = metadata("recent-canonical-session");
+        recent.updated_at = "2026-07-02T12:00:00.000Z".to_string();
+        store.create_session(recent.clone()).unwrap();
+
+        let rogue_dir = store.sessions_dir().join("rogue-duplicate");
+        fs::create_dir_all(&rogue_dir).unwrap();
+        let mut stale_duplicate = recent;
+        stale_duplicate.updated_at = "2026-06-01T12:00:00.000Z".to_string();
+        fs::write(
+            rogue_dir.join(SESSION_META_FILE),
+            serde_json::to_vec(&stale_duplicate).unwrap(),
+        )
+        .unwrap();
+
+        let result = store
+            .list_expired_session_trees("2026-07-01T12:00:00.000Z", &HashSet::new())
+            .unwrap();
+
+        assert!(result.trees.is_empty());
+        assert_eq!(result.inspected_session_count, 1);
+        assert_eq!(result.invalid_metadata_count, 1);
+        assert_eq!(result.protected_tree_count, 1);
+        assert!(store.has_session(&stale_duplicate.session_id));
+    }
+
+    #[test]
     fn list_treats_null_and_canonical_primary_worktrees_as_one_scope() {
         let (_temp, store) = store();
         let mut null_primary = metadata("null_primary");
@@ -5044,6 +5359,28 @@ mod tests {
         assert!(!store.has_session(&child.session_id));
         assert!(!store.has_session(&grandchild.session_id));
         assert!(store.has_session(&unrelated.session_id));
+    }
+
+    #[test]
+    fn deleting_a_known_tree_does_not_rescan_unrelated_metadata() {
+        let (_temp, store) = store();
+        let parent = metadata("known-parent");
+        store.create_session(parent.clone()).unwrap();
+        let mut child = metadata("known-child");
+        child.parent_session_id = Some(parent.session_id.clone());
+        store.create_session(child.clone()).unwrap();
+
+        let corrupt_dir = store.sessions_dir().join("corrupt-unrelated");
+        fs::create_dir_all(&corrupt_dir).unwrap();
+        fs::write(corrupt_dir.join(SESSION_META_FILE), b"not-json").unwrap();
+
+        store
+            .delete_session_tree(&[parent.session_id.clone(), child.session_id.clone()])
+            .unwrap();
+
+        assert!(!store.has_session(&parent.session_id));
+        assert!(!store.has_session(&child.session_id));
+        assert!(corrupt_dir.exists());
     }
 
     #[test]
@@ -5318,6 +5655,27 @@ mod tests {
         assert_eq!(
             history[0].runtime_session_id.as_ref().unwrap().0,
             "runtime_legacy_1"
+        );
+    }
+
+    #[test]
+    fn legacy_reader_deletes_retained_source_sessions() {
+        let connection = legacy_connection();
+        insert_legacy_session(
+            &connection,
+            "legacy-delete",
+            vec![message("message-1", "legacy")],
+        );
+        let reader = LegacyAiHistoryReader::new(&connection);
+
+        reader
+            .delete_sessions(&[SessionId("legacy-delete".to_string())])
+            .unwrap();
+
+        assert!(
+            !reader
+                .has_session(&SessionId("legacy-delete".to_string()))
+                .unwrap()
         );
     }
 

--- a/crates/comando-types/src/ai.rs
+++ b/crates/comando-types/src/ai.rs
@@ -870,6 +870,28 @@ pub struct NativeAiDeleteSessionInput {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct NativeAiPruneSessionHistoryInput {
+    pub cutoff: String,
+    pub retention_days: u16,
+    #[serde(default)]
+    pub protected_session_ids: Vec<SessionId>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeAiPruneSessionHistoryOutput {
+    pub deleted_root_ids: Vec<SessionId>,
+    pub deleted_session_ids: Vec<SessionId>,
+    pub failed_root_ids: Vec<SessionId>,
+    pub inspected_session_count: usize,
+    pub protected_tree_count: usize,
+    pub invalid_metadata_count: usize,
+    pub invalid_timestamp_count: usize,
+    pub policy_changed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct NativeAiRenameSessionInput {
     pub session_id: SessionId,
     pub title: String,

--- a/crates/comando-types/src/commands.rs
+++ b/crates/comando-types/src/commands.rs
@@ -204,6 +204,7 @@ pub const AI_COMMANDS: &[&str] = &[
     "ai_list_session_runtime_mappings",
     "ai_set_session_pinned",
     "ai_delete_session",
+    "ai_prune_session_history",
     "ai_migrate_session_history",
     "ai_get_history_storage_health",
     "ai_capture_review_baseline",

--- a/fixtures/native-backend/protocol/capabilities.v1.json
+++ b/fixtures/native-backend/protocol/capabilities.v1.json
@@ -162,6 +162,7 @@
       "ai_list_session_runtime_mappings",
       "ai_set_session_pinned",
       "ai_delete_session",
+      "ai_prune_session_history",
       "ai_migrate_session_history",
       "ai_get_history_storage_health",
       "ai_capture_review_baseline",

--- a/fixtures/native-backend/protocol/registry.commands.json
+++ b/fixtures/native-backend/protocol/registry.commands.json
@@ -138,6 +138,7 @@
   "ai_list_session_runtime_mappings",
   "ai_set_session_pinned",
   "ai_delete_session",
+  "ai_prune_session_history",
   "ai_migrate_session_history",
   "ai_get_history_storage_health",
   "ai_capture_review_baseline",

--- a/src/main/ai/contracts.ts
+++ b/src/main/ai/contracts.ts
@@ -138,6 +138,23 @@ export interface AiSessionRetentionConfig {
     readonly maxHotSessionsPerWindow: number;
 }
 
+export interface AiHistoryPruneInput {
+    readonly cutoff: string;
+    readonly protectedSessionIds: readonly string[];
+    readonly retentionDays: number;
+}
+
+export interface AiHistoryPruneResult {
+    readonly deletedRootIds: readonly string[];
+    readonly deletedSessionIds: readonly string[];
+    readonly failedRootIds: readonly string[];
+    readonly inspectedSessionCount: number;
+    readonly protectedTreeCount: number;
+    readonly invalidMetadataCount: number;
+    readonly invalidTimestampCount: number;
+    readonly policyChanged: boolean;
+}
+
 export type AiSessionFreezeReason =
     | "budget"
     | "runtime_change"
@@ -166,6 +183,9 @@ export interface NativeAiGateway {
     closeOwnedByWindow(ownerWindowId: string): Promise<void> | void;
     closeSession(sessionId: string): Promise<void>;
     deleteSession(sessionId: string): Promise<void>;
+    pruneSessionHistory?(
+        input: AiHistoryPruneInput,
+    ): Promise<AiHistoryPruneResult>;
     countSessionHistoryByRuntime?(
         runtimeId: AiRuntimeId,
     ): Promise<number>;

--- a/src/main/ai/history-retention.test.ts
+++ b/src/main/ai/history-retention.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+    applyPrunedHistorySideEffects,
+    HistoryRetentionCoordinator,
+} from "./history-retention";
+
+const EMPTY_RESULT = {
+    deletedRootIds: [],
+    deletedSessionIds: [],
+    failedRootIds: [],
+    inspectedSessionCount: 0,
+    protectedTreeCount: 0,
+    invalidMetadataCount: 0,
+    invalidTimestampCount: 0,
+    policyChanged: false,
+} as const;
+
+describe("HistoryRetentionCoordinator", () => {
+    it("runs at startup and on the daily schedule when retention is enabled", async () => {
+        let scheduled: () => void = () => {
+            throw new Error("Expected the retention schedule to be installed.");
+        };
+        const pruneExpiredHistory = vi.fn().mockResolvedValue(EMPTY_RESULT);
+        const coordinator = new HistoryRetentionCoordinator({
+            getRetentionDays: () => 7,
+            now: () => Date.parse("2026-08-08T12:00:00.000Z"),
+            pruneExpiredHistory,
+            scheduleEvery: (callback, intervalMs) => {
+                expect(intervalMs).toBe(24 * 60 * 60 * 1_000);
+                scheduled = callback;
+                return vi.fn();
+            },
+        });
+
+        coordinator.start();
+        await vi.waitFor(() => expect(pruneExpiredHistory).toHaveBeenCalledTimes(1));
+        expect(pruneExpiredHistory).toHaveBeenLastCalledWith(
+            "2026-08-01T12:00:00.000Z",
+            7,
+        );
+
+        scheduled();
+        await vi.waitFor(() => expect(pruneExpiredHistory).toHaveBeenCalledTimes(2));
+        coordinator.close();
+    });
+
+    it("does not run for Forever or a less restrictive change", async () => {
+        const pruneExpiredHistory = vi.fn().mockResolvedValue(EMPTY_RESULT);
+        const coordinator = new HistoryRetentionCoordinator({
+            getRetentionDays: () => 0,
+            pruneExpiredHistory,
+            scheduleEvery: () => vi.fn(),
+        });
+
+        coordinator.start();
+        coordinator.updateRetentionDays(30);
+        await vi.waitFor(() => expect(pruneExpiredHistory).toHaveBeenCalledTimes(1));
+        coordinator.updateRetentionDays(90);
+        coordinator.updateRetentionDays(0);
+        await Promise.resolve();
+
+        expect(pruneExpiredHistory).toHaveBeenCalledTimes(1);
+        coordinator.close();
+    });
+
+    it("runs immediately when the saved policy becomes more restrictive", async () => {
+        const onPruned = vi.fn();
+        const pruneExpiredHistory = vi.fn().mockResolvedValue({
+            ...EMPTY_RESULT,
+            deletedRootIds: ["root"],
+            deletedSessionIds: ["root", "child"],
+            inspectedSessionCount: 2,
+        });
+        const coordinator = new HistoryRetentionCoordinator({
+            getRetentionDays: () => 30,
+            now: () => Date.parse("2026-08-08T12:00:00.000Z"),
+            onPruned,
+            pruneExpiredHistory,
+            scheduleEvery: () => vi.fn(),
+        });
+
+        coordinator.start();
+        await vi.waitFor(() => expect(pruneExpiredHistory).toHaveBeenCalledTimes(1));
+        coordinator.updateRetentionDays(7);
+        await vi.waitFor(() => expect(pruneExpiredHistory).toHaveBeenCalledTimes(2));
+
+        expect(pruneExpiredHistory).toHaveBeenLastCalledWith(
+            "2026-08-01T12:00:00.000Z",
+            7,
+        );
+        expect(onPruned).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                deletedSessionIds: ["root", "child"],
+                reason: "settings_change",
+                retentionDays: 7,
+            }),
+        );
+        coordinator.close();
+    });
+
+    it("coalesces concurrent triggers into one follow-up run", async () => {
+        let resolveFirst!: (value: typeof EMPTY_RESULT) => void;
+        const first = new Promise<typeof EMPTY_RESULT>((resolve) => {
+            resolveFirst = resolve;
+        });
+        const pruneExpiredHistory = vi
+            .fn()
+            .mockReturnValueOnce(first)
+            .mockResolvedValue(EMPTY_RESULT);
+        const coordinator = new HistoryRetentionCoordinator({
+            getRetentionDays: () => 7,
+            pruneExpiredHistory,
+            scheduleEvery: () => vi.fn(),
+        });
+
+        coordinator.start();
+        await vi.waitFor(() => expect(pruneExpiredHistory).toHaveBeenCalledTimes(1));
+        void coordinator.trigger("scheduled");
+        void coordinator.trigger("scheduled");
+        resolveFirst(EMPTY_RESULT);
+
+        await vi.waitFor(() => expect(pruneExpiredHistory).toHaveBeenCalledTimes(2));
+        coordinator.close();
+    });
+});
+
+describe("applyPrunedHistorySideEffects", () => {
+    it("broadcasts deleted sessions when durable reference cleanup partially fails", async () => {
+        const broadcast = vi.fn();
+        const onDiagnostic = vi.fn();
+        const forgetSessionReferences = vi.fn((sessionId: string) =>
+            sessionId === "child"
+                ? Promise.reject(new Error("Injected cleanup failure"))
+                : Promise.resolve(1),
+        );
+        const result = {
+            ...EMPTY_RESULT,
+            cutoff: "2026-08-01T12:00:00.000Z",
+            deletedRootIds: ["root"],
+            deletedSessionIds: ["root", "child"],
+            reason: "startup" as const,
+            retentionDays: 7 as const,
+        };
+
+        await applyPrunedHistorySideEffects(result, {
+            broadcast,
+            forgetSessionReferences,
+            onDiagnostic,
+        });
+
+        expect(forgetSessionReferences).toHaveBeenCalledTimes(2);
+        expect(onDiagnostic).toHaveBeenCalledWith(
+            expect.stringContaining("1 durable workspace reference"),
+        );
+        expect(broadcast).toHaveBeenCalledWith(result);
+    });
+});

--- a/src/main/ai/history-retention.ts
+++ b/src/main/ai/history-retention.ts
@@ -1,0 +1,197 @@
+import {
+    isMoreRestrictiveHistoryRetention,
+    normalizeChatHistoryRetentionDays,
+    type ChatHistoryRetentionDays,
+} from "@shared/chat-history-retention";
+
+import type { AiHistoryPruneResult } from "./contracts";
+
+const RETENTION_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+export type HistoryRetentionReason = "scheduled" | "settings_change" | "startup";
+
+export interface HistoryRetentionRunResult extends AiHistoryPruneResult {
+    readonly cutoff: string;
+    readonly reason: HistoryRetentionReason;
+    readonly retentionDays: ChatHistoryRetentionDays;
+}
+
+interface PrunedHistorySideEffectsOptions {
+    readonly broadcast: (result: HistoryRetentionRunResult) => void;
+    readonly forgetSessionReferences?: (sessionId: string) => Promise<unknown>;
+    readonly onDiagnostic?: (message: string) => void;
+}
+
+export async function applyPrunedHistorySideEffects(
+    result: HistoryRetentionRunResult,
+    options: PrunedHistorySideEffectsOptions,
+): Promise<void> {
+    const failures = options.forgetSessionReferences
+        ? (
+              await Promise.allSettled(
+                  result.deletedSessionIds.map((sessionId) =>
+                      options.forgetSessionReferences!(sessionId),
+                  ),
+              )
+          ).filter((outcome) => outcome.status === "rejected").length
+        : 0;
+    if (failures > 0) {
+        options.onDiagnostic?.(
+            `Failed to clear ${failures} durable workspace reference(s) after chat history pruning.`,
+        );
+    }
+    // Files are already gone at this point, so renderer reconciliation must
+    // happen even when cleanup of a secondary durable reference failed.
+    options.broadcast(result);
+}
+
+interface HistoryRetentionCoordinatorOptions {
+    readonly getRetentionDays: () => unknown;
+    readonly now?: () => number;
+    readonly onDiagnostic?: (message: string) => void;
+    readonly onPruned?: (result: HistoryRetentionRunResult) => Promise<void> | void;
+    readonly pruneExpiredHistory: (
+        cutoff: string,
+        retentionDays: ChatHistoryRetentionDays,
+    ) => Promise<AiHistoryPruneResult>;
+    readonly scheduleEvery?: (callback: () => void, intervalMs: number) => () => void;
+}
+
+export class HistoryRetentionCoordinator {
+    readonly #getRetentionDays: () => unknown;
+    readonly #now: () => number;
+    readonly #onDiagnostic: (message: string) => void;
+    readonly #onPruned: (result: HistoryRetentionRunResult) => Promise<void> | void;
+    readonly #pruneExpiredHistory: (
+        cutoff: string,
+        retentionDays: ChatHistoryRetentionDays,
+    ) => Promise<AiHistoryPruneResult>;
+    readonly #scheduleEvery: (callback: () => void, intervalMs: number) => () => void;
+    #cancelSchedule: (() => void) | null = null;
+    #currentRetentionDays: ChatHistoryRetentionDays = 0;
+    #nextReason: HistoryRetentionReason | null = null;
+    #running: Promise<void> | null = null;
+
+    constructor(options: HistoryRetentionCoordinatorOptions) {
+        this.#getRetentionDays = options.getRetentionDays;
+        this.#now = options.now ?? Date.now;
+        this.#onDiagnostic = options.onDiagnostic ?? (() => undefined);
+        this.#onPruned = options.onPruned ?? (() => undefined);
+        this.#pruneExpiredHistory = options.pruneExpiredHistory;
+        this.#scheduleEvery = options.scheduleEvery ?? defaultScheduleEvery;
+    }
+
+    start(): void {
+        if (this.#cancelSchedule) {
+            return;
+        }
+        this.#currentRetentionDays = normalizeChatHistoryRetentionDays(
+            this.#getRetentionDays(),
+        );
+        this.#cancelSchedule = this.#scheduleEvery(() => {
+            void this.trigger("scheduled");
+        }, RETENTION_INTERVAL_MS);
+        if (this.#currentRetentionDays > 0) {
+            void this.trigger("startup");
+        }
+    }
+
+    close(): void {
+        this.#cancelSchedule?.();
+        this.#cancelSchedule = null;
+        this.#nextReason = null;
+    }
+
+    updateRetentionDays(value: unknown): void {
+        const next = normalizeChatHistoryRetentionDays(value);
+        const previous = this.#currentRetentionDays;
+        this.#currentRetentionDays = next;
+        if (isMoreRestrictiveHistoryRetention(previous, next)) {
+            void this.trigger("settings_change");
+        }
+    }
+
+    trigger(reason: HistoryRetentionReason): Promise<void> {
+        this.#nextReason = preferReason(this.#nextReason, reason);
+        if (!this.#running) {
+            this.#running = this.#drain().finally(() => {
+                this.#running = null;
+                // A trigger can arrive after the drain loop resolves but before
+                // this finalizer runs, so hand it to a fresh drain explicitly.
+                if (this.#nextReason) {
+                    void this.trigger(this.#nextReason);
+                }
+            });
+        }
+        return this.#running;
+    }
+
+    async #drain(): Promise<void> {
+        while (this.#nextReason) {
+            const reason = this.#nextReason;
+            this.#nextReason = null;
+            const retentionDays = this.#currentRetentionDays;
+            if (retentionDays === 0) {
+                continue;
+            }
+            const startedAt = this.#now();
+            const cutoff = new Date(startedAt - retentionDays * DAY_MS).toISOString();
+            try {
+                const result = await this.#pruneExpiredHistory(
+                    cutoff,
+                    retentionDays,
+                );
+                const runResult: HistoryRetentionRunResult = {
+                    ...result,
+                    cutoff,
+                    reason,
+                    retentionDays,
+                };
+                if (result.deletedSessionIds.length > 0) {
+                    await this.#onPruned(runResult);
+                }
+                this.#onDiagnostic(
+                    JSON.stringify({
+                        action: "chat_history_retention",
+                        cutoff,
+                        deletedSessionCount: result.deletedSessionIds.length,
+                        durationMs: Math.max(0, this.#now() - startedAt),
+                        failedRootCount: result.failedRootIds.length,
+                        inspectedSessionCount: result.inspectedSessionCount,
+                        reason,
+                        retentionDays,
+                    }),
+                );
+            } catch (error) {
+                this.#onDiagnostic(
+                    `Chat history retention failed: ${error instanceof Error ? error.message : String(error)}`,
+                );
+            }
+        }
+    }
+}
+
+function defaultScheduleEvery(
+    callback: () => void,
+    intervalMs: number,
+): () => void {
+    const timer = setInterval(callback, intervalMs);
+    timer.unref();
+    return () => {
+        clearInterval(timer);
+    };
+}
+
+function preferReason(
+    current: HistoryRetentionReason | null,
+    next: HistoryRetentionReason,
+): HistoryRetentionReason {
+    if (current === "settings_change" || next === "settings_change") {
+        return "settings_change";
+    }
+    if (current === "startup" || next === "startup") {
+        return "startup";
+    }
+    return "scheduled";
+}

--- a/src/main/ai/prompt-queue.ts
+++ b/src/main/ai/prompt-queue.ts
@@ -108,6 +108,18 @@ export class AiPromptQueue {
         }
     }
 
+    getSessionIdsWithQueuedWork(): readonly string[] {
+        const sessionIds: string[] = [];
+        for (const [sessionId, record] of this.#records) {
+            // Queue state is user-authored durable data, so any retained item
+            // protects its history until the user clears or dispatches it.
+            if (record.activeItem || record.editingItem || record.items.length > 0) {
+                sessionIds.push(sessionId);
+            }
+        }
+        return sessionIds;
+    }
+
     bindSession(sessionId: string, ownerWindowId: string): AiPromptQueueSnapshot {
         const record = this.#getRecord(sessionId);
         record.ownerWindowId = ownerWindowId;

--- a/src/main/ai/service.history.test.ts
+++ b/src/main/ai/service.history.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type {
     AiHistorySessionSummary,
     AiOpenTranscriptTail,
+    AiPromptQueueSnapshot,
     AiSessionSnapshot,
     AiSessionTranscriptPage,
     AiSessionUpdate,
@@ -768,6 +769,98 @@ describe("AiService history", () => {
         expect(deleteSession).toHaveBeenCalledWith("session-1");
     });
 
+    it("prunes expired native history and ignores later snapshots", async () => {
+        const pruneSessionHistory = vi.fn(() =>
+            Promise.resolve({
+                deletedRootIds: ["session-1"],
+                deletedSessionIds: ["session-1", "session-child"],
+                failedRootIds: [],
+                inspectedSessionCount: 3,
+                protectedTreeCount: 1,
+                invalidMetadataCount: 0,
+                invalidTimestampCount: 0,
+                policyChanged: false,
+            }),
+        );
+        const onSessionSnapshot = vi.fn();
+        const service = createService({
+            nativeAi: createNativeAiGateway({ pruneSessionHistory }),
+            onSessionSnapshot,
+        });
+
+        const result = await service.pruneExpiredHistory(
+            "2026-08-01T12:00:00.000Z",
+            7,
+        );
+        service.handleNativeSessionSnapshot("window-1", {
+            kind: "snapshot",
+            snapshot: createSnapshot({ sessionId: "session-child" }),
+        });
+
+        expect(pruneSessionHistory).toHaveBeenCalledWith({
+            cutoff: "2026-08-01T12:00:00.000Z",
+            protectedSessionIds: [],
+            retentionDays: 7,
+        });
+        expect(result.deletedSessionIds).toEqual([
+            "session-1",
+            "session-child",
+        ]);
+        expect(onSessionSnapshot).not.toHaveBeenCalled();
+    });
+
+    it("protects restored prompt queues from retention pruning", async () => {
+        const pruneSessionHistory = vi.fn(() =>
+            Promise.resolve({
+                deletedRootIds: [],
+                deletedSessionIds: [],
+                failedRootIds: [],
+                inspectedSessionCount: 1,
+                protectedTreeCount: 1,
+                invalidMetadataCount: 0,
+                invalidTimestampCount: 0,
+                policyChanged: false,
+            }),
+        );
+        const restoredPrompt = {
+            additionalRoots: [],
+            attachments: [],
+            composerPartsSnapshot: [{ text: "Keep this prompt", type: "text" as const }],
+            createdAt: "2026-07-01T12:00:00.000Z",
+            error: null,
+            fileContextsSnapshot: [],
+            id: "queued-1",
+            messageId: "message-1",
+            projectId: "project-1",
+            prompt: "Keep this prompt",
+            runtimeId: "codex" as const,
+            sessionId: "queued-session",
+            status: "queued" as const,
+            title: "Queued session",
+            worktreeId: null,
+        };
+        const restoredQueue: AiPromptQueueSnapshot = {
+            activeItem: null,
+            editingItem: null,
+            items: [restoredPrompt],
+            paused: true,
+            revision: 1,
+            sessionId: "queued-session",
+        };
+        const service = createService({
+            loadPromptQueueSnapshots: vi.fn(() => [restoredQueue]),
+            nativeAi: createNativeAiGateway({ pruneSessionHistory }),
+        });
+
+        await service.pruneExpiredHistory("2026-08-01T12:00:00.000Z", 7);
+
+        expect(pruneSessionHistory).toHaveBeenCalledWith({
+            cutoff: "2026-08-01T12:00:00.000Z",
+            protectedSessionIds: ["queued-session"],
+            retentionDays: 7,
+        });
+    });
+
     it("deletes every persisted descendant from leaf to root", async () => {
         const deleteSession = vi.fn();
         const listSessionRuntimeMappingsForParent = vi.fn(() => [
@@ -1488,6 +1581,7 @@ function createTrackedFile(
 function createService(overrides: {
     readonly deleteSession?: ReturnType<typeof vi.fn>;
     readonly loadLatestRuntimeCatalog?: ReturnType<typeof vi.fn>;
+    readonly loadPromptQueueSnapshots?: ReturnType<typeof vi.fn>;
     readonly listSessionHistory?: ReturnType<typeof vi.fn>;
     readonly listSessionRuntimeMappingsForParent?: ReturnType<typeof vi.fn>;
     readonly loadSessionSnapshot?: ReturnType<typeof vi.fn>;
@@ -1513,6 +1607,8 @@ function createService(overrides: {
             listSessionHistory: overrides.listSessionHistory ?? vi.fn(() => []),
             loadLatestRuntimeCatalog:
                 overrides.loadLatestRuntimeCatalog ?? vi.fn(() => null),
+            loadPromptQueueSnapshots:
+                overrides.loadPromptQueueSnapshots ?? vi.fn(() => []),
             loadRuntimeSelectionPreferences: vi.fn(() => ({
                 configOptions: {},
                 modeId: null,

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -110,6 +110,7 @@ import { createAiEnvironmentDiagnostics } from "./environment-diagnostics";
 import { AiPromptQueue } from "./prompt-queue";
 import { listOpenFileBuffers } from "./openFileBuffers";
 import {
+    type AiHistoryPruneResult,
     type AiReviewMutationResult,
     type AiReviewSessionContext,
     type AiRuntimeSessionMapping,
@@ -1416,6 +1417,52 @@ export class AiService {
             (await this.#nativeAi?.countSessionHistoryByRuntime?.(runtimeId)) ??
             0
         );
+    }
+
+    async pruneExpiredHistory(
+        cutoff: string,
+        retentionDays: number,
+    ): Promise<AiHistoryPruneResult> {
+        const nativeAi = this.#nativeAi;
+        if (!nativeAi?.pruneSessionHistory) {
+            return {
+                deletedRootIds: [],
+                deletedSessionIds: [],
+                failedRootIds: [],
+                inspectedSessionCount: 0,
+                protectedTreeCount: 0,
+                invalidMetadataCount: 0,
+                invalidTimestampCount: 0,
+                policyChanged: false,
+            };
+        }
+
+        const protectedSessionIds = new Set<string>([
+            ...this.#liveSessionContexts.keys(),
+            ...this.#freezingSessionIds,
+            ...this.#frozenSessionIds,
+            ...this.#retentionCloseEventSessionIds,
+            ...this.#transcriptRecoveryPromises.keys(),
+            ...this.#promptQueue.getSessionIdsWithQueuedWork(),
+        ]);
+        const result = await nativeAi.pruneSessionHistory({
+            cutoff,
+            protectedSessionIds: [...protectedSessionIds],
+            retentionDays,
+        });
+
+        for (const sessionId of result.deletedSessionIds) {
+            this.#deletedSessionIds.add(sessionId);
+            this.#frozenSessionIds.delete(sessionId);
+            this.#freezingSessionIds.delete(sessionId);
+            this.#retentionCloseEventSessionIds.delete(sessionId);
+            this.#forgetRetentionCloseRuntimeSessions(sessionId);
+            this.#nativeSessionIds.delete(sessionId);
+            this.#liveSnapshots.delete(sessionId);
+            this.#liveSessionTouches.delete(sessionId);
+            await this.#promptQueue.deleteSession(sessionId);
+        }
+        return result;
     }
 
     async setSessionPinned(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,6 +42,10 @@ import {
 import { appChannel, appIdentity, configureMainProcessApp } from "./app-runtime";
 import type { SecretStoreGateway } from "./ai/secret-store";
 import { AiService } from "./ai/service";
+import {
+    applyPrunedHistorySideEffects,
+    HistoryRetentionCoordinator,
+} from "./ai/history-retention";
 import type { NormalizedSessionCatalogPayload } from "./ai/session-core";
 import {
     buildAiSessionStreamRecoveryFallbackPayloads,
@@ -125,6 +129,7 @@ void initReviewEngine();
 let nativeAppDataClient: NativeAppDataClient | null = null;
 let bootstrapSnapshot: AppBootstrapSnapshot | null = null;
 let aiService: AiService | null = null;
+let historyRetentionCoordinator: HistoryRetentionCoordinator | null = null;
 let persistenceService: PersistenceGateway | null = null;
 let projectService: ProjectService | null = null;
 let projectInvalidationCoordinator: ProjectInvalidationCoordinator | null = null;
@@ -320,6 +325,36 @@ if (!hasSingleInstanceLock) {
                 secretStore,
                 settingsService,
             });
+            historyRetentionCoordinator = new HistoryRetentionCoordinator({
+                getRetentionDays: () =>
+                    settingsService?.loadAiChatSettings().historyRetentionDays ?? 0,
+                onDiagnostic: (message) => {
+                    console.info(`[ai-history-retention] ${message}`);
+                },
+                onPruned: async (result) => {
+                    const repository = nativePersistenceGateway;
+                    await applyPrunedHistorySideEffects(result, {
+                        broadcast: (pruned) => {
+                            broadcastAiHistoryPruned({
+                                cutoff: pruned.cutoff,
+                                deletedSessionIds: pruned.deletedSessionIds,
+                                retentionDays: pruned.retentionDays,
+                            });
+                        },
+                        forgetSessionReferences: repository
+                            ? (sessionId) =>
+                                  repository.forgetWorkspaceSessionReferences(
+                                      sessionId,
+                                  )
+                            : undefined,
+                        onDiagnostic: (message) => {
+                            console.warn(`[ai-history-retention] ${message}`);
+                        },
+                    });
+                },
+                pruneExpiredHistory: (cutoff, retentionDays) =>
+                    aiService!.pruneExpiredHistory(cutoff, retentionDays),
+            });
             terminalService = createTerminalGateway({
                 nativeClient,
                 onData: broadcastTerminalData,
@@ -417,6 +452,7 @@ if (!hasSingleInstanceLock) {
                 persistenceService,
                 gitService,
                 githubService,
+                historyRetentionCoordinator,
                 activateProjectWorkspace,
                 openSettingsView,
                 projectService,
@@ -424,6 +460,7 @@ if (!hasSingleInstanceLock) {
                 terminalService,
                 workspaceService,
             });
+            historyRetentionCoordinator.start();
 
             installApplicationMenu({
                 adjustAppZoom: (direction) => {
@@ -572,6 +609,7 @@ async function shutdownApplication(): Promise<void> {
         detachAiSessionStream(windowId);
     }
 
+    historyRetentionCoordinator?.close();
     aiService?.close();
 
     const nativeAppDataClientToClose = nativeAppDataClient;
@@ -582,6 +620,7 @@ async function shutdownApplication(): Promise<void> {
     const terminalServiceToClose = terminalService;
 
     aiService = null;
+    historyRetentionCoordinator = null;
     nativeAppDataClient = null;
     gitService = null;
     githubService = null;
@@ -1512,6 +1551,14 @@ function broadcastNativeBackendEvent(event: NativeBackendEvent): void {
 function broadcastAiRuntimeStatus(payload: AiRuntimeStatus): void {
     windowRegistry.forEachLiveWebContents((webContents) => {
         webContents.send(IPC_EVENTS.aiRuntimeStatus, payload);
+    });
+}
+
+function broadcastAiHistoryPruned(
+    payload: import("@shared/ipc").AiHistoryPrunedEvent,
+): void {
+    windowRegistry.forEachLiveWebContents((webContents) => {
+        webContents.send(IPC_EVENTS.aiHistoryPruned, payload);
     });
 }
 

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -221,6 +221,7 @@ import { resolveCodexGeneratedImageFilePath } from "@main/file-preview-protocol"
 import { isNativeBackendOperationCancelled } from "@main/native-backend/client";
 
 import type { AiService } from "@main/ai/service";
+import type { HistoryRetentionCoordinator } from "@main/ai/history-retention";
 import { createCustomAcpRuntimeDefinition } from "@main/ai/custom-acp-runtimes";
 import { resolveCustomAcpRuntime } from "@main/ai/custom-acp-launch";
 import {
@@ -272,6 +273,7 @@ interface RegisterIpcHandlersOptions {
     readonly aiService: AiService;
     readonly gitService: GitGateway;
     readonly githubService: GitHubGateway;
+    readonly historyRetentionCoordinator: HistoryRetentionCoordinator;
     readonly getSnapshot: () => AppBootstrapSnapshot;
     readonly durableWorkspaceRepository: NativePersistenceGateway;
     readonly focusMainWindow: () => void;
@@ -785,8 +787,13 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
     );
     ipcMain.handle(
         IPC_CHANNELS.saveSettingsSnapshot,
-        (_event, snapshot: SettingsSnapshot) => {
-            options.settingsService.saveSnapshot(snapshot);
+        async (_event, snapshot: SettingsSnapshot) => {
+            if (options.settingsService.saveSnapshotNow) {
+                await options.settingsService.saveSnapshotNow(snapshot);
+            } else {
+                options.settingsService.saveSnapshot(snapshot);
+                await options.settingsService.flush?.();
+            }
             const effects = resolveSettingsSnapshotSaveEffects(snapshot);
             if (effects.broadcastSettingsUpdated) {
                 const persisted = options.settingsService.loadSnapshot();
@@ -805,6 +812,9 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
                     persisted.editor ?? null,
                     persisted.aiChat ?? null,
                     persisted.terminal ?? null,
+                );
+                options.historyRetentionCoordinator.updateRetentionDays(
+                    persisted.aiChat?.historyRetentionDays,
                 );
             }
         },

--- a/src/main/native-backend/ai.test.ts
+++ b/src/main/native-backend/ai.test.ts
@@ -945,6 +945,45 @@ describe("NativeAiGateway", () => {
         );
     });
 
+    it("routes history retention pruning and forgets deleted sessions", async () => {
+        const client = createClient();
+        client.request.mockImplementation(<T = unknown>(command: string): Promise<T> => {
+            if (command === "ai_prune_session_history") {
+                return Promise.resolve({
+                    deletedRootIds: ["session-1"],
+                    deletedSessionIds: ["session-1", "session-child"],
+                    failedRootIds: [],
+                    inspectedSessionCount: 2,
+                    protectedTreeCount: 0,
+                    invalidMetadataCount: 0,
+                    invalidTimestampCount: 0,
+                    policyChanged: false,
+                } as T);
+            }
+            return Promise.resolve(undefined as T);
+        });
+        const gateway = createGateway(client);
+
+        await expect(
+            gateway.pruneSessionHistory({
+                cutoff: "2026-08-01T12:00:00.000Z",
+                protectedSessionIds: ["session-live"],
+                retentionDays: 7,
+            }),
+        ).resolves.toMatchObject({
+            deletedSessionIds: ["session-1", "session-child"],
+        });
+
+        expect(client.request).toHaveBeenCalledWith(
+            "ai_prune_session_history",
+            {
+                cutoff: "2026-08-01T12:00:00.000Z",
+                protectedSessionIds: ["session-live"],
+                retentionDays: 7,
+            },
+        );
+    });
+
     it("exposes versioned paged transcript, payload and migration capabilities", async () => {
         const client = createClient();
         const tail = openTranscriptTail();

--- a/src/main/native-backend/ai.ts
+++ b/src/main/native-backend/ai.ts
@@ -61,6 +61,7 @@ import {
     type NativeAiCloseSessionOutput,
     type NativeAiHistorySessionSummary,
     type NativeAiHistoryStorageHealth,
+    type NativeAiPruneSessionHistoryOutput,
     type NativeAiTranscriptCompatibilityCleanupResult,
     type NativeAiMigrateSessionHistoryOutput,
     type NativeAiLaunchRuntimeAuthOutput,
@@ -88,6 +89,8 @@ import {
 
 import { AI_SESSION_BUSY_MESSAGE } from "@shared/ai-errors";
 import type {
+    AiHistoryPruneInput,
+    AiHistoryPruneResult,
     AiReviewMutationResult,
     AiReviewSessionRpcInput,
     AiRuntimeSessionMapping,
@@ -714,6 +717,35 @@ export class NativeAiGateway implements NativeAiGatewayContract {
         }
         await this.#client.request("ai_delete_session", { sessionId });
         this.#forgetSession(sessionId);
+    }
+
+    async pruneSessionHistory(
+        input: AiHistoryPruneInput,
+    ): Promise<AiHistoryPruneResult> {
+        if (!this.#historyEnabled) {
+            return {
+                deletedRootIds: [],
+                deletedSessionIds: [],
+                failedRootIds: [],
+                inspectedSessionCount: 0,
+                protectedTreeCount: 0,
+                invalidMetadataCount: 0,
+                invalidTimestampCount: 0,
+                policyChanged: false,
+            };
+        }
+        const output = await this.#client.request<NativeAiPruneSessionHistoryOutput>(
+            "ai_prune_session_history",
+            {
+                cutoff: input.cutoff,
+                protectedSessionIds: input.protectedSessionIds,
+                retentionDays: input.retentionDays,
+            },
+        );
+        for (const sessionId of output.deletedSessionIds) {
+            this.#forgetSession(sessionId);
+        }
+        return output;
     }
 
     async renameSession(input: AiSessionRenameMutationInput): Promise<void> {

--- a/src/main/native-backend/app-data.test.ts
+++ b/src/main/native-backend/app-data.test.ts
@@ -27,6 +27,87 @@ afterEach(() => {
 });
 
 describe("createNativeAppDataClient", () => {
+    it("normalizes unsupported chat history retention to Forever", async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "comando-app-data-"));
+        tempDirs.push(tempDir);
+        const databaseFile = path.join(tempDir, "comando.sqlite");
+        new DatabaseSync(databaseFile).close();
+        const native = createFakeNativeRequester();
+        const { createNativeAppDataClient } = await import("./app-data");
+        const client = await createNativeAppDataClient({
+            client: native.requester,
+            databaseFile,
+        });
+        const snapshot = client.settings.loadSnapshot();
+
+        client.settings.saveSnapshot({
+            ...snapshot,
+            aiChat: {
+                ...snapshot.aiChat!,
+                historyRetentionDays: -7,
+            } as never,
+        });
+
+        expect(
+            client.settings.loadAiChatSettings().historyRetentionDays,
+        ).toBe(0);
+        await client.close();
+    });
+
+    it("keeps the previous settings snapshot when a durable save fails", async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "comando-app-data-"));
+        tempDirs.push(tempDir);
+        const databaseFile = path.join(tempDir, "comando.sqlite");
+        new DatabaseSync(databaseFile).close();
+        const native = createFakeNativeRequester();
+        let rejectSettingsWrite = false;
+        const requester: NativeBackendRequester = {
+            request: <T = unknown>(
+                command: string,
+                args: Record<string, unknown> = {},
+            ): Promise<T> => {
+                if (
+                    rejectSettingsWrite &&
+                    command === "app_data_set_json" &&
+                    args.key === "settings.snapshot"
+                ) {
+                    rejectSettingsWrite = false;
+                    return Promise.reject(new Error("Injected settings write failure"));
+                }
+                return native.requester.request<T>(command, args);
+            },
+        };
+        const { createNativeAppDataClient } = await import("./app-data");
+        const client = await createNativeAppDataClient({
+            client: requester,
+            databaseFile,
+        });
+        const previous = client.settings.loadSnapshot();
+        rejectSettingsWrite = true;
+        const rejected = {
+            ...previous,
+            aiChat: {
+                ...previous.aiChat!,
+                historyRetentionDays: 7 as const,
+            },
+        };
+
+        await expect(client.settings.saveSnapshotNow!(rejected)).rejects.toThrow(
+            "Injected settings write failure",
+        );
+        expect(client.settings.loadAiChatSettings().historyRetentionDays).toBe(0);
+
+        await client.settings.saveSnapshotNow!({
+            ...previous,
+            aiChat: {
+                ...previous.aiChat!,
+                historyRetentionDays: 30,
+            },
+        });
+        expect(client.settings.loadAiChatSettings().historyRetentionDays).toBe(30);
+        await client.close();
+    });
+
     it("persists custom ACP CRUD without trusting renderer snapshots", async () => {
         const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "comando-app-data-"));
         tempDirs.push(tempDir);

--- a/src/main/native-backend/app-data.ts
+++ b/src/main/native-backend/app-data.ts
@@ -11,6 +11,7 @@ import {
     CHAT_CONTENT_WIDTH_DEFAULT,
     clampChatContentWidth,
 } from "@shared/chat-content-width";
+import { normalizeChatHistoryRetentionDays } from "@shared/chat-history-retention";
 import {
     DEFAULT_APP_TERMINAL_SETTINGS,
     normalizeWindowsTerminalShell,
@@ -559,6 +560,7 @@ class NativeSettingsClient implements SettingsGateway {
     readonly #store: NativeJsonStore;
     readonly #secretStore: SecretStoreGateway;
     readonly #projectSettingsById = new Map<string, ProjectSettingsSnapshot>();
+    #durableSnapshotSave: Promise<void> = Promise.resolve();
     #snapshot: SettingsSnapshot;
 
     constructor(
@@ -581,6 +583,10 @@ class NativeSettingsClient implements SettingsGateway {
         return structuredClone(this.#snapshot);
     }
 
+    async flush(): Promise<void> {
+        await this.#store.flush();
+    }
+
     saveSnapshot(snapshot: SettingsSnapshot): void {
         // Dedicated CRUD keeps renderer snapshots from choosing IDs, revisions,
         // fingerprints, or silently replacing the custom runtime collection.
@@ -589,6 +595,25 @@ class NativeSettingsClient implements SettingsGateway {
             customAcpRuntimes: this.#snapshot.customAcpRuntimes,
         });
         this.#persistSoon();
+    }
+
+    saveSnapshotNow(snapshot: SettingsSnapshot): Promise<void> {
+        const save = this.#durableSnapshotSave.then(async () => {
+            const currentSnapshot = this.#snapshot;
+            const nextSnapshot = normalizeSettingsSnapshot({
+                ...snapshot,
+                customAcpRuntimes: currentSnapshot.customAcpRuntimes,
+            });
+            await this.#store.saveNow(SETTINGS_KEY, nextSnapshot);
+            // A synchronous dedicated mutation may have happened while the
+            // native write was pending; its newer in-memory state must win.
+            if (this.#snapshot === currentSnapshot) {
+                this.#snapshot = nextSnapshot;
+            }
+        });
+        // Keep later durable saves ordered even when one caller observes a failure.
+        this.#durableSnapshotSave = save.catch(() => undefined);
+        return save;
     }
 
     loadAppAppearanceSettings(): AppAppearanceSettings {
@@ -1413,10 +1438,12 @@ function createLegacySettingsSnapshot(
                     "ai.composer.context_usage_bar_enabled",
                 ) ?? defaults.aiChat.contextUsageBarEnabled,
             historyRetentionDays:
-                readLegacyNumberSetting(
-                    settings,
-                    "ai.chat.history_retention_days",
-                ) ?? defaults.aiChat.historyRetentionDays,
+                normalizeChatHistoryRetentionDays(
+                    readLegacyNumberSetting(
+                        settings,
+                        "ai.chat.history_retention_days",
+                    ),
+                ),
             requireCmdEnterToSend:
                 readLegacyBooleanSetting(
                     settings,
@@ -2135,6 +2162,9 @@ function normalizeSettingsSnapshot(snapshot: SettingsSnapshot): SettingsSnapshot
         aiChat: {
             ...defaults.aiChat,
             ...aiChat,
+            historyRetentionDays: normalizeChatHistoryRetentionDays(
+                persistedAiChat?.historyRetentionDays,
+            ),
             toolActivityDefaultExpansion:
                 persistedAiChat?.toolActivityDefaultExpansion === "expanded"
                     ? "expanded"

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -19,6 +19,7 @@ import type {
 import type { SecretRecordPatch } from "@main/ai/secret-store";
 
 export interface SettingsGateway {
+    flush?(): Promise<void>;
     clearProjectSettings?(projectId: string): Promise<void> | void;
     runTransaction?(action: () => void): void;
     saveCodexAuth?(
@@ -43,6 +44,7 @@ export interface SettingsGateway {
     ): Promise<void>;
     loadSnapshot(): SettingsSnapshot;
     saveSnapshot(snapshot: SettingsSnapshot): void;
+    saveSnapshotNow?(snapshot: SettingsSnapshot): Promise<void>;
     loadAppAppearanceSettings(): AppAppearanceSettings;
     saveAppAppearanceSettings(settings: AppAppearanceSettings): void;
     loadAppEditorSettings(): AppEditorSettings;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,7 @@ import {
     type AppUpdateState,
     type AppBootstrapSnapshot,
     type AiHistorySessionSummary,
+    type AiHistoryPrunedEvent,
     type AiPromptQueueSnapshot,
     type AiQueuedPromptMutationInput,
     type AiSessionDomainEvent,
@@ -2003,6 +2004,20 @@ const comandoApi: ComandoApi = {
                     handleAiSessionEventFallback,
                 );
             }
+        };
+    },
+    onAiHistoryPruned: (listener) => {
+        const handleEvent = (
+            _event: Electron.IpcRendererEvent,
+            payload: AiHistoryPrunedEvent,
+        ) => {
+            listener(payload);
+        };
+
+        ipcRenderer.on(IPC_EVENTS.aiHistoryPruned, handleEvent);
+
+        return () => {
+            ipcRenderer.removeListener(IPC_EVENTS.aiHistoryPruned, handleEvent);
         };
     },
     onAiPromptQueue: (listener) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -31,6 +31,7 @@ import type {
 import { resolveEditorLanguage } from "@shared/editor-language";
 
 import { useSystemTheme } from "./app/hooks/use-system-theme";
+import { subscribeToAiHistoryPruned } from "./app/ai/historyRetentionEvents";
 import { writeClipboardText } from "./app/utils/clipboard";
 import { joinProjectPath } from "./app/utils/projectPath";
 import { setCachedAppEditorSettings } from "./app/settings/client";
@@ -263,6 +264,8 @@ function resolveStateAction<T>(action: SetStateAction<T>, current: T): T {
 
 export function WorkspaceHostApp() {
     useSystemTheme();
+
+    useEffect(() => subscribeToAiHistoryPruned(), []);
 
     const bootstrap = useAppStore((state) => state.bootstrap);
     const bootstrapError = useAppStore((state) => state.error);

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -115,6 +115,9 @@ export function SettingsApp({
     const [aiChat, setAiChat] = useState<AppAiChatSettings>(
         getDefaultAiChatSettings(),
     );
+    const aiChatRef = useRef(aiChat);
+    const aiChatSaveRevisionRef = useRef(0);
+    const [aiChatSaveError, setAiChatSaveError] = useState<string | null>(null);
     const [terminal, setTerminal] = useState<AppTerminalSettings>(
         DEFAULT_APP_TERMINAL_SETTINGS,
     );
@@ -440,6 +443,7 @@ export function SettingsApp({
     }, []);
 
     useEffect(() => {
+        aiChatRef.current = storeAiChat;
         setAiChat(storeAiChat);
     }, [storeAiChat]);
 
@@ -661,9 +665,25 @@ export function SettingsApp({
     };
 
     const updateAiChat = (patch: Partial<AppAiChatSettings>) => {
-        const next: AppAiChatSettings = { ...aiChat, ...patch };
+        const previous = aiChatRef.current;
+        const next: AppAiChatSettings = { ...previous, ...patch };
+        const saveRevision = aiChatSaveRevisionRef.current + 1;
+        aiChatSaveRevisionRef.current = saveRevision;
+        aiChatRef.current = next;
         setAiChat(next);
-        void saveAiChatSettings(next);
+        setAiChatSaveError(null);
+        void saveAiChatSettings(next).catch((error: unknown) => {
+            if (aiChatSaveRevisionRef.current !== saveRevision) {
+                return;
+            }
+            aiChatRef.current = previous;
+            setAiChat(previous);
+            setAiChatSaveError(
+                error instanceof Error
+                    ? `Could not save AI settings: ${error.message}`
+                    : "Could not save AI settings.",
+            );
+        });
     };
 
     const updateTerminal = (patch: Partial<AppTerminalSettings>) => {
@@ -901,6 +921,7 @@ export function SettingsApp({
             initialCategoryRequestId={requestedCategory.requestId}
             onClose={onClose}
             aiChat={{
+                error: aiChatSaveError,
                 chatFontFamily: aiChat.chatFontFamily,
                 chatFontFamilies: chatFontFamilies,
                 chatFontSize: aiChat.chatFontSize,

--- a/src/renderer/src/WorkspaceSurfaceApp.tsx
+++ b/src/renderer/src/WorkspaceSurfaceApp.tsx
@@ -10,6 +10,7 @@ import type {
 } from "@shared/ipc";
 
 import { useSystemTheme } from "./app/hooks/use-system-theme";
+import { subscribeToAiHistoryPruned } from "./app/ai/historyRetentionEvents";
 import { parseWorkspaceSurfaceRendererDescriptor } from "./app/renderer-mode";
 import { setCachedAppEditorSettings } from "./app/settings/client";
 import {
@@ -146,6 +147,7 @@ function collectRuntimeWorkspaceSurfaceLeases(
 
 export function WorkspaceSurfaceApp() {
     useSystemTheme();
+    useEffect(() => subscribeToAiHistoryPruned(), []);
 
     const bootstrap = useAppStore((state) => state.bootstrap);
     const hydrateBootstrap = useAppStore((state) => state.hydrate);

--- a/src/renderer/src/app/ai/historyRetentionEvents.ts
+++ b/src/renderer/src/app/ai/historyRetentionEvents.ts
@@ -1,0 +1,43 @@
+import { clearSidebarAgentsHistoryCache } from "@renderer/components/sidebar/sidebarAgentsHistoryCache";
+import { releaseCachedChatTimeline } from "@renderer/components/workspace/chat/chatTimelineCache";
+import { releaseScopedToolUiStateStore } from "@renderer/components/workspace/chat/toolExpansionStore";
+import { useAiStore } from "@renderer/app/store/ai-store";
+import { useWorkspaceStore } from "@renderer/app/store/workspace-store";
+
+export function subscribeToAiHistoryPruned(): () => void {
+    const api = window.comando;
+    if (!api?.onAiHistoryPruned) {
+        return () => undefined;
+    }
+
+    return api.onAiHistoryPruned((event) => {
+        const deletedSessionIds = new Set(event.deletedSessionIds);
+        clearSidebarAgentsHistoryCache();
+        useAiStore.setState((state) => {
+            const sessions = { ...state.sessions };
+            for (const sessionId of deletedSessionIds) {
+                delete sessions[sessionId];
+                releaseCachedChatTimeline(sessionId);
+                releaseScopedToolUiStateStore(sessionId);
+            }
+            return { sessions };
+        });
+
+        const workspace = useWorkspaceStore.getState();
+        const matchingTabIds = Object.values(workspace.tabsById)
+            .filter(
+                (tab) =>
+                    (tab.kind === "chat" || tab.kind === "review") &&
+                    deletedSessionIds.has(tab.sessionId),
+            )
+            .map((tab) => tab.id);
+        void (async () => {
+            // Sequential closes preserve pane selection while each mutation persists layout.
+            for (const tabId of matchingTabIds) {
+                await workspace.closeTab(tabId);
+            }
+        })().catch((error: unknown) => {
+            console.warn("Could not close a pruned chat history tab.", error);
+        });
+    });
+}

--- a/src/renderer/src/components/settings/SettingsWindow.test.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.test.tsx
@@ -216,6 +216,22 @@ describe("SettingsWindow terminal settings", () => {
         expect(expandedMarkup).toContain("Expanded");
     });
 
+    it("shows an AI settings persistence error", () => {
+        const props = createSettingsWindowProps({ initialCategory: "ai" });
+        const markup = renderToStaticMarkup(
+            <SettingsWindow
+                {...props}
+                aiChat={{
+                    ...props.aiChat,
+                    error: "Could not save AI settings.",
+                }}
+            />,
+        );
+
+        expect(markup).toContain('role="alert"');
+        expect(markup).toContain("Could not save AI settings.");
+    });
+
     it("renders a release notes action in the Updates category", () => {
         const markup = renderToStaticMarkup(
             <SettingsWindow

--- a/src/renderer/src/components/settings/SettingsWindow.tsx
+++ b/src/renderer/src/components/settings/SettingsWindow.tsx
@@ -32,6 +32,10 @@ import {
     CHAT_CONTENT_WIDTH_STEP,
 } from "@shared/chat-content-width";
 import {
+    CHAT_HISTORY_RETENTION_OPTIONS,
+    normalizeChatHistoryRetentionDays,
+} from "@shared/chat-history-retention";
+import {
     AI_CHAT_FONT_SIZE_MAX,
     AI_CHAT_FONT_SIZE_MIN,
     AI_COMPOSER_FONT_SIZE_MAX,
@@ -2583,6 +2587,25 @@ function AiChatContent({
 
     return (
         <div>
+            {state.error ? (
+                <div
+                    role="alert"
+                    style={{
+                        background:
+                            "color-mix(in srgb, var(--color-danger, #f87171) 10%, transparent)",
+                        border:
+                            "1px solid color-mix(in srgb, var(--color-danger, #f87171) 35%, transparent)",
+                        borderRadius: 6,
+                        color: "var(--color-text-primary)",
+                        fontSize: 11,
+                        lineHeight: 1.5,
+                        marginBottom: 10,
+                        padding: "8px 10px",
+                    }}
+                >
+                    {state.error}
+                </div>
+            ) : null}
             {showChat ? <SectionLabel>Chat</SectionLabel> : null}
             <SearchableRow
                 searchQuery={searchQuery}
@@ -2659,16 +2682,11 @@ function AiChatContent({
                 control={
                     <SelectField
                         value={state.historyRetentionDays}
-                        options={[
-                            { value: 0, label: "Forever" },
-                            { value: 1, label: "1 day" },
-                            { value: 7, label: "7 days" },
-                            { value: 30, label: "30 days" },
-                            { value: 90, label: "90 days" },
-                            { value: 365, label: "1 year" },
-                        ]}
+                        options={CHAT_HISTORY_RETENTION_OPTIONS}
                         onChange={(v) =>
-                            state.onHistoryRetentionChange?.(Number(v))
+                            state.onHistoryRetentionChange?.(
+                                normalizeChatHistoryRetentionDays(v),
+                            )
                         }
                     />
                 }

--- a/src/renderer/src/components/settings/settings-types.ts
+++ b/src/renderer/src/components/settings/settings-types.ts
@@ -7,6 +7,7 @@ import type {
     GitHubAuthStatus,
     SettingsWindowCategory,
 } from "@shared/ipc";
+import type { ChatHistoryRetentionDays } from "@shared/chat-history-retention";
 
 import type { AIProvidersSettingsProps } from "./AIProvidersSettings";
 
@@ -115,6 +116,7 @@ export interface ChatFontFamilyOption {
 }
 
 export interface SettingsAiChatState {
+    readonly error?: string | null;
     readonly chatFontFamily: string;
     readonly chatFontFamilies: readonly ChatFontFamilyOption[];
     readonly chatFontSize: number;
@@ -123,7 +125,7 @@ export interface SettingsAiChatState {
     readonly composerFontSize: number;
     readonly requireCmdEnterToSend: boolean;
     readonly screenshotRetentionSeconds: number;
-    readonly historyRetentionDays: number;
+    readonly historyRetentionDays: ChatHistoryRetentionDays;
     readonly contextUsageBarEnabled: boolean;
     readonly toolActivityDefaultExpansion: AiToolActivityDefaultExpansion;
     readonly onChatFontFamilyChange?: (id: string) => void;
@@ -132,7 +134,7 @@ export interface SettingsAiChatState {
     readonly onComposerFontSizeChange?: (size: number) => void;
     readonly onRequireCmdEnterChange?: (value: boolean) => void;
     readonly onScreenshotRetentionChange?: (seconds: number) => void;
-    readonly onHistoryRetentionChange?: (days: number) => void;
+    readonly onHistoryRetentionChange?: (days: ChatHistoryRetentionDays) => void;
     readonly onContextUsageBarEnabledChange?: (value: boolean) => void;
     readonly onToolActivityDefaultExpansionChange?: (
         value: AiToolActivityDefaultExpansion,

--- a/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsPanel.tsx
@@ -413,6 +413,23 @@ export function SidebarAgentsPanel({
         [historyScopeKey, loadedHistoryScopeKey, projectId, worktreeId],
     );
 
+    useEffect(() => {
+        const api = getComandoApi();
+        return (
+            api?.onAiHistoryPruned?.((event) => {
+                const deletedSessionIds = new Set(event.deletedSessionIds);
+                for (const sessionId of deletedSessionIds) {
+                    deletedSessionIdsRef.current.add(sessionId);
+                }
+                setSessionsAndCache((current) =>
+                    current.filter(
+                        (session) => !deletedSessionIds.has(session.sessionId),
+                    ),
+                );
+            }) ?? (() => undefined)
+        );
+    }, [setSessionsAndCache]);
+
     const updateFolderState = useCallback(
         (
             updater: (

--- a/src/shared/chat-history-retention.test.ts
+++ b/src/shared/chat-history-retention.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    CHAT_HISTORY_RETENTION_DAYS,
+    isMoreRestrictiveHistoryRetention,
+    normalizeChatHistoryRetentionDays,
+} from "./chat-history-retention";
+
+describe("chat history retention", () => {
+    it.each(CHAT_HISTORY_RETENTION_DAYS)("preserves supported value %s", (value) => {
+        expect(normalizeChatHistoryRetentionDays(value)).toBe(value);
+    });
+
+    it.each([-1, 2, 7.5, 366, "7", null, undefined, Number.NaN])(
+        "falls back to Forever for unsupported value %s",
+        (value) => {
+            expect(normalizeChatHistoryRetentionDays(value)).toBe(0);
+        },
+    );
+
+    it("detects only changes that can delete history sooner", () => {
+        expect(isMoreRestrictiveHistoryRetention(0, 30)).toBe(true);
+        expect(isMoreRestrictiveHistoryRetention(30, 7)).toBe(true);
+        expect(isMoreRestrictiveHistoryRetention(7, 30)).toBe(false);
+        expect(isMoreRestrictiveHistoryRetention(7, 0)).toBe(false);
+        expect(isMoreRestrictiveHistoryRetention(7, 7)).toBe(false);
+    });
+});

--- a/src/shared/chat-history-retention.ts
+++ b/src/shared/chat-history-retention.ts
@@ -1,0 +1,35 @@
+export const CHAT_HISTORY_RETENTION_DAYS = [0, 1, 7, 30, 90, 365] as const;
+
+export type ChatHistoryRetentionDays =
+    (typeof CHAT_HISTORY_RETENTION_DAYS)[number];
+
+export interface ChatHistoryRetentionOption {
+    readonly label: string;
+    readonly value: ChatHistoryRetentionDays;
+}
+
+export const CHAT_HISTORY_RETENTION_OPTIONS: ChatHistoryRetentionOption[] = [
+    { value: 0, label: "Forever" },
+    { value: 1, label: "1 day" },
+    { value: 7, label: "7 days" },
+    { value: 30, label: "30 days" },
+    { value: 90, label: "90 days" },
+    { value: 365, label: "1 year" },
+];
+
+export function normalizeChatHistoryRetentionDays(
+    value: unknown,
+): ChatHistoryRetentionDays {
+    return CHAT_HISTORY_RETENTION_DAYS.includes(
+        value as ChatHistoryRetentionDays,
+    )
+        ? (value as ChatHistoryRetentionDays)
+        : 0;
+}
+
+export function isMoreRestrictiveHistoryRetention(
+    previous: ChatHistoryRetentionDays,
+    next: ChatHistoryRetentionDays,
+): boolean {
+    return next > 0 && (previous === 0 || next < previous);
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -2,6 +2,7 @@ import type { AppIdentity } from "@shared/app-identity";
 import type { AiReviewActionLogState } from "./ai-review-action-log";
 import type { AppTerminalSettings } from "./terminal-settings";
 import type { ChatFontFamily, EditorFontFamily } from "./typography";
+import type { ChatHistoryRetentionDays } from "./chat-history-retention";
 import type {
     NativeAppWorkspaceNavigation,
     NativeDurableWorkspace,
@@ -11,6 +12,7 @@ import type {
 
 export type { AppTerminalSettings } from "./terminal-settings";
 export type { ChatFontFamily, EditorFontFamily } from "./typography";
+export type { ChatHistoryRetentionDays } from "./chat-history-retention";
 
 export const IPC_CHANNELS = {
     getBootstrapSnapshot: "app:get-bootstrap-snapshot",
@@ -273,6 +275,7 @@ export const IPC_EVENTS = {
     aiRuntimeStatus: "ai:runtime-status",
     aiSessionSnapshot: "ai:session-snapshot",
     aiSessionEvent: "ai:session-event",
+    aiHistoryPruned: "ai:history-pruned",
     aiPromptQueue: "ai:prompt-queue",
     aiSessionStreamPort: "ai:session-stream-port",
     nativeBackendEvent: "native-backend:event",
@@ -325,9 +328,15 @@ export interface AppAiChatSettings {
     readonly reviewDiffZoom: number;
     readonly requireCmdEnterToSend: boolean;
     readonly screenshotRetentionSeconds: number;
-    readonly historyRetentionDays: number;
+    readonly historyRetentionDays: ChatHistoryRetentionDays;
     readonly contextUsageBarEnabled: boolean;
     readonly toolActivityDefaultExpansion: AiToolActivityDefaultExpansion;
+}
+
+export interface AiHistoryPrunedEvent {
+    readonly cutoff: string;
+    readonly deletedSessionIds: readonly string[];
+    readonly retentionDays: ChatHistoryRetentionDays;
 }
 
 export interface AppAppearanceSettings {
@@ -4510,6 +4519,9 @@ export interface ComandoApi {
     ) => () => void;
     onAiSessionEvent?: (
         listener: (event: AiSessionDomainEvent) => void,
+    ) => () => void;
+    onAiHistoryPruned?: (
+        listener: (event: AiHistoryPrunedEvent) => void,
     ) => () => void;
     onAiPromptQueue: (
         listener: (snapshot: AiPromptQueueSnapshot) => void,

--- a/src/shared/native-backend/ai.ts
+++ b/src/shared/native-backend/ai.ts
@@ -518,6 +518,17 @@ export type NativeAiDeleteSessionInput = {
     readonly sessionId: NativeSessionId;
 };
 
+export type NativeAiPruneSessionHistoryOutput = {
+    readonly deletedRootIds: readonly NativeSessionId[];
+    readonly deletedSessionIds: readonly NativeSessionId[];
+    readonly failedRootIds: readonly NativeSessionId[];
+    readonly inspectedSessionCount: number;
+    readonly protectedTreeCount: number;
+    readonly invalidMetadataCount: number;
+    readonly invalidTimestampCount: number;
+    readonly policyChanged: boolean;
+};
+
 export type NativeAiRenameSessionInput = {
     readonly sessionId: NativeSessionId;
     readonly title: string;

--- a/src/shared/native-backend/commands.ts
+++ b/src/shared/native-backend/commands.ts
@@ -162,6 +162,7 @@ export const NATIVE_AI_COMMANDS = [
     "ai_list_session_runtime_mappings",
     "ai_set_session_pinned",
     "ai_delete_session",
+    "ai_prune_session_history",
     "ai_migrate_session_history",
     "ai_get_history_storage_health",
     "ai_capture_review_baseline",


### PR DESCRIPTION
## Summary

- enforce chat history retention on startup, on restrictive settings changes, and every 24 hours
- prune complete parent/subagent trees while protecting pinned, active, queued, recent, or structurally invalid sessions
- revalidate persisted retention settings before deletion and remove legacy sources safely
- synchronize pruned history across renderer caches, sidebars, tabs, and durable workspace references
- make settings persistence failure-safe and add protocol, backend, coordinator, and UI regression coverage

## Testing

- `pnpm run check`
- `cargo test -p comando-ai`
- `cargo test -p comando-native-backend --lib`
- `cargo test -p comando-types --test fixtures`
- `pnpm run native:protocol:check`
- independent audit completed with no blocking or important findings