### PR TITLE
Prevent workspace freezes during verbose AI command streaming

### DIFF
--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc as std_mpsc};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use agent_client_protocol::schema::v1::{
     AuthenticateRequest, AvailableCommand, AvailableCommandsUpdate, CancelNotification,
@@ -2154,9 +2154,50 @@ impl NotificationContext {
     }
 
     fn handle(&self, notification: SessionNotification) {
-        if let Ok(mut inner) = self.inner.lock() {
+        let schedules = if let Ok(mut inner) = self.inner.lock() {
             inner.handle(notification);
+            inner.take_terminal_flush_schedules()
+        } else {
+            Vec::new()
+        };
+        for schedule in schedules {
+            self.schedule_terminal_flush(schedule);
         }
+    }
+
+    fn schedule_terminal_flush(&self, schedule: ScheduledTerminalFlush) {
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let context = self.clone();
+        runtime.spawn(async move {
+            tokio::time::sleep(Duration::from_millis(schedule.delay_ms)).await;
+            context.run_terminal_flush(schedule);
+        });
+    }
+
+    fn run_terminal_flush(&self, schedule: ScheduledTerminalFlush) {
+        let retry = self.inner.lock().ok().and_then(|mut inner| {
+            inner.flush_scheduled_terminal_activity(&schedule.buffer_key, schedule.generation)
+        });
+        if let Some(retry) = retry {
+            self.schedule_terminal_flush(retry);
+        }
+    }
+
+    #[cfg(test)]
+    fn flush_due_terminal_activities(&self) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.flush_due_terminal_activities();
+        }
+    }
+
+    #[cfg(test)]
+    fn terminal_activity_metrics(&self) -> TerminalActivityMetrics {
+        self.inner
+            .lock()
+            .map(|inner| inner.terminal_activity_metrics)
+            .unwrap_or_default()
     }
 
     #[cfg(test)]
@@ -2219,6 +2260,7 @@ struct NotificationContextInner {
     synthetic_message_ids: HashMap<String, String>,
     synthetic_message_next_id: usize,
     terminal_clock: MonotonicClock,
+    terminal_activity_metrics: TerminalActivityMetrics,
     terminal_output_buffers: HashMap<String, TerminalOutputState>,
     tool_calls: HashMap<String, ToolCall>,
 }
@@ -2250,9 +2292,32 @@ struct TerminalToolUpdate {
     output_buffer_key: Option<String>,
 }
 
+#[derive(Clone)]
+struct PendingTerminalActivity {
+    runtime_session_id: RuntimeSessionId,
+    tool_call_id: NativeToolCallId,
+}
+
+struct ScheduledTerminalFlush {
+    buffer_key: String,
+    delay_ms: u64,
+    generation: u64,
+}
+
+#[derive(Clone, Copy, Default)]
+struct TerminalActivityMetrics {
+    coalesced: u64,
+    emitted: u64,
+    received: u64,
+    trailing_flushes: u64,
+}
+
 struct TerminalOutputState {
+    flush_generation: u64,
+    flush_scheduled: bool,
     last_emitted_at_ms: Option<u64>,
     output: String,
+    pending_activity: Option<PendingTerminalActivity>,
 }
 
 #[derive(Clone)]
@@ -2378,6 +2443,7 @@ impl NotificationContextInner {
             synthetic_message_ids: HashMap::new(),
             synthetic_message_next_id: 1,
             terminal_clock,
+            terminal_activity_metrics: TerminalActivityMetrics::default(),
             terminal_output_buffers: HashMap::new(),
             tool_calls: HashMap::new(),
         }
@@ -2387,6 +2453,7 @@ impl NotificationContextInner {
         if let Some(previous_runtime_session_id) = self.runtime_session_id.clone()
             && previous_runtime_session_id != runtime_session_id
         {
+            self.flush_terminal_activities_for_session(&previous_runtime_session_id);
             self.clear_terminal_output_buffers(&previous_runtime_session_id);
         }
         self.runtime_session_id = Some(runtime_session_id.clone());
@@ -2635,33 +2702,7 @@ impl NotificationContextInner {
         }
         let terminal_update = self.consume_terminal_meta(runtime_session_id, meta);
         self.mark_terminal_activity_emitted(&terminal_update);
-        let diffs = self.tool_call_activity_diffs_for_runtime_session(
-            runtime_session_id,
-            tool_call_id.clone(),
-            &tool_call,
-            tool_call.meta.as_ref().unwrap_or(meta),
-            terminal_update.clone(),
-        );
-        self.emit(
-            AI_TOOL_ACTIVITY_EVENT,
-            &NativeAiToolActivityPayload {
-                base: self.event_base_for_runtime_session(runtime_session_id),
-                kind: serde_label(&tool_call.kind),
-                status: serde_label(&tool_call.status),
-                summary: tool_call_summary(&tool_call),
-                tool_activity_detail_id: None,
-                change_stats: None,
-                raw_input: tool_call.raw_input.clone(),
-                raw_output: tool_call.raw_output.clone(),
-                title: tool_call.title,
-                tool_call_id: tool_call_id.clone(),
-                diffs,
-                locations: native_tool_activity_locations(&tool_call.locations),
-                terminal_output: terminal_update.terminal_output,
-                exit_code: terminal_update.exit_code,
-            },
-        );
-        self.emit_subagent_breadcrumb(runtime_session_id, tool_call_id, meta);
+        self.emit_tool_call_activity(runtime_session_id, tool_call, terminal_update, meta);
     }
 
     fn handle_tool_call_update(
@@ -2686,15 +2727,36 @@ impl NotificationContextInner {
             self.emit_image_generation(runtime_session_id, &tool_call_id, &tool_call);
             return;
         }
-        let terminal_update = self.consume_terminal_meta(runtime_session_id, meta);
+        let mut terminal_update = self.consume_terminal_meta(runtime_session_id, meta);
         let terminal_only = terminal_update.output_buffer_key.is_some()
             && terminal_update.exit_code.is_none()
             && !tool_call_has_semantic_change(previous_tool_call.as_ref(), &tool_call)
             && meta.keys().all(|key| key == ACP_TERMINAL_OUTPUT_META_KEY);
         if terminal_only && !self.should_emit_terminal_activity(&terminal_update) {
+            self.defer_terminal_activity(runtime_session_id, &tool_call_id, &terminal_update);
             return;
         }
+        self.attach_pending_terminal_output(
+            runtime_session_id,
+            &tool_call_id,
+            &mut terminal_update,
+        );
         self.mark_terminal_activity_emitted(&terminal_update);
+        self.emit_tool_call_activity(runtime_session_id, tool_call, terminal_update, meta);
+    }
+
+    fn emit_tool_call_activity(
+        &mut self,
+        runtime_session_id: &RuntimeSessionId,
+        tool_call: ToolCall,
+        terminal_update: TerminalToolUpdate,
+        meta: &Meta,
+    ) {
+        let tool_call_id = NativeToolCallId(tool_call.tool_call_id.to_string());
+        if terminal_update.terminal_output.is_some() {
+            self.terminal_activity_metrics.emitted =
+                self.terminal_activity_metrics.emitted.saturating_add(1);
+        }
         let diffs = self.tool_call_activity_diffs_for_runtime_session(
             runtime_session_id,
             tool_call_id.clone(),
@@ -2884,6 +2946,8 @@ impl NotificationContextInner {
         let mode = output_meta
             .get(ACP_TERMINAL_OUTPUT_MODE_META_KEY)
             .and_then(serde_json::Value::as_str);
+        self.terminal_activity_metrics.received =
+            self.terminal_activity_metrics.received.saturating_add(1);
         let buffer_key = terminal_output_buffer_key(runtime_session_id, terminal_id);
         let previous = self
             .terminal_output_buffers
@@ -2895,8 +2959,11 @@ impl NotificationContextInner {
             .entry(buffer_key.clone())
             .and_modify(|state| state.output.clone_from(&next))
             .or_insert_with(|| TerminalOutputState {
+                flush_generation: 0,
+                flush_scheduled: false,
                 last_emitted_at_ms: None,
                 output: next.clone(),
+                pending_activity: None,
             });
         Some((next, buffer_key))
     }
@@ -2923,6 +2990,176 @@ impl NotificationContextInner {
         let now_ms = (self.terminal_clock)();
         if let Some(state) = self.terminal_output_buffers.get_mut(buffer_key) {
             state.last_emitted_at_ms = Some(now_ms);
+            state.pending_activity = None;
+            state.flush_scheduled = false;
+            state.flush_generation = state.flush_generation.saturating_add(1);
+        }
+    }
+
+    fn defer_terminal_activity(
+        &mut self,
+        runtime_session_id: &RuntimeSessionId,
+        tool_call_id: &NativeToolCallId,
+        update: &TerminalToolUpdate,
+    ) {
+        let Some(buffer_key) = update.output_buffer_key.as_ref() else {
+            return;
+        };
+        if let Some(state) = self.terminal_output_buffers.get_mut(buffer_key) {
+            state.pending_activity = Some(PendingTerminalActivity {
+                runtime_session_id: runtime_session_id.clone(),
+                tool_call_id: tool_call_id.clone(),
+            });
+            self.terminal_activity_metrics.coalesced =
+                self.terminal_activity_metrics.coalesced.saturating_add(1);
+        }
+    }
+
+    fn attach_pending_terminal_output(
+        &mut self,
+        runtime_session_id: &RuntimeSessionId,
+        tool_call_id: &NativeToolCallId,
+        update: &mut TerminalToolUpdate,
+    ) {
+        let matching_key = self
+            .terminal_output_buffers
+            .iter()
+            .find_map(|(key, state)| {
+                state.pending_activity.as_ref().and_then(|pending| {
+                    (&pending.runtime_session_id == runtime_session_id
+                        && &pending.tool_call_id == tool_call_id)
+                        .then(|| key.clone())
+                })
+            });
+        let Some(buffer_key) = matching_key else {
+            return;
+        };
+        if update.output_buffer_key.is_none()
+            && let Some(state) = self.terminal_output_buffers.get(&buffer_key)
+        {
+            update.terminal_output = Some(state.output.clone());
+            update.output_buffer_key = Some(buffer_key);
+        }
+    }
+
+    fn take_terminal_flush_schedules(&mut self) -> Vec<ScheduledTerminalFlush> {
+        let now_ms = (self.terminal_clock)();
+        self.terminal_output_buffers
+            .iter_mut()
+            .filter_map(|(buffer_key, state)| {
+                if state.pending_activity.is_none() || state.flush_scheduled {
+                    return None;
+                }
+                let deadline_ms = state
+                    .last_emitted_at_ms
+                    .unwrap_or(now_ms)
+                    .saturating_add(TERMINAL_ACTIVITY_EMIT_INTERVAL_MS);
+                state.flush_scheduled = true;
+                Some(ScheduledTerminalFlush {
+                    buffer_key: buffer_key.clone(),
+                    delay_ms: deadline_ms.saturating_sub(now_ms),
+                    generation: state.flush_generation,
+                })
+            })
+            .collect()
+    }
+
+    fn flush_scheduled_terminal_activity(
+        &mut self,
+        buffer_key: &str,
+        generation: u64,
+    ) -> Option<ScheduledTerminalFlush> {
+        let now_ms = (self.terminal_clock)();
+        let state = self.terminal_output_buffers.get(buffer_key)?;
+        if state.flush_generation != generation || state.pending_activity.is_none() {
+            return None;
+        }
+        let deadline_ms = state
+            .last_emitted_at_ms
+            .unwrap_or(now_ms)
+            .saturating_add(TERMINAL_ACTIVITY_EMIT_INTERVAL_MS);
+        if now_ms < deadline_ms {
+            return Some(ScheduledTerminalFlush {
+                buffer_key: buffer_key.to_string(),
+                delay_ms: deadline_ms - now_ms,
+                generation,
+            });
+        }
+        self.flush_terminal_activity(buffer_key);
+        None
+    }
+
+    #[cfg(test)]
+    fn flush_due_terminal_activities(&mut self) {
+        let now_ms = (self.terminal_clock)();
+        let due_keys = self
+            .terminal_output_buffers
+            .iter()
+            .filter_map(|(key, state)| {
+                let deadline_ms = state
+                    .last_emitted_at_ms
+                    .unwrap_or(now_ms)
+                    .saturating_add(TERMINAL_ACTIVITY_EMIT_INTERVAL_MS);
+                (state.pending_activity.is_some() && now_ms >= deadline_ms).then(|| key.clone())
+            })
+            .collect::<Vec<_>>();
+        for key in due_keys {
+            self.flush_terminal_activity(&key);
+        }
+    }
+
+    fn flush_terminal_activity(&mut self, buffer_key: &str) {
+        let Some((pending, output)) =
+            self.terminal_output_buffers
+                .get(buffer_key)
+                .and_then(|state| {
+                    state
+                        .pending_activity
+                        .clone()
+                        .map(|pending| (pending, state.output.clone()))
+                })
+        else {
+            return;
+        };
+        let tool_call_key =
+            tool_call_state_key(&pending.runtime_session_id, &pending.tool_call_id.0);
+        let Some(tool_call) = self.tool_calls.get(&tool_call_key).cloned() else {
+            self.terminal_output_buffers.remove(buffer_key);
+            return;
+        };
+        let meta = tool_call.meta.clone().unwrap_or_default();
+        let terminal_update = TerminalToolUpdate {
+            exit_code: None,
+            output_buffer_key: Some(buffer_key.to_string()),
+            terminal_output: Some(output),
+        };
+        self.terminal_activity_metrics.trailing_flushes = self
+            .terminal_activity_metrics
+            .trailing_flushes
+            .saturating_add(1);
+        self.mark_terminal_activity_emitted(&terminal_update);
+        self.emit_tool_call_activity(
+            &pending.runtime_session_id,
+            tool_call,
+            terminal_update,
+            &meta,
+        );
+    }
+
+    fn flush_terminal_activities_for_session(&mut self, runtime_session_id: &RuntimeSessionId) {
+        let keys = self
+            .terminal_output_buffers
+            .iter()
+            .filter_map(|(key, state)| {
+                state
+                    .pending_activity
+                    .as_ref()
+                    .is_some_and(|pending| &pending.runtime_session_id == runtime_session_id)
+                    .then(|| key.clone())
+            })
+            .collect::<Vec<_>>();
+        for key in keys {
+            self.flush_terminal_activity(&key);
         }
     }
 
@@ -3850,6 +4087,15 @@ impl NotificationContextInner {
         runtime_session_id: &RuntimeSessionId,
         status: NativeAiSessionStatus,
     ) {
+        if matches!(
+            status,
+            NativeAiSessionStatus::Idle
+                | NativeAiSessionStatus::Error
+                | NativeAiSessionStatus::Closed
+        ) {
+            self.flush_terminal_activities_for_session(runtime_session_id);
+            self.clear_terminal_output_buffers(runtime_session_id);
+        }
         match status {
             NativeAiSessionStatus::Streaming => {
                 if self
@@ -3888,6 +4134,7 @@ impl NotificationContextInner {
         self.structured_subagent_runtime_session_ids
             .remove(&runtime_session_id.0);
         self.subagent_active_turn_ids.remove(&runtime_session_id.0);
+        self.flush_terminal_activities_for_session(runtime_session_id);
         self.clear_terminal_output_buffers(runtime_session_id);
 
         if !self.is_known_runtime_session(runtime_session_id) {
@@ -8390,6 +8637,163 @@ mod tests {
             events[2].payload["terminalOutput"]
                 .as_str()
                 .is_some_and(|output| output.ends_with("9999\n") && output.len() <= 10_000)
+        );
+        let metrics = context.terminal_activity_metrics();
+        assert_eq!(metrics.received, 10_000);
+        assert_eq!(metrics.coalesced, 9_999);
+        assert_eq!(metrics.emitted, 2);
+    }
+
+    #[test]
+    fn notification_context_flushes_a_silent_trailing_terminal_window() {
+        let now_ms = Arc::new(AtomicU64::new(0));
+        let clock_state = now_ms.clone();
+        let (sender, receiver) = std_mpsc::sync_channel(8);
+        let context = NotificationContext::new_with_clock(
+            native_test_session(),
+            Some(sender),
+            true,
+            Arc::new(move || clock_state.load(Ordering::Relaxed)),
+        );
+        context.set_runtime_session_id(RuntimeSessionId("runtime-parent".to_string()));
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCall(
+                ToolCall::new("tool-1", "Run command").status(ToolCallStatus::InProgress),
+            ),
+        ));
+        for data in ["a", "b"] {
+            context.handle(SessionNotification::new(
+                "runtime-parent",
+                SessionUpdate::ToolCallUpdate(
+                    ToolCallUpdate::new("tool-1", ToolCallUpdateFields::new())
+                        .meta(terminal_output_meta("tool-1", data, "delta")),
+                ),
+            ));
+        }
+
+        now_ms.store(249, Ordering::Relaxed);
+        context.flush_due_terminal_activities();
+        let leading = receiver.try_iter().collect::<Vec<_>>();
+        assert_eq!(leading.len(), 2);
+        now_ms.store(250, Ordering::Relaxed);
+        context.flush_due_terminal_activities();
+
+        let trailing = receiver.recv().unwrap();
+        assert_eq!(trailing.event_name, AI_TOOL_ACTIVITY_EVENT);
+        assert_eq!(trailing.payload["terminalOutput"], "ab");
+        let metrics = context.terminal_activity_metrics();
+        assert_eq!(metrics.received, 2);
+        assert_eq!(metrics.coalesced, 1);
+        assert_eq!(metrics.emitted, 2);
+        assert_eq!(metrics.trailing_flushes, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn notification_context_schedules_a_product_trailing_flush() {
+        let (sender, receiver) = std_mpsc::sync_channel(8);
+        let context =
+            NotificationContext::new(native_test_session(), Some(sender), Vec::new(), true);
+        context.set_runtime_session_id(RuntimeSessionId("runtime-parent".to_string()));
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCall(
+                ToolCall::new("tool-1", "Run command").status(ToolCallStatus::InProgress),
+            ),
+        ));
+        for data in ["a", "b"] {
+            context.handle(SessionNotification::new(
+                "runtime-parent",
+                SessionUpdate::ToolCallUpdate(
+                    ToolCallUpdate::new("tool-1", ToolCallUpdateFields::new())
+                        .meta(terminal_output_meta("tool-1", data, "delta")),
+                ),
+            ));
+        }
+
+        assert_eq!(receiver.recv().unwrap().event_name, AI_TOOL_ACTIVITY_EVENT);
+        assert_eq!(receiver.recv().unwrap().payload["terminalOutput"], "a");
+        let trailing = receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert_eq!(trailing.payload["terminalOutput"], "ab");
+    }
+
+    #[test]
+    fn notification_context_flushes_and_clears_terminal_on_terminal_statuses() {
+        for status in [
+            NativeAiSessionStatus::Idle,
+            NativeAiSessionStatus::Error,
+            NativeAiSessionStatus::Closed,
+        ] {
+            let now_ms = Arc::new(AtomicU64::new(0));
+            let clock_state = now_ms.clone();
+            let (sender, receiver) = std_mpsc::sync_channel(8);
+            let context = NotificationContext::new_with_clock(
+                native_test_session(),
+                Some(sender),
+                true,
+                Arc::new(move || clock_state.load(Ordering::Relaxed)),
+            );
+            let runtime_session_id = RuntimeSessionId("runtime-parent".to_string());
+            context.set_runtime_session_id(runtime_session_id.clone());
+            context.handle(SessionNotification::new(
+                "runtime-parent",
+                SessionUpdate::ToolCall(
+                    ToolCall::new("tool-1", "Run command").status(ToolCallStatus::InProgress),
+                ),
+            ));
+            for data in ["a", "b"] {
+                context.handle(SessionNotification::new(
+                    "runtime-parent",
+                    SessionUpdate::ToolCallUpdate(
+                        ToolCallUpdate::new("tool-1", ToolCallUpdateFields::new())
+                            .meta(terminal_output_meta("tool-1", data, "delta")),
+                    ),
+                ));
+            }
+            if let Ok(mut inner) = context.inner.lock() {
+                inner.emit_runtime_session_status(&runtime_session_id, status);
+                assert!(inner.terminal_output_buffers.is_empty());
+            }
+
+            let events = receiver.try_iter().collect::<Vec<_>>();
+            assert_eq!(events.len(), 4);
+            assert_eq!(events[2].payload["terminalOutput"], "ab");
+            assert_eq!(events[3].event_name, AI_SESSION_UPDATED_EVENT);
+        }
+    }
+
+    #[test]
+    fn notification_context_flushes_terminal_before_runtime_replacement() {
+        let (sender, receiver) = std_mpsc::sync_channel(8);
+        let context =
+            NotificationContext::new(native_test_session(), Some(sender), Vec::new(), true);
+        context.set_runtime_session_id(RuntimeSessionId("runtime-parent".to_string()));
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCall(
+                ToolCall::new("tool-1", "Run command").status(ToolCallStatus::InProgress),
+            ),
+        ));
+        for data in ["a", "b"] {
+            context.handle(SessionNotification::new(
+                "runtime-parent",
+                SessionUpdate::ToolCallUpdate(
+                    ToolCallUpdate::new("tool-1", ToolCallUpdateFields::new())
+                        .meta(terminal_output_meta("tool-1", data, "delta")),
+                ),
+            ));
+        }
+
+        context.set_runtime_session_id(RuntimeSessionId("runtime-replacement".to_string()));
+
+        let events = receiver.try_iter().collect::<Vec<_>>();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[2].payload["terminalOutput"], "ab");
+        assert!(
+            context
+                .inner
+                .lock()
+                .is_ok_and(|inner| inner.terminal_output_buffers.is_empty())
         );
     }
 

--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc as std_mpsc};
+use std::time::Instant;
 
 use agent_client_protocol::schema::v1::{
     AuthenticateRequest, AvailableCommand, AvailableCommandsUpdate, CancelNotification,
@@ -91,6 +92,9 @@ const ACP_TERMINAL_OUTPUT_DATA_META_KEY: &str = "data";
 const ACP_TERMINAL_OUTPUT_MODE_META_KEY: &str = "mode";
 const ACP_TERMINAL_EXIT_CODE_META_KEY: &str = "exit_code";
 const TERMINAL_OUTPUT_MAX_LENGTH: usize = 10_000;
+const TERMINAL_ACTIVITY_EMIT_INTERVAL_MS: u64 = 250;
+
+type MonotonicClock = Arc<dyn Fn() -> u64 + Send + Sync>;
 
 type PermissionWaiterMap = Arc<Mutex<HashMap<String, PendingPermissionRequest>>>;
 type PromptCapabilitiesState = Arc<Mutex<AcpPromptCapabilities>>;
@@ -2104,15 +2108,36 @@ impl NotificationContext {
         supports_subagents: bool,
         session_registry: Option<Arc<Mutex<SessionRegistry>>>,
     ) -> Self {
+        let started_at = Instant::now();
         let inner = NotificationContextInner::new(
             session,
             event_sender,
             persisted_subagent_session_mappings,
             supports_subagents,
             session_registry,
+            Arc::new(move || u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX)),
         );
         Self {
             inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_clock(
+        session: NativeAiSession,
+        event_sender: Option<std_mpsc::SyncSender<AiRuntimeEvent>>,
+        supports_subagents: bool,
+        clock: MonotonicClock,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(NotificationContextInner::new(
+                session,
+                event_sender,
+                Vec::new(),
+                supports_subagents,
+                None,
+                clock,
+            ))),
         }
     }
 
@@ -2193,7 +2218,8 @@ struct NotificationContextInner {
     synthetic_message_epoch: String,
     synthetic_message_ids: HashMap<String, String>,
     synthetic_message_next_id: usize,
-    terminal_output_buffers: HashMap<String, String>,
+    terminal_clock: MonotonicClock,
+    terminal_output_buffers: HashMap<String, TerminalOutputState>,
     tool_calls: HashMap<String, ToolCall>,
 }
 
@@ -2221,6 +2247,12 @@ struct PendingToolActivity {
 struct TerminalToolUpdate {
     terminal_output: Option<String>,
     exit_code: Option<i32>,
+    output_buffer_key: Option<String>,
+}
+
+struct TerminalOutputState {
+    last_emitted_at_ms: Option<u64>,
+    output: String,
 }
 
 #[derive(Clone)]
@@ -2269,6 +2301,7 @@ impl NotificationContextInner {
         persisted_subagent_session_mappings: Vec<NativeAiRuntimeSessionMapping>,
         supports_subagents: bool,
         session_registry: Option<Arc<Mutex<SessionRegistry>>>,
+        terminal_clock: MonotonicClock,
     ) -> Self {
         let mut app_session_id_by_runtime_session_id = HashMap::new();
         let mut subagents_by_runtime_session_id = HashMap::new();
@@ -2344,12 +2377,18 @@ impl NotificationContextInner {
             synthetic_message_epoch: Uuid::new_v4().to_string(),
             synthetic_message_ids: HashMap::new(),
             synthetic_message_next_id: 1,
+            terminal_clock,
             terminal_output_buffers: HashMap::new(),
             tool_calls: HashMap::new(),
         }
     }
 
     fn set_root_runtime_session_id(&mut self, runtime_session_id: RuntimeSessionId) {
+        if let Some(previous_runtime_session_id) = self.runtime_session_id.clone()
+            && previous_runtime_session_id != runtime_session_id
+        {
+            self.clear_terminal_output_buffers(&previous_runtime_session_id);
+        }
         self.runtime_session_id = Some(runtime_session_id.clone());
         self.app_session_id_by_runtime_session_id.insert(
             runtime_session_id.0.clone(),
@@ -2595,6 +2634,7 @@ impl NotificationContextInner {
             return;
         }
         let terminal_update = self.consume_terminal_meta(runtime_session_id, meta);
+        self.mark_terminal_activity_emitted(&terminal_update);
         let diffs = self.tool_call_activity_diffs_for_runtime_session(
             runtime_session_id,
             tool_call_id.clone(),
@@ -2634,6 +2674,7 @@ impl NotificationContextInner {
             return;
         }
 
+        let previous_tool_call = self.tool_call_for_update(runtime_session_id, &tool_call_update);
         let Some(tool_call) =
             self.apply_tool_call_update(runtime_session_id, tool_call_update, meta)
         else {
@@ -2646,6 +2687,14 @@ impl NotificationContextInner {
             return;
         }
         let terminal_update = self.consume_terminal_meta(runtime_session_id, meta);
+        let terminal_only = terminal_update.output_buffer_key.is_some()
+            && terminal_update.exit_code.is_none()
+            && !tool_call_has_semantic_change(previous_tool_call.as_ref(), &tool_call)
+            && meta.keys().all(|key| key == ACP_TERMINAL_OUTPUT_META_KEY);
+        if terminal_only && !self.should_emit_terminal_activity(&terminal_update) {
+            return;
+        }
+        self.mark_terminal_activity_emitted(&terminal_update);
         let diffs = self.tool_call_activity_diffs_for_runtime_session(
             runtime_session_id,
             tool_call_id.clone(),
@@ -2784,6 +2833,9 @@ impl NotificationContextInner {
     ) -> TerminalToolUpdate {
         let mut terminal_output = self.consume_terminal_output_meta(runtime_session_id, meta);
         let mut exit_code = None;
+        let mut output_buffer_key = terminal_output
+            .as_ref()
+            .map(|(_, buffer_key)| buffer_key.clone());
 
         if let Some(exit_meta) = meta
             .get(ACP_TERMINAL_EXIT_META_KEY)
@@ -2801,15 +2853,17 @@ impl NotificationContextInner {
             }
             if let Some(terminal_id) = terminal_id {
                 let buffer_key = terminal_output_buffer_key(runtime_session_id, terminal_id);
+                output_buffer_key = Some(buffer_key.clone());
                 if let Some(final_output) = self.terminal_output_buffers.remove(&buffer_key) {
-                    terminal_output = Some(final_output);
+                    terminal_output = Some((final_output.output, buffer_key));
                 }
             }
         }
 
         TerminalToolUpdate {
-            terminal_output,
+            terminal_output: terminal_output.map(|(output, _)| output),
             exit_code,
+            output_buffer_key,
         }
     }
 
@@ -2817,7 +2871,7 @@ impl NotificationContextInner {
         &mut self,
         runtime_session_id: &RuntimeSessionId,
         meta: &Meta,
-    ) -> Option<String> {
+    ) -> Option<(String, String)> {
         let output_meta = meta
             .get(ACP_TERMINAL_OUTPUT_META_KEY)
             .and_then(serde_json::Value::as_object)?;
@@ -2834,12 +2888,60 @@ impl NotificationContextInner {
         let previous = self
             .terminal_output_buffers
             .get(&buffer_key)
-            .map(String::as_str)
+            .map(|state| state.output.as_str())
             .unwrap_or_default();
         let next = merge_terminal_output_buffer(previous, data, mode);
         self.terminal_output_buffers
-            .insert(buffer_key, next.clone());
-        Some(next)
+            .entry(buffer_key.clone())
+            .and_modify(|state| state.output.clone_from(&next))
+            .or_insert_with(|| TerminalOutputState {
+                last_emitted_at_ms: None,
+                output: next.clone(),
+            });
+        Some((next, buffer_key))
+    }
+
+    fn should_emit_terminal_activity(&self, update: &TerminalToolUpdate) -> bool {
+        let Some(buffer_key) = update.output_buffer_key.as_ref() else {
+            return true;
+        };
+        let Some(last_emitted_at_ms) = self
+            .terminal_output_buffers
+            .get(buffer_key)
+            .and_then(|state| state.last_emitted_at_ms)
+        else {
+            return true;
+        };
+        (self.terminal_clock)().saturating_sub(last_emitted_at_ms)
+            >= TERMINAL_ACTIVITY_EMIT_INTERVAL_MS
+    }
+
+    fn mark_terminal_activity_emitted(&mut self, update: &TerminalToolUpdate) {
+        let Some(buffer_key) = update.output_buffer_key.as_ref() else {
+            return;
+        };
+        let now_ms = (self.terminal_clock)();
+        if let Some(state) = self.terminal_output_buffers.get_mut(buffer_key) {
+            state.last_emitted_at_ms = Some(now_ms);
+        }
+    }
+
+    fn tool_call_for_update(
+        &self,
+        runtime_session_id: &RuntimeSessionId,
+        tool_call_update: &ToolCallUpdate,
+    ) -> Option<ToolCall> {
+        let tool_call_id =
+            self.resolve_tool_call_id_for_update(runtime_session_id, tool_call_update);
+        self.tool_calls
+            .get(&tool_call_state_key(runtime_session_id, &tool_call_id))
+            .cloned()
+    }
+
+    fn clear_terminal_output_buffers(&mut self, runtime_session_id: &RuntimeSessionId) {
+        let prefix = format!("{}:", runtime_session_id.0);
+        self.terminal_output_buffers
+            .retain(|key, _| !key.starts_with(&prefix));
     }
 
     fn emit_image_generation(
@@ -3786,6 +3888,7 @@ impl NotificationContextInner {
         self.structured_subagent_runtime_session_ids
             .remove(&runtime_session_id.0);
         self.subagent_active_turn_ids.remove(&runtime_session_id.0);
+        self.clear_terminal_output_buffers(runtime_session_id);
 
         if !self.is_known_runtime_session(runtime_session_id) {
             return;
@@ -4327,6 +4430,19 @@ fn is_generic_subagent_title(title: &str) -> bool {
 
 fn terminal_output_buffer_key(runtime_session_id: &RuntimeSessionId, terminal_id: &str) -> String {
     format!("{}:{terminal_id}", runtime_session_id.0)
+}
+
+fn tool_call_has_semantic_change(previous: Option<&ToolCall>, next: &ToolCall) -> bool {
+    let Some(previous) = previous else {
+        return true;
+    };
+    previous.kind != next.kind
+        || previous.status != next.status
+        || previous.title != next.title
+        || previous.content != next.content
+        || previous.locations != next.locations
+        || previous.raw_input != next.raw_input
+        || previous.raw_output != next.raw_output
 }
 
 fn merge_terminal_output_buffer(previous: &str, data: &str, mode: Option<&str>) -> String {
@@ -8222,6 +8338,128 @@ mod tests {
         assert_eq!(completed.event_name, AI_TOOL_ACTIVITY_EVENT);
         assert_eq!(completed.payload["terminalOutput"], "hello world");
         assert_eq!(completed.payload["exitCode"], 0);
+    }
+
+    #[test]
+    fn notification_context_coalesces_terminal_only_updates_per_window() {
+        let now_ms = Arc::new(AtomicU64::new(0));
+        let clock_state = now_ms.clone();
+        let (sender, receiver) = std_mpsc::sync_channel(8);
+        let context = NotificationContext::new_with_clock(
+            native_test_session(),
+            Some(sender),
+            true,
+            Arc::new(move || clock_state.load(Ordering::Relaxed)),
+        );
+        context.set_runtime_session_id(RuntimeSessionId("runtime-parent".to_string()));
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCall(
+                ToolCall::new("tool-1", "Run command").status(ToolCallStatus::InProgress),
+            ),
+        ));
+
+        for index in 0..10_000 {
+            context.handle(SessionNotification::new(
+                "runtime-parent",
+                SessionUpdate::ToolCallUpdate(
+                    ToolCallUpdate::new("tool-1", ToolCallUpdateFields::new()).meta(
+                        terminal_output_meta("tool-1", &format!("{index}\n"), "delta"),
+                    ),
+                ),
+            ));
+        }
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCallUpdate(
+                ToolCallUpdate::new(
+                    "tool-1",
+                    ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
+                )
+                .meta(terminal_exit_meta("tool-1", 0)),
+            ),
+        ));
+
+        let events = receiver.try_iter().collect::<Vec<_>>();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].payload["status"], "in_progress");
+        assert_eq!(events[1].payload["terminalOutput"], "0\n");
+        assert_eq!(events[2].payload["status"], "completed");
+        assert_eq!(events[2].payload["exitCode"], 0);
+        assert!(
+            events[2].payload["terminalOutput"]
+                .as_str()
+                .is_some_and(|output| output.ends_with("9999\n") && output.len() <= 10_000)
+        );
+    }
+
+    #[test]
+    fn notification_context_emits_terminal_windows_and_semantic_updates_immediately() {
+        let now_ms = Arc::new(AtomicU64::new(0));
+        let clock_state = now_ms.clone();
+        let (sender, receiver) = std_mpsc::sync_channel(16);
+        let context = NotificationContext::new_with_clock(
+            native_test_session(),
+            Some(sender),
+            true,
+            Arc::new(move || clock_state.load(Ordering::Relaxed)),
+        );
+        context.set_runtime_session_id(RuntimeSessionId("runtime-parent".to_string()));
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCall(
+                ToolCall::new("tool-1", "Run command").status(ToolCallStatus::InProgress),
+            ),
+        ));
+
+        for (at_ms, data) in [(0, "a"), (249, "b"), (250, "c"), (251, "d")] {
+            now_ms.store(at_ms, Ordering::Relaxed);
+            context.handle(SessionNotification::new(
+                "runtime-parent",
+                SessionUpdate::ToolCallUpdate(
+                    ToolCallUpdate::new("tool-1", ToolCallUpdateFields::new())
+                        .meta(terminal_output_meta("tool-1", data, "delta")),
+                ),
+            ));
+        }
+        context.handle(SessionNotification::new(
+            "runtime-parent",
+            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                "tool-1",
+                ToolCallUpdateFields::new().title("Run tests".to_string()),
+            )),
+        ));
+
+        let events = receiver.try_iter().collect::<Vec<_>>();
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[1].payload["terminalOutput"], "a");
+        assert_eq!(events[2].payload["terminalOutput"], "abc");
+        assert_eq!(events[3].payload["title"], "Run tests");
+    }
+
+    fn terminal_output_meta(terminal_id: &str, data: &str, mode: &str) -> Meta {
+        let mut meta = Meta::default();
+        meta.insert(
+            ACP_TERMINAL_OUTPUT_META_KEY.to_string(),
+            serde_json::json!({
+                "terminal_id": terminal_id,
+                "data": data,
+                "mode": mode,
+            }),
+        );
+        meta
+    }
+
+    fn terminal_exit_meta(terminal_id: &str, exit_code: i32) -> Meta {
+        let mut meta = Meta::default();
+        meta.insert(
+            ACP_TERMINAL_EXIT_META_KEY.to_string(),
+            serde_json::json!({
+                "terminal_id": terminal_id,
+                "exit_code": exit_code,
+            }),
+        );
+        meta
     }
 
     #[test]

--- a/crates/comando-ai/src/acp.rs
+++ b/crates/comando-ai/src/acp.rs
@@ -3150,13 +3150,13 @@ impl NotificationContextInner {
         let keys = self
             .terminal_output_buffers
             .iter()
-            .filter_map(|(key, state)| {
+            .filter(|(_, state)| {
                 state
                     .pending_activity
                     .as_ref()
                     .is_some_and(|pending| &pending.runtime_session_id == runtime_session_id)
-                    .then(|| key.clone())
             })
+            .map(|(key, _)| key.clone())
             .collect::<Vec<_>>();
         for key in keys {
             self.flush_terminal_activity(&key);

--- a/crates/comando-ai/src/history.rs
+++ b/crates/comando-ai/src/history.rs
@@ -626,7 +626,9 @@ impl AiHistoryStore {
                 error,
             )
         })?;
-        self.atomic_write_json(&path, &AiToolActivityDetail { hash, payload })
+        self.atomic_write_json(&path, &AiToolActivityDetail { hash, payload })?;
+        self.work_metrics.record_tool_activity_detail_write();
+        Ok(())
     }
 
     pub fn load_tool_activity_detail(
@@ -4560,6 +4562,26 @@ mod tests {
             store.work_metrics(),
             AiStorageWorkMetricsSnapshot::default()
         );
+    }
+
+    #[test]
+    fn storage_work_metrics_count_only_changed_tool_activity_details() {
+        let (_temp, store) = store();
+        let session_id = SessionId("tool-detail-work-metrics".to_string());
+        store.create_session(metadata(&session_id.0)).unwrap();
+        store.set_work_metrics_enabled(true);
+
+        for terminal_output in ["first", "first", "second"] {
+            store
+                .store_tool_activity_detail(
+                    &session_id,
+                    "tool-1",
+                    json!({ "terminalOutput": terminal_output }),
+                )
+                .unwrap();
+        }
+
+        assert_eq!(store.work_metrics().tool_activity_detail_write_count, 2);
     }
 
     fn legacy_connection() -> Connection {

--- a/crates/comando-ai/src/storage_work_metrics.rs
+++ b/crates/comando-ai/src/storage_work_metrics.rs
@@ -6,6 +6,7 @@ pub struct AiStorageWorkMetricsSnapshot {
     pub durable_write_bytes: u64,
     pub serialized_bytes: u64,
     pub sync_count: u64,
+    pub tool_activity_detail_write_count: u64,
 }
 
 #[derive(Debug, Default)]
@@ -15,6 +16,7 @@ pub(crate) struct StorageWorkMetrics {
     enabled: AtomicBool,
     serialized_bytes: AtomicU64,
     sync_count: AtomicU64,
+    tool_activity_detail_write_count: AtomicU64,
 }
 
 impl StorageWorkMetrics {
@@ -42,11 +44,17 @@ impl StorageWorkMetrics {
         self.add(&self.sync_count, 1);
     }
 
+    pub(crate) fn record_tool_activity_detail_write(&self) {
+        self.add(&self.tool_activity_detail_write_count, 1);
+    }
+
     pub(crate) fn reset(&self) {
         self.checkpoint_count.store(0, Ordering::Relaxed);
         self.durable_write_bytes.store(0, Ordering::Relaxed);
         self.serialized_bytes.store(0, Ordering::Relaxed);
         self.sync_count.store(0, Ordering::Relaxed);
+        self.tool_activity_detail_write_count
+            .store(0, Ordering::Relaxed);
     }
 
     pub(crate) fn snapshot(&self) -> AiStorageWorkMetricsSnapshot {
@@ -55,6 +63,9 @@ impl StorageWorkMetrics {
             durable_write_bytes: self.durable_write_bytes.load(Ordering::Relaxed),
             serialized_bytes: self.serialized_bytes.load(Ordering::Relaxed),
             sync_count: self.sync_count.load(Ordering::Relaxed),
+            tool_activity_detail_write_count: self
+                .tool_activity_detail_write_count
+                .load(Ordering::Relaxed),
         }
     }
 

--- a/e2e/harness/TerminalPressureHarness.tsx
+++ b/e2e/harness/TerminalPressureHarness.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import type {
     AiSessionDomainEvent,
     AiSessionSnapshot,
+    AiSessionStreamMessage,
     AiSessionStreamPayload,
     AiSessionToolActivityEvent,
     WorkspaceChatTab,
@@ -22,12 +23,9 @@ import {
 import { createWorkspaceSurfaceAgentPresencePublisher } from "@renderer/app/workspace/workspaceSurfaceAgentPresencePublisher";
 import type { WorkspaceSurfaceAgentPresencePublisher } from "@renderer/app/workspace/workspaceSurfaceAgentPresencePublisher";
 import {
-    AI_SESSION_STREAM_MAX_IN_FLIGHT,
-    AI_SESSION_STREAM_MAX_PENDING_PAYLOADS,
+    AiSessionStreamController,
+    buildAiSessionStreamRecoveryFallbackPayloads,
     isAiSessionUpdate,
-    rememberAiSessionStreamPayloadForDelivery,
-    takeNextAiSessionStreamDelivery,
-    type AiSessionStreamDeliveryQueue,
 } from "../../src/main/ai/session-stream";
 import { deliverAiSessionStreamMessage } from "../../src/preload/ai-session-stream";
 
@@ -80,32 +78,28 @@ class BrowserAiSessionPressureTransport {
     readonly criticalKindsDelivered = new Set<string>();
     private ackBeforeIngestion = false;
     private acknowledgedPayloads = 0;
-    private coalesced = 0;
+    private controller: AiSessionStreamController;
     private duplicatePayloads = 0;
     private readonly deliveredSeqs = new Set<number>();
-    private readonly inFlight: Array<{
-        readonly payload: AiSessionStreamPayload;
-        readonly seq: number;
-    }> = [];
-    private nextOrder = 0;
-    private nextSeq = 1;
-    private readonly pending: AiSessionStreamDeliveryQueue = new Map();
-    private peakInFlight = 0;
     private producerComplete = false;
     private scheduled = false;
+    private readonly wireMessages: AiSessionStreamMessage[] = [];
 
     constructor(
         private readonly deliverPayload: (payload: AiSessionStreamPayload) => void,
         private readonly onIdle: () => void,
-    ) {}
+    ) {
+        this.controller = this.createController();
+    }
 
     get metrics() {
         return {
             ackBeforeIngestion: this.ackBeforeIngestion,
             acknowledgedPayloads: this.acknowledgedPayloads,
             duplicatePayloads: this.duplicatePayloads,
-            peakInFlight: this.peakInFlight,
-            transportCoalesced: this.coalesced,
+            peakInFlight: this.controller.metrics.peakInFlightPayloadCount,
+            transportCoalesced:
+                this.controller.metrics.coalescedPendingPayloadCount,
         };
     }
 
@@ -115,51 +109,48 @@ class BrowserAiSessionPressureTransport {
     }
 
     post(payload: AiSessionStreamPayload): void {
-        if (this.inFlight.length < AI_SESSION_STREAM_MAX_IN_FLIGHT) {
-            this.send(payload);
-            return;
-        }
-        const result = rememberAiSessionStreamPayloadForDelivery({
-            maxPayloads: AI_SESSION_STREAM_MAX_PENDING_PAYLOADS,
-            order: this.nextOrder,
-            payload,
-            queue: this.pending,
-        });
-        this.nextOrder += 1;
-        if (result.coalesced) this.coalesced += 1;
-        if (!result.preserved || result.droppedOldest) {
-            throw new Error("Pressure transport could not preserve a payload.");
-        }
-        this.scheduleDrain();
+        this.controller.postPayload(payload);
     }
 
-    private deliver(envelope: {
-        readonly payload: AiSessionStreamPayload;
-        readonly seq: number;
-    }): void {
-        let ingested = false;
+    private createController(): AiSessionStreamController {
+        return new AiSessionStreamController({
+            onRecovery: ({ additionalPayloads }) => {
+                const recovered = this.controller.takeRecoveryPayloads(
+                    additionalPayloads,
+                );
+                this.wireMessages.length = 0;
+                this.controller = this.createController();
+                for (const payload of buildAiSessionStreamRecoveryFallbackPayloads({
+                    pendingPreservedPayloads: recovered,
+                    resyncSnapshots: [],
+                })) {
+                    this.recordCriticalKind(payload);
+                    this.deliverPayload(payload);
+                }
+            },
+            postMessage: (message) => {
+                this.wireMessages.push(message);
+                this.scheduleDrain();
+            },
+        });
+    }
+
+    private deliver(message: AiSessionStreamMessage): void {
+        let ingested = message.type === "ping";
         deliverAiSessionStreamMessage(
-            { payload: envelope.payload, seq: envelope.seq, type: "payload" },
+            message,
             {
                 acknowledge: (seq) => {
                     if (!ingested) this.ackBeforeIngestion = true;
                     this.acknowledgedPayloads += 1;
                     if (this.deliveredSeqs.has(seq)) this.duplicatePayloads += 1;
                     this.deliveredSeqs.add(seq);
+                    this.controller.acknowledge(seq);
                 },
                 notifyPayload: (payload) => {
                     ingested = true;
                     const typedPayload = payload as AiSessionStreamPayload;
-                    if (!isAiSessionUpdate(typedPayload)) {
-                        if (
-                            typedPayload.kind === "permission-request" ||
-                            typedPayload.kind === "user-input-request" ||
-                            typedPayload.kind === "turn-status" ||
-                            typedPayload.kind === "status"
-                        ) {
-                            this.criticalKindsDelivered.add(typedPayload.kind);
-                        }
-                    }
+                    this.recordCriticalKind(typedPayload);
                     this.deliverPayload(typedPayload);
                 },
                 reportDispatchError: (_message, error) => {
@@ -174,14 +165,14 @@ class BrowserAiSessionPressureTransport {
 
     private drain = () => {
         this.scheduled = false;
-        const delivered = this.inFlight.splice(0);
-        for (const envelope of delivered) this.deliver(envelope);
-        while (this.inFlight.length < AI_SESSION_STREAM_MAX_IN_FLIGHT) {
-            const pending = takeNextAiSessionStreamDelivery(this.pending);
-            if (!pending) break;
-            this.send(pending.payload);
-        }
-        if (this.inFlight.length > 0 || this.pending.size > 0) {
+        const delivered = this.wireMessages.splice(0);
+        for (const message of delivered) this.deliver(message);
+        const metrics = this.controller.metrics;
+        if (
+            this.wireMessages.length > 0 ||
+            metrics.pendingInFlightPayloadCount > 0 ||
+            metrics.pendingDeliveryPayloadCount > 0
+        ) {
             this.scheduleDrain();
             return;
         }
@@ -194,11 +185,16 @@ class BrowserAiSessionPressureTransport {
         requestAnimationFrame(this.drain);
     }
 
-    private send(payload: AiSessionStreamPayload): void {
-        this.inFlight.push({ payload, seq: this.nextSeq });
-        this.nextSeq += 1;
-        this.peakInFlight = Math.max(this.peakInFlight, this.inFlight.length);
-        this.scheduleDrain();
+    private recordCriticalKind(payload: AiSessionStreamPayload): void {
+        if (isAiSessionUpdate(payload)) return;
+        if (
+            payload.kind === "permission-request" ||
+            payload.kind === "user-input-request" ||
+            payload.kind === "turn-status" ||
+            payload.kind === "status"
+        ) {
+            this.criticalKindsDelivered.add(payload.kind);
+        }
     }
 }
 

--- a/e2e/harness/TerminalPressureHarness.tsx
+++ b/e2e/harness/TerminalPressureHarness.tsx
@@ -1,19 +1,57 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-import type { AiSessionToolActivityEvent } from "@shared/ipc";
+import type {
+    AiSessionDomainEvent,
+    AiSessionSnapshot,
+    AiSessionStreamPayload,
+    AiSessionToolActivityEvent,
+    WorkspaceChatTab,
+    WorkspaceSurfaceLifecycleState,
+} from "@shared/ipc";
 import { createTerminalStreamPressureFixture } from "@shared/testing/chatLoadFactories";
 import {
-    AiSessionEventFrameBuffer,
-} from "@renderer/app/ai/aiSessionEventFrameBuffer";
+    incrementChatPerformanceCounter,
+    readChatPerformanceCounters,
+    resetChatPerformanceCounters,
+    setChatPerformanceCountersEnabledForTests,
+} from "@renderer/app/debug/chatPerformanceCounters";
+import {
+    resetAiStoreRuntimeBuffersForTests,
+    useAiStore,
+} from "@renderer/app/store/ai-store";
+import { createWorkspaceSurfaceAgentPresencePublisher } from "@renderer/app/workspace/workspaceSurfaceAgentPresencePublisher";
+import type { WorkspaceSurfaceAgentPresencePublisher } from "@renderer/app/workspace/workspaceSurfaceAgentPresencePublisher";
+import {
+    AI_SESSION_STREAM_MAX_IN_FLIGHT,
+    AI_SESSION_STREAM_MAX_PENDING_PAYLOADS,
+    isAiSessionUpdate,
+    rememberAiSessionStreamPayloadForDelivery,
+    takeNextAiSessionStreamDelivery,
+    type AiSessionStreamDeliveryQueue,
+} from "../../src/main/ai/session-stream";
+import { deliverAiSessionStreamMessage } from "../../src/preload/ai-session-stream";
 
 interface TerminalPressureHarnessSnapshot {
+    readonly ackBeforeIngestion: boolean;
+    readonly acknowledgedPayloads: number;
     readonly activeTab: string;
-    readonly appliedToolEvents: number;
-    readonly composerValue: string;
+    readonly criticalKindsDelivered: readonly string[];
+    readonly duplicatePayloads: number;
     readonly expectedFinalOutput: string;
+    readonly frameCoalesced: number;
+    readonly framePeakPending: number;
+    readonly finalDiffCount: number;
+    readonly finalExitCode: number | null;
     readonly finalOutput: string;
+    readonly lifecycle: WorkspaceSurfaceLifecycleState;
+    readonly peakInFlight: number;
+    readonly presencePublishes: number;
     readonly producerEvents: number;
+    readonly scrollAtBottom: boolean;
     readonly status: "complete" | "idle" | "streaming";
+    readonly storeToolApplies: number;
+    readonly toolEventsReceived: number;
+    readonly transportCoalesced: number;
 }
 
 interface ComandoTerminalPressureHarness {
@@ -28,78 +66,240 @@ declare global {
 }
 
 const EVENTS_PER_PRODUCER_FRAME = 250;
+const STREAM_SESSION_ID = "session-pressure";
+const BACKGROUND_SESSION_ID = "session-background";
+
+const STREAM_TAB = createTab("tab-pressure", STREAM_SESSION_ID, "Pressure");
+const BACKGROUND_TAB = createTab(
+    "tab-background",
+    BACKGROUND_SESSION_ID,
+    "Background",
+);
+
+class BrowserAiSessionPressureTransport {
+    readonly criticalKindsDelivered = new Set<string>();
+    private ackBeforeIngestion = false;
+    private acknowledgedPayloads = 0;
+    private coalesced = 0;
+    private duplicatePayloads = 0;
+    private readonly deliveredSeqs = new Set<number>();
+    private readonly inFlight: Array<{
+        readonly payload: AiSessionStreamPayload;
+        readonly seq: number;
+    }> = [];
+    private nextOrder = 0;
+    private nextSeq = 1;
+    private readonly pending: AiSessionStreamDeliveryQueue = new Map();
+    private peakInFlight = 0;
+    private producerComplete = false;
+    private scheduled = false;
+
+    constructor(
+        private readonly deliverPayload: (payload: AiSessionStreamPayload) => void,
+        private readonly onIdle: () => void,
+    ) {}
+
+    get metrics() {
+        return {
+            ackBeforeIngestion: this.ackBeforeIngestion,
+            acknowledgedPayloads: this.acknowledgedPayloads,
+            duplicatePayloads: this.duplicatePayloads,
+            peakInFlight: this.peakInFlight,
+            transportCoalesced: this.coalesced,
+        };
+    }
+
+    finishProducer(): void {
+        this.producerComplete = true;
+        this.scheduleDrain();
+    }
+
+    post(payload: AiSessionStreamPayload): void {
+        if (this.inFlight.length < AI_SESSION_STREAM_MAX_IN_FLIGHT) {
+            this.send(payload);
+            return;
+        }
+        const result = rememberAiSessionStreamPayloadForDelivery({
+            maxPayloads: AI_SESSION_STREAM_MAX_PENDING_PAYLOADS,
+            order: this.nextOrder,
+            payload,
+            queue: this.pending,
+        });
+        this.nextOrder += 1;
+        if (result.coalesced) this.coalesced += 1;
+        if (!result.preserved || result.droppedOldest) {
+            throw new Error("Pressure transport could not preserve a payload.");
+        }
+        this.scheduleDrain();
+    }
+
+    private deliver(envelope: {
+        readonly payload: AiSessionStreamPayload;
+        readonly seq: number;
+    }): void {
+        let ingested = false;
+        deliverAiSessionStreamMessage(
+            { payload: envelope.payload, seq: envelope.seq, type: "payload" },
+            {
+                acknowledge: (seq) => {
+                    if (!ingested) this.ackBeforeIngestion = true;
+                    this.acknowledgedPayloads += 1;
+                    if (this.deliveredSeqs.has(seq)) this.duplicatePayloads += 1;
+                    this.deliveredSeqs.add(seq);
+                },
+                notifyPayload: (payload) => {
+                    ingested = true;
+                    const typedPayload = payload as AiSessionStreamPayload;
+                    if (!isAiSessionUpdate(typedPayload)) {
+                        if (
+                            typedPayload.kind === "permission-request" ||
+                            typedPayload.kind === "user-input-request" ||
+                            typedPayload.kind === "turn-status" ||
+                            typedPayload.kind === "status"
+                        ) {
+                            this.criticalKindsDelivered.add(typedPayload.kind);
+                        }
+                    }
+                    this.deliverPayload(typedPayload);
+                },
+                reportDispatchError: (_message, error) => {
+                    throw error;
+                },
+                reportWarning: (message) => {
+                    throw new Error(message);
+                },
+            },
+        );
+    }
+
+    private drain = () => {
+        this.scheduled = false;
+        const delivered = this.inFlight.splice(0);
+        for (const envelope of delivered) this.deliver(envelope);
+        while (this.inFlight.length < AI_SESSION_STREAM_MAX_IN_FLIGHT) {
+            const pending = takeNextAiSessionStreamDelivery(this.pending);
+            if (!pending) break;
+            this.send(pending.payload);
+        }
+        if (this.inFlight.length > 0 || this.pending.size > 0) {
+            this.scheduleDrain();
+            return;
+        }
+        if (this.producerComplete) requestAnimationFrame(this.onIdle);
+    };
+
+    private scheduleDrain(): void {
+        if (this.scheduled) return;
+        this.scheduled = true;
+        requestAnimationFrame(this.drain);
+    }
+
+    private send(payload: AiSessionStreamPayload): void {
+        this.inFlight.push({ payload, seq: this.nextSeq });
+        this.nextSeq += 1;
+        this.peakInFlight = Math.max(this.peakInFlight, this.inFlight.length);
+        this.scheduleDrain();
+    }
+}
 
 export function TerminalPressureHarness() {
     const [activeTab, setActiveTab] = useState("foreground");
-    const [appliedToolEvents, setAppliedToolEvents] = useState(0);
-    const [finalOutput, setFinalOutput] = useState("");
-    const [status, setStatus] = useState<
-        TerminalPressureHarnessSnapshot["status"]
-    >("idle");
-    const composerRef = useRef<HTMLInputElement | null>(null);
+    const [lifecycle, setLifecycle] =
+        useState<WorkspaceSurfaceLifecycleState>("visible");
+    const [status, setStatus] =
+        useState<TerminalPressureHarnessSnapshot["status"]>("idle");
+    const activeTabRef = useRef(activeTab);
     const expectedFinalOutputRef = useRef("");
+    const lifecycleRef = useRef(lifecycle);
     const producerEventsRef = useRef(0);
+    const publisherRef =
+        useRef<WorkspaceSurfaceAgentPresencePublisher | null>(null);
     const runGenerationRef = useRef(0);
-    const snapshotRef = useRef<TerminalPressureHarnessSnapshot>({
-        activeTab,
-        appliedToolEvents,
-        composerValue: "",
-        expectedFinalOutput: "",
-        finalOutput,
-        producerEvents: 0,
-        status,
-    });
-    const apply = useCallback((event: AiSessionToolActivityEvent) => {
-        setAppliedToolEvents((current) => current + 1);
-        if (event.activity.status === "completed") {
-            setFinalOutput(event.activity.terminalOutput ?? "");
-            setStatus("complete");
-        }
-    }, []);
-    const frameBuffer = useMemo(
-        () =>
-            new AiSessionEventFrameBuffer({
-                apply: (event) => {
-                    if (event.kind === "tool-activity") apply(event);
+    const scrollRef = useRef<HTMLDivElement | null>(null);
+    const transportRef = useRef<BrowserAiSessionPressureTransport | null>(null);
+    const workspaceListenersRef = useRef(new Set<() => void>());
+
+    useEffect(() => {
+        activeTabRef.current = activeTab;
+        for (const listener of workspaceListenersRef.current) listener();
+    }, [activeTab]);
+
+    useEffect(() => {
+        lifecycleRef.current = lifecycle;
+    }, [lifecycle]);
+
+    useEffect(() => {
+        setChatPerformanceCountersEnabledForTests(true);
+        resetHarnessStore();
+        const unsubscribeStore = useAiStore.subscribe(() => {
+            const snapshot = pressureSnapshot();
+            if (
+                snapshot?.status === "idle" &&
+                snapshot.toolActivity.some(
+                    (activity) => activity.status === "completed",
+                )
+            ) {
+                setStatus("complete");
+            }
+        });
+        const publisher = createWorkspaceSurfaceAgentPresencePublisher({
+            getAiSessions: () => useAiStore.getState().sessions,
+            getWorkspaceProjection: () => ({
+                activeTab:
+                    activeTabRef.current === "background"
+                        ? BACKGROUND_TAB
+                        : STREAM_TAB,
+                tabsById: {
+                    [BACKGROUND_TAB.id]: BACKGROUND_TAB,
+                    [STREAM_TAB.id]: STREAM_TAB,
                 },
             }),
-        [apply],
-    );
+            publish: () => {
+                incrementChatPerformanceCounter("workspace_presence_publishes");
+                return Promise.resolve({ delivered: true });
+            },
+            subscribeAiSessions: (listener) => useAiStore.subscribe(listener),
+            subscribeWorkspace: (listener) => {
+                workspaceListenersRef.current.add(listener);
+                return () => workspaceListenersRef.current.delete(listener);
+            },
+        });
+        publisherRef.current = publisher;
+        publisher.updateContext(publisherContext("visible"));
 
-    useEffect(() => {
-        snapshotRef.current = {
-            activeTab,
-            appliedToolEvents,
-            composerValue: composerRef.current?.value ?? "",
-            expectedFinalOutput: expectedFinalOutputRef.current,
-            finalOutput,
-            producerEvents: producerEventsRef.current,
-            status,
-        };
-    }, [activeTab, appliedToolEvents, finalOutput, status]);
-
-    useEffect(() => {
         window.comandoTerminalPressureHarness = {
-            snapshot: () => ({
-                ...snapshotRef.current,
-                composerValue: composerRef.current?.value ?? "",
-            }),
+            snapshot: () => readHarnessSnapshot(),
             start: () => {
                 runGenerationRef.current += 1;
                 const generation = runGenerationRef.current;
-                frameBuffer.reset();
-                setAppliedToolEvents(0);
-                setFinalOutput("");
+                resetHarnessStore();
+                resetChatPerformanceCounters();
                 setStatus("streaming");
                 const fixture = createTerminalStreamPressureFixture({
                     chunkBytes: 4,
                     chunkCount: 10_000,
                     durationMs: 10_000,
                     runtimeId: "custom:pressure-e2e",
+                    sessionId: STREAM_SESSION_ID,
+                    toolCallId: "tool-pressure-1",
                 });
                 expectedFinalOutputRef.current = fixture.expectedFinalOutput;
-                producerEventsRef.current = fixture.events.length;
+                const criticalEvents = createCriticalEvents(
+                    fixture.events.at(-1)?.updatedAt ?? new Date().toISOString(),
+                );
+                producerEventsRef.current =
+                    fixture.events.length + criticalEvents.length + 1;
+                const transport = new BrowserAiSessionPressureTransport(
+                    applyStreamPayload,
+                    () => {
+                        if (generation !== runGenerationRef.current) return;
+                        transportRef.current = transport;
+                    },
+                );
+                transportRef.current = transport;
+                transport.post(createStreamingStatusEvent());
                 let cursor = 0;
+                let criticalSent = false;
                 const produceFrame = () => {
                     if (generation !== runGenerationRef.current) return;
                     const end = Math.min(
@@ -107,62 +307,123 @@ export function TerminalPressureHarness() {
                         cursor + EVENTS_PER_PRODUCER_FRAME,
                     );
                     while (cursor < end) {
-                        const event = fixture.events[cursor];
+                        const sourceEvent = fixture.events[cursor];
                         cursor += 1;
-                        if (!event) continue;
-                        if (
-                            event.activity.status === "pending" ||
-                            event.activity.status === "in_progress"
-                        ) {
-                            frameBuffer.buffer(event);
-                        } else {
-                            frameBuffer.flushSession(event.sessionId);
-                            apply(event);
+                        if (!sourceEvent) continue;
+                        transport.post(withFinalDiff(sourceEvent));
+                    }
+                    if (!criticalSent && cursor >= fixture.events.length / 2) {
+                        criticalSent = true;
+                        for (const event of criticalEvents.slice(0, 2)) {
+                            transport.post(event);
                         }
                     }
                     if (cursor < fixture.events.length) {
                         requestAnimationFrame(produceFrame);
+                        return;
                     }
+                    for (const event of criticalEvents.slice(2)) {
+                        transport.post(event);
+                    }
+                    transport.finishProducer();
                 };
                 requestAnimationFrame(produceFrame);
             },
         };
+
         return () => {
             runGenerationRef.current += 1;
-            frameBuffer.reset();
+            publisherRef.current = null;
+            publisher.dispose();
+            unsubscribeStore();
+            resetAiStoreRuntimeBuffersForTests();
+            setChatPerformanceCountersEnabledForTests(null);
         };
-    }, [frameBuffer]);
+    }, []);
+
+    useEffect(() => {
+        lifecycleRef.current = lifecycle;
+        publisherRef.current?.updateContext(publisherContext(lifecycle));
+    }, [lifecycle]);
+
+    const readHarnessSnapshot = (): TerminalPressureHarnessSnapshot => {
+        const counters = readChatPerformanceCounters();
+        const snapshot = pressureSnapshot();
+        const finalActivity = snapshot?.toolActivity.find(
+            (activity) => activity.id === "tool-pressure-1",
+        );
+        const scroll = scrollRef.current;
+        const transportMetrics = transportRef.current?.metrics ?? {
+            ackBeforeIngestion: false,
+            acknowledgedPayloads: 0,
+            duplicatePayloads: 0,
+            peakInFlight: 0,
+            transportCoalesced: 0,
+        };
+        return {
+            ...transportMetrics,
+            activeTab: activeTabRef.current,
+            criticalKindsDelivered: [
+                ...(transportRef.current?.criticalKindsDelivered ?? []),
+            ].sort(),
+            expectedFinalOutput: expectedFinalOutputRef.current,
+            frameCoalesced: counters.ai_frame_payloads_coalesced,
+            framePeakPending: counters.ai_frame_peak_pending_per_session,
+            finalDiffCount: finalActivity?.diffs.length ?? 0,
+            finalExitCode: finalActivity?.exitCode ?? null,
+            finalOutput: finalActivity?.terminalOutput ?? "",
+            lifecycle: lifecycleRef.current,
+            presencePublishes: counters.workspace_presence_publishes,
+            producerEvents: producerEventsRef.current,
+            scrollAtBottom: Boolean(
+                scroll &&
+                    scroll.scrollTop + scroll.clientHeight >=
+                        scroll.scrollHeight - 1,
+            ),
+            status:
+                snapshot?.status === "idle" &&
+                finalActivity?.status === "completed"
+                    ? "complete"
+                    : producerEventsRef.current > 0
+                      ? "streaming"
+                      : "idle",
+            storeToolApplies: counters.tool_activity_store_applies,
+            toolEventsReceived: counters.tool_activity_events_received,
+        };
+    };
 
     return (
         <main className="flex h-screen min-h-0 flex-col gap-3 bg-bg-primary p-4 text-text-primary">
             <nav className="flex gap-2" aria-label="Pressure test tabs">
-                {(
-                    [
-                        ["foreground", "Foreground"],
-                        ["background", "Background"],
-                    ] as const
-                ).map(([id, label]) => (
-                    <button
-                        aria-pressed={activeTab === id}
-                        key={id}
-                        onClick={() => setActiveTab(id)}
-                        type="button"
-                    >
-                        {label}
-                    </button>
-                ))}
+                <button
+                    aria-pressed={activeTab === "foreground"}
+                    onClick={() => setActiveTab("foreground")}
+                    type="button"
+                >
+                    Foreground
+                </button>
+                <button
+                    aria-pressed={activeTab === "background"}
+                    onClick={() => setActiveTab("background")}
+                    type="button"
+                >
+                    Background
+                </button>
+                <button onClick={() => setLifecycle("suspended")} type="button">
+                    Suspend
+                </button>
             </nav>
             <label>
                 Composer
                 <input
                     aria-label="Composer"
                     className="ml-2 border border-border-default bg-bg-secondary"
-                    ref={composerRef}
                 />
             </label>
             <div
                 className="min-h-0 flex-1 overflow-auto border border-border-default"
                 data-pressure-scroll
+                ref={scrollRef}
             >
                 {Array.from({ length: 500 }, (_, index) => (
                     <div key={index}>Workspace row {index + 1}</div>
@@ -171,4 +432,187 @@ export function TerminalPressureHarness() {
             <output data-pressure-status>{status}</output>
         </main>
     );
+}
+
+function applyStreamPayload(payload: AiSessionStreamPayload): void {
+    if (isAiSessionUpdate(payload)) {
+        useAiStore.getState().applySessionUpdate(payload);
+        return;
+    }
+    useAiStore.getState().applySessionEvent(payload);
+}
+
+function createCriticalEvents(updatedAt: string): readonly AiSessionDomainEvent[] {
+    const base = eventBase(updatedAt);
+    return [
+        {
+            ...base,
+            kind: "permission-request",
+            request: {
+                description: "Allow the command",
+                options: [
+                    {
+                        description: null,
+                        kind: "allow_once",
+                        name: "Allow",
+                        optionId: "allow",
+                    },
+                ],
+                requestId: "permission-pressure",
+                sessionId: STREAM_SESSION_ID,
+                title: "Permission",
+                toolCallId: "tool-pressure-1",
+                updatedAt,
+            },
+        },
+        {
+            ...base,
+            kind: "user-input-request",
+            request: {
+                questions: [
+                    {
+                        customAnswerId: null,
+                        header: "Input",
+                        id: "question-pressure",
+                        isOther: false,
+                        isSecret: false,
+                        options: [],
+                        question: "Continue?",
+                    },
+                ],
+                requestId: "input-pressure",
+                sessionId: STREAM_SESSION_ID,
+                title: "Input",
+                toolCallId: "tool-pressure-1",
+                turnId: "turn-pressure",
+                updatedAt,
+            },
+        },
+        {
+            ...base,
+            error: null,
+            kind: "turn-status",
+            status: "completed",
+            turnId: "turn-pressure",
+        },
+        {
+            ...base,
+            activeTurnStartedAt: null,
+            kind: "status",
+            lastError: null,
+            status: "idle",
+        },
+    ];
+}
+
+function createStreamingStatusEvent(): AiSessionDomainEvent {
+    return {
+        ...eventBase("2026-08-08T12:00:00.000Z"),
+        activeTurnStartedAt: "2026-08-08T12:00:00.000Z",
+        kind: "status",
+        lastError: null,
+        status: "streaming",
+    };
+}
+
+function createSnapshot(sessionId: string, title: string): AiSessionSnapshot {
+    return {
+        activeTurnStartedAt: null,
+        availableCommands: [],
+        configOptions: [],
+        lastError: null,
+        messages: [],
+        modeId: null,
+        modes: [],
+        modelId: null,
+        models: [],
+        pendingPermission: null,
+        pendingUserInput: null,
+        plan: null,
+        projectId: "project-pressure",
+        runtimeId: "custom:pressure-e2e",
+        runtimeSessionId: `runtime-${sessionId}`,
+        sessionId,
+        status: "idle",
+        title,
+        tokenUsage: null,
+        toolActivity: [],
+        trackedFiles: [],
+        updatedAt: "2026-08-08T12:00:00.000Z",
+        worktreeId: "worktree-pressure",
+    };
+}
+
+function createTab(id: string, sessionId: string, title: string): WorkspaceChatTab {
+    return {
+        createdAt: "2026-08-08T12:00:00.000Z",
+        draft: "",
+        id,
+        kind: "chat",
+        projectId: "project-pressure",
+        runtimeId: "custom:pressure-e2e",
+        sessionId,
+        title,
+        worktreeId: "worktree-pressure",
+    };
+}
+
+function eventBase(updatedAt: string) {
+    return {
+        origin: "live" as const,
+        parentSessionId: null,
+        runtimeId: "custom:pressure-e2e" as const,
+        runtimeSessionId: "runtime-pressure",
+        sessionId: STREAM_SESSION_ID,
+        updatedAt,
+    };
+}
+
+function pressureSnapshot(): AiSessionSnapshot | null {
+    return useAiStore.getState().sessions[STREAM_SESSION_ID]?.snapshot ?? null;
+}
+
+function publisherContext(lifecycle: WorkspaceSurfaceLifecycleState) {
+    return {
+        contextKey: "project-pressure:worktree-pressure",
+        lifecycle,
+        projectId: "project-pressure",
+        terminalSessions: [],
+        worktreeId: "worktree-pressure",
+    };
+}
+
+function resetHarnessStore(): void {
+    resetAiStoreRuntimeBuffersForTests();
+    useAiStore.setState({ sessions: {} });
+    useAiStore
+        .getState()
+        .applySessionSnapshot(createSnapshot(STREAM_SESSION_ID, "Pressure"));
+    useAiStore
+        .getState()
+        .applySessionSnapshot(createSnapshot(BACKGROUND_SESSION_ID, "Background"));
+}
+
+function withFinalDiff(
+    event: AiSessionToolActivityEvent,
+): AiSessionToolActivityEvent {
+    if (event.activity.status !== "completed") return event;
+    return {
+        ...event,
+        activity: {
+            ...event.activity,
+            diffs: [
+                {
+                    hunks: [],
+                    isText: true,
+                    kind: "update",
+                    newText: "after\n",
+                    oldText: "before\n",
+                    path: "src/pressure.ts",
+                    previousPath: null,
+                    reversible: true,
+                },
+            ],
+        },
+    };
 }

--- a/e2e/harness/TerminalPressureHarness.tsx
+++ b/e2e/harness/TerminalPressureHarness.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { AiSessionToolActivityEvent } from "@shared/ipc";
+import { createTerminalStreamPressureFixture } from "@shared/testing/chatLoadFactories";
+import {
+    AiSessionEventFrameBuffer,
+} from "@renderer/app/ai/aiSessionEventFrameBuffer";
+
+interface TerminalPressureHarnessSnapshot {
+    readonly activeTab: string;
+    readonly appliedToolEvents: number;
+    readonly composerValue: string;
+    readonly expectedFinalOutput: string;
+    readonly finalOutput: string;
+    readonly producerEvents: number;
+    readonly status: "complete" | "idle" | "streaming";
+}
+
+interface ComandoTerminalPressureHarness {
+    readonly snapshot: () => TerminalPressureHarnessSnapshot;
+    readonly start: () => void;
+}
+
+declare global {
+    interface Window {
+        comandoTerminalPressureHarness: ComandoTerminalPressureHarness;
+    }
+}
+
+const EVENTS_PER_PRODUCER_FRAME = 250;
+
+export function TerminalPressureHarness() {
+    const [activeTab, setActiveTab] = useState("foreground");
+    const [appliedToolEvents, setAppliedToolEvents] = useState(0);
+    const [finalOutput, setFinalOutput] = useState("");
+    const [status, setStatus] = useState<
+        TerminalPressureHarnessSnapshot["status"]
+    >("idle");
+    const composerRef = useRef<HTMLInputElement | null>(null);
+    const expectedFinalOutputRef = useRef("");
+    const producerEventsRef = useRef(0);
+    const runGenerationRef = useRef(0);
+    const snapshotRef = useRef<TerminalPressureHarnessSnapshot>({
+        activeTab,
+        appliedToolEvents,
+        composerValue: "",
+        expectedFinalOutput: "",
+        finalOutput,
+        producerEvents: 0,
+        status,
+    });
+    const apply = useCallback((event: AiSessionToolActivityEvent) => {
+        setAppliedToolEvents((current) => current + 1);
+        if (event.activity.status === "completed") {
+            setFinalOutput(event.activity.terminalOutput ?? "");
+            setStatus("complete");
+        }
+    }, []);
+    const frameBuffer = useMemo(
+        () =>
+            new AiSessionEventFrameBuffer({
+                apply: (event) => {
+                    if (event.kind === "tool-activity") apply(event);
+                },
+            }),
+        [apply],
+    );
+
+    useEffect(() => {
+        snapshotRef.current = {
+            activeTab,
+            appliedToolEvents,
+            composerValue: composerRef.current?.value ?? "",
+            expectedFinalOutput: expectedFinalOutputRef.current,
+            finalOutput,
+            producerEvents: producerEventsRef.current,
+            status,
+        };
+    }, [activeTab, appliedToolEvents, finalOutput, status]);
+
+    useEffect(() => {
+        window.comandoTerminalPressureHarness = {
+            snapshot: () => ({
+                ...snapshotRef.current,
+                composerValue: composerRef.current?.value ?? "",
+            }),
+            start: () => {
+                runGenerationRef.current += 1;
+                const generation = runGenerationRef.current;
+                frameBuffer.reset();
+                setAppliedToolEvents(0);
+                setFinalOutput("");
+                setStatus("streaming");
+                const fixture = createTerminalStreamPressureFixture({
+                    chunkBytes: 4,
+                    chunkCount: 10_000,
+                    durationMs: 10_000,
+                    runtimeId: "custom:pressure-e2e",
+                });
+                expectedFinalOutputRef.current = fixture.expectedFinalOutput;
+                producerEventsRef.current = fixture.events.length;
+                let cursor = 0;
+                const produceFrame = () => {
+                    if (generation !== runGenerationRef.current) return;
+                    const end = Math.min(
+                        fixture.events.length,
+                        cursor + EVENTS_PER_PRODUCER_FRAME,
+                    );
+                    while (cursor < end) {
+                        const event = fixture.events[cursor];
+                        cursor += 1;
+                        if (!event) continue;
+                        if (
+                            event.activity.status === "pending" ||
+                            event.activity.status === "in_progress"
+                        ) {
+                            frameBuffer.buffer(event);
+                        } else {
+                            frameBuffer.flushSession(event.sessionId);
+                            apply(event);
+                        }
+                    }
+                    if (cursor < fixture.events.length) {
+                        requestAnimationFrame(produceFrame);
+                    }
+                };
+                requestAnimationFrame(produceFrame);
+            },
+        };
+        return () => {
+            runGenerationRef.current += 1;
+            frameBuffer.reset();
+        };
+    }, [frameBuffer]);
+
+    return (
+        <main className="flex h-screen min-h-0 flex-col gap-3 bg-bg-primary p-4 text-text-primary">
+            <nav className="flex gap-2" aria-label="Pressure test tabs">
+                {(
+                    [
+                        ["foreground", "Foreground"],
+                        ["background", "Background"],
+                    ] as const
+                ).map(([id, label]) => (
+                    <button
+                        aria-pressed={activeTab === id}
+                        key={id}
+                        onClick={() => setActiveTab(id)}
+                        type="button"
+                    >
+                        {label}
+                    </button>
+                ))}
+            </nav>
+            <label>
+                Composer
+                <input
+                    aria-label="Composer"
+                    className="ml-2 border border-border-default bg-bg-secondary"
+                    ref={composerRef}
+                />
+            </label>
+            <div
+                className="min-h-0 flex-1 overflow-auto border border-border-default"
+                data-pressure-scroll
+            >
+                {Array.from({ length: 500 }, (_, index) => (
+                    <div key={index}>Workspace row {index + 1}</div>
+                ))}
+            </div>
+            <output data-pressure-status>{status}</output>
+        </main>
+    );
+}

--- a/e2e/harness/main.tsx
+++ b/e2e/harness/main.tsx
@@ -43,6 +43,7 @@ import {
 import "@renderer/styles.css";
 import "./transcript-harness.css";
 import { ShellHarness } from "./ShellHarness";
+import { TerminalPressureHarness } from "./TerminalPressureHarness";
 
 const INITIAL_HISTORY_SIZE = 2_000;
 const INITIAL_HISTORY_SCENARIO = {
@@ -1161,5 +1162,11 @@ function TranscriptHarness() {
 
 const harness = new URLSearchParams(window.location.search).get("harness");
 createRoot(document.getElementById("root")!).render(
-    harness === "shell" ? <ShellHarness /> : <TranscriptHarness />,
+    harness === "shell" ? (
+        <ShellHarness />
+    ) : harness === "terminal-pressure" ? (
+        <TerminalPressureHarness />
+    ) : (
+        <TranscriptHarness />
+    ),
 );

--- a/e2e/tests/ai-terminal-stream-pressure.spec.ts
+++ b/e2e/tests/ai-terminal-stream-pressure.spec.ts
@@ -11,6 +11,7 @@ test("verbose terminal streaming keeps workspace interactions responsive", async
     await page.evaluate(() => window.comandoTerminalPressureHarness.start());
     await page.getByLabel("Composer").fill("workspace remains interactive");
     await page.getByRole("button", { name: "Background" }).click();
+    await page.getByRole("button", { name: "Suspend" }).click();
     await page.locator("[data-pressure-scroll]").evaluate((element) => {
         element.scrollTop = element.scrollHeight;
     });
@@ -23,11 +24,18 @@ test("verbose terminal streaming keeps workspace interactions responsive", async
         body: JSON.stringify(
             {
                 activeTab: snapshot.activeTab,
-                appliedToolEvents: snapshot.appliedToolEvents,
-                composerValueLength: snapshot.composerValue.length,
+                acknowledgedPayloads: snapshot.acknowledgedPayloads,
+                criticalKindsDelivered: snapshot.criticalKindsDelivered,
                 finalOutputLength: snapshot.finalOutput.length,
+                frameCoalesced: snapshot.frameCoalesced,
+                framePeakPending: snapshot.framePeakPending,
+                peakInFlight: snapshot.peakInFlight,
+                presencePublishes: snapshot.presencePublishes,
                 producerEvents: snapshot.producerEvents,
                 status: snapshot.status,
+                storeToolApplies: snapshot.storeToolApplies,
+                toolEventsReceived: snapshot.toolEventsReceived,
+                transportCoalesced: snapshot.transportCoalesced,
             },
             null,
             2,
@@ -35,10 +43,31 @@ test("verbose terminal streaming keeps workspace interactions responsive", async
         contentType: "application/json",
     });
 
-    expect(snapshot.producerEvents).toBe(10_002);
-    expect(snapshot.appliedToolEvents).toBeLessThanOrEqual(42);
+    expect(snapshot.producerEvents).toBe(10_007);
+    expect(snapshot.peakInFlight).toBe(32);
+    expect(snapshot.transportCoalesced).toBeGreaterThan(8_000);
+    expect(snapshot.frameCoalesced).toBeGreaterThan(1_000);
+    expect(snapshot.framePeakPending).toBe(1);
+    expect(snapshot.toolEventsReceived).toBeLessThanOrEqual(1_400);
+    expect(snapshot.storeToolApplies).toBeLessThanOrEqual(45);
+    expect(snapshot.presencePublishes).toBeLessThanOrEqual(8);
+    expect(snapshot.ackBeforeIngestion).toBe(false);
+    expect(snapshot.duplicatePayloads).toBe(0);
+    expect(snapshot.acknowledgedPayloads).toBeGreaterThan(0);
+    expect(snapshot.criticalKindsDelivered).toEqual([
+        "permission-request",
+        "status",
+        "turn-status",
+        "user-input-request",
+    ]);
     expect(snapshot.finalOutput).toBe(snapshot.expectedFinalOutput);
     expect(snapshot.finalOutput).toHaveLength(10_000);
-    expect(snapshot.composerValue).toBe("workspace remains interactive");
+    expect(snapshot.finalExitCode).toBe(0);
+    expect(snapshot.finalDiffCount).toBe(1);
+    await expect(page.getByLabel("Composer")).toHaveValue(
+        "workspace remains interactive",
+    );
     expect(snapshot.activeTab).toBe("background");
+    expect(snapshot.lifecycle).toBe("suspended");
+    expect(snapshot.scrollAtBottom).toBe(true);
 });

--- a/e2e/tests/ai-terminal-stream-pressure.spec.ts
+++ b/e2e/tests/ai-terminal-stream-pressure.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+test("verbose terminal streaming keeps workspace interactions responsive", async ({
+    page,
+}, testInfo) => {
+    await page.goto("/?harness=terminal-pressure");
+    await page.waitForFunction(
+        () => typeof window.comandoTerminalPressureHarness?.start === "function",
+    );
+
+    await page.evaluate(() => window.comandoTerminalPressureHarness.start());
+    await page.getByLabel("Composer").fill("workspace remains interactive");
+    await page.getByRole("button", { name: "Background" }).click();
+    await page.locator("[data-pressure-scroll]").evaluate((element) => {
+        element.scrollTop = element.scrollHeight;
+    });
+    await expect(page.locator("[data-pressure-status]")).toHaveText("complete");
+
+    const snapshot = await page.evaluate(() =>
+        window.comandoTerminalPressureHarness.snapshot(),
+    );
+    await testInfo.attach("ai-terminal-stream-pressure", {
+        body: JSON.stringify(
+            {
+                activeTab: snapshot.activeTab,
+                appliedToolEvents: snapshot.appliedToolEvents,
+                composerValueLength: snapshot.composerValue.length,
+                finalOutputLength: snapshot.finalOutput.length,
+                producerEvents: snapshot.producerEvents,
+                status: snapshot.status,
+            },
+            null,
+            2,
+        ),
+        contentType: "application/json",
+    });
+
+    expect(snapshot.producerEvents).toBe(10_002);
+    expect(snapshot.appliedToolEvents).toBeLessThanOrEqual(42);
+    expect(snapshot.finalOutput).toBe(snapshot.expectedFinalOutput);
+    expect(snapshot.finalOutput).toHaveLength(10_000);
+    expect(snapshot.composerValue).toBe("workspace remains interactive");
+    expect(snapshot.activeTab).toBe("background");
+});

--- a/src/main/ai/service.history.test.ts
+++ b/src/main/ai/service.history.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type {
     AiHistorySessionSummary,
     AiOpenTranscriptTail,
+    AiSessionDomainEvent,
     AiSessionSnapshot,
     AiSessionTranscriptPage,
     AiSessionUpdate,
@@ -16,6 +17,60 @@ import { AiService } from "./service";
 import type { NativeAiGateway } from "./contracts";
 
 describe("AiService history", () => {
+    it("publishes one renderer path for noisy live tool revisions", async () => {
+        const onSessionEvent = vi.fn();
+        const onSessionSnapshot = vi.fn();
+        const service = createService({ onSessionEvent, onSessionSnapshot });
+        const snapshot = createSnapshot({ status: "streaming" });
+        service.handleNativeSessionSnapshot("window-1", {
+            kind: "snapshot",
+            snapshot,
+        });
+        onSessionEvent.mockClear();
+        onSessionSnapshot.mockClear();
+
+        for (let index = 0; index < 10_000; index += 1) {
+            const updatedAt = new Date(index + 1).toISOString();
+            service.handleNativeSessionEvent("window-1", {
+                activity: {
+                    createdAt: snapshot.updatedAt,
+                    diffs: [],
+                    exitCode: null,
+                    id: "tool-pressure",
+                    kind: "shell",
+                    locations: [],
+                    rawInputJson: null,
+                    rawOutputJson: null,
+                    sessionId: snapshot.sessionId,
+                    status: "in_progress",
+                    summary: null,
+                    terminalOutput: null,
+                    title: "Run tests",
+                    updatedAt,
+                },
+                kind: "tool-activity",
+                origin: "live",
+                parentSessionId: null,
+                runtimeId: snapshot.runtimeId,
+                runtimeSessionId: snapshot.runtimeSessionId,
+                sessionId: snapshot.sessionId,
+                updatedAt,
+            });
+        }
+
+        expect(onSessionEvent).toHaveBeenCalledTimes(10_000);
+        expect(onSessionSnapshot).not.toHaveBeenCalled();
+        expect(await service.getSessionSnapshot(snapshot.sessionId)).toMatchObject({
+            toolActivity: [
+                expect.objectContaining({
+                    id: "tool-pressure",
+                    status: "in_progress",
+                }),
+            ],
+        });
+        service.close();
+    });
+
     it("returns session history from persistence", async () => {
         const expectedHistory: readonly AiHistorySessionSummary[] = [
             {
@@ -1496,6 +1551,10 @@ function createService(overrides: {
         ownerWindowId: string,
         update: AiSessionUpdate,
     ) => void;
+    readonly onSessionEvent?: (
+        ownerWindowId: string,
+        event: AiSessionDomainEvent,
+    ) => void;
     readonly saveSessionSnapshot?: (
         snapshot: AiSessionSnapshot,
         draft?: string,
@@ -1507,6 +1566,7 @@ function createService(overrides: {
     return new AiService({
         nativeAi: overrides.nativeAi ?? null,
         onRuntimeStatus: vi.fn(),
+        onSessionEvent: overrides.onSessionEvent,
         onSessionSnapshot: overrides.onSessionSnapshot ?? vi.fn(),
         persistence: {
             deleteSession: overrides.deleteSession ?? vi.fn(),

--- a/src/main/ai/service.opencode.test.ts
+++ b/src/main/ai/service.opencode.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
     AiRuntimeStatus,
     AiReviewDeltaSummary,
+    AiSessionDomainEvent,
     AiSessionSnapshot,
     AiSessionUpdate,
     AiTrackedFile,
@@ -2293,6 +2294,9 @@ describe("AiService OpenCode branch", () => {
             const onSessionSnapshot = vi.fn<
                 (ownerWindowId: string, update: AiSessionUpdate) => void
             >();
+            const onSessionEvent = vi.fn<
+                (ownerWindowId: string, event: AiSessionDomainEvent) => void
+            >();
             const nativeAi = createNativeAi({
                 cancelSession: vi.fn(),
                 close: vi.fn(),
@@ -2324,6 +2328,7 @@ describe("AiService OpenCode branch", () => {
             });
             const service = createService({
                 nativeAi,
+                onSessionEvent,
                 onSessionSnapshot,
                 persistence: {
                     saveSessionSnapshot,
@@ -2366,6 +2371,7 @@ describe("AiService OpenCode branch", () => {
                 sessionId: "session-opencode",
                 updatedAt: "2026-06-20T00:00:01.000Z",
             });
+            const snapshotCallsAfterStarted = onSessionSnapshot.mock.calls.length;
             service.handleNativeSessionEvent("window-1", {
                 content: "Hello",
                 delta: "Hello",
@@ -2381,18 +2387,15 @@ describe("AiService OpenCode branch", () => {
             });
 
             expect(saveSessionSnapshot).not.toHaveBeenCalled();
-            const snapshotCall = onSessionSnapshot.mock.calls.at(-1);
-            expect(snapshotCall?.[0]).toBe("window-1");
-            const update = snapshotCall?.[1];
-            expect(update?.kind).toBe("patch");
-            if (update?.kind !== "patch") {
-                throw new Error("Expected a patch update.");
-            }
-            expect(update.patch.changes.messages).toEqual([
+            expect(onSessionSnapshot).toHaveBeenCalledTimes(
+                snapshotCallsAfterStarted,
+            );
+            expect(onSessionEvent.mock.lastCall).toEqual([
+                "window-1",
                 expect.objectContaining({
                     content: "Hello",
-                    id: "assistant-1",
-                    status: "streaming",
+                    kind: "message-delta",
+                    messageId: "assistant-1",
                 }),
             ]);
             const liveTail =
@@ -5000,6 +5003,10 @@ describe("AiService OpenCode branch", () => {
 function createService(overrides: {
     readonly nativeAi?: NativeAiGateway;
     readonly onRuntimeStatus?: (status: AiRuntimeStatus) => void;
+    readonly onSessionEvent?: (
+        ownerWindowId: string,
+        event: AiSessionDomainEvent,
+    ) => void;
     readonly onSessionSnapshot?: (
         ownerWindowId: string,
         update: AiSessionUpdate,
@@ -5026,6 +5033,7 @@ function createService(overrides: {
     return new AiService({
         nativeAi: overrides.nativeAi ?? null,
         onRuntimeStatus: overrides.onRuntimeStatus ?? vi.fn(),
+        onSessionEvent: overrides.onSessionEvent,
         onSessionSnapshot: overrides.onSessionSnapshot ?? vi.fn(),
         persistence: persistence as never,
         projectService: {

--- a/src/main/ai/service.ts
+++ b/src/main/ai/service.ts
@@ -481,6 +481,30 @@ interface PendingNativeCatalogPatch {
     readonly updatedAt: string;
 }
 
+export function isRedundantStreamingRendererUpdate(
+    event: AiSessionDomainEvent,
+    update: AiSessionUpdate,
+): boolean {
+    if (update.kind !== "patch") return false;
+
+    const frameBuffered =
+        event.kind === "message-delta" ||
+        event.kind === "thinking-delta" ||
+        (event.kind === "tool-activity" &&
+            (event.activity.status === "pending" ||
+                event.activity.status === "in_progress"));
+    if (!frameBuffered) return false;
+
+    // ai-store applies these fields from the domain event itself. Sending the
+    // equivalent patch first would flush every buffered live revision.
+    return Object.keys(update.patch.changes).every(
+        (key) =>
+            key === "messages" ||
+            key === "toolActivity" ||
+            key === "updatedAt",
+    );
+}
+
 export class AiService {
     readonly #deletedSessionIds = new Set<string>();
     readonly #freezingSessionIds = new Set<string>();
@@ -905,10 +929,13 @@ export class AiService {
                     event.delta,
                 );
             }
-            this.#onSessionSnapshot(
-                ownerWindowId,
-                this.#buildRendererSessionUpdate(previousSnapshot, cachedSnapshot),
+            const rendererUpdate = this.#buildRendererSessionUpdate(
+                previousSnapshot,
+                cachedSnapshot,
             );
+            if (!isRedundantStreamingRendererUpdate(event, rendererUpdate)) {
+                this.#onSessionSnapshot(ownerWindowId, rendererUpdate);
+            }
             if (this.#isNativeAiSession(event.sessionId)) {
                 if (event.kind === "status" && event.status === "streaming") {
                     this.#markNativeReviewTurnStarted(event.sessionId);

--- a/src/main/ai/session-stream.test.ts
+++ b/src/main/ai/session-stream.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "@shared/ipc";
 
 import {
+    AI_SESSION_STREAM_MAX_IN_FLIGHT,
     buildAiSessionStreamRecoveryDiagnostic,
     buildAiSessionStreamRecoveryFallbackPayloads,
     getAiSessionStreamPayloadKind,
@@ -19,7 +20,11 @@ import {
     isAiSessionUpdate,
     isCriticalAiSessionStreamPayload,
     isPreservableAiSessionStreamPayload,
+    releaseAcknowledgedAiSessionStreamPayloads,
+    rememberAiSessionStreamPayloadForDelivery,
     rememberAiSessionStreamPayloadForRecovery,
+    takeNextAiSessionStreamDelivery,
+    type AiSessionStreamDeliveryQueue,
     type AiSessionStreamPreservationQueue,
 } from "./session-stream";
 
@@ -34,7 +39,7 @@ const BASE_EVENT = {
 
 function createStatusEvent(
     status: "error" | "idle" | "starting" | "streaming",
-): AiSessionStreamPayload {
+): Extract<AiSessionDomainEvent, { kind: "status" }> {
     return {
         ...BASE_EVENT,
         activeTurnStartedAt: null,
@@ -112,7 +117,9 @@ function createVisibleTranscriptEvent(
     };
 }
 
-function createToolActivity(): AiToolActivity {
+function createToolActivity(
+    overrides: Partial<AiToolActivity> = {},
+): AiToolActivity {
     return {
         createdAt: "2026-04-14T00:00:00.000Z",
         diffs: [],
@@ -128,6 +135,7 @@ function createToolActivity(): AiToolActivity {
         terminalOutput: null,
         title: "Run command",
         updatedAt: "2026-04-14T00:00:00.000Z",
+        ...overrides,
     };
 }
 
@@ -526,12 +534,94 @@ describe("AI session stream helpers", () => {
             }),
         ).toEqual({
             ackLagMs: 2_500,
+            coalescedPendingPayloadCount: 0,
             lastAckSeq: 7,
             lastSentSeq: 9,
+            peakInFlightPayloadCount: 0,
             pendingPreservedPayloadCount: 2,
             reason: "ack-timeout",
             resyncSnapshotCount: 1,
         });
+    });
+
+    it("coalesces pending tool activity while the delivery window is full", () => {
+        const queue: AiSessionStreamDeliveryQueue = new Map();
+
+        for (let index = 0; index < 10_000; index += 1) {
+            rememberAiSessionStreamPayloadForDelivery({
+                maxPayloads: 100,
+                order: index,
+                payload: {
+                    ...BASE_EVENT,
+                    activity: createToolActivity({
+                        summary: `Revision ${index}`,
+                        updatedAt: new Date(index).toISOString(),
+                    }),
+                    kind: "tool-activity",
+                },
+                queue,
+            });
+        }
+
+        expect(queue).toHaveLength(1);
+        expect(takeNextAiSessionStreamDelivery(queue)?.payload).toMatchObject({
+            activity: { summary: "Revision 9999" },
+            kind: "tool-activity",
+        });
+    });
+
+    it("evicts noncritical pending work before terminal state", () => {
+        const queue: AiSessionStreamDeliveryQueue = new Map();
+        for (let index = 0; index < 2; index += 1) {
+            rememberAiSessionStreamPayloadForDelivery({
+                maxPayloads: 2,
+                order: index,
+                payload: {
+                    ...createStatusEvent("streaming"),
+                    sessionId: `session-${index}`,
+                },
+                queue,
+            });
+        }
+
+        const result = rememberAiSessionStreamPayloadForDelivery({
+            maxPayloads: 2,
+            order: 3,
+            payload: { ...createStatusEvent("idle"), sessionId: "terminal" },
+            queue,
+        });
+
+        expect(result).toMatchObject({
+            droppedCritical: false,
+            droppedOldest: true,
+            preserved: true,
+        });
+        expect(
+            [...queue.values()].some(
+                (pending) =>
+                    pending.payload.kind === "status" &&
+                    pending.payload.status === "idle",
+            ),
+        ).toBe(true);
+    });
+
+    it("releases exactly the payload capacity covered by a partial ACK", () => {
+        const inFlight = new Set(
+            Array.from(
+                { length: AI_SESSION_STREAM_MAX_IN_FLIGHT },
+                (_, index) => index + 1,
+            ),
+        );
+
+        let released = 0;
+        for (let seq = 1; seq <= 7; seq += 1) {
+            released += releaseAcknowledgedAiSessionStreamPayloads(inFlight, seq);
+        }
+        expect(released).toBe(7);
+        expect(inFlight.size).toBe(AI_SESSION_STREAM_MAX_IN_FLIGHT - 7);
+        expect(Math.min(...inFlight)).toBe(8);
+        expect(releaseAcknowledgedAiSessionStreamPayloads(inFlight, 40)).toBe(0);
+        expect(inFlight.size).toBe(AI_SESSION_STREAM_MAX_IN_FLIGHT - 7);
     });
 
     it("builds recovery fallback payloads with critical entries before resync snapshots", () => {

--- a/src/main/ai/session-stream.test.ts
+++ b/src/main/ai/session-stream.test.ts
@@ -12,6 +12,7 @@ import type {
 
 import {
     AI_SESSION_STREAM_MAX_IN_FLIGHT,
+    AiSessionStreamController,
     buildAiSessionStreamRecoveryDiagnostic,
     buildAiSessionStreamRecoveryFallbackPayloads,
     getAiSessionStreamPayloadKind,
@@ -136,6 +137,42 @@ function createToolActivity(
         title: "Run command",
         updatedAt: "2026-04-14T00:00:00.000Z",
         ...overrides,
+    };
+}
+
+function createPermissionRequest(
+    toolCallId: string,
+): Extract<AiSessionDomainEvent, { kind: "permission-request" }> {
+    return {
+        ...BASE_EVENT,
+        kind: "permission-request",
+        request: {
+            description: "Allow the command",
+            options: [],
+            requestId: `permission-${toolCallId}`,
+            sessionId: BASE_EVENT.sessionId,
+            title: "Permission",
+            toolCallId,
+            updatedAt: BASE_EVENT.updatedAt,
+        },
+    };
+}
+
+function createUserInputRequest(
+    toolCallId: string,
+): Extract<AiSessionDomainEvent, { kind: "user-input-request" }> {
+    return {
+        ...BASE_EVENT,
+        kind: "user-input-request",
+        request: {
+            questions: [],
+            requestId: `input-${toolCallId}`,
+            sessionId: BASE_EVENT.sessionId,
+            title: "Input",
+            toolCallId,
+            turnId: "turn-1",
+            updatedAt: BASE_EVENT.updatedAt,
+        },
     };
 }
 
@@ -647,6 +684,150 @@ describe("AI session stream helpers", () => {
         );
         expect(takeNextAiSessionStreamDelivery(queue)?.payload).toEqual(
             otherSessionDelta,
+        );
+    });
+
+    it.each([
+        ["permission", createPermissionRequest("tool-49")],
+        ["user input", createUserInputRequest("tool-49")],
+    ])(
+        "prioritizes %s after only its causal tool activity",
+        (_label, request) => {
+            const queue: AiSessionStreamDeliveryQueue = new Map();
+            for (let index = 0; index < 50; index += 1) {
+                rememberAiSessionStreamPayloadForDelivery({
+                    maxPayloads: 100,
+                    order: index,
+                    payload: {
+                        ...BASE_EVENT,
+                        activity: createToolActivity({ id: `tool-${index}` }),
+                        kind: "tool-activity",
+                    },
+                    queue,
+                });
+            }
+            rememberAiSessionStreamPayloadForDelivery({
+                maxPayloads: 100,
+                order: 50,
+                payload: request,
+                queue,
+            });
+
+            expect(takeNextAiSessionStreamDelivery(queue)?.payload).toMatchObject(
+                {
+                    activity: { id: "tool-49" },
+                    kind: "tool-activity",
+                },
+            );
+            expect(takeNextAiSessionStreamDelivery(queue)?.payload).toEqual(
+                request,
+            );
+            expect(queue.size).toBe(49);
+        },
+    );
+
+    it("runs the bounded window and partial ACK drain through the production controller", () => {
+        const posted: Array<{
+            readonly payload: AiSessionStreamPayload;
+            readonly seq: number;
+        }> = [];
+        const controller = new AiSessionStreamController({
+            onRecovery: () => {
+                throw new Error("Unexpected recovery");
+            },
+            postMessage: (message) => {
+                if (message.type === "payload") posted.push(message);
+            },
+        });
+        for (let index = 0; index < AI_SESSION_STREAM_MAX_IN_FLIGHT; index += 1) {
+            controller.postPayload(
+                createVisibleTranscriptEvent(
+                    "message-delta",
+                    `message-${index}`,
+                    `Delta ${index}`,
+                ),
+            );
+        }
+        for (let index = 0; index < 10_000; index += 1) {
+            controller.postPayload({
+                ...BASE_EVENT,
+                activity: createToolActivity({
+                    summary: `Revision ${index}`,
+                    updatedAt: new Date(index).toISOString(),
+                }),
+                kind: "tool-activity",
+            });
+        }
+
+        expect(controller.metrics).toMatchObject({
+            coalescedPendingPayloadCount: 9_999,
+            peakInFlightPayloadCount: AI_SESSION_STREAM_MAX_IN_FLIGHT,
+            pendingDeliveryPayloadCount: 1,
+            pendingInFlightPayloadCount: AI_SESSION_STREAM_MAX_IN_FLIGHT,
+        });
+        controller.acknowledge(posted[0]?.seq ?? -1);
+        expect(posted).toHaveLength(AI_SESSION_STREAM_MAX_IN_FLIGHT + 1);
+        expect(posted.at(-1)?.payload).toMatchObject({
+            activity: { summary: "Revision 9999" },
+            kind: "tool-activity",
+        });
+        for (const message of posted.slice(1)) {
+            controller.acknowledge(message.seq);
+        }
+        expect(controller.metrics).toMatchObject({
+            pendingDeliveryPayloadCount: 0,
+            pendingInFlightPayloadCount: 0,
+        });
+    });
+
+    it("recovers a production-controller post error without duplicating the current payload", () => {
+        const payload = {
+            ...BASE_EVENT,
+            activity: createToolActivity(),
+            kind: "tool-activity",
+        } satisfies AiSessionStreamPayload;
+        let recovered: readonly AiSessionStreamPayload[] = [];
+        const controller = new AiSessionStreamController({
+            onRecovery: ({ additionalPayloads }) => {
+                recovered = controller
+                    .takeRecoveryPayloads(additionalPayloads)
+                    .map((pending) => pending.payload);
+            },
+            postMessage: () => {
+                throw new Error("Closed port");
+            },
+        });
+
+        controller.postPayload(payload);
+
+        expect(recovered).toEqual([payload]);
+    });
+
+    it("recovers a rejected overflow payload exactly once", () => {
+        const pendingCritical = createPermissionRequest("tool-pending");
+        const rejected = createVisibleTranscriptEvent(
+            "message-delta",
+            "message-rejected",
+            "Keep me",
+        );
+        let recovered: readonly AiSessionStreamPayload[] = [];
+        const controller = new AiSessionStreamController({
+            maxInFlight: 1,
+            maxPendingPayloads: 1,
+            onRecovery: ({ additionalPayloads }) => {
+                recovered = controller
+                    .takeRecoveryPayloads(additionalPayloads)
+                    .map((pending) => pending.payload);
+            },
+            postMessage: () => undefined,
+        });
+        controller.postPayload(createStatusEvent("streaming"));
+        controller.postPayload(pendingCritical);
+        controller.postPayload(rejected);
+
+        expect(recovered).toEqual([pendingCritical, rejected]);
+        expect(recovered.filter((payload) => payload === rejected)).toHaveLength(
+            1,
         );
     });
 

--- a/src/main/ai/session-stream.test.ts
+++ b/src/main/ai/session-stream.test.ts
@@ -570,6 +570,139 @@ describe("AI session stream helpers", () => {
         });
     });
 
+    it("keeps one delivery slot while patch criticity changes", () => {
+        const queue: AiSessionStreamDeliveryQueue = new Map();
+        const revisions = [
+            createPatchUpdateWithChanges({ title: "A" }),
+            createPatchUpdateWithChanges({ status: "idle", title: "B" }),
+            createPatchUpdateWithChanges({ title: "C" }),
+        ];
+
+        for (const [order, payload] of revisions.entries()) {
+            rememberAiSessionStreamPayloadForDelivery({
+                maxPayloads: 10,
+                order,
+                payload,
+                queue,
+            });
+        }
+
+        expect(queue).toHaveLength(1);
+        expect(takeNextAiSessionStreamDelivery(queue)?.payload).toEqual(
+            createPatchUpdateWithChanges({ status: "idle", title: "C" }),
+        );
+    });
+
+    it("keeps one delivery slot while snapshot criticity changes", () => {
+        const queue: AiSessionStreamDeliveryQueue = new Map();
+        const idle = createSnapshotUpdate("idle");
+        const streaming = createSnapshotUpdate("streaming");
+
+        rememberAiSessionStreamPayloadForDelivery({
+            maxPayloads: 10,
+            order: 0,
+            payload: idle,
+            queue,
+        });
+        rememberAiSessionStreamPayloadForDelivery({
+            maxPayloads: 10,
+            order: 1,
+            payload: streaming,
+            queue,
+        });
+
+        expect(queue).toHaveLength(1);
+        expect(takeNextAiSessionStreamDelivery(queue)?.payload).toEqual(
+            streaming,
+        );
+    });
+
+    it("prioritizes critical work across sessions without overtaking same-session deltas", () => {
+        const queue: AiSessionStreamDeliveryQueue = new Map();
+        const otherSessionDelta = {
+            ...createVisibleTranscriptEvent("message-delta"),
+            sessionId: "session-other",
+        } as AiSessionStreamPayload;
+        const sameSessionDelta = createVisibleTranscriptEvent("message-delta");
+        const completion = createCompletedEvent("message-completed");
+
+        for (const [order, payload] of [
+            otherSessionDelta,
+            sameSessionDelta,
+            completion,
+        ].entries()) {
+            rememberAiSessionStreamPayloadForDelivery({
+                maxPayloads: 10,
+                order,
+                payload,
+                queue,
+            });
+        }
+
+        expect(takeNextAiSessionStreamDelivery(queue)?.payload).toEqual(
+            sameSessionDelta,
+        );
+        expect(takeNextAiSessionStreamDelivery(queue)?.payload).toEqual(
+            completion,
+        );
+        expect(takeNextAiSessionStreamDelivery(queue)?.payload).toEqual(
+            otherSessionDelta,
+        );
+    });
+
+    it("recovers a failed posted payload exactly once", () => {
+        const payload = {
+            ...BASE_EVENT,
+            activity: createToolActivity(),
+            kind: "tool-activity",
+        } satisfies AiSessionStreamPayload;
+        const recoveryQueue: AiSessionStreamPreservationQueue = new Map();
+        const result = rememberAiSessionStreamPayloadForRecovery({
+            maxPayloads: 10,
+            payload,
+            queue: recoveryQueue,
+            seq: 7,
+        });
+        const recovered = buildAiSessionStreamRecoveryFallbackPayloads({
+            pendingPreservedPayloads: [...recoveryQueue.values()],
+            resyncSnapshots: [],
+        });
+        const callerFallback = result.preserved ? [] : [payload];
+
+        expect([...recovered, ...callerFallback]).toEqual([payload]);
+    });
+
+    it("recovers an overflow-inserted payload exactly once", () => {
+        const queue: AiSessionStreamDeliveryQueue = new Map();
+        rememberAiSessionStreamPayloadForDelivery({
+            maxPayloads: 1,
+            order: 0,
+            payload: {
+                ...createStatusEvent("streaming"),
+                sessionId: "session-other",
+            },
+            queue,
+        });
+        const payload = createStatusEvent("idle");
+        const result = rememberAiSessionStreamPayloadForDelivery({
+            maxPayloads: 1,
+            order: 1,
+            payload,
+            queue,
+        });
+        const recovered = buildAiSessionStreamRecoveryFallbackPayloads({
+            pendingPreservedPayloads: [...queue.values()].map((pending) => ({
+                payload: pending.payload,
+                seq: pending.order,
+            })),
+            resyncSnapshots: [],
+        });
+        const callerFallback = result.preserved ? [] : [payload];
+
+        expect(result.droppedOldest).toBe(true);
+        expect([...recovered, ...callerFallback]).toEqual([payload]);
+    });
+
     it("evicts noncritical pending work before terminal state", () => {
         const queue: AiSessionStreamDeliveryQueue = new Map();
         for (let index = 0; index < 2; index += 1) {

--- a/src/main/ai/session-stream.ts
+++ b/src/main/ai/session-stream.ts
@@ -1,5 +1,6 @@
 import type {
     AiSessionSnapshot,
+    AiSessionStreamMessage,
     AiSessionStreamPayload,
     AiSessionUpdate,
 } from "@shared/ipc";
@@ -68,6 +69,32 @@ export interface AiSessionStreamDeliveryQueueResult {
     readonly droppedOldest: boolean;
     readonly pendingCount: number;
     readonly preserved: boolean;
+}
+
+export interface AiSessionStreamControllerMetrics {
+    readonly coalescedPendingPayloadCount: number;
+    readonly peakInFlightPayloadCount: number;
+    readonly pendingDeliveryPayloadCount: number;
+    readonly pendingInFlightPayloadCount: number;
+    readonly pendingPreservedPayloadCount: number;
+}
+
+export interface AiSessionStreamControllerRecoveryRequest {
+    readonly additionalPayloads: readonly AiSessionStreamPayload[];
+    readonly reason: AiSessionStreamRecoveryReason;
+}
+
+export interface AiSessionStreamControllerOptions {
+    readonly maxInFlight?: number;
+    readonly maxPendingPayloads?: number;
+    readonly maxPreservedPayloads?: number;
+    readonly now?: () => number;
+    readonly onMessageSent?: () => void;
+    readonly onRecovery: (
+        request: AiSessionStreamControllerRecoveryRequest,
+    ) => void;
+    readonly postMessage: (message: AiSessionStreamMessage) => void;
+    readonly staleMs?: number;
 }
 
 export function getAiSessionStreamPayloadKind(
@@ -291,14 +318,13 @@ export function takeNextAiSessionStreamDelivery(
     let dependencyKey: string | null = null;
     let dependency: PendingAiSessionStreamDelivery | null = null;
     if (critical) {
-        const criticalSessionId = getAiSessionStreamPayloadSessionId(
-            critical.payload,
-        );
         for (const [key, candidate] of queue) {
             if (
                 candidate.order < critical.order &&
-                getAiSessionStreamPayloadSessionId(candidate.payload) ===
-                    criticalSessionId &&
+                isAiSessionStreamCausalDependency(
+                    candidate.payload,
+                    critical.payload,
+                ) &&
                 (!dependency || candidate.order < dependency.order)
             ) {
                 dependencyKey = key;
@@ -320,11 +346,312 @@ function getAiSessionStreamPayloadSessionId(
     return payload.sessionId;
 }
 
+function getAiSessionStreamCausalEntityKey(
+    payload: AiSessionStreamPayload,
+): string | null {
+    const sessionId = getAiSessionStreamPayloadSessionId(payload);
+    if (payload.kind === "message-started") {
+        return `${sessionId}:message:${payload.message.id}`;
+    }
+    if (payload.kind === "thinking-started") {
+        return `${sessionId}:thinking:${payload.message.id}`;
+    }
+    if (
+        payload.kind === "message-delta" ||
+        payload.kind === "message-completed"
+    ) {
+        return `${sessionId}:message:${payload.messageId}`;
+    }
+    if (
+        payload.kind === "thinking-delta" ||
+        payload.kind === "thinking-completed"
+    ) {
+        return `${sessionId}:thinking:${payload.messageId}`;
+    }
+    if (payload.kind === "tool-activity") {
+        return `${sessionId}:tool:${payload.activity.id}`;
+    }
+    if (
+        (payload.kind === "permission-request" ||
+            payload.kind === "user-input-request") &&
+        payload.request
+    ) {
+        return `${sessionId}:tool:${payload.request.toolCallId}`;
+    }
+    return null;
+}
+
+function isAiSessionStreamSessionBarrier(
+    payload: AiSessionStreamPayload,
+): boolean {
+    if (payload.kind === "session-closed" || payload.kind === "turn-status") {
+        return true;
+    }
+    if (payload.kind === "status") {
+        return payload.status === "idle" || payload.status === "error";
+    }
+    if (payload.kind === "patch") {
+        return (
+            payload.patch.changes.status === "idle" ||
+            payload.patch.changes.status === "error"
+        );
+    }
+    if (payload.kind === "snapshot") {
+        return (
+            payload.snapshot.status === "idle" ||
+            payload.snapshot.status === "error"
+        );
+    }
+    return false;
+}
+
+function isAiSessionStreamCausalDependency(
+    candidate: AiSessionStreamPayload,
+    critical: AiSessionStreamPayload,
+): boolean {
+    const criticalEntityKey = getAiSessionStreamCausalEntityKey(critical);
+    if (criticalEntityKey !== null) {
+        return (
+            getAiSessionStreamCausalEntityKey(candidate) === criticalEntityKey
+        );
+    }
+    return (
+        isAiSessionStreamSessionBarrier(critical) &&
+        getAiSessionStreamPayloadSessionId(candidate) ===
+            getAiSessionStreamPayloadSessionId(critical)
+    );
+}
+
 export function releaseAcknowledgedAiSessionStreamPayloads(
     inFlightPayloadSeqs: Set<number>,
     acknowledgedSeq: number,
 ): number {
     return inFlightPayloadSeqs.delete(acknowledgedSeq) ? 1 : 0;
+}
+
+export class AiSessionStreamController {
+    private coalescedPendingPayloadCount = 0;
+    private lastAckSeq = 0;
+    private lastSentAt: number;
+    private lastSentSeq = 0;
+    private readonly maxInFlight: number;
+    private readonly maxPendingPayloads: number;
+    private readonly maxPreservedPayloads: number;
+    private nextPendingOrder = 1;
+    private nextSeq = 1;
+    private readonly now: () => number;
+    private readonly onMessageSent: () => void;
+    private readonly onRecovery: (
+        request: AiSessionStreamControllerRecoveryRequest,
+    ) => void;
+    private peakInFlightPayloadCount = 0;
+    private readonly pendingAckSentAtBySeq = new Map<number, number>();
+    private readonly pendingDeliveryPayloads: AiSessionStreamDeliveryQueue =
+        new Map();
+    private readonly pendingInFlightPayloadSeqs = new Set<number>();
+    private readonly pendingPreservedPayloads: AiSessionStreamPreservationQueue =
+        new Map();
+    private readonly postMessage: (message: AiSessionStreamMessage) => void;
+    private recovering = false;
+    private readonly staleMs: number;
+
+    constructor(options: AiSessionStreamControllerOptions) {
+        this.maxInFlight =
+            options.maxInFlight ?? AI_SESSION_STREAM_MAX_IN_FLIGHT;
+        this.maxPendingPayloads =
+            options.maxPendingPayloads ??
+            AI_SESSION_STREAM_MAX_PENDING_PAYLOADS;
+        this.maxPreservedPayloads = options.maxPreservedPayloads ?? 100;
+        this.now = options.now ?? Date.now;
+        this.onMessageSent = options.onMessageSent ?? (() => undefined);
+        this.onRecovery = options.onRecovery;
+        this.postMessage = options.postMessage;
+        this.staleMs = options.staleMs ?? 10_000;
+        const now = this.now();
+        this.lastSentAt = now;
+    }
+
+    get ackState(): AiSessionStreamAckState {
+        return {
+            lastAckSeq: this.lastAckSeq,
+            lastSentAt: this.lastSentAt,
+            lastSentSeq: this.lastSentSeq,
+            pendingAckSentAtBySeq: new Map(this.pendingAckSentAtBySeq),
+        };
+    }
+
+    get metrics(): AiSessionStreamControllerMetrics {
+        return {
+            coalescedPendingPayloadCount: this.coalescedPendingPayloadCount,
+            peakInFlightPayloadCount: this.peakInFlightPayloadCount,
+            pendingDeliveryPayloadCount: this.pendingDeliveryPayloads.size,
+            pendingInFlightPayloadCount:
+                this.pendingInFlightPayloadSeqs.size,
+            pendingPreservedPayloadCount:
+                this.pendingPreservedPayloads.size +
+                this.pendingDeliveryPayloads.size,
+        };
+    }
+
+    acknowledge(seq: number): void {
+        if (this.recovering) return;
+        this.lastAckSeq = Math.max(this.lastAckSeq, seq);
+        // ACKs stay exact so a newer ping cannot release an older payload.
+        this.pendingAckSentAtBySeq.delete(seq);
+        releaseAcknowledgedAiSessionStreamPayloads(
+            this.pendingInFlightPayloadSeqs,
+            seq,
+        );
+        for (const [key, pendingPayload] of this.pendingPreservedPayloads) {
+            if (pendingPayload.seq === seq) {
+                this.pendingPreservedPayloads.delete(key);
+            }
+        }
+        this.drain();
+    }
+
+    isAckStale(nowMs = this.now()): boolean {
+        return isAiSessionStreamAckStale(
+            this.ackState,
+            nowMs,
+            this.staleMs,
+        );
+    }
+
+    postHeartbeat(): void {
+        if (this.recovering) return;
+        if (this.isAckStale()) {
+            this.requestRecovery("heartbeat-stale");
+            return;
+        }
+        const message = this.nextMessage("ping");
+        try {
+            this.postMessage(message);
+            this.onMessageSent();
+        } catch {
+            this.requestRecovery("heartbeat-error");
+        }
+    }
+
+    postPayload(payload: AiSessionStreamPayload): void {
+        if (this.recovering) return;
+        if (this.isAckStale()) {
+            this.requestRecovery("pre-send-stale", [payload]);
+            return;
+        }
+        if (this.pendingInFlightPayloadSeqs.size < this.maxInFlight) {
+            this.sendPayload(payload);
+            return;
+        }
+
+        const result = rememberAiSessionStreamPayloadForDelivery({
+            maxPayloads: this.maxPendingPayloads,
+            order: this.nextPendingOrder,
+            payload,
+            queue: this.pendingDeliveryPayloads,
+        });
+        this.nextPendingOrder += 1;
+        if (result.coalesced) this.coalescedPendingPayloadCount += 1;
+        if (result.preserved && !result.droppedOldest) return;
+
+        // A rejected payload is not present in either recovery queue.
+        this.requestRecovery(
+            "post-error",
+            result.preserved ? [] : [payload],
+        );
+    }
+
+    takeRecoveryPayloads(
+        additionalPayloads: readonly AiSessionStreamPayload[] = [],
+    ): readonly PendingPreservedAiSessionStreamPayload[] {
+        const pendingPayloads: PendingPreservedAiSessionStreamPayload[] = [
+            ...this.pendingPreservedPayloads.values(),
+            ...[...this.pendingDeliveryPayloads.values()].map((pending) => ({
+                payload: pending.payload,
+                seq: this.nextSeq + pending.order,
+            })),
+        ];
+        let nextAdditionalSeq =
+            pendingPayloads.reduce(
+                (highest, pending) => Math.max(highest, pending.seq),
+                this.nextSeq,
+            ) + 1;
+        for (const payload of additionalPayloads) {
+            pendingPayloads.push({ payload, seq: nextAdditionalSeq });
+            nextAdditionalSeq += 1;
+        }
+        this.pendingPreservedPayloads.clear();
+        this.pendingDeliveryPayloads.clear();
+        this.pendingInFlightPayloadSeqs.clear();
+        this.pendingAckSentAtBySeq.clear();
+        return pendingPayloads;
+    }
+
+    private drain(): void {
+        while (
+            !this.recovering &&
+            this.pendingInFlightPayloadSeqs.size < this.maxInFlight
+        ) {
+            const pending = takeNextAiSessionStreamDelivery(
+                this.pendingDeliveryPayloads,
+            );
+            if (!pending) return;
+            this.sendPayload(pending.payload);
+        }
+    }
+
+    private nextMessage(type: "ping"): AiSessionStreamMessage;
+    private nextMessage(
+        type: "payload",
+        payload: AiSessionStreamPayload,
+    ): AiSessionStreamMessage;
+    private nextMessage(
+        type: "payload" | "ping",
+        payload?: AiSessionStreamPayload,
+    ): AiSessionStreamMessage {
+        const seq = this.nextSeq;
+        this.nextSeq += 1;
+        this.lastSentAt = this.now();
+        this.lastSentSeq = seq;
+        this.pendingAckSentAtBySeq.set(seq, this.lastSentAt);
+        if (type === "ping") {
+            return { sentAt: this.lastSentAt, seq, type };
+        }
+        return { payload: payload as AiSessionStreamPayload, seq, type };
+    }
+
+    private requestRecovery(
+        reason: AiSessionStreamRecoveryReason,
+        additionalPayloads: readonly AiSessionStreamPayload[] = [],
+    ): void {
+        if (this.recovering) return;
+        this.recovering = true;
+        this.onRecovery({ additionalPayloads, reason });
+    }
+
+    private sendPayload(payload: AiSessionStreamPayload): void {
+        const message = this.nextMessage("payload", payload);
+        const preservation = rememberAiSessionStreamPayloadForRecovery({
+            maxPayloads: this.maxPreservedPayloads,
+            payload,
+            queue: this.pendingPreservedPayloads,
+            seq: message.seq,
+        });
+        this.pendingInFlightPayloadSeqs.add(message.seq);
+        this.peakInFlightPayloadCount = Math.max(
+            this.peakInFlightPayloadCount,
+            this.pendingInFlightPayloadSeqs.size,
+        );
+        try {
+            this.postMessage(message);
+            this.onMessageSent();
+        } catch {
+            this.requestRecovery(
+                "post-error",
+                preservation.preserved ? [] : [payload],
+            );
+        }
+    }
 }
 
 function mergePendingDeliveryPayload(

--- a/src/main/ai/session-stream.ts
+++ b/src/main/ai/session-stream.ts
@@ -181,6 +181,14 @@ export function getAiSessionStreamPreservationKey(
 export function getAiSessionStreamDeliveryKey(
     payload: AiSessionStreamPayload,
 ): string {
+    // Session updates must keep one stable slot even when their status changes
+    // whether the payload is currently classified as critical.
+    if (payload.kind === "patch") {
+        return `${payload.patch.sessionId}:patch`;
+    }
+    if (payload.kind === "snapshot") {
+        return `${payload.snapshot.sessionId}:snapshot`;
+    }
     const preservedKey = getAiSessionStreamPreservationKey(payload);
     if (preservedKey !== null) return preservedKey;
     if (payload.kind === "image-generation") {
@@ -195,9 +203,7 @@ export function getAiSessionStreamDeliveryKey(
     if (payload.kind === "subagent-breadcrumb") {
         return `${payload.sessionId}:${payload.childSessionId}:${payload.kind}`;
     }
-    return isAiSessionUpdate(payload)
-        ? `${payload.kind}:${payload.kind === "patch" ? payload.patch.sessionId : payload.snapshot.sessionId}`
-        : `${payload.sessionId}:${payload.kind}`;
+    return `${payload.sessionId}:${payload.kind}`;
 }
 
 export function rememberAiSessionStreamPayloadForDelivery(input: {
@@ -268,16 +274,50 @@ export function rememberAiSessionStreamPayloadForDelivery(input: {
 export function takeNextAiSessionStreamDelivery(
     queue: AiSessionStreamDeliveryQueue,
 ): PendingAiSessionStreamDelivery | null {
-    let nextKey: string | null = null;
-    let next: PendingAiSessionStreamDelivery | null = null;
+    let oldestKey: string | null = null;
+    let oldest: PendingAiSessionStreamDelivery | null = null;
+    let criticalKey: string | null = null;
+    let critical: PendingAiSessionStreamDelivery | null = null;
     for (const [key, candidate] of queue) {
-        if (!next || candidate.order < next.order) {
-            nextKey = key;
-            next = candidate;
+        if (!oldest || candidate.order < oldest.order) {
+            oldestKey = key;
+            oldest = candidate;
+        }
+        if (candidate.critical && (!critical || candidate.order < critical.order)) {
+            criticalKey = key;
+            critical = candidate;
         }
     }
+    let dependencyKey: string | null = null;
+    let dependency: PendingAiSessionStreamDelivery | null = null;
+    if (critical) {
+        const criticalSessionId = getAiSessionStreamPayloadSessionId(
+            critical.payload,
+        );
+        for (const [key, candidate] of queue) {
+            if (
+                candidate.order < critical.order &&
+                getAiSessionStreamPayloadSessionId(candidate.payload) ===
+                    criticalSessionId &&
+                (!dependency || candidate.order < dependency.order)
+            ) {
+                dependencyKey = key;
+                dependency = candidate;
+            }
+        }
+    }
+    const nextKey = dependencyKey ?? criticalKey ?? oldestKey;
+    const next = dependency ?? critical ?? oldest;
     if (nextKey !== null) queue.delete(nextKey);
     return next;
+}
+
+function getAiSessionStreamPayloadSessionId(
+    payload: AiSessionStreamPayload,
+): string {
+    if (payload.kind === "patch") return payload.patch.sessionId;
+    if (payload.kind === "snapshot") return payload.snapshot.sessionId;
+    return payload.sessionId;
 }
 
 export function releaseAcknowledgedAiSessionStreamPayloads(

--- a/src/main/ai/session-stream.ts
+++ b/src/main/ai/session-stream.ts
@@ -3,6 +3,10 @@ import type {
     AiSessionStreamPayload,
     AiSessionUpdate,
 } from "@shared/ipc";
+import { mergeAiTranscriptToolActivity } from "@shared/ai-transcript";
+
+export const AI_SESSION_STREAM_MAX_IN_FLIGHT = 32;
+export const AI_SESSION_STREAM_MAX_PENDING_PAYLOADS = 100;
 
 export type AiSessionStreamRecoveryReason =
     | "ack-timeout"
@@ -22,6 +26,8 @@ export interface AiSessionStreamRecoveryDiagnostic {
     readonly ackLagMs: number;
     readonly lastAckSeq: number;
     readonly lastSentSeq: number;
+    readonly coalescedPendingPayloadCount: number;
+    readonly peakInFlightPayloadCount: number;
     readonly pendingPreservedPayloadCount: number;
     readonly reason: AiSessionStreamRecoveryReason;
     readonly resyncSnapshotCount: number;
@@ -44,6 +50,25 @@ export type AiSessionStreamPreservationQueue = Map<
 >;
 
 export type AiSessionStreamPayloadKind = AiSessionStreamPayload["kind"];
+
+export interface PendingAiSessionStreamDelivery {
+    readonly critical: boolean;
+    readonly order: number;
+    readonly payload: AiSessionStreamPayload;
+}
+
+export type AiSessionStreamDeliveryQueue = Map<
+    string,
+    PendingAiSessionStreamDelivery
+>;
+
+export interface AiSessionStreamDeliveryQueueResult {
+    readonly coalesced: boolean;
+    readonly droppedCritical: boolean;
+    readonly droppedOldest: boolean;
+    readonly pendingCount: number;
+    readonly preserved: boolean;
+}
 
 export function getAiSessionStreamPayloadKind(
     payload: AiSessionStreamPayload,
@@ -70,9 +95,20 @@ export function isCriticalAiSessionStreamPayload(
 
     if (
         payload.kind === "message-completed" ||
-        payload.kind === "thinking-completed"
+        payload.kind === "thinking-completed" ||
+        payload.kind === "permission-request" ||
+        payload.kind === "session-closed" ||
+        payload.kind === "turn-status" ||
+        payload.kind === "user-input-request"
     ) {
         return true;
+    }
+
+    if (payload.kind === "tool-activity") {
+        return (
+            payload.activity.status === "completed" ||
+            payload.activity.status === "failed"
+        );
     }
 
     return (
@@ -99,7 +135,8 @@ export function isPreservableAiSessionStreamPayload(
         payload.kind === "message-started" ||
         payload.kind === "message-delta" ||
         payload.kind === "thinking-started" ||
-        payload.kind === "thinking-delta"
+        payload.kind === "thinking-delta" ||
+        payload.kind === "tool-activity"
     );
 }
 
@@ -134,7 +171,166 @@ export function getAiSessionStreamPreservationKey(
         return `${payload.sessionId}:${payload.messageId}:${payload.kind}`;
     }
 
+    if (payload.kind === "tool-activity") {
+        return `${payload.sessionId}:${payload.activity.id}:${payload.kind}`;
+    }
+
     return `${payload.sessionId}:${payload.kind}`;
+}
+
+export function getAiSessionStreamDeliveryKey(
+    payload: AiSessionStreamPayload,
+): string {
+    const preservedKey = getAiSessionStreamPreservationKey(payload);
+    if (preservedKey !== null) return preservedKey;
+    if (payload.kind === "image-generation") {
+        return `${payload.sessionId}:${payload.message.id}:${payload.kind}`;
+    }
+    if (payload.kind === "review-delta") {
+        return `${payload.sessionId}:${payload.delta.toolCallId}:${payload.kind}`;
+    }
+    if (payload.kind === "subagent-created") {
+        return `${payload.sessionId}:${payload.childSessionId}:${payload.kind}`;
+    }
+    if (payload.kind === "subagent-breadcrumb") {
+        return `${payload.sessionId}:${payload.childSessionId}:${payload.kind}`;
+    }
+    return isAiSessionUpdate(payload)
+        ? `${payload.kind}:${payload.kind === "patch" ? payload.patch.sessionId : payload.snapshot.sessionId}`
+        : `${payload.sessionId}:${payload.kind}`;
+}
+
+export function rememberAiSessionStreamPayloadForDelivery(input: {
+    readonly maxPayloads: number;
+    readonly order: number;
+    readonly payload: AiSessionStreamPayload;
+    readonly queue: AiSessionStreamDeliveryQueue;
+}): AiSessionStreamDeliveryQueueResult {
+    const key = getAiSessionStreamDeliveryKey(input.payload);
+    const existing = input.queue.get(key);
+    const critical = isCriticalAiSessionStreamPayload(input.payload);
+    if (existing) {
+        input.queue.set(key, {
+            critical: existing.critical || critical,
+            order: existing.order,
+            payload: mergePendingDeliveryPayload(existing.payload, input.payload),
+        });
+        return {
+            coalesced: true,
+            droppedCritical: false,
+            droppedOldest: false,
+            pendingCount: input.queue.size,
+            preserved: true,
+        };
+    }
+
+    let droppedCritical = false;
+    let droppedOldest = false;
+    if (input.queue.size >= input.maxPayloads) {
+        const evictable = [...input.queue].find(
+            ([, pending]) => !pending.critical,
+        );
+        if (evictable) {
+            input.queue.delete(evictable[0]);
+            droppedOldest = true;
+        } else if (!critical) {
+            return {
+                coalesced: false,
+                droppedCritical: false,
+                droppedOldest: false,
+                pendingCount: input.queue.size,
+                preserved: false,
+            };
+        } else {
+            const oldest = input.queue.keys().next().value;
+            if (oldest !== undefined) {
+                input.queue.delete(oldest);
+                droppedCritical = true;
+                droppedOldest = true;
+            }
+        }
+    }
+
+    input.queue.set(key, {
+        critical,
+        order: input.order,
+        payload: input.payload,
+    });
+    return {
+        coalesced: false,
+        droppedCritical,
+        droppedOldest,
+        pendingCount: input.queue.size,
+        preserved: true,
+    };
+}
+
+export function takeNextAiSessionStreamDelivery(
+    queue: AiSessionStreamDeliveryQueue,
+): PendingAiSessionStreamDelivery | null {
+    let nextKey: string | null = null;
+    let next: PendingAiSessionStreamDelivery | null = null;
+    for (const [key, candidate] of queue) {
+        if (!next || candidate.order < next.order) {
+            nextKey = key;
+            next = candidate;
+        }
+    }
+    if (nextKey !== null) queue.delete(nextKey);
+    return next;
+}
+
+export function releaseAcknowledgedAiSessionStreamPayloads(
+    inFlightPayloadSeqs: Set<number>,
+    acknowledgedSeq: number,
+): number {
+    return inFlightPayloadSeqs.delete(acknowledgedSeq) ? 1 : 0;
+}
+
+function mergePendingDeliveryPayload(
+    existing: AiSessionStreamPayload,
+    incoming: AiSessionStreamPayload,
+): AiSessionStreamPayload {
+    if (existing.kind === "patch" && incoming.kind === "patch") {
+        return {
+            kind: "patch",
+            patch: {
+                ...incoming.patch,
+                changes: {
+                    ...existing.patch.changes,
+                    ...incoming.patch.changes,
+                },
+            },
+        };
+    }
+    if (existing.kind === "tool-activity" && incoming.kind === "tool-activity") {
+        const merged = mergeAiTranscriptToolActivity(
+            existing.activity,
+            incoming.activity,
+        );
+        return {
+            ...incoming,
+            activity: {
+                ...merged,
+                locations:
+                    incoming.activity.locations.length > 0
+                        ? incoming.activity.locations
+                        : existing.activity.locations,
+                rawInputJson:
+                    incoming.activity.rawInputJson ??
+                    existing.activity.rawInputJson,
+                rawOutputJson:
+                    incoming.activity.rawOutputJson ??
+                    existing.activity.rawOutputJson,
+                summary:
+                    incoming.activity.summary ?? existing.activity.summary,
+                toolActivityDetailId:
+                    incoming.activity.toolActivityDetailId ??
+                    existing.activity.toolActivityDetailId,
+            },
+        };
+    }
+    return incoming;
 }
 
 export function rememberAiSessionStreamPayloadForRecovery(input: {
@@ -168,6 +364,17 @@ export function rememberAiSessionStreamPayloadForRecovery(input: {
                     },
                 },
             },
+            seq: input.seq,
+        });
+    } else if (
+        existing?.payload.kind === "tool-activity" &&
+        input.payload.kind === "tool-activity"
+    ) {
+        input.queue.set(key, {
+            payload: mergePendingDeliveryPayload(
+                existing.payload,
+                input.payload,
+            ),
             seq: input.seq,
         });
     } else {
@@ -213,7 +420,9 @@ export function isAiSessionStreamAckStale(
 }
 
 export function buildAiSessionStreamRecoveryDiagnostic(input: {
+    readonly coalescedPendingPayloadCount?: number;
     readonly nowMs: number;
+    readonly peakInFlightPayloadCount?: number;
     readonly pendingPreservedPayloadCount: number;
     readonly reason: AiSessionStreamRecoveryReason;
     readonly resyncSnapshotCount: number;
@@ -229,6 +438,9 @@ export function buildAiSessionStreamRecoveryDiagnostic(input: {
                 : Math.max(0, input.nowMs - oldestPendingSentAt),
         lastAckSeq: input.state.lastAckSeq,
         lastSentSeq: input.state.lastSentSeq,
+        coalescedPendingPayloadCount:
+            input.coalescedPendingPayloadCount ?? 0,
+        peakInFlightPayloadCount: input.peakInFlightPayloadCount ?? 0,
         pendingPreservedPayloadCount: input.pendingPreservedPayloadCount,
         reason: input.reason,
         resyncSnapshotCount: input.resyncSnapshotCount,
@@ -256,10 +468,7 @@ function getOldestPendingAiSessionStreamAckSentAt(
     state: AiSessionStreamAckState,
 ): number | null {
     let oldestPendingSentAt: number | null = null;
-    for (const [seq, sentAt] of state.pendingAckSentAtBySeq) {
-        if (seq <= state.lastAckSeq) {
-            continue;
-        }
+    for (const sentAt of state.pendingAckSentAtBySeq.values()) {
         if (oldestPendingSentAt === null || sentAt < oldestPendingSentAt) {
             oldestPendingSentAt = sentAt;
         }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1743,7 +1743,12 @@ function sendAiSessionStreamPayload(
     payload: AiSessionStreamPayload,
 ): boolean {
     const message = nextAiSessionStreamMessage(state, payload);
-    preserveAiSessionStreamPayload(windowId, state, payload, message.seq);
+    const preservedForRecovery = preserveAiSessionStreamPayload(
+        windowId,
+        state,
+        payload,
+        message.seq,
+    );
     state.pendingInFlightPayloadSeqs.add(message.seq);
     state.peakInFlightPayloadCount = Math.max(
         state.peakInFlightPayloadCount,
@@ -1756,7 +1761,9 @@ function sendAiSessionStreamPayload(
     } catch (error) {
         debugBenignError("aiSessionStreamPort.postMessage", error);
         recoverAiSessionStreamPort(windowId, "post-error");
-        return false;
+        // Only preserved payloads were included in recovery; other events need
+        // the caller's direct IPC fallback.
+        return preservedForRecovery;
     }
 }
 
@@ -1797,7 +1804,7 @@ function preserveAiSessionStreamPayload(
     state: AiSessionStreamPortState,
     payload: AiSessionStreamPayload,
     seq: number,
-): void {
+): boolean {
     const result = rememberAiSessionStreamPayloadForRecovery({
         maxPayloads: AI_SESSION_STREAM_MAX_PRESERVED_PAYLOADS,
         payload,
@@ -1805,7 +1812,7 @@ function preserveAiSessionStreamPayload(
         seq,
     });
     if (!result.droppedOldest) {
-        return;
+        return result.preserved;
     }
 
     debugBenignError(
@@ -1818,6 +1825,7 @@ function preserveAiSessionStreamPayload(
             }),
         ),
     );
+    return result.preserved;
 }
 
 function sendAiSessionStreamHeartbeat(windowId: string): void {
@@ -2000,7 +2008,9 @@ function postAiSessionStreamPayload(
             ),
         );
         recoverAiSessionStreamPort(windowId, "post-error");
-        return false;
+        // An inserted payload is part of recovery; only a rejected payload
+        // still needs the caller's direct IPC fallback.
+        return result.preserved;
     }
 
     if (sendAiSessionStreamPayload(windowId, state, payload)) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -44,11 +44,17 @@ import type { SecretStoreGateway } from "./ai/secret-store";
 import { AiService } from "./ai/service";
 import type { NormalizedSessionCatalogPayload } from "./ai/session-core";
 import {
+    AI_SESSION_STREAM_MAX_IN_FLIGHT,
+    AI_SESSION_STREAM_MAX_PENDING_PAYLOADS,
     buildAiSessionStreamRecoveryFallbackPayloads,
     buildAiSessionStreamRecoveryDiagnostic,
     isAiSessionStreamAckStale,
     isAiSessionUpdate,
+    rememberAiSessionStreamPayloadForDelivery,
     rememberAiSessionStreamPayloadForRecovery,
+    releaseAcknowledgedAiSessionStreamPayloads,
+    takeNextAiSessionStreamDelivery,
+    type AiSessionStreamDeliveryQueue,
     type AiSessionStreamPreservationQueue,
     type AiSessionStreamRecoveryReason,
 } from "./ai/session-stream";
@@ -175,13 +181,18 @@ const AI_SESSION_STREAM_HEARTBEAT_MS = 1_000;
 const AI_SESSION_STREAM_MAX_PRESERVED_PAYLOADS = 100;
 
 type AiSessionStreamPortState = {
+    coalescedPendingPayloadCount: number;
     readonly port: MessagePortMain;
     heartbeatTimer: ReturnType<typeof setInterval> | null;
     lastAckAt: number;
     lastAckSeq: number;
     lastSentAt: number;
     lastSentSeq: number;
+    nextPendingOrder: number;
     nextSeq: number;
+    peakInFlightPayloadCount: number;
+    readonly pendingDeliveryPayloads: AiSessionStreamDeliveryQueue;
+    readonly pendingInFlightPayloadSeqs: Set<number>;
     readonly pendingAckSentAtBySeq: Map<number, number>;
     readonly pendingPreservedPayloads: AiSessionStreamPreservationQueue;
     staleTimer: ReturnType<typeof setTimeout> | null;
@@ -1621,13 +1632,18 @@ function attachAiSessionStream(
         ]);
         const now = Date.now();
         const state: AiSessionStreamPortState = {
+            coalescedPendingPayloadCount: 0,
             heartbeatTimer: null,
             lastAckAt: now,
             lastAckSeq: 0,
             lastSentAt: now,
             lastSentSeq: 0,
+            nextPendingOrder: 1,
             nextSeq: 1,
+            peakInFlightPayloadCount: 0,
             pendingAckSentAtBySeq: new Map(),
+            pendingDeliveryPayloads: new Map(),
+            pendingInFlightPayloadSeqs: new Set(),
             pendingPreservedPayloads: new Map(),
             port: channel.port1,
             runtimeOwnerId,
@@ -1691,16 +1707,18 @@ function handleAiSessionStreamPortMessage(
 
     state.lastAckAt = Date.now();
     state.lastAckSeq = Math.max(state.lastAckSeq, candidate.seq);
-    for (const seq of [...state.pendingAckSentAtBySeq.keys()]) {
-        if (seq <= state.lastAckSeq) {
-            state.pendingAckSentAtBySeq.delete(seq);
-        }
-    }
+    // ACKs are exact so a later ping cannot hide a failed payload dispatch.
+    state.pendingAckSentAtBySeq.delete(candidate.seq);
+    releaseAcknowledgedAiSessionStreamPayloads(
+        state.pendingInFlightPayloadSeqs,
+        candidate.seq,
+    );
     for (const [key, pendingPayload] of state.pendingPreservedPayloads) {
-        if (pendingPayload.seq <= state.lastAckSeq) {
+        if (pendingPayload.seq === candidate.seq) {
             state.pendingPreservedPayloads.delete(key);
         }
     }
+    drainPendingAiSessionStreamPayloads(windowId, state);
 }
 
 function nextAiSessionStreamMessage(
@@ -1717,6 +1735,46 @@ function nextAiSessionStreamMessage(
         seq,
         type: "payload",
     };
+}
+
+function sendAiSessionStreamPayload(
+    windowId: string,
+    state: AiSessionStreamPortState,
+    payload: AiSessionStreamPayload,
+): boolean {
+    const message = nextAiSessionStreamMessage(state, payload);
+    preserveAiSessionStreamPayload(windowId, state, payload, message.seq);
+    state.pendingInFlightPayloadSeqs.add(message.seq);
+    state.peakInFlightPayloadCount = Math.max(
+        state.peakInFlightPayloadCount,
+        state.pendingInFlightPayloadSeqs.size,
+    );
+    try {
+        state.port.postMessage(message);
+        scheduleAiSessionStreamStaleCheck(windowId);
+        return true;
+    } catch (error) {
+        debugBenignError("aiSessionStreamPort.postMessage", error);
+        recoverAiSessionStreamPort(windowId, "post-error");
+        return false;
+    }
+}
+
+function drainPendingAiSessionStreamPayloads(
+    windowId: string,
+    state: AiSessionStreamPortState,
+): void {
+    while (
+        aiSessionStreamPorts.get(windowId) === state &&
+        state.pendingInFlightPayloadSeqs.size <
+            AI_SESSION_STREAM_MAX_IN_FLIGHT
+    ) {
+        const pending = takeNextAiSessionStreamDelivery(
+            state.pendingDeliveryPayloads,
+        );
+        if (!pending) return;
+        if (!sendAiSessionStreamPayload(windowId, state, pending.payload)) return;
+    }
 }
 
 function nextAiSessionStreamPing(
@@ -1820,8 +1878,10 @@ function recoverAiSessionStreamPort(
 ): void {
     const state = aiSessionStreamPorts.get(windowId);
     const targetContents = state?.webContents ?? null;
-    const pendingPreservedPayloadCount =
-        state?.pendingPreservedPayloads.size ?? 0;
+    const pendingPreservedPayloadCount = state
+        ? state.pendingPreservedPayloads.size +
+          state.pendingDeliveryPayloads.size
+        : 0;
     const canSendFallback = Boolean(
         targetContents && !targetContents.isDestroyed(),
     );
@@ -1835,7 +1895,15 @@ function recoverAiSessionStreamPort(
     if (targetContents && canSendFallback) {
         const fallbackPayloads = buildAiSessionStreamRecoveryFallbackPayloads({
             pendingPreservedPayloads: state
-                ? [...state.pendingPreservedPayloads.values()]
+                ? [
+                      ...state.pendingPreservedPayloads.values(),
+                      ...[...state.pendingDeliveryPayloads.values()].map(
+                          (pending) => ({
+                              payload: pending.payload,
+                              seq: state.nextSeq + pending.order,
+                          }),
+                      ),
+                  ]
                 : [],
             resyncSnapshots,
         });
@@ -1850,6 +1918,9 @@ function recoverAiSessionStreamPort(
               buildAiSessionStreamRecoveryDiagnostic({
                   nowMs: Date.now(),
                   pendingPreservedPayloadCount,
+                  coalescedPendingPayloadCount:
+                      state.coalescedPendingPayloadCount,
+                  peakInFlightPayloadCount: state.peakInFlightPayloadCount,
                   reason,
                   resyncSnapshotCount: resyncSnapshots.length,
                   state,
@@ -1898,18 +1969,44 @@ function postAiSessionStreamPayload(
         return false;
     }
 
-    const message = nextAiSessionStreamMessage(state, payload);
-    preserveAiSessionStreamPayload(windowId, state, payload, message.seq);
-
-    try {
-        state.port.postMessage(message);
-        scheduleAiSessionStreamStaleCheck(windowId);
-        return true;
-    } catch (error) {
-        debugBenignError("aiSessionStreamPort.postMessage", error);
+    if (
+        state.pendingInFlightPayloadSeqs.size >=
+        AI_SESSION_STREAM_MAX_IN_FLIGHT
+    ) {
+        // Keep producer pressure behind a bounded, key-coalesced queue.
+        const result = rememberAiSessionStreamPayloadForDelivery({
+            maxPayloads: AI_SESSION_STREAM_MAX_PENDING_PAYLOADS,
+            order: state.nextPendingOrder,
+            payload,
+            queue: state.pendingDeliveryPayloads,
+        });
+        state.nextPendingOrder += 1;
+        if (result.coalesced) {
+            state.coalescedPendingPayloadCount += 1;
+        }
+        if (result.preserved && !result.droppedOldest) {
+            scheduleAiSessionStreamStaleCheck(windowId);
+            return true;
+        }
+        debugBenignError(
+            "aiSessionStreamPort.pendingPayloads",
+            new Error(
+                JSON.stringify({
+                    droppedCritical: result.droppedCritical,
+                    limit: AI_SESSION_STREAM_MAX_PENDING_PAYLOADS,
+                    pendingCount: result.pendingCount,
+                    windowId,
+                }),
+            ),
+        );
         recoverAiSessionStreamPort(windowId, "post-error");
         return false;
     }
+
+    if (sendAiSessionStreamPayload(windowId, state, payload)) {
+        return true;
+    }
+    return false;
 }
 
 function dispatchAiSessionSnapshot(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,7 +15,6 @@ import {
     type AiRuntimeStatus,
     type AiPromptQueueSnapshot,
     type AiSessionDomainEvent,
-    type AiSessionStreamMessage,
     type AiSessionStreamPayload,
     type AiSessionUpdate,
     type AppBootstrapSnapshot,
@@ -44,18 +43,10 @@ import type { SecretStoreGateway } from "./ai/secret-store";
 import { AiService } from "./ai/service";
 import type { NormalizedSessionCatalogPayload } from "./ai/session-core";
 import {
-    AI_SESSION_STREAM_MAX_IN_FLIGHT,
-    AI_SESSION_STREAM_MAX_PENDING_PAYLOADS,
+    AiSessionStreamController,
     buildAiSessionStreamRecoveryFallbackPayloads,
     buildAiSessionStreamRecoveryDiagnostic,
-    isAiSessionStreamAckStale,
     isAiSessionUpdate,
-    rememberAiSessionStreamPayloadForDelivery,
-    rememberAiSessionStreamPayloadForRecovery,
-    releaseAcknowledgedAiSessionStreamPayloads,
-    takeNextAiSessionStreamDelivery,
-    type AiSessionStreamDeliveryQueue,
-    type AiSessionStreamPreservationQueue,
     type AiSessionStreamRecoveryReason,
 } from "./ai/session-stream";
 import { GitHubService } from "./github/service";
@@ -181,20 +172,9 @@ const AI_SESSION_STREAM_HEARTBEAT_MS = 1_000;
 const AI_SESSION_STREAM_MAX_PRESERVED_PAYLOADS = 100;
 
 type AiSessionStreamPortState = {
-    coalescedPendingPayloadCount: number;
+    readonly controller: AiSessionStreamController;
     readonly port: MessagePortMain;
     heartbeatTimer: ReturnType<typeof setInterval> | null;
-    lastAckAt: number;
-    lastAckSeq: number;
-    lastSentAt: number;
-    lastSentSeq: number;
-    nextPendingOrder: number;
-    nextSeq: number;
-    peakInFlightPayloadCount: number;
-    readonly pendingDeliveryPayloads: AiSessionStreamDeliveryQueue;
-    readonly pendingInFlightPayloadSeqs: Set<number>;
-    readonly pendingAckSentAtBySeq: Map<number, number>;
-    readonly pendingPreservedPayloads: AiSessionStreamPreservationQueue;
     staleTimer: ReturnType<typeof setTimeout> | null;
     readonly runtimeOwnerId: string;
     readonly webContents: WebContents;
@@ -1630,21 +1610,26 @@ function attachAiSessionStream(
         webContents.postMessage(IPC_EVENTS.aiSessionStreamPort, null, [
             channel.port2,
         ]);
-        const now = Date.now();
+        const controller = new AiSessionStreamController({
+            maxPreservedPayloads: AI_SESSION_STREAM_MAX_PRESERVED_PAYLOADS,
+            onMessageSent: () => {
+                scheduleAiSessionStreamStaleCheck(subscriberId);
+            },
+            onRecovery: ({ additionalPayloads, reason }) => {
+                recoverAiSessionStreamPort(
+                    subscriberId,
+                    reason,
+                    additionalPayloads,
+                );
+            },
+            postMessage: (message) => {
+                channel.port1.postMessage(message);
+            },
+            staleMs: AI_SESSION_STREAM_ACK_STALE_MS,
+        });
         const state: AiSessionStreamPortState = {
-            coalescedPendingPayloadCount: 0,
+            controller,
             heartbeatTimer: null,
-            lastAckAt: now,
-            lastAckSeq: 0,
-            lastSentAt: now,
-            lastSentSeq: 0,
-            nextPendingOrder: 1,
-            nextSeq: 1,
-            peakInFlightPayloadCount: 0,
-            pendingAckSentAtBySeq: new Map(),
-            pendingDeliveryPayloads: new Map(),
-            pendingInFlightPayloadSeqs: new Set(),
-            pendingPreservedPayloads: new Map(),
             port: channel.port1,
             runtimeOwnerId,
             staleTimer: null,
@@ -1705,127 +1690,7 @@ function handleAiSessionStreamPortMessage(
         return;
     }
 
-    state.lastAckAt = Date.now();
-    state.lastAckSeq = Math.max(state.lastAckSeq, candidate.seq);
-    // ACKs are exact so a later ping cannot hide a failed payload dispatch.
-    state.pendingAckSentAtBySeq.delete(candidate.seq);
-    releaseAcknowledgedAiSessionStreamPayloads(
-        state.pendingInFlightPayloadSeqs,
-        candidate.seq,
-    );
-    for (const [key, pendingPayload] of state.pendingPreservedPayloads) {
-        if (pendingPayload.seq === candidate.seq) {
-            state.pendingPreservedPayloads.delete(key);
-        }
-    }
-    drainPendingAiSessionStreamPayloads(windowId, state);
-}
-
-function nextAiSessionStreamMessage(
-    state: AiSessionStreamPortState,
-    payload: AiSessionStreamPayload,
-): AiSessionStreamMessage {
-    const seq = state.nextSeq;
-    state.nextSeq += 1;
-    state.lastSentAt = Date.now();
-    state.lastSentSeq = seq;
-    state.pendingAckSentAtBySeq.set(seq, state.lastSentAt);
-    return {
-        payload,
-        seq,
-        type: "payload",
-    };
-}
-
-function sendAiSessionStreamPayload(
-    windowId: string,
-    state: AiSessionStreamPortState,
-    payload: AiSessionStreamPayload,
-): boolean {
-    const message = nextAiSessionStreamMessage(state, payload);
-    const preservedForRecovery = preserveAiSessionStreamPayload(
-        windowId,
-        state,
-        payload,
-        message.seq,
-    );
-    state.pendingInFlightPayloadSeqs.add(message.seq);
-    state.peakInFlightPayloadCount = Math.max(
-        state.peakInFlightPayloadCount,
-        state.pendingInFlightPayloadSeqs.size,
-    );
-    try {
-        state.port.postMessage(message);
-        scheduleAiSessionStreamStaleCheck(windowId);
-        return true;
-    } catch (error) {
-        debugBenignError("aiSessionStreamPort.postMessage", error);
-        recoverAiSessionStreamPort(windowId, "post-error");
-        // Only preserved payloads were included in recovery; other events need
-        // the caller's direct IPC fallback.
-        return preservedForRecovery;
-    }
-}
-
-function drainPendingAiSessionStreamPayloads(
-    windowId: string,
-    state: AiSessionStreamPortState,
-): void {
-    while (
-        aiSessionStreamPorts.get(windowId) === state &&
-        state.pendingInFlightPayloadSeqs.size <
-            AI_SESSION_STREAM_MAX_IN_FLIGHT
-    ) {
-        const pending = takeNextAiSessionStreamDelivery(
-            state.pendingDeliveryPayloads,
-        );
-        if (!pending) return;
-        if (!sendAiSessionStreamPayload(windowId, state, pending.payload)) return;
-    }
-}
-
-function nextAiSessionStreamPing(
-    state: AiSessionStreamPortState,
-): AiSessionStreamMessage {
-    const seq = state.nextSeq;
-    state.nextSeq += 1;
-    state.lastSentAt = Date.now();
-    state.lastSentSeq = seq;
-    state.pendingAckSentAtBySeq.set(seq, state.lastSentAt);
-    return {
-        sentAt: state.lastSentAt,
-        seq,
-        type: "ping",
-    };
-}
-
-function preserveAiSessionStreamPayload(
-    windowId: string,
-    state: AiSessionStreamPortState,
-    payload: AiSessionStreamPayload,
-    seq: number,
-): boolean {
-    const result = rememberAiSessionStreamPayloadForRecovery({
-        maxPayloads: AI_SESSION_STREAM_MAX_PRESERVED_PAYLOADS,
-        payload,
-        queue: state.pendingPreservedPayloads,
-        seq,
-    });
-    if (!result.droppedOldest) {
-        return result.preserved;
-    }
-
-    debugBenignError(
-        "aiSessionStreamPort.preservedPayloads",
-        new Error(
-            JSON.stringify({
-                limit: AI_SESSION_STREAM_MAX_PRESERVED_PAYLOADS,
-                pendingPreservedPayloadCount: result.pendingCount,
-                windowId,
-            }),
-        ),
-    );
-    return result.preserved;
+    state.controller.acknowledge(candidate.seq);
 }
 
 function sendAiSessionStreamHeartbeat(windowId: string): void {
@@ -1834,24 +1699,7 @@ function sendAiSessionStreamHeartbeat(windowId: string): void {
         return;
     }
 
-    if (
-        isAiSessionStreamAckStale(
-            state,
-            Date.now(),
-            AI_SESSION_STREAM_ACK_STALE_MS,
-        )
-    ) {
-        recoverAiSessionStreamPort(windowId, "heartbeat-stale");
-        return;
-    }
-
-    try {
-        state.port.postMessage(nextAiSessionStreamPing(state));
-        scheduleAiSessionStreamStaleCheck(windowId);
-    } catch (error) {
-        debugBenignError("aiSessionStreamPort.heartbeat", error);
-        recoverAiSessionStreamPort(windowId, "heartbeat-error");
-    }
+    state.controller.postHeartbeat();
 }
 
 function scheduleAiSessionStreamStaleCheck(windowId: string): void {
@@ -1865,14 +1713,7 @@ function scheduleAiSessionStreamStaleCheck(windowId: string): void {
     }
     state.staleTimer = setTimeout(() => {
         const latestState = aiSessionStreamPorts.get(windowId);
-        if (
-            !latestState ||
-            !isAiSessionStreamAckStale(
-                latestState,
-                Date.now(),
-                AI_SESSION_STREAM_ACK_STALE_MS,
-            )
-        ) {
+        if (!latestState || !latestState.controller.isAckStale()) {
             return;
         }
         recoverAiSessionStreamPort(windowId, "ack-timeout");
@@ -1883,13 +1724,16 @@ function scheduleAiSessionStreamStaleCheck(windowId: string): void {
 function recoverAiSessionStreamPort(
     windowId: string,
     reason: AiSessionStreamRecoveryReason,
+    additionalPayloads: readonly AiSessionStreamPayload[] = [],
 ): void {
     const state = aiSessionStreamPorts.get(windowId);
     const targetContents = state?.webContents ?? null;
-    const pendingPreservedPayloadCount = state
-        ? state.pendingPreservedPayloads.size +
-          state.pendingDeliveryPayloads.size
-        : 0;
+    const ackState = state?.controller.ackState;
+    const streamMetrics = state?.controller.metrics;
+    const pendingPreservedPayloads = state?.controller.takeRecoveryPayloads(
+        additionalPayloads,
+    ) ?? [];
+    const pendingPreservedPayloadCount = pendingPreservedPayloads.length;
     const canSendFallback = Boolean(
         targetContents && !targetContents.isDestroyed(),
     );
@@ -1902,36 +1746,26 @@ function recoverAiSessionStreamPort(
 
     if (targetContents && canSendFallback) {
         const fallbackPayloads = buildAiSessionStreamRecoveryFallbackPayloads({
-            pendingPreservedPayloads: state
-                ? [
-                      ...state.pendingPreservedPayloads.values(),
-                      ...[...state.pendingDeliveryPayloads.values()].map(
-                          (pending) => ({
-                              payload: pending.payload,
-                              seq: state.nextSeq + pending.order,
-                          }),
-                      ),
-                  ]
-                : [],
+            pendingPreservedPayloads,
             resyncSnapshots,
         });
-        state?.pendingPreservedPayloads.clear();
         for (const payload of fallbackPayloads) {
             sendAiSessionStreamPayloadOverIpc(targetContents, payload);
         }
     }
 
-    const message = state
+    const message = state && ackState && streamMetrics
         ? JSON.stringify(
               buildAiSessionStreamRecoveryDiagnostic({
                   nowMs: Date.now(),
                   pendingPreservedPayloadCount,
                   coalescedPendingPayloadCount:
-                      state.coalescedPendingPayloadCount,
-                  peakInFlightPayloadCount: state.peakInFlightPayloadCount,
+                      streamMetrics.coalescedPendingPayloadCount,
+                  peakInFlightPayloadCount:
+                      streamMetrics.peakInFlightPayloadCount,
                   reason,
                   resyncSnapshotCount: resyncSnapshots.length,
-                  state,
+                  state: ackState,
               }),
           )
         : reason;
@@ -1966,57 +1800,8 @@ function postAiSessionStreamPayload(
         return false;
     }
 
-    if (
-        isAiSessionStreamAckStale(
-            state,
-            Date.now(),
-            AI_SESSION_STREAM_ACK_STALE_MS,
-        )
-    ) {
-        recoverAiSessionStreamPort(windowId, "pre-send-stale");
-        return false;
-    }
-
-    if (
-        state.pendingInFlightPayloadSeqs.size >=
-        AI_SESSION_STREAM_MAX_IN_FLIGHT
-    ) {
-        // Keep producer pressure behind a bounded, key-coalesced queue.
-        const result = rememberAiSessionStreamPayloadForDelivery({
-            maxPayloads: AI_SESSION_STREAM_MAX_PENDING_PAYLOADS,
-            order: state.nextPendingOrder,
-            payload,
-            queue: state.pendingDeliveryPayloads,
-        });
-        state.nextPendingOrder += 1;
-        if (result.coalesced) {
-            state.coalescedPendingPayloadCount += 1;
-        }
-        if (result.preserved && !result.droppedOldest) {
-            scheduleAiSessionStreamStaleCheck(windowId);
-            return true;
-        }
-        debugBenignError(
-            "aiSessionStreamPort.pendingPayloads",
-            new Error(
-                JSON.stringify({
-                    droppedCritical: result.droppedCritical,
-                    limit: AI_SESSION_STREAM_MAX_PENDING_PAYLOADS,
-                    pendingCount: result.pendingCount,
-                    windowId,
-                }),
-            ),
-        );
-        recoverAiSessionStreamPort(windowId, "post-error");
-        // An inserted payload is part of recovery; only a rejected payload
-        // still needs the caller's direct IPC fallback.
-        return result.preserved;
-    }
-
-    if (sendAiSessionStreamPayload(windowId, state, payload)) {
-        return true;
-    }
-    return false;
+    state.controller.postPayload(payload);
+    return true;
 }
 
 function dispatchAiSessionSnapshot(

--- a/src/preload/ai-session-stream.test.ts
+++ b/src/preload/ai-session-stream.test.ts
@@ -43,14 +43,14 @@ function createHandlers() {
 }
 
 describe("AI session stream preload delivery", () => {
-    it("acknowledges valid payloads before notifying listeners", () => {
+    it("acknowledges valid payloads after notifying listeners", () => {
         const handlers = createHandlers();
 
         deliverAiSessionStreamMessage(createMessage(), handlers);
 
         expect(handlers.acknowledge).toHaveBeenCalledWith(7);
         expect(handlers.notifyPayload).toHaveBeenCalledTimes(1);
-        expect(handlers.acknowledge.mock.invocationCallOrder[0]).toBeLessThan(
+        expect(handlers.acknowledge.mock.invocationCallOrder[0]).toBeGreaterThan(
             handlers.notifyPayload.mock.invocationCallOrder[0],
         );
     });
@@ -71,7 +71,7 @@ describe("AI session stream preload delivery", () => {
         expect(handlers.notifyPayload).not.toHaveBeenCalled();
     });
 
-    it("acknowledges a valid payload even when listener dispatch fails", () => {
+    it("does not acknowledge a payload when listener dispatch fails", () => {
         const error = new Error("listener failed");
         const handlers = createHandlers();
         handlers.notifyPayload.mockImplementation(() => {
@@ -80,7 +80,7 @@ describe("AI session stream preload delivery", () => {
 
         deliverAiSessionStreamMessage(createMessage(), handlers);
 
-        expect(handlers.acknowledge).toHaveBeenCalledWith(7);
+        expect(handlers.acknowledge).not.toHaveBeenCalled();
         expect(handlers.reportDispatchError).toHaveBeenCalledWith(
             "[comando] AI session stream listener dispatch failed.",
             error,
@@ -99,7 +99,7 @@ describe("AI session stream preload delivery", () => {
         );
     });
 
-    it("logs ACK failures and still notifies valid payload listeners", () => {
+    it("logs ACK failures after notifying valid payload listeners", () => {
         const error = new Error("port closed");
         const handlers = createHandlers();
         handlers.acknowledge.mockImplementation(() => {

--- a/src/preload/ai-session-stream.ts
+++ b/src/preload/ai-session-stream.ts
@@ -38,17 +38,15 @@ export function deliverAiSessionStreamMessage(
         return;
     }
 
-    // ACK confirms delivery to preload, not completed renderer rendering.
-    try {
-        handlers.acknowledge(message.seq);
-    } catch (error) {
-        handlers.reportWarning(
-            "[comando] Failed to acknowledge AI session stream.",
-            error,
-        );
-    }
-
     if (message.type !== "payload") {
+        try {
+            handlers.acknowledge(message.seq);
+        } catch (error) {
+            handlers.reportWarning(
+                "[comando] Failed to acknowledge AI session stream.",
+                error,
+            );
+        }
         return;
     }
 
@@ -57,6 +55,17 @@ export function deliverAiSessionStreamMessage(
     } catch (error) {
         handlers.reportDispatchError(
             "[comando] AI session stream listener dispatch failed.",
+            error,
+        );
+        return;
+    }
+
+    // ACK confirms synchronous listener ingestion, not a completed React paint.
+    try {
+        handlers.acknowledge(message.seq);
+    } catch (error) {
+        handlers.reportWarning(
+            "[comando] Failed to acknowledge AI session stream.",
             error,
         );
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -404,53 +404,73 @@ function isAiSessionDomainEvent(value: unknown): value is AiSessionDomainEvent {
     );
 }
 
-function notifyAiSessionSnapshotListeners(update: unknown): void {
+function notifyAiSessionSnapshotListeners(
+    update: unknown,
+    propagateListenerError = false,
+): void {
     if (!isAiSessionUpdate(update)) {
         console.warn(
             "[comando] Dropped AiSessionUpdate with unexpected shape.",
         );
         return;
     }
+    let firstError: unknown;
+    let listenerFailed = false;
     for (const listener of aiSessionSnapshotListeners) {
         try {
             listener(update);
         } catch (error) {
-            console.error("[comando] AiSessionUpdate listener failed.", error);
+            if (!listenerFailed) firstError = error;
+            listenerFailed = true;
+            if (!propagateListenerError) {
+                console.error("[comando] AiSessionUpdate listener failed.", error);
+            }
         }
     }
+    if (propagateListenerError && listenerFailed) throw firstError;
 }
 
-function notifyAiSessionEventListeners(event: unknown): void {
+function notifyAiSessionEventListeners(
+    event: unknown,
+    propagateListenerError = false,
+): void {
     if (!isAiSessionDomainEvent(event)) {
         console.warn(
             "[comando] Dropped AiSessionDomainEvent with unexpected shape.",
         );
         return;
     }
+    let firstError: unknown;
+    let listenerFailed = false;
     for (const listener of aiSessionEventListeners) {
         try {
             listener(event);
         } catch (error) {
-            console.error(
-                "[comando] AiSessionDomainEvent listener failed.",
-                error,
-            );
+            if (!listenerFailed) firstError = error;
+            listenerFailed = true;
+            if (!propagateListenerError) {
+                console.error(
+                    "[comando] AiSessionDomainEvent listener failed.",
+                    error,
+                );
+            }
         }
     }
+    if (propagateListenerError && listenerFailed) throw firstError;
 }
 
 function notifyAiSessionStreamPayload(payload: unknown): void {
     if (isAiSessionUpdate(payload)) {
-        notifyAiSessionSnapshotListeners(payload);
+        notifyAiSessionSnapshotListeners(payload, true);
         return;
     }
 
     if (isAiSessionDomainEvent(payload)) {
-        notifyAiSessionEventListeners(payload);
+        notifyAiSessionEventListeners(payload, true);
         return;
     }
 
-    console.warn("[comando] Dropped AI session stream payload.");
+    throw new Error("Dropped AI session stream payload with an invalid shape.");
 }
 
 function acknowledgeAiSessionStreamPort(seq: number): void {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -111,6 +111,7 @@ import {
     updateWorkspaceActiveFilePaths,
     type WorkspaceActiveFilePaths,
 } from "./app/workspace/surface-active-file";
+import { workspaceSurfaceAgentPresenceSignature } from "./app/workspace/surface-agent-presence";
 import { findPaneById } from "./app/workspace/tree";
 import {
     compactGitTreeEntriesByAncestor,
@@ -954,7 +955,12 @@ export function WorkspaceHostApp() {
         }
         return api.onWorkspaceSurfaceAgentPresenceChanged((presence) => {
             setAgentPresenceByContext((current) => {
-                if (current[presence.contextKey] === presence) {
+                const existing = current[presence.contextKey];
+                if (
+                    existing &&
+                    workspaceSurfaceAgentPresenceSignature(existing) ===
+                        workspaceSurfaceAgentPresenceSignature(presence)
+                ) {
                     return current;
                 }
                 return {

--- a/src/renderer/src/WorkspaceSurfaceApp.tsx
+++ b/src/renderer/src/WorkspaceSurfaceApp.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import type {
-    WorkspaceSurfaceAgentPresenceState,
     WorkspaceSurfaceActionEnvelope,
     WorkspaceSurfaceHardLease,
     WorkspaceSurfaceLifecycleState,
@@ -31,7 +30,11 @@ import {
     resolveCommittedProjectWorktreeId,
 } from "./app/git/context-key";
 import { executeWorkspaceSurfaceAction } from "./app/workspace/surface-actions";
-import { collectWorkspaceSurfaceAiAgentPresence } from "./app/workspace/surface-agent-presence";
+import {
+    createWorkspaceSurfaceAgentPresencePublisher,
+    type WorkspaceSurfaceAgentPresencePublisher,
+} from "./app/workspace/workspaceSurfaceAgentPresencePublisher";
+import { incrementChatPerformanceCounter } from "./app/debug/chatPerformanceCounters";
 import { resolveWorkspaceSurfaceActiveFileState } from "./app/workspace/surface-active-file";
 import { isWorkspaceSurfaceLifecycleCurrent } from "./app/workspace/surface-presentation-lifecycle";
 import {
@@ -162,7 +165,6 @@ export function WorkspaceSurfaceApp() {
     const applyAiPromptQueueSnapshot = useAiStore(
         (state) => state.applyPromptQueueSnapshot,
     );
-    const aiSessions = useAiStore((state) => state.sessions);
     const hydrateProjects = useProjectsStore((state) => state.hydrate);
     const projects = useProjectsStore((state) => state.projects);
     const addProjects = useProjectsStore((state) => state.addProjects);
@@ -178,7 +180,6 @@ export function WorkspaceSurfaceApp() {
     );
     const openFileTab = useWorkspaceStore((state) => state.openFileTab);
     const activePaneId = useWorkspaceStore((state) => state.activePaneId);
-    const rootNode = useWorkspaceStore((state) => state.rootNode);
     const tabsById = useWorkspaceStore((state) => state.tabsById);
     const [terminalAgentSessions, setTerminalAgentSessions] = useState(() =>
         getClaudeCodeSidebarSessions(),
@@ -220,68 +221,8 @@ export function WorkspaceSurfaceApp() {
               activeContext?.worktreeId ?? descriptor?.worktreeId ?? null,
           )
         : null;
-    const agentPresence = useMemo<WorkspaceSurfaceAgentPresenceState | null>(
-        () => {
-            if (!activeContext || !activeProjectId) {
-                return null;
-            }
-
-            const terminalSessionsByTerminalId = new Map(
-                terminalAgentSessions.map((session) => [
-                    session.terminalId,
-                    session,
-                ]),
-            );
-            const activePane = findPaneById(rootNode, activePaneId);
-            const activeTab = activePane?.activeTabId
-                ? tabsById[activePane.activeTabId]
-                : null;
-            const aiSessionPresence = collectWorkspaceSurfaceAiAgentPresence({
-                aiSessions,
-                projectId: activeProjectId,
-                tabsById,
-                worktreeId: activeWorktreeId,
-            });
-            const terminalSessions = terminalAgentSessions.map((session) => ({
-                createdAt: session.createdAt,
-                kind: "terminal" as const,
-                preview: session.preview,
-                runtimeId: session.runtimeId,
-                runtimeSessionId: session.runtimeSessionId ?? null,
-                sessionId: session.sessionId,
-                status: null,
-                terminalId: session.terminalId,
-                title: session.title,
-                updatedAt: session.updatedAt,
-            }));
-
-            return {
-                activeSessionId:
-                    activeTab?.kind === "chat" || activeTab?.kind === "review"
-                        ? activeTab.sessionId
-                        : activeTab?.kind === "terminal"
-                          ? (terminalSessionsByTerminalId.get(
-                                activeTab.terminalId,
-                            )?.sessionId ?? null)
-                        : null,
-                contextKey: activeContext.key,
-                projectId: activeProjectId,
-                sessions: [...aiSessionPresence, ...terminalSessions],
-                worktreeId: activeWorktreeId,
-            };
-        },
-        [
-            activeContext,
-            activePaneId,
-            activeProjectId,
-            activeWorktreeId,
-            aiSessions,
-            rootNode,
-            tabsById,
-            terminalAgentSessions,
-        ],
-    );
-    const publishedAgentPresenceSignatureRef = useRef("");
+    const agentPresencePublisherRef =
+        useRef<WorkspaceSurfaceAgentPresencePublisher | null>(null);
     const runtimeBinding = useMemo<WorkspaceSurfaceRuntimeBinding | null>(
         () =>
             descriptor
@@ -621,23 +562,73 @@ export function WorkspaceSurfaceApp() {
     }, [surfaceLifecycle, terminalAgentSessions]);
 
     useEffect(() => {
-        if (surfaceStatus !== "ready" || !agentPresence) {
+        const publisher = createWorkspaceSurfaceAgentPresencePublisher({
+            getAiSessions: () => useAiStore.getState().sessions,
+            getWorkspaceProjection: () => {
+                const state = useWorkspaceStore.getState();
+                const activePane = findPaneById(
+                    state.rootNode,
+                    state.activePaneId,
+                );
+                return {
+                    activeTab: activePane?.activeTabId
+                        ? (state.tabsById[activePane.activeTabId] ?? null)
+                        : null,
+                    tabsById: state.tabsById,
+                };
+            },
+            publish: (presence) => {
+                incrementChatPerformanceCounter(
+                    "workspace_presence_publishes",
+                );
+                return window.comando.publishWorkspaceSurfaceAgentPresence(
+                    presence,
+                );
+            },
+            subscribeAiSessions: (listener) => useAiStore.subscribe(listener),
+            subscribeWorkspace: (listener) =>
+                useWorkspaceStore.subscribe(listener),
+        });
+        agentPresencePublisherRef.current = publisher;
+        return () => {
+            agentPresencePublisherRef.current = null;
+            publisher.dispose();
+        };
+    }, []);
+
+    useEffect(() => {
+        const publisher = agentPresencePublisherRef.current;
+        if (!publisher) return;
+        if (surfaceStatus !== "ready" || !activeContext || !activeProjectId) {
+            publisher.updateContext(null);
             return;
         }
-        const signature = JSON.stringify(agentPresence);
-        if (publishedAgentPresenceSignatureRef.current === signature) {
-            return;
-        }
-        // Keep the host informed without duplicating message or transcript payloads.
-        void window.comando
-            .publishWorkspaceSurfaceAgentPresence(agentPresence)
-            .then((result) => {
-                if (result.delivered) {
-                    publishedAgentPresenceSignatureRef.current = signature;
-                }
-            })
-            .catch(() => undefined);
-    }, [agentPresence, surfaceLifecycle, surfaceStatus]);
+        publisher.updateContext({
+            contextKey: activeContext.key,
+            lifecycle: surfaceLifecycle,
+            projectId: activeProjectId,
+            terminalSessions: terminalAgentSessions.map((session) => ({
+                createdAt: session.createdAt,
+                kind: "terminal",
+                preview: session.preview,
+                runtimeId: session.runtimeId,
+                runtimeSessionId: session.runtimeSessionId ?? null,
+                sessionId: session.sessionId,
+                status: null,
+                terminalId: session.terminalId,
+                title: session.title,
+                updatedAt: session.updatedAt,
+            })),
+            worktreeId: activeWorktreeId,
+        });
+    }, [
+        activeContext,
+        activeProjectId,
+        activeWorktreeId,
+        surfaceLifecycle,
+        surfaceStatus,
+        terminalAgentSessions,
+    ]);
 
     useEffect(() => {
         if (surfaceLifecycle !== "visible") {

--- a/src/renderer/src/app/ai/aiSessionEventFrameBuffer.test.ts
+++ b/src/renderer/src/app/ai/aiSessionEventFrameBuffer.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+    AiSessionDomainEvent,
+    AiSessionToolActivityEvent,
+    AiToolActivity,
+} from "@shared/ipc";
+import { createTerminalStreamPressureFixture } from "@shared/testing/chatLoadFactories";
+
+import {
+    AiSessionEventFrameBuffer,
+    isFrameBufferableAiSessionEvent,
+} from "./aiSessionEventFrameBuffer";
+
+describe("AiSessionEventFrameBuffer", () => {
+    it("reduces thousands of live tool updates to one frame application", () => {
+        const scheduled: Array<() => void> = [];
+        const applied: AiSessionDomainEvent[] = [];
+        const fixture = createTerminalStreamPressureFixture({
+            chunkBytes: 4,
+            chunkCount: 10_000,
+            durationMs: 100,
+            runtimeId: "codex",
+        });
+        const buffer = new AiSessionEventFrameBuffer({
+            apply: (event) => applied.push(event),
+            schedule: (flush) => {
+                scheduled.push(flush);
+                return () => undefined;
+            },
+        });
+
+        for (const event of fixture.events.slice(0, -1)) buffer.buffer(event);
+        expect(scheduled).toHaveLength(1);
+        scheduled[0]?.();
+
+        expect(applied).toHaveLength(1);
+        expect(applied[0]).toMatchObject({
+            activity: {
+                terminalOutput:
+                    fixture.events.at(-2)?.activity.terminalOutput ?? null,
+            },
+            kind: "tool-activity",
+        });
+    });
+
+    it("keeps first slot order and rich activity fields", () => {
+        const applied: AiSessionDomainEvent[] = [];
+        const buffer = new AiSessionEventFrameBuffer({
+            apply: (event) => applied.push(event),
+            schedule: () => () => undefined,
+        });
+        const first = toolEvent("tool-a", {
+            diffs: [
+                {
+                    hunks: [],
+                    isText: true,
+                    kind: "update",
+                    newText: "after",
+                    oldText: "before",
+                    path: "src/a.ts",
+                    previousPath: null,
+                    reversible: true,
+                },
+            ],
+            rawInputJson: "rich-input",
+            terminalOutput: "first",
+        });
+        buffer.buffer(first);
+        buffer.buffer(toolEvent("tool-b"));
+        buffer.buffer(
+            toolEvent("tool-a", {
+                summary: "Latest",
+                terminalOutput: null,
+                updatedAt: "2026-01-01T00:00:02.000Z",
+            }),
+        );
+        buffer.flushSession("session-1");
+
+        expect(
+            applied.map((event) =>
+                event.kind === "tool-activity" ? event.activity.id : event.kind,
+            ),
+        ).toEqual(["tool-a", "tool-b"]);
+        expect(applied[0]).toMatchObject({
+            activity: {
+                diffs: first.activity.diffs,
+                rawInputJson: "rich-input",
+                summary: "Latest",
+                terminalOutput: "first",
+            },
+        });
+    });
+
+    it("does not buffer terminal tool states", () => {
+        expect(isFrameBufferableAiSessionEvent(toolEvent("tool-a"))).toBe(true);
+        expect(
+            isFrameBufferableAiSessionEvent(
+                toolEvent("tool-a", { status: "completed" }),
+            ),
+        ).toBe(false);
+        expect(
+            isFrameBufferableAiSessionEvent(
+                toolEvent("tool-a", { status: "failed" }),
+            ),
+        ).toBe(false);
+    });
+
+    it("cancels scheduled work and drops retained sessions on reset", () => {
+        const cancel = vi.fn();
+        const applied: AiSessionDomainEvent[] = [];
+        const buffer = new AiSessionEventFrameBuffer({
+            apply: (event) => applied.push(event),
+            schedule: () => cancel,
+        });
+        buffer.buffer(toolEvent("tool-a"));
+
+        buffer.reset();
+        buffer.flushSession("session-1");
+
+        expect(cancel).toHaveBeenCalledOnce();
+        expect(applied).toHaveLength(0);
+    });
+});
+
+function toolEvent(
+    id: string,
+    overrides: Partial<AiToolActivity> = {},
+): AiSessionToolActivityEvent {
+    const updatedAt = overrides.updatedAt ?? "2026-01-01T00:00:01.000Z";
+    return {
+        activity: {
+            createdAt: "2026-01-01T00:00:00.000Z",
+            diffs: [],
+            exitCode: null,
+            id,
+            kind: "shell",
+            locations: [],
+            rawInputJson: null,
+            rawOutputJson: null,
+            sessionId: "session-1",
+            status: "in_progress",
+            summary: null,
+            terminalOutput: null,
+            title: "Run command",
+            updatedAt,
+            ...overrides,
+        },
+        kind: "tool-activity",
+        origin: "live",
+        parentSessionId: null,
+        runtimeId: "codex",
+        runtimeSessionId: "runtime-session-1",
+        sessionId: "session-1",
+        updatedAt,
+    };
+}

--- a/src/renderer/src/app/ai/aiSessionEventFrameBuffer.ts
+++ b/src/renderer/src/app/ai/aiSessionEventFrameBuffer.ts
@@ -1,0 +1,216 @@
+import { mergeAiTranscriptToolActivity } from "@shared/ai-transcript";
+import type { AiSessionDomainEvent, AiToolActivity } from "@shared/ipc";
+
+export type FrameBufferedAiSessionEvent = Extract<
+    AiSessionDomainEvent,
+    {
+        kind: "message-delta" | "thinking-delta" | "tool-activity";
+    }
+>;
+
+interface SessionEventFrame {
+    cancelScheduledFlush: (() => void) | null;
+    readonly events: Map<string, FrameBufferedAiSessionEvent>;
+    firstQueuedAt: number;
+}
+
+interface AiSessionEventFrameBufferOptions {
+    readonly apply: (event: FrameBufferedAiSessionEvent) => void;
+    readonly now?: () => number | null;
+    readonly onCoalesced?: (event: FrameBufferedAiSessionEvent) => void;
+    readonly onFlush?: (input: {
+        readonly eventCount: number;
+        readonly firstQueuedAt: number;
+        readonly sessionId: string;
+    }) => void;
+    readonly schedule?: (flush: () => void) => () => void;
+}
+
+const MAX_EVENTS_PER_SESSION_FRAME = 512;
+const MAX_EVENTS_ACROSS_SESSION_FRAMES = 2_048;
+
+export class AiSessionEventFrameBuffer {
+    private readonly framesBySessionId = new Map<string, SessionEventFrame>();
+    private flushing = false;
+
+    constructor(private readonly options: AiSessionEventFrameBufferOptions) {}
+
+    get isFlushing(): boolean {
+        return this.flushing;
+    }
+
+    pendingCount(sessionId: string): number {
+        return this.framesBySessionId.get(sessionId)?.events.size ?? 0;
+    }
+
+    buffer(event: FrameBufferedAiSessionEvent): void {
+        let frame = this.framesBySessionId.get(event.sessionId);
+        if (!frame) {
+            frame = {
+                cancelScheduledFlush: null,
+                events: new Map(),
+                firstQueuedAt: this.options.now?.() ?? performance.now(),
+            };
+            this.framesBySessionId.set(event.sessionId, frame);
+        }
+
+        const key = frameEventKey(event);
+        const existing = frame.events.get(key);
+        if (existing) {
+            frame.events.set(key, mergeFrameEvent(existing, event));
+            this.options.onCoalesced?.(event);
+        } else {
+            frame.events.set(key, event);
+        }
+
+        if (
+            frame.events.size >= MAX_EVENTS_PER_SESSION_FRAME ||
+            this.pendingEventCount() >= MAX_EVENTS_ACROSS_SESSION_FRAMES
+        ) {
+            // Flushing preserves order and bounds memory without dropping a critical event.
+            this.flushSession(event.sessionId);
+            return;
+        }
+        this.scheduleFlush(event.sessionId, frame);
+    }
+
+    flushSession(sessionId: string): void {
+        const frame = this.framesBySessionId.get(sessionId);
+        if (!frame || frame.events.size === 0) return;
+
+        frame.cancelScheduledFlush?.();
+        frame.cancelScheduledFlush = null;
+        const events = [...frame.events.values()];
+        this.framesBySessionId.delete(sessionId);
+        this.options.onFlush?.({
+            eventCount: events.length,
+            firstQueuedAt: frame.firstQueuedAt,
+            sessionId,
+        });
+        this.flushing = true;
+        try {
+            for (const event of events) this.options.apply(event);
+        } finally {
+            this.flushing = false;
+        }
+    }
+
+    reset(): void {
+        for (const frame of this.framesBySessionId.values()) {
+            frame.cancelScheduledFlush?.();
+        }
+        this.framesBySessionId.clear();
+        this.flushing = false;
+    }
+
+    private pendingEventCount(): number {
+        let total = 0;
+        for (const frame of this.framesBySessionId.values()) {
+            total += frame.events.size;
+        }
+        return total;
+    }
+
+    private scheduleFlush(sessionId: string, frame: SessionEventFrame): void {
+        if (frame.cancelScheduledFlush) return;
+        const flush = () => {
+            if (this.framesBySessionId.get(sessionId) === frame) {
+                frame.cancelScheduledFlush = null;
+            }
+            this.flushSession(sessionId);
+        };
+        frame.cancelScheduledFlush = (this.options.schedule ?? scheduleNextFrame)(
+            flush,
+        );
+    }
+}
+
+export function isFrameBufferableAiSessionEvent(
+    event: AiSessionDomainEvent,
+): event is FrameBufferedAiSessionEvent {
+    return (
+        event.kind === "message-delta" ||
+        event.kind === "thinking-delta" ||
+        (event.kind === "tool-activity" &&
+            (event.activity.status === "pending" ||
+                event.activity.status === "in_progress"))
+    );
+}
+
+function frameEventKey(event: FrameBufferedAiSessionEvent): string {
+    if (event.kind === "message-delta") {
+        return `${event.kind}\u{1f}${event.messageKind}\u{1f}${event.messageId}`;
+    }
+    if (event.kind === "thinking-delta") {
+        return `${event.kind}\u{1f}${event.messageId}`;
+    }
+    return `${event.kind}\u{1f}${event.activity.id}`;
+}
+
+function mergeFrameEvent(
+    existing: FrameBufferedAiSessionEvent,
+    incoming: FrameBufferedAiSessionEvent,
+): FrameBufferedAiSessionEvent {
+    if (existing.kind === "tool-activity" && incoming.kind === "tool-activity") {
+        return {
+            ...incoming,
+            activity: mergeBufferedToolActivity(
+                existing.activity,
+                incoming.activity,
+            ),
+        };
+    }
+    if (existing.kind === "message-delta" && incoming.kind === "message-delta") {
+        return {
+            ...incoming,
+            content:
+                incoming.content.length >= existing.content.length
+                    ? incoming.content
+                    : `${existing.content}${incoming.delta}`,
+            delta: `${existing.delta}${incoming.delta}`,
+        };
+    }
+    if (existing.kind === "thinking-delta" && incoming.kind === "thinking-delta") {
+        return {
+            ...incoming,
+            content:
+                incoming.content.length >= existing.content.length
+                    ? incoming.content
+                    : `${existing.content}${incoming.delta}`,
+            delta: `${existing.delta}${incoming.delta}`,
+        };
+    }
+    return incoming;
+}
+
+function mergeBufferedToolActivity(
+    existing: AiToolActivity,
+    incoming: AiToolActivity,
+): AiToolActivity {
+    const merged = mergeAiTranscriptToolActivity(existing, incoming);
+    return {
+        ...merged,
+        action: incoming.action ?? existing.action,
+        changeStats: incoming.changeStats ?? existing.changeStats,
+        diffs: incoming.diffs.length > 0 ? incoming.diffs : existing.diffs,
+        locations:
+            incoming.locations.length > 0
+                ? incoming.locations
+                : existing.locations,
+        rawInputJson: incoming.rawInputJson ?? existing.rawInputJson,
+        rawOutputJson: incoming.rawOutputJson ?? existing.rawOutputJson,
+        summary: incoming.summary ?? existing.summary,
+        terminalOutput: incoming.terminalOutput ?? existing.terminalOutput,
+        toolActivityDetailId:
+            incoming.toolActivityDetailId ?? existing.toolActivityDetailId,
+    };
+}
+
+function scheduleNextFrame(flush: () => void): () => void {
+    if (typeof globalThis.requestAnimationFrame === "function") {
+        const frameId = globalThis.requestAnimationFrame(flush);
+        return () => globalThis.cancelAnimationFrame(frameId);
+    }
+    const timer = setTimeout(flush, 16);
+    return () => clearTimeout(timer);
+}

--- a/src/renderer/src/app/debug/chatPerformanceCounters.test.ts
+++ b/src/renderer/src/app/debug/chatPerformanceCounters.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
     incrementChatPerformanceCounter,
     readChatPerformanceCounters,
+    recordChatPerformanceCounterPeak,
     resetChatPerformanceCounters,
     setChatPerformanceCountersEnabledForTests,
 } from "./chatPerformanceCounters";
@@ -25,6 +26,13 @@ describe("chatPerformanceCounters", () => {
         });
     });
 
+    it("records peak counters without retaining payload data", () => {
+        recordChatPerformanceCounterPeak("ai_stream_peak_in_flight", 7);
+        recordChatPerformanceCounterPeak("ai_stream_peak_in_flight", 3);
+
+        expect(readChatPerformanceCounters().ai_stream_peak_in_flight).toBe(7);
+    });
+
     it("can disable counters without allocating diagnostic payloads", () => {
         setChatPerformanceCountersEnabledForTests(false);
         incrementChatPerformanceCounter("transcript_entries_visited", 1_024);
@@ -43,6 +51,8 @@ describe("chatPerformanceCounters", () => {
         resetChatPerformanceCounters();
 
         expect(readChatPerformanceCounters()).toEqual({
+            ai_stream_payloads_coalesced: 0,
+            ai_stream_peak_in_flight: 0,
             activity_segments_rebuilt: 0,
             activity_items_mounted: 0,
             code_highlight_chars_reparsed: 0,
@@ -57,6 +67,8 @@ describe("chatPerformanceCounters", () => {
             timeline_full_rebuilds: 0,
             timeline_rows_reconciled: 0,
             timeline_tail_patches: 0,
+            tool_activity_events_received: 0,
+            tool_activity_store_applies: 0,
             transcript_blocks_evicted: 0,
             transcript_blocks_loaded: 0,
             transcript_blocks_projected: 0,

--- a/src/renderer/src/app/debug/chatPerformanceCounters.test.ts
+++ b/src/renderer/src/app/debug/chatPerformanceCounters.test.ts
@@ -77,6 +77,7 @@ describe("chatPerformanceCounters", () => {
             transcript_payload_ipc_count: 0,
             tool_payload_bytes_loaded: 0,
             tool_payloads_requested: 0,
+            workspace_presence_publishes: 0,
         });
     });
 });

--- a/src/renderer/src/app/debug/chatPerformanceCounters.test.ts
+++ b/src/renderer/src/app/debug/chatPerformanceCounters.test.ts
@@ -27,10 +27,12 @@ describe("chatPerformanceCounters", () => {
     });
 
     it("records peak counters without retaining payload data", () => {
-        recordChatPerformanceCounterPeak("ai_stream_peak_in_flight", 7);
-        recordChatPerformanceCounterPeak("ai_stream_peak_in_flight", 3);
+        recordChatPerformanceCounterPeak("ai_frame_peak_pending_per_session", 7);
+        recordChatPerformanceCounterPeak("ai_frame_peak_pending_per_session", 3);
 
-        expect(readChatPerformanceCounters().ai_stream_peak_in_flight).toBe(7);
+        expect(
+            readChatPerformanceCounters().ai_frame_peak_pending_per_session,
+        ).toBe(7);
     });
 
     it("can disable counters without allocating diagnostic payloads", () => {
@@ -51,8 +53,8 @@ describe("chatPerformanceCounters", () => {
         resetChatPerformanceCounters();
 
         expect(readChatPerformanceCounters()).toEqual({
-            ai_stream_payloads_coalesced: 0,
-            ai_stream_peak_in_flight: 0,
+            ai_frame_payloads_coalesced: 0,
+            ai_frame_peak_pending_per_session: 0,
             activity_segments_rebuilt: 0,
             activity_items_mounted: 0,
             code_highlight_chars_reparsed: 0,

--- a/src/renderer/src/app/debug/chatPerformanceCounters.ts
+++ b/src/renderer/src/app/debug/chatPerformanceCounters.ts
@@ -26,7 +26,8 @@ export type ChatPerformanceCounter =
     | "transcript_payload_bytes"
     | "transcript_payload_ipc_count"
     | "tool_payload_bytes_loaded"
-    | "tool_payloads_requested";
+    | "tool_payloads_requested"
+    | "workspace_presence_publishes";
 
 export type ChatPerformanceCounterSnapshot = Readonly<
     Record<ChatPerformanceCounter, number>
@@ -59,6 +60,7 @@ const EMPTY_COUNTERS: ChatPerformanceCounterSnapshot = {
     transcript_payload_ipc_count: 0,
     tool_payload_bytes_loaded: 0,
     tool_payloads_requested: 0,
+    workspace_presence_publishes: 0,
 };
 
 let counters: Record<ChatPerformanceCounter, number> = { ...EMPTY_COUNTERS };

--- a/src/renderer/src/app/debug/chatPerformanceCounters.ts
+++ b/src/renderer/src/app/debug/chatPerformanceCounters.ts
@@ -1,8 +1,8 @@
 import { isChatPerformanceProbeEnabled } from "./chatPerformanceProbe";
 
 export type ChatPerformanceCounter =
-    | "ai_stream_payloads_coalesced"
-    | "ai_stream_peak_in_flight"
+    | "ai_frame_payloads_coalesced"
+    | "ai_frame_peak_pending_per_session"
     | "activity_segments_rebuilt"
     | "activity_items_mounted"
     | "code_highlight_chars_reparsed"
@@ -34,8 +34,8 @@ export type ChatPerformanceCounterSnapshot = Readonly<
 >;
 
 const EMPTY_COUNTERS: ChatPerformanceCounterSnapshot = {
-    ai_stream_payloads_coalesced: 0,
-    ai_stream_peak_in_flight: 0,
+    ai_frame_payloads_coalesced: 0,
+    ai_frame_peak_pending_per_session: 0,
     activity_segments_rebuilt: 0,
     activity_items_mounted: 0,
     code_highlight_chars_reparsed: 0,

--- a/src/renderer/src/app/debug/chatPerformanceCounters.ts
+++ b/src/renderer/src/app/debug/chatPerformanceCounters.ts
@@ -1,6 +1,8 @@
 import { isChatPerformanceProbeEnabled } from "./chatPerformanceProbe";
 
 export type ChatPerformanceCounter =
+    | "ai_stream_payloads_coalesced"
+    | "ai_stream_peak_in_flight"
     | "activity_segments_rebuilt"
     | "activity_items_mounted"
     | "code_highlight_chars_reparsed"
@@ -15,6 +17,8 @@ export type ChatPerformanceCounter =
     | "timeline_full_rebuilds"
     | "timeline_rows_reconciled"
     | "timeline_tail_patches"
+    | "tool_activity_events_received"
+    | "tool_activity_store_applies"
     | "transcript_blocks_evicted"
     | "transcript_blocks_loaded"
     | "transcript_blocks_projected"
@@ -29,6 +33,8 @@ export type ChatPerformanceCounterSnapshot = Readonly<
 >;
 
 const EMPTY_COUNTERS: ChatPerformanceCounterSnapshot = {
+    ai_stream_payloads_coalesced: 0,
+    ai_stream_peak_in_flight: 0,
     activity_segments_rebuilt: 0,
     activity_items_mounted: 0,
     code_highlight_chars_reparsed: 0,
@@ -43,6 +49,8 @@ const EMPTY_COUNTERS: ChatPerformanceCounterSnapshot = {
     timeline_full_rebuilds: 0,
     timeline_rows_reconciled: 0,
     timeline_tail_patches: 0,
+    tool_activity_events_received: 0,
+    tool_activity_store_applies: 0,
     transcript_blocks_evicted: 0,
     transcript_blocks_loaded: 0,
     transcript_blocks_projected: 0,
@@ -62,6 +70,14 @@ export function incrementChatPerformanceCounter(
 ): void {
     if (!isChatPerformanceCounterEnabled()) return;
     counters[counter] += amount;
+}
+
+export function recordChatPerformanceCounterPeak(
+    counter: ChatPerformanceCounter,
+    value: number,
+): void {
+    if (!isChatPerformanceCounterEnabled()) return;
+    counters[counter] = Math.max(counters[counter], value);
 }
 
 export function readChatPerformanceCounters(): ChatPerformanceCounterSnapshot {

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -103,6 +103,10 @@ import { TranscriptPayloadCache } from "@renderer/app/ai/transcriptPayloadCache"
 import { resolveTranscriptPrefetchBlockId } from "@renderer/app/ai/transcriptWindowNavigation";
 import { matchesTrackedFilePath } from "@renderer/app/ai/trackedFilePath";
 import {
+    AiSessionEventFrameBuffer,
+    isFrameBufferableAiSessionEvent,
+} from "@renderer/app/ai/aiSessionEventFrameBuffer";
+import {
     getChatPerformanceTimestamp,
     measureChatPerformance,
     measureChatPerformanceAsync,
@@ -451,22 +455,22 @@ interface AiStore {
 type SetAiState = typeof useAiStore.setState;
 type GetAiState = () => AiStore;
 
-type BufferedSessionDeltaEvent = Extract<
-    AiSessionDomainEvent,
-    { kind: "message-delta" | "thinking-delta" }
->;
-
-interface BufferedSessionDeltaBuffer {
-    readonly events: Map<string, BufferedSessionDeltaEvent>;
-    cancelScheduledFlush: (() => void) | null;
-    firstQueuedAt: number | null;
-}
-
-const bufferedSessionDeltasBySessionId = new Map<
-    string,
-    BufferedSessionDeltaBuffer
->();
-let isFlushingBufferedSessionDeltas = false;
+const sessionEventFrameBuffer = new AiSessionEventFrameBuffer({
+    apply: (event) => useAiStore.getState().applySessionEvent(event),
+    now: getChatPerformanceTimestamp,
+    onCoalesced: (event) => {
+        if (event.kind === "tool-activity") {
+            incrementChatPerformanceCounter("ai_stream_payloads_coalesced");
+        }
+    },
+    onFlush: ({ eventCount, firstQueuedAt, sessionId }) => {
+        recordChatPerformanceMetric("delta_buffer_wait_ms", {
+            durationMs: performance.now() - firstQueuedAt,
+            sessionId,
+            values: { payloadDepth: eventCount },
+        });
+    },
+});
 const AI_SESSION_RESYNC_SILENCE_MS = 20_000;
 const AI_SESSION_RESYNC_RETRY_DELAYS_MS = [20_000, 30_000, 45_000, 60_000];
 
@@ -479,133 +483,6 @@ interface AiSessionResyncWatchdog {
 }
 
 const aiSessionResyncWatchdogs = new Map<string, AiSessionResyncWatchdog>();
-
-function isSessionDeltaEvent(
-    event: AiSessionDomainEvent,
-): event is BufferedSessionDeltaEvent {
-    return event.kind === "message-delta" || event.kind === "thinking-delta";
-}
-
-function sessionDeltaBufferKey(event: BufferedSessionDeltaEvent): string {
-    return event.kind === "message-delta"
-        ? `${event.sessionId}\u{1f}${event.kind}\u{1f}${event.messageKind}\u{1f}${event.messageId}`
-        : `${event.sessionId}\u{1f}${event.kind}\u{1f}${event.messageId}`;
-}
-
-function mergeBufferedSessionDelta(
-    existing: BufferedSessionDeltaEvent,
-    incoming: BufferedSessionDeltaEvent,
-): BufferedSessionDeltaEvent {
-    const nextContent =
-        incoming.content.length >= existing.content.length
-            ? incoming.content
-            : `${existing.content}${incoming.delta}`;
-    return {
-        ...incoming,
-        content: nextContent,
-        delta: `${existing.delta}${incoming.delta}`,
-    };
-}
-
-function getBufferedSessionDeltaBuffer(
-    sessionId: string,
-): BufferedSessionDeltaBuffer {
-    const existing = bufferedSessionDeltasBySessionId.get(sessionId);
-    if (existing) {
-        return existing;
-    }
-
-    const buffer: BufferedSessionDeltaBuffer = {
-        cancelScheduledFlush: null,
-        events: new Map(),
-        firstQueuedAt: null,
-    };
-    bufferedSessionDeltasBySessionId.set(sessionId, buffer);
-    return buffer;
-}
-
-function scheduleBufferedSessionDeltaFlush(
-    sessionId: string,
-    buffer: BufferedSessionDeltaBuffer,
-    get: GetAiState,
-): void {
-    if (buffer.cancelScheduledFlush !== null) {
-        return;
-    }
-
-    const flush = () => {
-        const currentBuffer = bufferedSessionDeltasBySessionId.get(sessionId);
-        if (currentBuffer === buffer) {
-            currentBuffer.cancelScheduledFlush = null;
-        }
-        flushBufferedSessionDeltas(get, sessionId);
-    };
-    if (typeof globalThis.requestAnimationFrame === "function") {
-        const frameId = globalThis.requestAnimationFrame(flush);
-        buffer.cancelScheduledFlush = () => {
-            globalThis.cancelAnimationFrame(frameId);
-        };
-        return;
-    }
-
-    const timer = setTimeout(flush, 16);
-    buffer.cancelScheduledFlush = () => {
-        clearTimeout(timer);
-    };
-}
-
-function bufferSessionDeltaEvent(
-    event: BufferedSessionDeltaEvent,
-    get: GetAiState,
-): void {
-    const buffer = getBufferedSessionDeltaBuffer(event.sessionId);
-    const key = sessionDeltaBufferKey(event);
-    const existing = buffer.events.get(key);
-    if (buffer.firstQueuedAt === null) {
-        buffer.firstQueuedAt = getChatPerformanceTimestamp();
-    }
-    buffer.events.set(
-        key,
-        existing ? mergeBufferedSessionDelta(existing, event) : event,
-    );
-    scheduleBufferedSessionDeltaFlush(event.sessionId, buffer, get);
-}
-
-function flushBufferedSessionDeltas(get: GetAiState, sessionId: string): void {
-    const buffer = bufferedSessionDeltasBySessionId.get(sessionId);
-    if (!buffer || buffer.events.size === 0) {
-        return;
-    }
-
-    buffer.cancelScheduledFlush?.();
-    buffer.cancelScheduledFlush = null;
-    const events = Array.from(buffer.events.values());
-    const queuedAt = buffer.firstQueuedAt;
-    bufferedSessionDeltasBySessionId.delete(sessionId);
-    if (queuedAt !== null) {
-        recordChatPerformanceMetric("delta_buffer_wait_ms", {
-            durationMs: performance.now() - queuedAt,
-            sessionId,
-            values: { payloadDepth: events.length },
-        });
-    }
-    isFlushingBufferedSessionDeltas = true;
-    try {
-        for (const event of events) {
-            get().applySessionEvent(event);
-        }
-    } finally {
-        isFlushingBufferedSessionDeltas = false;
-    }
-}
-
-function resetBufferedSessionDeltas(): void {
-    for (const buffer of bufferedSessionDeltasBySessionId.values()) {
-        buffer.cancelScheduledFlush?.();
-    }
-    bufferedSessionDeltasBySessionId.clear();
-    isFlushingBufferedSessionDeltas = false;
-}
 
 function isAiSessionResyncWatchdogActive(snapshot: AiSessionSnapshot): boolean {
     return (
@@ -780,7 +657,7 @@ async function requestAiSessionResyncAfterSilence(
 }
 
 export function resetAiStoreRuntimeBuffersForTests(): void {
-    resetBufferedSessionDeltas();
+    sessionEventFrameBuffer.reset();
     resetAiSessionResyncWatchdogs();
     optimisticSnapshotMutationStates.clear();
     reviewDeltaHydrations.clear();
@@ -1327,14 +1204,20 @@ export const useAiStore = create<AiStore>((set, get) => ({
             activePromptMessageAlias,
         );
         if (
-            !isFlushingBufferedSessionDeltas &&
-            isSessionDeltaEvent(normalizedEvent)
+            normalizedEvent.kind === "tool-activity" &&
+            !sessionEventFrameBuffer.isFlushing
         ) {
-            bufferSessionDeltaEvent(normalizedEvent, get);
+            incrementChatPerformanceCounter("tool_activity_events_received");
+        }
+        if (
+            !sessionEventFrameBuffer.isFlushing &&
+            isFrameBufferableAiSessionEvent(normalizedEvent)
+        ) {
+            sessionEventFrameBuffer.buffer(normalizedEvent);
             return;
         }
-        if (!isSessionDeltaEvent(normalizedEvent)) {
-            flushBufferedSessionDeltas(get, normalizedEvent.sessionId);
+        if (!isFrameBufferableAiSessionEvent(normalizedEvent)) {
+            sessionEventFrameBuffer.flushSession(normalizedEvent.sessionId);
         }
 
         let syncedTitle: string | null = null;
@@ -1344,13 +1227,16 @@ export const useAiStore = create<AiStore>((set, get) => ({
                 sessionId: normalizedEvent.sessionId,
                 values: {
                     payloadDepth:
-                        bufferedSessionDeltasBySessionId.get(
+                        sessionEventFrameBuffer.pendingCount(
                             normalizedEvent.sessionId,
-                        )?.events.size ?? 0,
+                        ),
                 },
             },
             () =>
                 set((state) => {
+            if (normalizedEvent.kind === "tool-activity") {
+                incrementChatPerformanceCounter("tool_activity_store_applies");
+            }
             const session =
                 state.sessions[normalizedEvent.sessionId] ?? createSessionState();
             const existingCatalog =
@@ -1429,7 +1315,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
             update.kind === "snapshot"
                 ? update.snapshot.sessionId
                 : update.patch.sessionId;
-        flushBufferedSessionDeltas(get, sessionId);
+        sessionEventFrameBuffer.flushSession(sessionId);
         if (update.kind === "snapshot") {
             get().applySessionSnapshot(update.snapshot);
             return;
@@ -1599,7 +1485,7 @@ export const useAiStore = create<AiStore>((set, get) => ({
     },
 
     applySessionSnapshot: (snapshot) => {
-        flushBufferedSessionDeltas(get, snapshot.sessionId);
+        sessionEventFrameBuffer.flushSession(snapshot.sessionId);
         let syncedTitle: string | null = null;
         let shouldRefreshSealedTranscript = false;
         set((state) => {

--- a/src/renderer/src/app/store/ai-store.ts
+++ b/src/renderer/src/app/store/ai-store.ts
@@ -112,7 +112,10 @@ import {
     measureChatPerformanceAsync,
     recordChatPerformanceMetric,
 } from "@renderer/app/debug/chatPerformanceProbe";
-import { incrementChatPerformanceCounter } from "@renderer/app/debug/chatPerformanceCounters";
+import {
+    incrementChatPerformanceCounter,
+    recordChatPerformanceCounterPeak,
+} from "@renderer/app/debug/chatPerformanceCounters";
 import type {
     RuntimeWorkspaceChatTab,
     RuntimeWorkspaceReviewTab,
@@ -460,7 +463,7 @@ const sessionEventFrameBuffer = new AiSessionEventFrameBuffer({
     now: getChatPerformanceTimestamp,
     onCoalesced: (event) => {
         if (event.kind === "tool-activity") {
-            incrementChatPerformanceCounter("ai_stream_payloads_coalesced");
+            incrementChatPerformanceCounter("ai_frame_payloads_coalesced");
         }
     },
     onFlush: ({ eventCount, firstQueuedAt, sessionId }) => {
@@ -1214,6 +1217,10 @@ export const useAiStore = create<AiStore>((set, get) => ({
             isFrameBufferableAiSessionEvent(normalizedEvent)
         ) {
             sessionEventFrameBuffer.buffer(normalizedEvent);
+            recordChatPerformanceCounterPeak(
+                "ai_frame_peak_pending_per_session",
+                sessionEventFrameBuffer.pendingCount(normalizedEvent.sessionId),
+            );
             return;
         }
         if (!isFrameBufferableAiSessionEvent(normalizedEvent)) {

--- a/src/renderer/src/app/workspace/surface-agent-presence.test.ts
+++ b/src/renderer/src/app/workspace/surface-agent-presence.test.ts
@@ -5,6 +5,8 @@ import type { RuntimeWorkspaceChatTab } from "@renderer/app/workspace/tree";
 
 import {
     collectWorkspaceSurfaceAiAgentPresence,
+    workspaceSurfaceAgentPresenceSemanticSignature,
+    workspaceSurfaceAgentPresenceSignature,
 } from "./surface-agent-presence";
 
 function createSnapshot(
@@ -113,5 +115,46 @@ describe("collectWorkspaceSurfaceAiAgentPresence", () => {
                 title: "Live idle session",
             }),
         ]);
+    });
+
+    it("distinguishes structural equality from temporal-only presence changes", () => {
+        const state = {
+            activeSessionId: "session-1",
+            contextKey: "project-1:worktree-1",
+            projectId: "project-1",
+            sessions: [
+                {
+                    createdAt: "2026-08-04T11:00:00.000Z",
+                    kind: "ai" as const,
+                    parentSessionId: null,
+                    runtimeId: "codex" as const,
+                    runtimeSessionId: "runtime-session-1",
+                    sessionId: "session-1",
+                    status: "streaming" as const,
+                    title: "Session",
+                    updatedAt: "2026-08-04T12:00:00.000Z",
+                },
+            ],
+            worktreeId: "worktree-1",
+        };
+        const temporalRevision = {
+            ...state,
+            sessions: [
+                {
+                    ...state.sessions[0],
+                    updatedAt: "2026-08-04T12:00:01.000Z",
+                },
+            ],
+        };
+
+        expect(workspaceSurfaceAgentPresenceSignature({ ...state })).toBe(
+            workspaceSurfaceAgentPresenceSignature(state),
+        );
+        expect(workspaceSurfaceAgentPresenceSignature(temporalRevision)).not.toBe(
+            workspaceSurfaceAgentPresenceSignature(state),
+        );
+        expect(
+            workspaceSurfaceAgentPresenceSemanticSignature(temporalRevision),
+        ).toBe(workspaceSurfaceAgentPresenceSemanticSignature(state));
     });
 });

--- a/src/renderer/src/app/workspace/surface-agent-presence.ts
+++ b/src/renderer/src/app/workspace/surface-agent-presence.ts
@@ -1,11 +1,83 @@
 import type {
     AiSessionSnapshot,
+    WorkspaceSurfaceAgentPresenceState,
     WorkspaceSurfaceAiAgentPresence,
 } from "@shared/ipc";
 import { getAiSessionDisplayTitle } from "@shared/ai-session-title";
 
 import { areGitWorktreeIdsEquivalent } from "@renderer/app/git/context-key";
 import type { RuntimeWorkspaceTab } from "@renderer/app/workspace/tree";
+
+export function workspaceSurfaceAgentPresenceSignature(
+    state: WorkspaceSurfaceAgentPresenceState,
+): string {
+    return JSON.stringify({
+        activeSessionId: state.activeSessionId,
+        contextKey: state.contextKey,
+        projectId: state.projectId,
+        sessions: state.sessions.map((session) =>
+            session.kind === "ai"
+                ? [
+                      session.kind,
+                      session.createdAt,
+                      session.parentSessionId,
+                      session.runtimeId,
+                      session.runtimeSessionId,
+                      session.sessionId,
+                      session.status,
+                      session.title,
+                      session.updatedAt,
+                  ]
+                : [
+                      session.kind,
+                      session.createdAt,
+                      session.preview,
+                      session.runtimeId,
+                      session.runtimeSessionId,
+                      session.sessionId,
+                      session.status,
+                      session.terminalId,
+                      session.title,
+                      session.updatedAt,
+                  ],
+        ),
+        worktreeId: state.worktreeId,
+    });
+}
+
+export function workspaceSurfaceAgentPresenceSemanticSignature(
+    state: WorkspaceSurfaceAgentPresenceState,
+): string {
+    return JSON.stringify({
+        activeSessionId: state.activeSessionId,
+        contextKey: state.contextKey,
+        projectId: state.projectId,
+        sessions: state.sessions.map((session) =>
+            session.kind === "ai"
+                ? [
+                      session.kind,
+                      session.createdAt,
+                      session.parentSessionId,
+                      session.runtimeId,
+                      session.runtimeSessionId,
+                      session.sessionId,
+                      session.status,
+                      session.title,
+                  ]
+                : [
+                      session.kind,
+                      session.createdAt,
+                      session.runtimeId,
+                      session.runtimeSessionId,
+                      session.sessionId,
+                      session.status,
+                      session.terminalId,
+                      session.title,
+                  ],
+        ),
+        worktreeId: state.worktreeId,
+    });
+}
 
 export interface WorkspaceSurfaceAiSessionState {
     readonly isDispatching: boolean;

--- a/src/renderer/src/app/workspace/workspaceSurfaceAgentPresencePublisher.test.ts
+++ b/src/renderer/src/app/workspace/workspaceSurfaceAgentPresencePublisher.test.ts
@@ -125,6 +125,58 @@ describe("workspaceSurfaceAgentPresencePublisher", () => {
         await settle();
         publisher.dispose();
     });
+
+    it("suppresses temporal churn while suspended but publishes semantic changes", async () => {
+        let sessions = { "session-1": sessionState() };
+        const listeners = new Set<() => void>();
+        const published: WorkspaceSurfaceAgentPresenceState[] = [];
+        const setTimer = vi.fn(() => 1);
+        const publisher = createWorkspaceSurfaceAgentPresencePublisher({
+            getAiSessions: () => sessions,
+            getWorkspaceProjection: workspaceProjection,
+            publish: (state) => {
+                published.push(state);
+                return Promise.resolve({ delivered: true });
+            },
+            setTimer,
+            subscribeAiSessions: (listener) => subscribe(listeners, listener),
+            subscribeWorkspace: () => () => undefined,
+        });
+        publisher.updateContext({
+            ...publisherContext(),
+            lifecycle: "suspended",
+        });
+        await settle();
+
+        for (let index = 1; index <= 10_000; index += 1) {
+            sessions = {
+                "session-1": sessionState({
+                    updatedAt: new Date(index).toISOString(),
+                }),
+            };
+            for (const listener of listeners) listener();
+        }
+        await settle();
+
+        expect(published).toHaveLength(1);
+        expect(setTimer).not.toHaveBeenCalled();
+
+        sessions = {
+            "session-1": sessionState({
+                status: "streaming",
+                title: "Semantic update",
+            }),
+        };
+        for (const listener of listeners) listener();
+        await settle();
+
+        expect(published).toHaveLength(2);
+        expect(published[1]?.sessions[0]).toMatchObject({
+            status: "streaming",
+            title: "Semantic update",
+        });
+        publisher.dispose();
+    });
 });
 
 function publisherContext() {

--- a/src/renderer/src/app/workspace/workspaceSurfaceAgentPresencePublisher.test.ts
+++ b/src/renderer/src/app/workspace/workspaceSurfaceAgentPresencePublisher.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+    AiSessionSnapshot,
+    WorkspaceSurfaceAgentPresenceState,
+    WorkspaceChatTab,
+} from "@shared/ipc";
+
+import { createWorkspaceSurfaceAgentPresencePublisher } from "./workspaceSurfaceAgentPresencePublisher";
+
+describe("workspaceSurfaceAgentPresencePublisher", () => {
+    it("throttles updatedAt-only bursts and publishes the latest revision", async () => {
+        let now = 0;
+        let sessions = { "session-1": sessionState() };
+        const aiListeners = new Set<() => void>();
+        const timers: Array<() => void> = [];
+        const published: WorkspaceSurfaceAgentPresenceState[] = [];
+        const publisher = createWorkspaceSurfaceAgentPresencePublisher({
+            getAiSessions: () => sessions,
+            getWorkspaceProjection: workspaceProjection,
+            now: () => now,
+            publish: (state) => {
+                published.push(state);
+                return Promise.resolve({ delivered: true });
+            },
+            setTimer: (callback) => {
+                timers.push(callback);
+                return timers.length;
+            },
+            clearTimer: () => undefined,
+            subscribeAiSessions: (listener) => subscribe(aiListeners, listener),
+            subscribeWorkspace: () => () => undefined,
+        });
+        publisher.updateContext(publisherContext());
+        await settle();
+
+        for (let index = 1; index <= 10_000; index += 1) {
+            sessions = {
+                "session-1": sessionState({
+                    updatedAt: new Date(index).toISOString(),
+                }),
+            };
+            for (const listener of aiListeners) listener();
+        }
+        await settle();
+
+        expect(published).toHaveLength(1);
+        expect(timers).toHaveLength(1);
+        now = 1_000;
+        timers[0]?.();
+        await settle();
+        expect(published).toHaveLength(2);
+        expect(published[1]?.sessions[0]?.updatedAt).toBe(
+            new Date(10_000).toISOString(),
+        );
+        publisher.dispose();
+    });
+
+    it("publishes semantic changes immediately inside the temporal window", async () => {
+        let sessions = { "session-1": sessionState() };
+        const listeners = new Set<() => void>();
+        const published: WorkspaceSurfaceAgentPresenceState[] = [];
+        const publish = vi.fn((state: WorkspaceSurfaceAgentPresenceState) => {
+            published.push(state);
+            return Promise.resolve({ delivered: true });
+        });
+        const publisher = createWorkspaceSurfaceAgentPresencePublisher({
+            getAiSessions: () => sessions,
+            getWorkspaceProjection: workspaceProjection,
+            now: () => 0,
+            publish,
+            subscribeAiSessions: (listener) => subscribe(listeners, listener),
+            subscribeWorkspace: () => () => undefined,
+        });
+        publisher.updateContext(publisherContext());
+        await settle();
+
+        sessions = {
+            "session-1": sessionState({
+                status: "streaming",
+                title: "New title",
+            }),
+        };
+        for (const listener of listeners) listener();
+        await settle();
+
+        expect(publish).toHaveBeenCalledTimes(2);
+        expect(published[1]?.sessions[0]).toMatchObject({
+            status: "streaming",
+            title: "New title",
+        });
+        publisher.dispose();
+    });
+
+    it("keeps one publication in flight and sends only the latest pending state", async () => {
+        let sessions = { "session-1": sessionState() };
+        const listeners = new Set<() => void>();
+        const published: WorkspaceSurfaceAgentPresenceState[] = [];
+        const resolvers: Array<() => void> = [];
+        const publisher = createWorkspaceSurfaceAgentPresencePublisher({
+            getAiSessions: () => sessions,
+            getWorkspaceProjection: workspaceProjection,
+            publish: (state) => {
+                published.push(state);
+                return new Promise((resolve) => {
+                    resolvers.push(() => resolve({ delivered: true }));
+                });
+            },
+            subscribeAiSessions: (listener) => subscribe(listeners, listener),
+            subscribeWorkspace: () => () => undefined,
+        });
+        publisher.updateContext(publisherContext());
+
+        for (const title of ["Second", "Third", "Latest"]) {
+            sessions = { "session-1": sessionState({ title }) };
+            for (const listener of listeners) listener();
+        }
+        expect(published).toHaveLength(1);
+        resolvers[0]?.();
+        await settle();
+
+        expect(published).toHaveLength(2);
+        expect(published[1]?.sessions[0]?.title).toBe("Latest");
+        resolvers[1]?.();
+        await settle();
+        publisher.dispose();
+    });
+});
+
+function publisherContext() {
+    return {
+        contextKey: "project-1:worktree-1",
+        lifecycle: "visible" as const,
+        projectId: "project-1",
+        terminalSessions: [],
+        worktreeId: "worktree-1",
+    };
+}
+
+function workspaceProjection() {
+    const tab: WorkspaceChatTab = {
+        createdAt: "2026-01-01T00:00:00.000Z",
+        draft: "",
+        id: "tab-1",
+        kind: "chat",
+        projectId: "project-1",
+        runtimeId: "codex",
+        sessionId: "session-1",
+        title: "Session",
+        worktreeId: "worktree-1",
+    };
+    return {
+        activeTab: tab,
+        tabsById: { [tab.id]: tab },
+    };
+}
+
+function sessionState(overrides: Partial<AiSessionSnapshot> = {}) {
+    return {
+        isDispatching: false,
+        snapshot: {
+            availableCommands: [],
+            configOptions: [],
+            lastError: null,
+            messages: [],
+            modeId: null,
+            modes: [],
+            modelId: null,
+            models: [],
+            pendingPermission: null,
+            pendingUserInput: null,
+            plan: null,
+            projectId: "project-1",
+            runtimeId: "codex" as const,
+            runtimeSessionId: "runtime-session-1",
+            sessionId: "session-1",
+            status: "idle" as const,
+            title: "Session",
+            tokenUsage: null,
+            toolActivity: [],
+            trackedFiles: [],
+            updatedAt: "2026-01-01T00:00:00.000Z",
+            worktreeId: "worktree-1",
+            ...overrides,
+        },
+    };
+}
+
+function subscribe(listeners: Set<() => void>, listener: () => void) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+}
+
+async function settle(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+}

--- a/src/renderer/src/app/workspace/workspaceSurfaceAgentPresencePublisher.ts
+++ b/src/renderer/src/app/workspace/workspaceSurfaceAgentPresencePublisher.ts
@@ -1,0 +1,189 @@
+import type {
+    WorkspaceSurfaceAgentPresenceState,
+    WorkspaceSurfaceLifecycleState,
+    WorkspaceSurfaceTerminalAgentPresence,
+} from "@shared/ipc";
+
+import type { RuntimeWorkspaceTab } from "@renderer/app/workspace/tree";
+
+import {
+    collectWorkspaceSurfaceAiAgentPresence,
+    type WorkspaceSurfaceAiSessionState,
+    workspaceSurfaceAgentPresenceSemanticSignature,
+    workspaceSurfaceAgentPresenceSignature,
+} from "./surface-agent-presence";
+
+export const WORKSPACE_AGENT_PRESENCE_TEMPORAL_INTERVAL_MS = 1_000;
+
+export interface WorkspaceSurfaceAgentPresencePublisherContext {
+    readonly contextKey: string;
+    readonly lifecycle: WorkspaceSurfaceLifecycleState;
+    readonly projectId: string;
+    readonly terminalSessions: readonly WorkspaceSurfaceTerminalAgentPresence[];
+    readonly worktreeId: string | null;
+}
+
+interface WorkspaceSurfaceAgentPresencePublisherDependencies {
+    readonly clearTimer?: (timer: number) => void;
+    readonly getAiSessions: () => Readonly<
+        Record<string, WorkspaceSurfaceAiSessionState>
+    >;
+    readonly getWorkspaceProjection: () => {
+        readonly activeTab: RuntimeWorkspaceTab | null;
+        readonly tabsById: Readonly<Record<string, RuntimeWorkspaceTab>>;
+    };
+    readonly now?: () => number;
+    readonly publish: (
+        state: WorkspaceSurfaceAgentPresenceState,
+    ) => Promise<{ readonly delivered: boolean }>;
+    readonly setTimer?: (
+        callback: () => void,
+        delayMs: number,
+    ) => number;
+    readonly subscribeAiSessions: (listener: () => void) => () => void;
+    readonly subscribeWorkspace: (listener: () => void) => () => void;
+}
+
+export interface WorkspaceSurfaceAgentPresencePublisher {
+    readonly dispose: () => void;
+    readonly updateContext: (
+        context: WorkspaceSurfaceAgentPresencePublisherContext | null,
+    ) => void;
+}
+
+export function createWorkspaceSurfaceAgentPresencePublisher(
+    dependencies: WorkspaceSurfaceAgentPresencePublisherDependencies,
+): WorkspaceSurfaceAgentPresencePublisher {
+    const now = dependencies.now ?? Date.now;
+    const setTimer =
+        dependencies.setTimer ??
+        ((callback: () => void, delayMs: number) =>
+            globalThis.setTimeout(callback, delayMs) as unknown as number);
+    const clearTimer =
+        dependencies.clearTimer ??
+        ((timer: number) =>
+            globalThis.clearTimeout(
+                timer as unknown as ReturnType<typeof setTimeout>,
+            ));
+    let context: WorkspaceSurfaceAgentPresencePublisherContext | null = null;
+    let disposed = false;
+    let inFlight = false;
+    let lastPublishedAt = Number.NEGATIVE_INFINITY;
+    let publishedFullSignature = "";
+    let publishedSemanticSignature = "";
+    let pendingState: WorkspaceSurfaceAgentPresenceState | null = null;
+    let temporalTimer: number | null = null;
+
+    const clearTemporalTimer = () => {
+        if (temporalTimer === null) return;
+        clearTimer(temporalTimer);
+        temporalTimer = null;
+    };
+
+    const scheduleTemporalPublish = () => {
+        if (temporalTimer !== null || !context || context.lifecycle !== "visible") {
+            return;
+        }
+        const delayMs = Math.max(
+            0,
+            WORKSPACE_AGENT_PRESENCE_TEMPORAL_INTERVAL_MS -
+                (now() - lastPublishedAt),
+        );
+        temporalTimer = setTimer(() => {
+            temporalTimer = null;
+            void publishPending();
+        }, delayMs);
+    };
+
+    const publishPending = async (): Promise<void> => {
+        if (disposed || inFlight || !pendingState) return;
+        const state = pendingState;
+        const fullSignature = workspaceSurfaceAgentPresenceSignature(state);
+        const semanticSignature =
+            workspaceSurfaceAgentPresenceSemanticSignature(state);
+        if (fullSignature === publishedFullSignature) {
+            pendingState = null;
+            return;
+        }
+        const semanticChange = semanticSignature !== publishedSemanticSignature;
+        if (
+            !semanticChange &&
+            (context?.lifecycle !== "visible" ||
+                now() - lastPublishedAt <
+                    WORKSPACE_AGENT_PRESENCE_TEMPORAL_INTERVAL_MS)
+        ) {
+            scheduleTemporalPublish();
+            return;
+        }
+
+        pendingState = null;
+        clearTemporalTimer();
+        inFlight = true;
+        try {
+            const result = await dependencies.publish(state);
+            if (!disposed && result.delivered) {
+                publishedFullSignature = fullSignature;
+                publishedSemanticSignature = semanticSignature;
+                lastPublishedAt = now();
+            }
+        } catch {
+            // A later store revision or lifecycle resync retries the latest state.
+        } finally {
+            inFlight = false;
+            if (!disposed && pendingState) void publishPending();
+        }
+    };
+
+    const refresh = () => {
+        if (disposed || !context) return;
+        const workspace = dependencies.getWorkspaceProjection();
+        const activeTab = workspace.activeTab;
+        const activeSessionId =
+            activeTab?.kind === "chat" || activeTab?.kind === "review"
+                ? activeTab.sessionId
+                : activeTab?.kind === "terminal"
+                  ? (context.terminalSessions.find(
+                        (session) =>
+                            session.terminalId === activeTab.terminalId,
+                    )?.sessionId ?? null)
+                  : null;
+        pendingState = {
+            activeSessionId,
+            contextKey: context.contextKey,
+            projectId: context.projectId,
+            sessions: [
+                ...collectWorkspaceSurfaceAiAgentPresence({
+                    aiSessions: dependencies.getAiSessions(),
+                    projectId: context.projectId,
+                    tabsById: workspace.tabsById,
+                    worktreeId: context.worktreeId,
+                }),
+                ...context.terminalSessions,
+            ],
+            worktreeId: context.worktreeId,
+        };
+        void publishPending();
+    };
+
+    const unsubscribeAiSessions = dependencies.subscribeAiSessions(refresh);
+    const unsubscribeWorkspace = dependencies.subscribeWorkspace(refresh);
+
+    return {
+        dispose() {
+            disposed = true;
+            pendingState = null;
+            clearTemporalTimer();
+            unsubscribeAiSessions();
+            unsubscribeWorkspace();
+        },
+        updateContext(nextContext) {
+            context = nextContext;
+            if (!context) {
+                pendingState = null;
+                clearTemporalTimer();
+                return;
+            }
+            refresh();
+        },
+    };
+}

--- a/src/shared/testing/chatLoadFactories.ts
+++ b/src/shared/testing/chatLoadFactories.ts
@@ -1,6 +1,8 @@
 import type {
     AiFileDiff,
     AiMessage,
+    AiRuntimeId,
+    AiSessionToolActivityEvent,
     AiToolActivity,
 } from "../ipc";
 
@@ -24,8 +26,146 @@ export interface ChatLoadFixture {
     readonly sessions: readonly ChatLoadSessionFixture[];
 }
 
+export interface TerminalStreamPressureScenario {
+    readonly chunkBytes: number;
+    readonly chunkCount: number;
+    readonly durationMs: number;
+    readonly runtimeId: AiRuntimeId;
+    readonly sessionId?: string;
+    readonly terminalOutputLimitBytes?: number;
+    readonly toolCallId?: string;
+}
+
+export interface TerminalStreamPressureFixture {
+    readonly chunks: readonly string[];
+    readonly diagnostic: {
+        readonly chunkBytes: number;
+        readonly chunkCount: number;
+        readonly durationMs: number;
+        readonly eventCount: number;
+        readonly finalOutputBytes: number;
+    };
+    readonly events: readonly AiSessionToolActivityEvent[];
+    readonly expectedFinalOutput: string;
+}
+
 const FIXTURE_EPOCH_MS = Date.UTC(2026, 0, 1, 0, 0, 0);
 const ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
+const DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES = 10_000;
+
+export function createTerminalStreamPressureFixture(
+    input: TerminalStreamPressureScenario,
+): TerminalStreamPressureFixture {
+    const chunkCount = normalizeFixtureCount(input.chunkCount);
+    const chunkBytes = normalizeFixtureCount(input.chunkBytes);
+    const durationMs = normalizeFixtureCount(input.durationMs);
+    const terminalOutputLimitBytes = normalizeFixtureCount(
+        input.terminalOutputLimitBytes ?? DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES,
+    );
+    const sessionId = input.sessionId ?? "terminal-pressure-session";
+    const toolCallId = input.toolCallId ?? "terminal-pressure-tool";
+    const random = createSeededChatLoadRandom(0x51deca7);
+    const chunks = Array.from({ length: chunkCount }, () =>
+        createSizedText(random, chunkBytes),
+    );
+    let terminalOutput = "";
+    const events: AiSessionToolActivityEvent[] = [
+        createTerminalPressureEvent({
+            input,
+            sessionId,
+            status: "in_progress",
+            terminalOutput: null,
+            timestampMs: 0,
+            toolCallId,
+        }),
+    ];
+
+    chunks.forEach((chunk, index) => {
+        terminalOutput = `${terminalOutput}${chunk}`.slice(
+            -terminalOutputLimitBytes,
+        );
+        events.push(
+            createTerminalPressureEvent({
+                input,
+                sessionId,
+                status: "in_progress",
+                terminalOutput,
+                timestampMs:
+                    chunkCount === 0
+                        ? 0
+                        : Math.floor(((index + 1) * durationMs) / chunkCount),
+                toolCallId,
+            }),
+        );
+    });
+    events.push(
+        createTerminalPressureEvent({
+            exitCode: 0,
+            input,
+            sessionId,
+            status: "completed",
+            terminalOutput,
+            timestampMs: durationMs + 1,
+            toolCallId,
+        }),
+    );
+
+    return {
+        chunks,
+        diagnostic: {
+            chunkBytes,
+            chunkCount,
+            durationMs,
+            eventCount: events.length,
+            finalOutputBytes: terminalOutput.length,
+        },
+        events,
+        expectedFinalOutput: terminalOutput,
+    };
+}
+
+function createTerminalPressureEvent(input: {
+    readonly exitCode?: number;
+    readonly input: TerminalStreamPressureScenario;
+    readonly sessionId: string;
+    readonly status: AiToolActivity["status"];
+    readonly terminalOutput: string | null;
+    readonly timestampMs: number;
+    readonly toolCallId: string;
+}): AiSessionToolActivityEvent {
+    const updatedAt = new Date(FIXTURE_EPOCH_MS + input.timestampMs).toISOString();
+    return {
+        activity: {
+            createdAt: new Date(FIXTURE_EPOCH_MS).toISOString(),
+            diffs: [],
+            exitCode: input.exitCode ?? null,
+            id: input.toolCallId,
+            kind: "shell",
+            locations: [],
+            rawInputJson: null,
+            rawOutputJson: null,
+            sessionId: input.sessionId,
+            status: input.status,
+            summary:
+                input.status === "completed" ? "Command completed" : null,
+            terminalOutput: input.terminalOutput,
+            title: "Run command",
+            updatedAt,
+        },
+        kind: "tool-activity",
+        origin: "live",
+        parentSessionId: null,
+        runtimeId: input.input.runtimeId,
+        runtimeSessionId: `${input.input.runtimeId}-runtime-session`,
+        sessionId: input.sessionId,
+        updatedAt,
+    };
+}
+
+function normalizeFixtureCount(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    return Math.min(1_000_000, Math.max(0, Math.floor(value)));
+}
 
 export function createChatLoadFixture(
     input: ChatLoadScenario,

--- a/src/shared/testing/chatLoadScenario.test.ts
+++ b/src/shared/testing/chatLoadScenario.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { createChatLoadFixture } from "./chatLoadFactories";
+import {
+    createChatLoadFixture,
+    createTerminalStreamPressureFixture,
+} from "./chatLoadFactories";
 import {
     createChatLoadDiagnosticSummary,
     normalizeChatLoadScenario,
@@ -146,5 +149,48 @@ describe("chatLoadScenario", () => {
                 .filter((tool) => tool.diffs.length > 0)
                 .every((tool) => tool.kind === "edit"),
         ).toBe(true);
+    });
+
+    it("generates a provider-independent terminal pressure stream", () => {
+        for (const runtimeId of ["codex", "claude", "custom:fixture"] as const) {
+            const fixture = createTerminalStreamPressureFixture({
+                chunkBytes: 7,
+                chunkCount: 10_000,
+                durationMs: 10_000,
+                runtimeId,
+            });
+
+            expect(fixture.chunks).toHaveLength(10_000);
+            expect(fixture.events).toHaveLength(10_002);
+            expect(fixture.events[0]?.activity.status).toBe("in_progress");
+            expect(fixture.events.at(-1)?.activity).toMatchObject({
+                exitCode: 0,
+                status: "completed",
+                terminalOutput: fixture.expectedFinalOutput,
+            });
+            expect(fixture.expectedFinalOutput).toHaveLength(10_000);
+            expect(fixture.diagnostic).toEqual({
+                chunkBytes: 7,
+                chunkCount: 10_000,
+                durationMs: 10_000,
+                eventCount: 10_002,
+                finalOutputBytes: 10_000,
+            });
+        }
+    });
+
+    it("keeps terminal pressure diagnostics numeric and content-free", () => {
+        const fixture = createTerminalStreamPressureFixture({
+            chunkBytes: 32,
+            chunkCount: 8,
+            durationMs: 250,
+            runtimeId: "opencode",
+        });
+        const diagnostic = JSON.stringify(fixture.diagnostic);
+
+        expect(Object.values(fixture.diagnostic).every(Number.isFinite)).toBe(true);
+        expect(diagnostic).not.toContain(fixture.chunks[0] ?? "fixture-content");
+        expect(diagnostic).not.toContain("terminal-pressure-session");
+        expect(diagnostic).not.toContain("Run command");
     });
 });


### PR DESCRIPTION
## Summary

- coalesce high-frequency terminal-only ACP tool updates while flushing semantic transitions and trailing output immediately
- route AI session traffic through a shared bounded delivery controller with a 32-message window, exact ACK handling, causal priority, keyed coalescing, and recovery fallback
- frame-buffer live renderer activity and isolate workspace agent presence from transcript churn
- add regression fixtures, transport metrics, and an end-to-end pressure scenario covering more than 10,000 terminal events

## Root cause

Verbose commands could amplify thousands of terminal chunks across the native runtime, main-process session stream, preload bridge, renderer store, persistence, and workspace presence projection. The resulting repeated writes and renders could saturate the renderer and freeze the workspace.

The transport behavior is provider-independent. Providers that emit many fine-grained tool updates were more likely to trigger it, but the bottleneck was in the shared streaming pipeline rather than a Codex-specific renderer path.

## Implementation notes

- terminal activity is coalesced per activity and time window, with a real trailing flush timer
- semantic changes such as completion, failure, permission, input, turn state, diffs, and exit codes bypass temporal coalescing
- pending stream delivery is bounded and coalesced by stable entity keys
- critical requests only wait for causally related entities, so unrelated tool storms cannot block permission or user-input prompts
- recovery preserves visible transcript state exactly once and resynchronizes authoritative snapshots
- the main process, unit tests, and browser pressure harness use the same production delivery controller

## Validation

- pnpm run typecheck
- pnpm run lint
- pnpm test: 323 files passed, 2,914 tests passed, 1 skipped
- pnpm run build:ci
- cargo test --workspace
- pnpm exec playwright test --config e2e/playwright.config.ts e2e/tests/ai-terminal-stream-pressure.spec.ts

The pressure E2E keeps the workspace interactive while processing more than 10,000 events, verifies a peak of 32 in-flight payloads, checks coalescing and renderer write bounds, and asserts no duplicate delivery or ACK-before-ingestion.